### PR TITLE
Changes to custom select dropdown to better sync with native element changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,6 @@
 				<p><a href="#" class="nice radius blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius large blue button">Nice Blue Button</a></p>
 
-
 			</div>
 
 			<div class="four columns">			

--- a/index.html
+++ b/index.html
@@ -106,22 +106,6 @@
 					<li id="simple3Tab">This is simple tab 3's content. It's, you know...okay.</li>
 				</ul>
 				
-				<h3>Forms</h3>
-				
-				<form id="testForm" class="custom">
-					<label for="checkbox1">
-						<input type="checkbox" id="checkbox1" /> Checkbox
-					</label>
-					<label for="radio1">
-						<input type="radio" id="radio1" /> Radio
-					</label>
-					
-					<select id="testSelect" name="testSelect">
-						<option value="0">Zero</option>
-						<option value="1">One</option>
-					</select>
-				</form>
-
 				<h3>Buttons</h3>
 				
 				<p><a href="#" class="small blue button">Small Blue Button</a></p>

--- a/index.html
+++ b/index.html
@@ -106,6 +106,22 @@
 					<li id="simple3Tab">This is simple tab 3's content. It's, you know...okay.</li>
 				</ul>
 				
+				<h3>Forms</h3>
+				
+				<form id="testForm" class="custom">
+					<label for="checkbox1">
+						<input type="checkbox" id="checkbox1" /> Checkbox
+					</label>
+					<label for="radio1">
+						<input type="radio" id="radio1" /> Radio
+					</label>
+					
+					<select id="testSelect" name="testSelect">
+						<option value="0">Zero</option>
+						<option value="1">One</option>
+					</select>
+				</form>
+
 				<h3>Buttons</h3>
 				
 				<p><a href="#" class="small blue button">Small Blue Button</a></p>
@@ -115,6 +131,7 @@
 				<p><a href="#" class="nice radius small blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius blue button">Nice Blue Button</a></p>
 				<p><a href="#" class="nice radius large blue button">Nice Blue Button</a></p>
+
 
 			</div>
 

--- a/javascripts/jquery.customforms.js
+++ b/javascripts/jquery.customforms.js
@@ -149,7 +149,6 @@ jQuery(document).ready(function ($) {
     toggleRadio($(this));
   });
   
-//  $('form.custom').delegate('select','change', function (event) {
   $('form.custom select').live('change', function (event) {
     refreshCustomSelect($(this));
   });

