### PR TITLE
Full-Screen container class

### DIFF
--- a/stylesheets/grid.css
+++ b/stylesheets/grid.css
@@ -9,6 +9,7 @@
 	-------------------------------------------------- */
 
 	.container { padding: 0 20px; }
+	.full.container{padding: 0 0;}
 	
 	.row { width: 100%; max-width: 980px; min-width: 727px; margin: 0 auto; }
 	/* To fix the grid into a certain size, set max-width to width */


### PR DESCRIPTION
I added a " .full.container " css class. I wanted to add this to Foundation in case one needs a full width bar (like in headers). The current containers have a padding which is inconvenient for full width elements. It can be used like so:

https://gist.github.com/1676047.js

P.S.: This code can be added to the documentation.
