### PR TITLE
Filepaths

### DIFF
--- a/stylesheets/foundation/components/_grid.scss
+++ b/stylesheets/foundation/components/_grid.scss
@@ -18,10 +18,15 @@
   [class*="column"] + [class*="column"]:last-child { float: right; }
   [class*="column"] + [class*="column"].end { float: left; }
 
+  // Creating column classes
+  @for $i from 1 through $totalColumns {
+    .#{convert-number-to-word($i)} { width: gridCalc($i, $totalColumns); }
+  }
+
   // Creating .row-# classes
   @for $i from 1 through $totalColumns {
     .row {
-      .#{convert-number-to-word($i)} { width: gridCalc($i, $totalColumns); }
+      .#{convert-number-to-word($i)} { @extend .#{convert-number-to-word($i)}; }
     }
   }
 

--- a/templates/project/sass/app.scss
+++ b/templates/project/sass/app.scss
@@ -9,10 +9,10 @@
 // and uncommenting what you want below. You must uncomment the following if customizing
 
 // @import "compass/css3";
-// @import "foundations/settings";
-// @import "foundations/function/all";
-// @import "foundations/common/globals";
-// @import "foundations/mixins/clearfix";
+// @import "foundation/settings";
+// @import "foundation/functions/all";
+// @import "foundation/common/globals";
+// @import "foundation/mixins/clearfix";
 
 // Control which mixins you have access too
 


### PR DESCRIPTION
Correct path references for a couple of sass files. Also, generating .one, .two, .three etc. classes for easier use in custom templates.

I am using it as such: nav { @extend .columns; @extend .twelve; }

If there's a different way to do this, do let me know.

Thanks, Babs
