### PR TITLE
Add support for semantic forms

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,103 +124,159 @@
 
 				<h3>Forms</h3>
 				<form>
-					<p>Inputs support a number of different base classes. Any text input has a class of 'input-text' and supports several sizes.</p>
-					<label>Standard Input</label>
-					<input type="text" class="input-text" />
+					<p>All form fields are encapsulated within a 'form-field' div. Inputs support a number of different base classes and supports several sizes.</p>
+					<div class='form-field'>
+						<label>Standard Input</label>
+						<input type="text" />
+					</div>
 
-					<label>Small Input</label>
-					<input type="text" class="small input-text" />
+					<div class='form-field'>
+						<label>Small Input</label>
+						<input type="text" class="small" />
+					</div>
 
-					<label>Medium Input</label>
-					<input type="text" class="medium input-text" />
+					<div class='form-field'>
+						<label>Medium Input</label>
+						<input type="text" class="medium" />
+					</div>
 
-					<label>Large Input</label>
-					<input type="text" class="large input-text" />
+					<div class='form-field'>
+						<label>Large Input</label>
+						<input type="text" class="large" />
+					</div>
 
-					<label>Oversize Input</label>
-					<input type="text" class="oversize input-text" />
+					<div class='form-field'>
+						<label>Oversize Input</label>
+						<input type="text" class="oversize" />
+					</div>
 
 					<p>Inline labels are accomplished using the HTML5 Placeholder attribute, with a built-in JS fallback.</p>
-					<input type="text" class="input-text" placeholder="Inline label" />
+					<div class='form-field'>
+						<input type="text" placeholder="Inline label" />
+					</div>
 
-					<p>Error states are built to be as flexible as they need to. Simple color classes can apply to labels and inputs, and a small element can be also be placed for the error message.</p>
-					<label class="red">Medium Input</label>
-					<input type="text" class="red medium input-text" />
-					<small class="error">Whoa, cowboy. Try that again.</small>
+					<p>Error states are set on the 'form-field' div. A small element can be also be placed for the error message.</p>
+					<div class='form-field error'>
+						<label>Medium Input</label>
+						<input type="text" class="medium" />
+						<small>Whoa, cowboy. Try that again.</small>
+					</div>
 
-					<label>Textarea</label>
-					<textarea>This is a textarea</textarea>
-					<label>Inline Label Textarea</label>
+					<div class='form-field'>
+						<label>Textarea</label>
+						<textarea>This is a textarea</textarea>
+					</div>
 
-					<textarea placeholder="This is a text area"></textarea>
+					<div class='form-field'>
+						<label>Inline Label Textarea</label>
+						<textarea placeholder="This is a text area"></textarea>
+					</div>
 
-					<label for="checkbox1"><input type="checkbox" id="checkbox1"> Label for Checkbox</label>
+					<div class='form-field'>
+						<label for="checkbox1"><input type="checkbox" id="checkbox1"> Label for Checkbox</label>
+					</div>
 
-					<label for="radio1"><input type="radio" id="radio1"> Label for Radio</label>
+					<div class='form-field'>
+						<label for="radio1"><input type="radio" id="radio1"> Label for Radio</label>
+					</div>
 
-					<label>Dropdown Label</label>
-					<select>
-						<option>This is a dropdown</option>
-						<option>This is another option</option>
-						<option>Look, a third option</option>
-					</select>
+					<div class='form-field'>
+						<label>Dropdown Label</label>
+						<select>
+							<option>This is a dropdown</option>
+							<option>This is another option</option>
+							<option>Look, a third option</option>
+						</select>
+					</div>
 
-					<div class="row"><div class="seven columns">
-						<fieldset>
-							<h5>Fieldset Header H2</h5>
-							<p>This is a paragraph within a fieldset.</p>
+					<div class="row">
+						<div class="seven columns">
+							<fieldset>
+								<h5>Fieldset Header H2</h5>
+								<p>This is a paragraph within a fieldset.</p>
 
-							<label>Standard Input</label> <input type="text" class="input-text" />
-						</fieldset>
-					</div></div>
+								<div class='form-field'>
+									<label>Standard Input</label>
+									<input type="text" />
+								</div>
+							</fieldset>
+						</div>
+					</div>
 				</form>
 				<hr>
 				<form class="nice">
 					<p>Changing the form style to a slightly fancier version is dead simple - just add a class of 'nice' to the form itself.</p>
 
