### PR TITLE
If a text input is too wide or too long, it will show the background ima...

### DIFF
--- a/stylesheets/forms.css
+++ b/stylesheets/forms.css
@@ -65,7 +65,7 @@
 	   Nicer Forms
 	----------------------------------------- */
 	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { border: solid 1px #bbb; border-radius: 2px; -webkit-border-radius: 2px; -moz-border-radius: 2px; }
-	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { font-size: 13px; padding: 6px 3px 4px; outline: none !important; background: url(../images/misc/input-bg.png) #fff; }
+	form.nice div.form-field input, form.nice input.input-text, form.nice textarea { font-size: 13px; padding: 6px 3px 4px; outline: none !important; background: url(../images/misc/input-bg.png) #fff; background-repeat: no-repeat;}
 	form.nice div.form-field input:focus, form.nice input.input-text:focus, form.nice textarea:focus { background-color: #f9f9f9; }
 
 	/* Text input and textarea, disabled */


### PR DESCRIPTION
...ge shading repeating.  This prevents this from happening.  It probably makes more sense to get rid of images entirely and use CSS to generate the shadows because inputs will still have an issue when they are too wide ... the shading along the top edge of the input will end if the input is wider than the image used as the background, but that's a larger change and this work-around will preserve the intended look & feel in most cases.
