### PR TITLE
Vertical tabs content border top

### DIFF
--- a/stylesheets/ui.css
+++ b/stylesheets/ui.css
@@ -174,6 +174,7 @@
 
     ul.contained.tabs-content { padding: 0; }
 	ul.contained.tabs-content>li { padding: 20px; border: solid 0 #ddd; border-width: 0 1px 1px 1px; }
+	ul.contained.vertical.tabs-content>li { border-width: 1px 1px 1px 1px; }
 	ul.nice.contained.tabs-content>li { border-color: #eee; }
 	
 /*  --------------------------------------------------


### PR DESCRIPTION
When I use .tabs .contained with .vertical, the JS works fine. But it lack the top border of the tab's content. Juste restore it with a border-width: 1px 1px 1px 1px;
