### PR TITLE
Vertically-centered .nav-bar input.input-text

### DIFF
--- a/stylesheets/ui.css
+++ b/stylesheets/ui.css
@@ -265,6 +265,7 @@
 	.nav-bar>li { float: left; display: block; position: relative; padding: 0; margin: 0; border-right: 1px solid #ddd; line-height: 45px; }
 	.nav-bar>li>a.main { position: relative; padding: 0 20px; display: block; text-decoration: none; font-size: 15px; font-size: 1.5rem; }
 	.nav-bar>li>input { margin: 0 16px; }
+	.nav-bar>li>input.input-text { display: inline-block; }
 	.nav-bar>li ul { margin-bottom: 0; }
 	.nav-bar>li li { line-height: 1.3; }
 	.nav-bar>li.has-flyout>a.main { padding-right: 36px; }


### PR DESCRIPTION
By default, input.input-text are rendered as display: block, causing
them to be aligned to the top of the .nav-bar.  Changed to inline-block
to display the input centered vertically.