--- a/javascripts/jquery.customforms.js
+++ b/javascripts/jquery.customforms.js
@@ -23,7 +23,6 @@ jQuery(document).ready(function ($) {
   }
   appendCustomMarkup('checkbox');
   appendCustomMarkup('radio');
-  
 
   function appendCustomSelect(sel) {
     var $this = $(sel),
@@ -79,15 +78,17 @@ jQuery(document).ready(function ($) {
 
 (function ($) {
   
-  function refreshSelect($select) {
+  function refreshCustomSelect($select) {
+    var maxWidth = 0;
     var $customSelect = $select.next();
     $options = $select.find('option');
     $customSelect.find('ul').html('');
+    
     $options.each(function () {
       $li = $('<li>' + $(this).html() + '</li>');
       $customSelect.find('ul').append($li);
     });
-
+    
     // re-populate
     $options.each(function (index) {
       if (this.selected) {
@@ -97,6 +98,8 @@ jQuery(document).ready(function ($) {
     });
     
     // fix width
+    $customSelect.removeAttr('style')
+      .find('ul').removeAttr('style');
     $customSelect.find('li').each(function () {
       $customSelect.addClass('open');
       if ($(this).outerWidth() > maxWidth) {
@@ -106,7 +109,6 @@ jQuery(document).ready(function ($) {
     });
     $customSelect.css('width', maxWidth + 18 + 'px');
     $customSelect.find('ul').css('width', maxWidth + 16 + 'px');
-    
     
   }
   
@@ -147,8 +149,9 @@ jQuery(document).ready(function ($) {
     toggleRadio($(this));
   });
   
-  $('form.custom').delegate('select','change', function (event) {
-    refreshSelect($(this));
+//  $('form.custom').delegate('select','change', function (event) {
+  $('form.custom select').live('change', function (event) {
+    refreshCustomSelect($(this));
   });
   
   $('form.custom label').live('click', function (event) {

--- a/javascripts/jquery.customforms.js
+++ b/javascripts/jquery.customforms.js
@@ -24,32 +24,41 @@ jQuery(document).ready(function ($) {
   appendCustomMarkup('checkbox');
   appendCustomMarkup('radio');
   
-  $('form.custom select').each(function () {
-    var $this = $(this),
+
+  function appendCustomSelect(sel) {
+    var $this = $(sel),
         $customSelect = $this.next('div.custom.dropdown'),
         $options = $this.find('option'),
         maxWidth = 0,
         $li;
-    
-    if ($customSelect.length === 0) {      
+
+    if ($customSelect.length === 0) {
       $customSelect = $('<div class="custom dropdown"><a href="#" class="selector"></a><ul></ul></div>"');
       $options.each(function () {
         $li = $('<li>' + $(this).html() + '</li>');
         $customSelect.find('ul').append($li);
       });
       $customSelect.prepend('<a href="#" class="current">' + $options.first().html() + '</a>');
-      
+
       $this.after($customSelect);
       $this.hide();
+      
+    } else {
+      // refresh the ul with options from the select in case the supplied markup doesn't match
+      $customSelect.find('ul').html('');
+      $options.each(function () {
+        $li = $('<li>' + $(this).html() + '</li>');
+        $customSelect.find('ul').append($li);
+      });
     }
-    
+
     $options.each(function (index) {
       if (this.selected) {
         $customSelect.find('li').eq(index).addClass('selected');
         $customSelect.find('.current').html($(this).html());
       }
     });
-    
+
     $customSelect.find('li').each(function () {
       $customSelect.addClass('open');
       if ($(this).outerWidth() > maxWidth) {
@@ -59,10 +68,47 @@ jQuery(document).ready(function ($) {
     });
     $customSelect.css('width', maxWidth + 18 + 'px');
     $customSelect.find('ul').css('width', maxWidth + 16 + 'px');
+
+  }
+
+  $('form.custom select').each(function () {
+    appendCustomSelect(this);
   });
+  
 });
 
 (function ($) {
+  
+  function refreshSelect($select) {
+    var $customSelect = $select.next();
+    $options = $select.find('option');
+    $customSelect.find('ul').html('');
+    $options.each(function () {
+      $li = $('<li>' + $(this).html() + '</li>');
+      $customSelect.find('ul').append($li);
+    });
+
+    // re-populate
+    $options.each(function (index) {
+      if (this.selected) {
+        $customSelect.find('li').eq(index).addClass('selected');
+        $customSelect.find('.current').html($(this).html());
+      }
+    });
+    
+    // fix width
+    $customSelect.find('li').each(function () {
+      $customSelect.addClass('open');
+      if ($(this).outerWidth() > maxWidth) {
+        maxWidth = $(this).outerWidth();
+      }
+      $customSelect.removeClass('open');
+    });
+    $customSelect.css('width', maxWidth + 18 + 'px');
+    $customSelect.find('ul').css('width', maxWidth + 16 + 'px');
+    
+    
+  }
   
   function toggleCheckbox($element) {
     var $input = $element.prev(),
@@ -99,6 +145,10 @@ jQuery(document).ready(function ($) {
     event.stopPropagation();
     
     toggleRadio($(this));
+  });
+  
+  $('form.custom').delegate('select','change', function (event) {
+    refreshSelect($(this));
   });
   
   $('form.custom label').live('click', function (event) {


### PR DESCRIPTION
Added two-way sync between native select form element and custom drop-drown markup.

If the native select is modified through code (and the "change" event is triggered as well - I don't think there is a way for this to happen automatically), the custom drop-down markup will refresh, re-populating the options and re-sizing as needed.

This is useful (to me at least!) in a scenario where a page action (such as selecting a country from one drop-down) causes the option list of another drop-down to change (populate with appropriate states/provinces).

Hopefully this is useful for others too..
