### PR TITLE
Put standard margin right on columns in order to automatically form rows

### DIFF
--- a/stylesheets/grid.css
+++ b/stylesheets/grid.css
@@ -14,8 +14,7 @@
 	/* To fix the grid into a certain size, set max-width to width */
 	.row .row { min-width: 0; }
 	
-	.column, .columns { margin-left: 4.4%; float: left; min-height: 1px; position: relative; }
-	.column:first-child, .columns:first-child { margin-left: 0; }
+	.column, .columns { margin-right: 3%; float: left; min-height: 1px; position: relative; }
 	
 	.row .one.columns 		{ width: 4.3%; }
 	.row .two.columns 		{ width: 13%; }


### PR DESCRIPTION
Hi,

Was was using Foundation to build an iGoogle like page where a user can sort content blocks.
For this I needed rows to be formed automatically instead of separating them by a `<div class="row">` every time.
By applying a neutral margin right to every column without a margin left the columns will always fill up the row and than start a new one.

Hope this is a nice feature for you guys!

Kind Regards,
Chris
