### PR TITLE
Change .width() to .outerWidth()

### DIFF
--- a/javascripts/jquery.orbit-1.4.0.js
+++ b/javascripts/jquery.orbit-1.4.0.js
@@ -153,21 +153,21 @@
       var self = this,
           $fluidPlaceholder;
 
-      self.$element.add(self.$wrapper).width(this.$slides.first().width());
+      self.$element.add(self.$wrapper).width(this.$slides.first().outerWidth());
       self.$element.add(self.$wrapper).height(this.$slides.first().height());
-      self.orbitWidth = this.$slides.first().width();
+      self.orbitWidth = this.$slides.first().outerWidth();
       self.orbitHeight = this.$slides.first().height();
       $fluidPlaceholder = this.$slides.first().findFirstImage().clone();
 
 
       this.$slides.each(function () {
         var slide = $(this),
-            slideWidth = slide.width(),
+            slideWidth = slide.outerWidth(),
             slideHeight = slide.height();
 
-        if (slideWidth > self.$element.width()) {
+        if (slideWidth > self.$element.outerWidth()) {
           self.$element.add(self.$wrapper).width(slideWidth);
-          self.orbitWidth = self.$element.width();
+          self.orbitWidth = self.$element.outerWidth();
         }
         if (slideHeight > self.$element.height()) {
           self.$element.add(self.$wrapper).height(slideHeight);
@@ -188,7 +188,7 @@
         self.$element.add(self.$wrapper).css({height: 'inherit'});
 
         $(window).bind('resize', function () {
-          self.orbitWidth = self.$element.width();
+          self.orbitWidth = self.$element.outerWidth();
           self.orbitHeight = self.$element.height();
         });
       }
@@ -393,7 +393,7 @@
     	this.$wrapper.append(this.$bullets);
     	this.$slides.each(this.addBullet);
     	this.$element.addClass('with-bullets');
-    	if (this.options.centerBullets) this.$bullets.css('margin-left', -this.$bullets.width() / 2);
+    	if (this.options.centerBullets) this.$bullets.css('margin-left', -this.$bullets.outerWidth() / 2);
     },
 
     addBullet: function (index, slide) {


### PR DESCRIPTION
I have a case where I wanted to apply padding to content slides while using box-sizing: border-box and the 'horizontal-push' slide effect.

.width() doesn't account for padding in its measurements, so I was having an interesting bug where slides would 'jump' into the slider container by the amount of padding on the slide. For example, if a slide had 50px of padding, when switching the slides, the next slide would 'jump' 50px into the frame before starting to slide over.