-					<label>Standard Input</label>
-					<input type="text" class="input-text" />
+					<div class='form-field'>
+						<label>Standard Input</label>
+						<input type="text" />
+					</div>
 
-					<input type="text" class="input-text" placeholder="Inline label" />
+					<div class='form-field'>
+						<input type="text" placeholder="Inline label" />
+					</div>
 
-					<label>Small Input</label>
-					<input type="text" class="small input-text" />
+					<div class='form-field'>
+						<label>Small Input</label>
+						<input type="text" class="small" />
+					</div>
 
-					<label class="red">Medium Input</label>
-					<input type="text" class="medium input-text" />
-					<small class="error">Whoa, cowboy. Try that again.</small>
+					<div class='form-field error'>
+						<label>Medium Input</label>
+						<input type="text" class="medium" />
+						<small>Whoa, cowboy. Try that again.</small>
+					</div>
 
-					<label>Large Input</label>
-					<input type="text" class="large input-text" />
+					<div class='form-field'>
+						<label>Large Input</label>
+						<input type="text" class="large" />
+					</div>
 
-					<label>Oversize Input</label>
-					<input type="text" class="oversize input-text" />
+					<div class='form-field'>
+						<label>Oversize Input</label>
+						<input type="text" class="oversize" />
+					</div>
 
-					<label>Textarea</label>
-					<textarea>This is a textarea</textarea>
+					<div class='form-field'>
+						<label>Textarea</label>
+						<textarea>This is a textarea</textarea>
+					</div>
 
-					<label>Inline Label Textarea</label>
-					<textarea placeholder="This is a text area"></textarea>
+					<div class='form-field'>
+						<label>Inline Label Textarea</label>
+						<textarea placeholder="This is a text area"></textarea>
+					</div>
 
-					<label for="checkbox1"><input type="checkbox" id="checkbox1"> Label for Checkbox</label>
+					<div class='form-field'>
+						<label for="checkbox1"><input type="checkbox" id="checkbox1"> Label for Checkbox</label>
+					</div>
 
-					<label for="radio1"><input type="radio" id="radio1"> Label for Radio</label>
+					<div class='form-field'>
+						<label for="radio1"><input type="radio" id="radio1"> Label for Radio</label>
+					</div>
 
-					<label>Dropdown Label</label>
-					<select>
-						<option>This is a dropdown</option>
-						<option>This is another option</option>
-						<option>Look, a third option</option>
-					</select>
+					<div class='form-field'>
+						<label>Dropdown Label</label>
+						<select>
+							<option>This is a dropdown</option>
+							<option>This is another option</option>
+							<option>Look, a third option</option>
+						</select>
+					</div>
 
-					<div class="row"><div class="seven columns">
-						<fieldset>
-							<h5>Fieldset Header H2</h5>
-							<p>This is a paragraph within a fieldset.</p>
+					<div class="row">
+						<div class="seven columns">
+							<fieldset>
+								<h5>Fieldset Header H2</h5>
+								<p>This is a paragraph within a fieldset.</p>
 
-							<label>Standard Input</label> <input type="text" class="input-text" />
-						</fieldset>
-					</div></div>
+								<div class='form-field'>
+									<label>Standard Input</label>
+									<input type="text" />
+								</div>
+							</fieldset>
+						</div>
+					</div>
 				</form>
 			</div>
 

--- a/index.html
+++ b/index.html
@@ -121,9 +121,109 @@
 				<p><a href="#" class="nice radius small blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius large blue button">Nice Blue Button</a></p>
