### PR TITLE
Minor bugfix to Mobile Block-Grids - apply width override only to immediate children, not all descendants.

### DIFF
--- a/stylesheets/mobile.css
+++ b/stylesheets/mobile.css
@@ -66,7 +66,7 @@
 	
 	@media only screen and (max-width: 767px) {
 		.block-grid.mobile { margin-left: 0; }
-		.block-grid.mobile li { float: none; width: 100%; margin-left: 0; }
+		.block-grid.mobile > li { float: none; width: 100%; margin-left: 0; }
 	}
 	
 	


### PR DESCRIPTION
...hildren, not all <li> descendants.
