### PR TITLE
Import Modular-Scale in Settings to fix Rails Asset Pipeline Precompilation

### DIFF
--- a/stylesheets/foundation/_settings.scss
+++ b/stylesheets/foundation/_settings.scss
@@ -1,5 +1,7 @@
 // Settings file containing Foundation defaults
 
+@import "foundation/modular-scale";
+
 // Grid Settings
 
 $rowWidth: 1000px !default;


### PR DESCRIPTION
Hey,

when I switched to using the Foundation Gem in a Rails project yesterday the `rake assets:precompile` command no longer works for me. Rake kept telling me `Undefined variable: "$golden".`.

This PR fixes this by importing `_modular-scale.sass` in which `$golden` is being defined in `_settings.scss` using `@import "foundation/modular-scale";`
I tested it by forking the current master, making the change and requiring my Github fork in my Rails app's Gemfile.

Issue happens in both Foundation 3.0.5 and 3.0.6.rc7. Foundation Gem etc. set up as described in the docs.

Currently active Gem Versions: sass (3.2.0.alpha.275), sass-rails (3.2.5), compass (0.12.2), compass-rails (1.0.3)
