### PR TITLE
Use hashchange event to allow any link to activate tabs

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -5,32 +5,27 @@ jQuery(document).ready(function ($) {
 	/* TABS --------------------------------- */
 	/* Remove if you don't need :) */
 
-	function activateTab($tab) {
-		var $activeTab = $tab.closest('dl').find('a.active'),
-				contentLocation = $tab.attr("href") + 'Tab';
-				
-		// Strip off the current url that IE adds
-		contentLocation = contentLocation.replace(/^.+#/, '#');
+	function activateTab() {
+		var loc = window.location.hash,
+			$theTab = $('a[href="' + loc + '"]'),
+			$content = $(loc+'Tab'),
+			$activeTab;
 
-		//Make Tab Active
+		// Activate contents
+		$content.closest('.tabs-content').children('li').hide();
+		$content.css('display', 'block');
+		
+		// De-active old tab
+		$activeTab = $theTab.closest('dl').find('a.active');
 		$activeTab.removeClass('active');
-		$tab.addClass('active');
-
-    //Show Tab Content
-		$(contentLocation).closest('.tabs-content').children('li').hide();
-		$(contentLocation).css('display', 'block');
+		
+		// Activate new tab
+		$theTab.addClass('active');
 	}
 
-	$('dl.tabs').each(function () {
-		//Get all tabs
-		var tabs = $(this).children('dd').children('a');
-		tabs.click(function (e) {
-			activateTab($(this));
-		});
-	});
-
+	$(window).on('hashchange', activateTab);
 	if (window.location.hash) {
-		activateTab($('a[href="' + window.location.hash + '"]'));
+		activateTab();
 		$.foundation.customForms.appendCustomMarkup();
 	}
 


### PR DESCRIPTION
Using this I can write things like `visit <a href="#there">the there tab</a>` and it will activate the tab content and the right tab.

Furthermore it still works after dynamically adding tabs.

It requires the hashchange event which [most browsers have](http://caniuse.com/#feat=hashchange). It didn't work on my iOS 3 ipod Touch. Perhaps the best approach is to have both the original onclick and this onhashchange  code? I tried using the Modernizr shim but that didn't seem to make a difference.
