### PR TITLE
Added label.inline class to vertically-align labels when displayed inline (next to) inputs

### DIFF
--- a/stylesheets/foundation/forms.scss
+++ b/stylesheets/foundation/forms.scss
@@ -18,7 +18,8 @@
 
   label { font-size: ms(0); color: lighten($black, 30%); cursor: pointer; display: block; font-weight: 500; margin-bottom: 3px;
 
-    &.right { float: none; text-align: right; padding-top: ($formSpacing / 2); }
+    &.right { float: none; text-align: right; }
+    &.inline { line-height: (ms(0) + ($formSpacing * 1.5)); margin: 0 0 $formSpacing 0; }
   }
 
   @media only screen and (max-width: $screenSmall - 1) {


### PR DESCRIPTION
Vertical alignment of the label is achieved by setting the same line-height and margin for inputs.  Also removed padding-top for label.right.

Example:

``` html
<form>
    <div class="row">
        <div class="two columns">
            <label class="inline">Name:</label>
        </div>
        <div class="ten columns">
            <input type="text" />
        </div>
    </div>
</form>
```
