### PR TITLE
Fixes Issue #405: Tabs Not Working When Base Href Set

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tabs.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tabs.js
@@ -24,6 +24,7 @@
     
     $('dl.tabs dd a', this).on('click.fndtn', function (event){
       activateTab($(this).parent('dd'));
+      $(this).attr("href", window.location.pathname + $(this).attr("href").replace(/^.+#/, '#'));
     });
     
     if (window.location.hash) {


### PR DESCRIPTION
**The problem:**
`<base href="/">`
+ `<a href="#something">`
= trouble when using tabs

You get redirected to / whenever you click a tab.

**The fix:**
Change the href to the full URL of the page plus the original hash when the tab is clicked, to prevent redirection.
