### PR TITLE
fix the bug when an alert-box is added after init

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -31,7 +31,7 @@ jQuery(document).ready(function ($) {
 	}
 
 	/* ALERT BOXES ------------ */
-	$(".alert-box").delegate("a.close", "click", function(event) {
+	$(document).on("click", ".alert-box a.close", function(event) {
     event.preventDefault();
 	  $(this).closest(".alert-box").fadeOut(function(event){
 	    $(this).remove();


### PR DESCRIPTION
when '$(".alert-box")' is used, its delegate don't apply alert-boxes what added
after page initialize. Specifically, if a alert-box is inserted by the button
click event, the alert-box cannot close if you click X.
To fix this problem, first selector use 'document' and delegate selector use
'.alert-box a.close'. In addition, after jQuery v1.7 .on() should be used
instead of .delegate(). It is also fixed.
