### PR TITLE
Minor bugs

### DIFF
--- a/stylesheets/foundation/_mixins.scss
+++ b/stylesheets/foundation/_mixins.scss
@@ -3,10 +3,10 @@
   @mixin font-size($size, $is-important: false) {
     @if $is-important {
       font-size: $size + px !important;
-      font-size: ($size / 10)rem !important;
+      font-size: ($size / 10) + rem !important;
     } @else {
       font-size: $size + px;
-      font-size: ($size / 10)rem;
+      font-size: ($size / 10) + rem;
     }
   }
 

--- a/stylesheets/foundation/forms.scss
+++ b/stylesheets/foundation/forms.scss
@@ -81,7 +81,7 @@
     }
     div.custom.dropdown { display: block; position: relative; width: auto; height: 28px; margin-bottom: 9px; margin-top: 2px;
 
-      a.current { display: block; width: auto; line-height: 26px; min-height: 28px; padding: 0 38px 0 6px; border: solid 1px #ddd; color: #141414; background-color: #fff; word-wrap: nowrap; }
+      a.current { display: block; width: auto; line-height: 26px; min-height: 28px; padding: 0 38px 0 6px; border: solid 1px #ddd; color: #141414; background-color: #fff; white-space: nowrap; }
       a.selector { position: absolute; width: 27px; height: 28px; display: block; right: 0; top: 0; border: solid 1px #ddd;
         &:after { content: ""; display: block; @include cssTriangle(5px, #aaa, top); position: absolute; left: 50%; top: 50%; margin-top: -2px; margin-left: -5px;  }
       }

--- a/vendor/assets/javascripts/foundation/app.js
+++ b/vendor/assets/javascripts/foundation/app.js
@@ -29,7 +29,7 @@ jQuery(document).ready(function ($) {
   });
 
   if (window.location.hash) {
-    activateTab($('a[href="' + window.location.hash + '"]'));
+    activateTab($('a[href="' + window.location.hash + '"]').parent('dd'));
     $.foundation.customForms.appendCustomMarkup();
   }
 


### PR DESCRIPTION
I noticed px was dropped from the font-size mixin, then added back in again. It causes problems rendering in Firefox because of the rem definition. Here's why:

$size: 10;

font-size: ($size / 10)rem;

produces

font-size: 1 rem;

Notice the space between 1 and rem, from what I gather, Firefox ignores "rem" and treats it as font-size:1; also Firefox refuses to acknowledge any cascading attempts at changing the font size.

font-size: ($size / 10) + rem;

produces

font-size: 1rem;

This commit fixes the problem and let's you go back to dropping the px if you desire. Although I'm happy for px to stay ;)
