### PR TITLE
added method to re-sync custom drop-downs if native element changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,6 @@
 				<p><a href="#" class="nice radius blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius large blue button">Nice Blue Button</a></p>
 
-
 			</div>
 
 			<div class="four columns">			

--- a/index.html
+++ b/index.html
@@ -106,22 +106,6 @@
 					<li id="simple3Tab">This is simple tab 3's content. It's, you know...okay.</li>
 				</ul>
 				
-				<h3>Forms</h3>
-				
-				<form id="testForm" class="custom">
-					<label for="checkbox1">
-						<input type="checkbox" id="checkbox1" /> Checkbox
-					</label>
-					<label for="radio1">
-						<input type="radio" id="radio1" /> Radio
-					</label>
-					
-					<select id="testSelect" name="testSelect">
-						<option value="0">Zero</option>
-						<option value="1">One</option>
-					</select>
-				</form>
-
 				<h3>Buttons</h3>
 				
 				<p><a href="#" class="small blue button">Small Blue Button</a></p>

--- a/index.html
+++ b/index.html
@@ -106,6 +106,22 @@
 					<li id="simple3Tab">This is simple tab 3's content. It's, you know...okay.</li>
 				</ul>
 				
+				<h3>Forms</h3>
+				
+				<form id="testForm" class="custom">
+					<label for="checkbox1">
+						<input type="checkbox" id="checkbox1" /> Checkbox
+					</label>
+					<label for="radio1">
+						<input type="radio" id="radio1" /> Radio
+					</label>
+					
+					<select id="testSelect" name="testSelect">
+						<option value="0">Zero</option>
+						<option value="1">One</option>
+					</select>
+				</form>
+
 				<h3>Buttons</h3>
 				
 				<p><a href="#" class="small blue button">Small Blue Button</a></p>
@@ -115,6 +131,7 @@
 				<p><a href="#" class="nice radius small blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius large blue button">Nice Blue Button</a></p>
+
 
 			</div>
 

--- a/javascripts/jquery.customforms.js
+++ b/javascripts/jquery.customforms.js
@@ -24,32 +24,41 @@ jQuery(document).ready(function ($) {
   appendCustomMarkup('checkbox');
   appendCustomMarkup('radio');
   
-  $('form.custom select').each(function () {
-    var $this = $(this),
+
+  function appendCustomSelect(sel) {
+    var $this = $(sel),
         $customSelect = $this.next('div.custom.dropdown'),
         $options = $this.find('option'),
         maxWidth = 0,
         $li;
-    
-    if ($customSelect.length === 0) {      
+
+    if ($customSelect.length === 0) {
       $customSelect = $('<div class="custom dropdown"><a href="#" class="selector"></a><ul></ul></div>"');
       $options.each(function () {
         $li = $('<li>' + $(this).html() + '</li>');
         $customSelect.find('ul').append($li);
       });
       $customSelect.prepend('<a href="#" class="current">' + $options.first().html() + '</a>');
-      
+
       $this.after($customSelect);
       $this.hide();
+      
+    } else {
+      // refresh the ul with options from the select in case the supplied markup doesn't match
+      $customSelect.find('ul').html('');
+      $options.each(function () {
+        $li = $('<li>' + $(this).html() + '</li>');
+        $customSelect.find('ul').append($li);
+      });
     }
-    
+
     $options.each(function (index) {
       if (this.selected) {
         $customSelect.find('li').eq(index).addClass('selected');
         $customSelect.find('.current').html($(this).html());
       }
     });
-    
+
     $customSelect.find('li').each(function () {
       $customSelect.addClass('open');
       if ($(this).outerWidth() > maxWidth) {
@@ -59,10 +68,47 @@ jQuery(document).ready(function ($) {
     });
     $customSelect.css('width', maxWidth + 18 + 'px');
     $customSelect.find('ul').css('width', maxWidth + 16 + 'px');
+
+  }
+
+  $('form.custom select').each(function () {
+    appendCustomSelect(this);
   });
+  
 });
 
 (function ($) {
+  
+  function refreshSelect($select) {
+    var $customSelect = $select.next();
+    $options = $select.find('option');
+    $customSelect.find('ul').html('');
+    $options.each(function () {
+      $li = $('<li>' + $(this).html() + '</li>');
+      $customSelect.find('ul').append($li);
+    });
+
+    // re-populate
+    $options.each(function (index) {
+      if (this.selected) {
+        $customSelect.find('li').eq(index).addClass('selected');
+        $customSelect.find('.current').html($(this).html());
+      }
+    });
+    
+    // fix width
+    $customSelect.find('li').each(function () {
+      $customSelect.addClass('open');
+      if ($(this).outerWidth() > maxWidth) {
+        maxWidth = $(this).outerWidth();
+      }
+      $customSelect.removeClass('open');
+    });
+    $customSelect.css('width', maxWidth + 18 + 'px');
+    $customSelect.find('ul').css('width', maxWidth + 16 + 'px');
+    
+    
+  }
   
   function toggleCheckbox($element) {
     var $input = $element.prev(),
@@ -99,6 +145,10 @@ jQuery(document).ready(function ($) {
     event.stopPropagation();
     
     toggleRadio($(this));
+  });
+  
+  $('form.custom').delegate('select','change', function (event) {
+    refreshSelect($(this));
   });
   
   $('form.custom label').live('click', function (event) {


### PR DESCRIPTION
I'm not sure if this would work for everyone, but I added a refreshSelect() method to jquery.customforms.js that gets attached to the change event of the native select to re-populate and re-flow the custom select in the event that the native hidden form element changes.

This is useful to me because I use Ajax methods to update the contents of selects in my forms (like the typical "change country, update states/provinces" scenario) and I need the custom drop-down to re-render if the contents of the native drop-down changes.

Note that you must actually call $el.trigger("change") in your code that re-populates the select because changing a select in code doesn't trigger the change event automatically (boooo!)