-				
+
+				<h3>Forms</h3>
+				<form>
+					<p>Inputs support a number of different base classes. Any text input has a class of 'input-text' and supports several sizes.</p>
+					<label>Standard Input</label>
+					<input type="text" class="input-text" />
+
+					<label>Small Input</label>
+					<input type="text" class="small input-text" />
+
+					<label>Medium Input</label>
+					<input type="text" class="medium input-text" />
+
+					<label>Large Input</label>
+					<input type="text" class="large input-text" />
+
+					<label>Oversize Input</label>
+					<input type="text" class="oversize input-text" />
+
+					<p>Inline labels are accomplished using the HTML5 Placeholder attribute, with a built-in JS fallback.</p>
+					<input type="text" class="input-text" placeholder="Inline label" />
+
+					<p>Error states are built to be as flexible as they need to. Simple color classes can apply to labels and inputs, and a small element can be also be placed for the error message.</p>
+					<label class="red">Medium Input</label>
+					<input type="text" class="red medium input-text" />
+					<small class="error">Whoa, cowboy. Try that again.</small>
+
+					<label>Textarea</label>
+					<textarea>This is a textarea</textarea>
+					<label>Inline Label Textarea</label>
+
+					<textarea placeholder="This is a text area"></textarea>
+
+					<label for="checkbox1"><input type="checkbox" id="checkbox1"> Label for Checkbox</label>
+
+					<label for="radio1"><input type="radio" id="radio1"> Label for Radio</label>
+
+					<label>Dropdown Label</label>
+					<select>
+						<option>This is a dropdown</option>
+						<option>This is another option</option>
+						<option>Look, a third option</option>
+					</select>
+
+					<div class="row"><div class="seven columns">
+						<fieldset>
+							<h5>Fieldset Header H2</h5>
+							<p>This is a paragraph within a fieldset.</p>
+
+							<label>Standard Input</label> <input type="text" class="input-text" />
+						</fieldset>
+					</div></div>
+				</form>
+				<hr>
+				<form class="nice">
+					<p>Changing the form style to a slightly fancier version is dead simple - just add a class of 'nice' to the form itself.</p>
+
+					<label>Standard Input</label>
+					<input type="text" class="input-text" />
+
+					<input type="text" class="input-text" placeholder="Inline label" />
+
+					<label>Small Input</label>
+					<input type="text" class="small input-text" />
+
+					<label class="red">Medium Input</label>
+					<input type="text" class="medium input-text" />
+					<small class="error">Whoa, cowboy. Try that again.</small>
+
+					<label>Large Input</label>
+					<input type="text" class="large input-text" />
+
+					<label>Oversize Input</label>
+					<input type="text" class="oversize input-text" />
+
+					<label>Textarea</label>
+					<textarea>This is a textarea</textarea>
+
+					<label>Inline Label Textarea</label>
+					<textarea placeholder="This is a text area"></textarea>
+
+					<label for="checkbox1"><input type="checkbox" id="checkbox1"> Label for Checkbox</label>
+
+					<label for="radio1"><input type="radio" id="radio1"> Label for Radio</label>
+
+					<label>Dropdown Label</label>
+					<select>
+						<option>This is a dropdown</option>
+						<option>This is another option</option>
+						<option>Look, a third option</option>
+					</select>
+
+					<div class="row"><div class="seven columns">
+						<fieldset>
+							<h5>Fieldset Header H2</h5>
+							<p>This is a paragraph within a fieldset.</p>
+
+							<label>Standard Input</label> <input type="text" class="input-text" />
+						</fieldset>
+					</div></div>
+				</form>
 			</div>
-			
+
 			<div class="four columns">
 				<h4>Getting Started</h4>
 				<p>We're stoked you want to try Foundation! To get going, this file (index.html) includes some basic styles you can modify, play around with, or totally destroy to get going.</p>

--- a/stylesheets/forms.css
+++ b/stylesheets/forms.css
@@ -10,52 +10,57 @@
 
 	form { margin: 0 0 18px; }
 	form label { display: block; font-size: 13px; line-height: 18px; cursor: pointer; margin-bottom: 9px; }
