### PR TITLE
activateTab function in app.js should only hide direct child li's of .tab-content

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -14,7 +14,7 @@ $(document).ready(function () {
 		$tab.addClass('active');
 
     	//Show Tab Content
-		$(contentLocation).closest('.tabs-content').children('li').hide();
+		$(contentLocation).closest('.tabs-content').children('> li').hide();
 		$(contentLocation).show();
 	}
 


### PR DESCRIPTION
modify activateTab function in app.js to only hide the direct child line items (> li)

this prevents other structures within the tab (like, say, a Foundation block-grid) from having it's li's hidden on tab change.
