### PR TITLE
Nice custom form styles

### DIFF
--- a/stylesheets/forms.css
+++ b/stylesheets/forms.css
@@ -85,4 +85,11 @@
 	
 	form.custom div.custom.dropdown.open ul { display: block; }
 
+	/* -----------------------------------------
+	   Nicer Custom Forms
+	----------------------------------------- */
+	form.custom.nice span.custom.checkbox { border-radius: 2px; -webkit-border-radius: 2px; -moz-border-radius: 2px; }
 	
+	form.custom.nice div.custom.dropdown a.current { border-radius: 2px; -webkit-border-radius: 2px; -moz-border-radius: 2px; background-image: url(../images/misc/input-bg.png); }
+	form.custom.nice div.custom.dropdown a.selector { height: 27px; border-width: 0 0 0 1px; }
+	form.custom.nice div.custom.dropdown ul { border-bottom-left-radius: 2px; border-bottom-right-radius: 2px; -webkit-border-bottom-left-radius: 2px; -webkit-border-bottom-right-radius: 2px; -moz-border-radius-bottomleft: 2px; -moz-border-radius-bottomright: 2px; }


### PR DESCRIPTION
Currently there are no `form.custom.nice` styles, so forms that combine the two look a little funny. This adds a minimal amount of styling to checkboxes and dropdowns inside of `form.custom.nice` to make them look at bit more like the nice styles.

Edit: Github didn't like my inline image, so here's a link instead: http://cl.ly/DE2l.
