### PR TITLE
added more specificity to the selector for part IE timer corrections to ...

### DIFF
--- a/stylesheets/orbit.css
+++ b/stylesheets/orbit.css
@@ -227,5 +227,5 @@ ul.orbit-bullets li.active.has-thumb {
     
     
 /* Correct timer in IE */
-	.timer { display: none !important; }
+	html.lt-ie9 .timer { display: none !important; }
 	div.caption { background:transparent; filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#99000000,endColorstr=#99000000);zoom: 1; }


### PR DESCRIPTION
...ensure display:none; does not happen in every other browser.  Please consider this pull request, or add something to the orbit JS to set .timer to something other than display:none; as it doesn't display in Chrome, Safari, and Firefox.
