### PR TITLE
Performance: Import Compass Mixins only partially

### DIFF
--- a/stylesheets/foundation/_base.scss
+++ b/stylesheets/foundation/_base.scss
@@ -1,6 +1,14 @@
-@import "compass/css3/border-radius";
-@import "compass/css3/text-shadow";
-@import "compass/css3/transition";
+// Imports
+
+// Compass Mixins
+@import "compass";
+// Speed up compilation by importing only the compass mixins
+// that are actually used by Foundation
+// @import "compass/css3/border-radius";
+// @import "compass/css3/text-shadow";
+// @import "compass/css3/transition";
+
+// Foundation Mixins and Settings
 @import "foundation/modular-scale";
 @import "foundation/settings";
 @import "foundation/semantic-grid";

--- a/stylesheets/foundation/_base.scss
+++ b/stylesheets/foundation/_base.scss
@@ -3,7 +3,7 @@
 // Compass Mixins
 @import "compass";
 // Speed up compilation by importing only the compass mixins
-// that are actually used by Foundation
+// that Foundation actually uses
 // @import "compass/css3/border-radius";
 // @import "compass/css3/text-shadow";
 // @import "compass/css3/transition";

--- a/stylesheets/foundation/_base.scss
+++ b/stylesheets/foundation/_base.scss
@@ -1,4 +1,6 @@
-@import "compass";
+@import "compass/css3/border-radius";
+@import "compass/css3/text-shadow";
+@import "compass/css3/transition";
 @import "foundation/modular-scale";
 @import "foundation/settings";
 @import "foundation/semantic-grid";


### PR DESCRIPTION
Hey,

stunning work on Foundation 3.0. It's become really awesome!

I use Foundation in a Rails app doing live reloading on file changes. I noticed a significant load time I was never used to before. Trying to trace the culprit and enabling myself to try more iterations in a shorter amout of time I was able to cut down site reload time from 12.4 seconds to 4.4 seconds by only partially importing the required compass mixins.

Is there another way to make compilation even faster?

_Edit_: No scientific time measurement done, just measuring it with the stopwatch three times for each version. It feels much more snappy now.

Cheers,
Thomas
