### PR TITLE
Updated javascripts/app.js: [activateTab()] to manage "active" class on ...

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -17,8 +17,9 @@ jQuery(document).ready(function ($) {
 		$tab.addClass('active');
 
     //Show Tab Content
-		$(contentLocation).closest('.tabs-content').children('li').hide();
+		$(contentLocation).closest('.tabs-content').children('li').removeClass('active').hide();
 		$(contentLocation).css('display', 'block');
+		$(contentLocation).addClass('active')
 	}
 
   $('dl.tabs dd a').live('click', function (event) {


### PR DESCRIPTION
....tabs-content elements.  Since an active class is expected to exist on a tab to display it onload, tab selection is done via location.hash, and no other external indication of a tab-content elements' state is given (besides the display property), it only seems appropriate to manage the "active" classname on those items.  Please consider this pull request
