### PR TITLE
Fix mobile visibility affordances for tables

### DIFF
--- a/stylesheets/mobile.css
+++ b/stylesheets/mobile.css
@@ -107,20 +107,35 @@
 	
 	/* Specific overrides for elements that require something other than display: block */
 	
+	table.show-on-phones { display: none !important; }	
+	table.show-on-tablets { display: none !important; }
 	table.show-on-desktops { display: table !important; }
+	
 	table.hide-on-phones { display: table !important; }	
 	table.hide-on-tablets { display: table !important; }
+	table.hide-on-desktops { display: none !important; }
 	
+	
+	/* Modernizr-enabled tablet targeting */
 	@media only screen and (max-width: 1280px) and (min-width: 768px) {
 		.touch table.hide-on-phones { display: table !important; }
+		.touch table.hide-on-tablets { display: none !important; }
 		.touch table.hide-on-desktops { display: table !important; }
+		
+		.touch table.show-on-phones { display: none !important; }
 		.touch table.show-on-tablets { display: table !important; }
+		.touch table.show-on-desktops { display: none !important; }
 	}
 	
+		
 	@media only screen and (max-width: 767px) {
+		table.hide-on-phones { display: none !important; }
 		table.hide-on-tablets { display: table !important; }
 		table.hide-on-desktops { display: table !important; }
+		
 		table.show-on-phones { display: table !important; }
+		table.show-on-tablets { display: none !important; }
+		table.show-on-desktops { display: none !important; }
 	}
 	
 	

--- a/test.html
+++ b/test.html
@@ -406,6 +406,44 @@
 					</p>
 				</form>
 
+				<h3>Tables</h3>
+				<table>
+					<thead>
+						<tr>
+							<th>Table Header</th>
+							<th>Table Header</th>
+							<th>Table Header</th>
+							<th>Table Header</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Content</td>
+							<td>This is longer content</td>
+							<td>Content</td>
+							<td>Content</td>
+						</tr>
+						<tr>
+							<td>Content</td>
+							<td>This is longer content</td>
+							<td>Content</td>
+							<td>Content</td>
+						</tr>
+						<tr>
+							<td>Content</td>
+							<td>This is longer content</td>
+							<td>Content</td>
+							<td>Content</td>
+						</tr>
+						<tr>
+							<td>Content</td>
+							<td>This is longer content</td>
+							<td>Content</td>
+							<td>Content</td>
+						</tr>
+					</tbody>
+				</table>
+
 			</div>
 
 			<div class="four columns">


### PR DESCRIPTION
I think someone thought that <code>display: none !important;</code> was getting inherited from some of the original visibility styles, when really they were being overwritten by the table styles. For example: if you put <code>hide-on-phones</code> on a table, it would still show up because there was no declaration in the phone media query to override `table.hide-on-phones { display: table !important; }`.

I also added a table to `test.html` for your testing pleasure.

**_Note:**_ _This will probably have to be fixed in the 3.0 branches as well._
