### PR TITLE
iOS Orientation Zoom Bug Fix

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -89,6 +89,65 @@ jQuery(document).ready(function ($) {
 
 	/* DISABLED BUTTONS ------------- */
 	/* Gives elements with a class of 'disabled' a return: false; */
+
+
+  /* iOS Orientation Fix ------------- */
+  /* Disables zoom on orientation change and re-enables after orientation is complete */
+  /*! A fix for the iOS orientationchange zoom bug.
+   Script by @scottjehl, rebound by @wilto.
+   MIT License.
+  */
+  (function(w){
+    
+    // This fix addresses an iOS bug, so return early if the UA claims it's something else.
+    if( !( /iPhone|iPad|iPod/.test( navigator.platform ) && navigator.userAgent.indexOf( "AppleWebKit" ) > -1 ) ){
+      return;
+    }
+    
+      var doc = w.document;
+
+      if( !doc.querySelector ){ return; }
+
+      var meta = doc.querySelector( "meta[name=viewport]" ),
+          initialContent = meta && meta.getAttribute( "content" ),
+          disabledZoom = initialContent + ",maximum-scale=1",
+          enabledZoom = initialContent + ",maximum-scale=10",
+          enabled = true,
+      x, y, z, aig;
+
+      if( !meta ){ return; }
+
+      function restoreZoom(){
+          meta.setAttribute( "content", enabledZoom );
+          enabled = true;
+      }
+
+      function disableZoom(){
+          meta.setAttribute( "content", disabledZoom );
+          enabled = false;
+      }
+    
+      function checkTilt( e ){
+      aig = e.accelerationIncludingGravity;
+      x = Math.abs( aig.x );
+      y = Math.abs( aig.y );
+      z = Math.abs( aig.z );
+          
+      // If portrait orientation and in one of the danger zones
+          if( !w.orientation && ( x > 7 || ( ( z > 6 && y < 8 || z < 8 && y > 6 ) && x > 5 ) ) ){
+        if( enabled ){
+          disableZoom();
+        }         
+          }
+      else if( !enabled ){
+        restoreZoom();
+          }
+      }
+    
+    w.addEventListener( "orientationchange", restoreZoom, false );
+    w.addEventListener( "devicemotion", checkTilt, false );
+
+  })( this );
   
 
 });


### PR DESCRIPTION
Mobile Safari in iOS has a pretty well-known bug where it keeps the same zoom ratio while rotated—causing the user to have to zoom out to get the full page view (see http://cl.ly/Eaqm & http://cl.ly/EZdo). Brought to my attention via [tweet](https://twitter.com/#!/foundationzurb/status/174190617075785728) (Yes I stalk the @foundationZURB twitter)—and knowing of the [iOS Orientation fix](http://filamentgroup.com/lab/a_fix_for_the_ios_orientationchange_zoom_bug/) by @[scottjehl](http://twitter.com/scottjehl) & filament group I thought we might be able to knock this one out pretty easily.
