### PR TITLE
fix refError for nubPos in tooltips.reposition

### DIFF
--- a/javascripts/jquery.tooltips.js
+++ b/javascripts/jquery.tooltips.js
@@ -111,13 +111,14 @@
         }).end();
       };
 
+
       objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', target.offset().left, width);
       objPos(nub, -nubHeight, 'auto', 'auto', 10);
 
       if ($(window).width() < 767) {
         row = target.parents('.row');
         tip.width(row.outerWidth() - 20).css('left', row.offset().left).addClass('tip-override');
-        nubPos(nub, -nubHeight, 'auto', 'auto', target.offset().left);
+        objPos(nub, -nubHeight, 'auto', 'auto', target.offset().left);
       } else {
         if (classes.indexOf('tip-top') > -1) {
           objPos(tip, (target.offset().top - tip.outerHeight() - nubHeight), 'auto', 'auto', target.offset().left, width)
@@ -126,11 +127,11 @@
         } else if (classes.indexOf('tip-left') > -1) {
           objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight), 'auto', 'auto', (target.offset().left - tip.outerWidth() - 10), width)
           .removeClass('tip-override');
-          nubPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), -nubHeight, 'auto', 'auto');
+          objPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), -nubHeight, 'auto', 'auto');
         } else if (classes.indexOf('tip-right') > -1) {
           objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight), 'auto', 'auto', (target.offset().left + target.outerWidth() + 10), width)
           .removeClass('tip-override');
-          nubPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), 'auto', 'auto', -nubHeight);
+          objPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), 'auto', 'auto', -nubHeight);
         }
       }
     },


### PR DESCRIPTION
function tooltips.reposition.nubPos() was missing and causing problems with dynamically loaded content - https://github.com/zurb/foundation/issues/462

fixed by replacing all calls of nubPos to objPos, which seemed more reasonable than copying objPos since they looked like identical functions.