-	
-	input.input-text, textarea { border-right: 1px solid #bbb; border-bottom: 1px solid #bbb; }
-	input.input-text, textarea, select { display: block; margin-bottom: 9px; }
-	label + input.input-text, label + textarea, label + select, label + div.dropdown, select + div.dropdown { margin-top: -9px; }
-	
+
+	div.form-field input, input.input-text, textarea { border-right: 1px solid #bbb; border-bottom: 1px solid #bbb; }
+	div.form-field input, input.input-text, textarea, select { display: block; margin-bottom: 9px; }
+	div.form-field label + input, label + input.input-text, label + textarea, label + select, label + div.dropdown, select + div.dropdown { margin-top: -9px; }
+
 	/* Text input and textarea font and padding */
-	input.input-text, textarea { font-size: 13px; padding: 4px 3px 2px; outline: none !important; background: #fff; }
-	input.input-text.oversize, textarea.oversize { font-size: 18px !important; padding: 4px 5px !important; }
-	input.input-text:focus, textarea:focus { background: #f9f9f9; }
-	
+	div.form-field input, input.input-text, textarea { font-size: 13px; padding: 4px 3px 2px; outline: none !important; background: #fff; }
+	div.form-field input.oversize, input.input-text.oversize, textarea.oversize { font-size: 18px !important; padding: 4px 5px !important; }
+	div.form-field input:focus, input.input-text:focus, textarea:focus { background: #f9f9f9; }
+
 	/* Inlined Label Style */
 	input.placeholder, textarea.placeholder { color: #888; }
 
 	/* Text input and textarea sizes */
-	input.input-text, textarea { width: 254px; }
-	input.small, textarea.small { width: 134px; }
-	input.medium, textarea.medium { width: 254px; }
-	input.large, textarea.large { width: 434px; }
-	
+	div.form-field input, input.input-text, textarea { width: 254px; }
+	div.form-field input.small, input.small, textarea.small { width: 134px; }
+	div.form-field input.medium, input.medium, textarea.medium { width: 254px; }
+	div.form-field input.large, input.large, textarea.large { width: 434px; }
+
 	/* Fieldsets */
 	form fieldset { padding: 9px 9px 2px 9px; border: solid 1px #ddd; margin: 18px 0; }
-	
+
+	/* Inlined Radio & Checkbox */
+	div.form-field input[type=radio], div.form-field input[type=checkbox] { display: inline; width:auto; margin-bottom:0; }
+
 	/* Errors */
-	input.input-text.red { border-color: red; background-color: rgba(255,0,0,0.15); }
-	label.red { color: red; }
-	small.error { margin-top: -6px; display: block; margin-bottom: 9px; font-size: 11px; color: red; width: 260px; }
-	
-	.small + .error { width: 140px; }
-	.medium + .error { width: 260px; }
-	.large + .error { width: 440px; }
-	
+	div.form-field.error input, input.input-text.red { border-color: red; background-color: rgba(255,0,0,0.15); }
+	div.form-field.error label, label.red { color: red; }
+	div.form-field.error small, small.error { margin-top: -6px; display: block; margin-bottom: 9px; font-size: 11px; color: red; width: 260px; }
+
+	div.form-field.error .small + small, .small + .error { width: 140px; }
+	div.form-field.error .medium + small, .medium + .error { width: 260px; }
+	div.form-field.error .large + small, .large + .error { width: 440px; }
+
 	/* -----------------------------------------
 	   Nicer Forms
 	----------------------------------------- */
-	form.nice input.input-text, form.nice textarea { border: solid 1px #bbb; border-radius: 2px; -webkit-border-radius: 2px; -moz-border-radius: 2px; }
-	form.nice input.input-text, form.nice textarea { font-size: 13px; padding: 6px 3px 4px; outline: none !important; background: url(../images/misc/input-bg.png) #fff; }
-	form.nice input.input-text:focus, form.nice textarea:focus { background-color: #f9f9f9; }
-	
+	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { border: solid 1px #bbb; border-radius: 2px; -webkit-border-radius: 2px; -moz-border-radius: 2px; }
+	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { font-size: 13px; padding: 6px 3px 4px; outline: none !important; background: url(../images/misc/input-bg.png) #fff; }
+	form.nice div.form-field input:focus, form.nice input.input-text:focus, form.nice textarea:focus { background-color: #f9f9f9; }
+
 	form.nice fieldset { border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; }
-	
-	form.nice small.error { padding: 6px 4px; border: solid 0px red; border-width: 0px 1px 1px 1px; margin-top: -10px; background: red; color: #fff; font-size: 12px; font-weight: bold; border-bottom-left-radius: 2px; border-bottom-right-radius: 2px; -webkit-border-bottom-left-radius: 2px; -webkit-border-bottom-right-radius: 2px; -moz-border-radius-bottomleft: 2px; -moz-border-radius-bottomright: 2px; }
-	
-	form.nice .small + .error { width: 132px; }
-	form.nice .medium + .error { width: 252px; }
-	form.nice .large + .error { width: 432px; }	
-	
+
+	form.nice div.form-field input[type=radio], form.nice div.form-field input[type=checkbox] { display: inline; width:auto; margin-bottom:0; }
+
+	form.nice div.form-field.error small, form.nice small.error { padding: 6px 4px; border: solid 0px red; border-width: 0px 1px 1px 1px; margin-top: -10px; background: red; color: #fff; font-size: 12px; font-weight: bold; border-bottom-left-radius: 2px; border-bottom-right-radius: 2px; -webkit-border-bottom-left-radius: 2px; -webkit-border-bottom-right-radius: 2px; -moz-border-radius-bottomleft: 2px; -moz-border-radius-bottomright: 2px; }
+
+	form.nice div.form-field.error .small + small, form.nice .small + .error { width: 132px; }
+	form.nice div.form-field.error .medium + small, form.nice .medium + .error { width: 252px; }
+	form.nice div.form-field.error .large + small, form.nice .large + .error { width: 432px; }
+
 	/* -----------------------------------------
 	   Custom Forms
 	----------------------------------------- */

--- a/stylesheets/mobile.css
+++ b/stylesheets/mobile.css
@@ -72,13 +72,13 @@
 
 
 	@media only screen and (max-width: 767px) {
-		input.input-text, input.input-text.oversize, textarea,
-		form.nice input.input-text, form.nice input.input-text.oversize, form.nice textarea { display: block; width: 96%; padding: 6px 2% 4px; font-size: 18px; }
-		form.nice input.input-text, form.nice input.input-text.oversize, form.nice textarea { -webkit-border-radius: 2px; -moz-border-radius: 2px; }
-		form.nice small.error { padding: 6px 2%; display: block; }
-		form.nice .small + .error { width: auto; }
-		form.nice .medium + .error { width: auto; }
-		form.nice .large + .error { width: auto; }	
+		div.form-field input, div.form-field input.small, div.form-field input.medium, div.form-field input.large, div.form-field input.oversize, input.input-text, input.input-text.oversize, textarea,
+		form.nice div.form-field input, form.nice div.form-field input.oversize, form.nice input.input-text, form.nice input.input-text.oversize, form.nice textarea { display: block; width: 96%; padding: 6px 2% 4px; font-size: 18px; }
+		form.nice div.form-field input, form.nice div.form-field input.oversize, form.nice input.input-text, form.nice input.input-text.oversize, form.nice textarea { -webkit-border-radius: 2px; -moz-border-radius: 2px; }
+		form.nice div.form-field.error small, form.nice small.error { padding: 6px 2%; display: block; }
+		form.nice div.form-field.error .small + small, form.nice .small + .error { width: auto; }
+		form.nice div.form-field.error .medium + small, form.nice .medium + .error { width: auto; }
+		form.nice div.form-field.error .large + small, form.nice .large + .error { width: auto; }
 	}
 	
 	
@@ -97,8 +97,8 @@
 	@media only screen and (max-width: 767px) {
 		dl.tabs.mobile, dl.nice.tabs.mobile { width: auto; margin: 20px -20px 40px; height: auto; }
 		dl.tabs.mobile dt, dl.tabs.mobile dd, dl.nice.tabs.mobile dt, dl.nice.tabs.mobile dd { float: none; height: auto; }
-		
-	    dl.tabs.mobile dd a { display: block; width: auto; height: auto; padding: 18px 20px; line-height: 1; border: solid 0px #ccc; border-width: 1px 0px 0px; margin: 0; color: #555; background: #eee; font-size: 15px; font-size: 1.5rem; }
+
+		dl.tabs.mobile dd a { display: block; width: auto; height: auto; padding: 18px 20px; line-height: 1; border: solid 0px #ccc; border-width: 1px 0px 0px; margin: 0; color: #555; background: #eee; font-size: 15px; font-size: 1.5rem; }
 		dl.tabs.mobile dd a.active { height: auto; margin: 0; border-width: 1px 0px 0px; }
 	
 		.nice.tabs.mobile { border-bottom: solid 1px #ccc; height: auto; }
@@ -107,6 +107,6 @@
 		.nice.tabs.mobile dd:first-child a.active { margin: 0; }
 		
 		dl.contained.mobile, dl.nice.contained.mobile { margin-bottom: 0px; }
-    	dl.contained.tabs.mobile dd a { padding: 18px 20px; }
-    	dl.nice.contained.tabs.mobile dd a { padding: 18px 20px; }
+		dl.contained.tabs.mobile dd a { padding: 18px 20px; }
+		dl.nice.contained.tabs.mobile dd a { padding: 18px 20px; }
 	}


### PR DESCRIPTION
Hello,

This is my attempt at adding some support to the form stylesheets to support semantic forms. Basically, I'm thinking of wrapping every form field element within a div.form-field which would encapsulate the label, the actual form element and the error message (i.e. the small element). This would then allow me to set the state of each form element on the div. So errors for example will only need to set one classname instead of updating 3 separate elements.

I've maintained the styling for the current method of building the form and updated index.html to show how I envisioned using div.form-field. I have not updated marketing/docs/forms.php with the new layout method.

Let me know if you like the direction of my change or if you would like me to update or change anything about it.

Thanks for the awesome framework!
@HypertextRanch
