### PR TITLE
Nice forms have explicit background-color

### DIFF
--- a/stylesheets/forms.css
+++ b/stylesheets/forms.css
@@ -48,8 +48,7 @@
 	   Nicer Forms
 	----------------------------------------- */
 	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { border: solid 1px #bbb; border-radius: 2px; -webkit-border-radius: 2px; -moz-border-radius: 2px; }
-	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { font-size: 13px; padding: 6px 3px 4px; outline: none !important; background: url(../images/misc/input-bg.png) #fff; }
-	form.nice div.form-field input:focus, form.nice input.input-text:focus, form.nice textarea:focus { background-color: #f9f9f9; }
+	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { font-size: 13px; padding: 6px 3px 4px; outline: none !important; background-image: url(../images/misc/input-bg.png); }
 
 	form.nice fieldset { border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; }
 


### PR DESCRIPTION
This prevents .red classes from being colored correctly when inside of a form.nice element.
