### PR TITLE
Added Gemfile and a bang path to build.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gem "jammit", "~> 0.6.5"

--- a/build.rb
+++ b/build.rb
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 # Creates a zip file of the Foundation template and the compessed assets
 
 VERSION_STRING = '2.1.3'


### PR DESCRIPTION
since build.rb can't be run without the jammit
gem installed I've added a Gemfile that requires it.

I've added a bang path of
  #!/usr/bin/env ruby
to build.rb and made it executable.
