### PR TITLE
Align the last column

### DIFF
--- a/stylesheets/grid.css
+++ b/stylesheets/grid.css
@@ -16,6 +16,7 @@
 	
 	.column, .columns { margin-left: 4.4%; float: left; min-height: 1px; position: relative; }
 	.column:first-child, .columns:first-child { margin-left: 0; }
+	.column:last-child, .columns:last-child, .column.last .columns.last { float: right; }
 	
 	.row .one.columns 		{ width: 4.3%; }
 	.row .two.columns 		{ width: 13%; }


### PR DESCRIPTION
This corrects an error caused by rounding column widths. So that the last column always ended at the end of the grid.
For IE and older browser is important to add this JS  $('.row .columns:last').addClass('.last');
