### PR TITLE
Fixes issue #613: all dropdown events were prevented from bubbling up the DOM tree

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -9,7 +9,11 @@
     $('.button.dropdown > ul', this).addClass('no-hover');
 
     $('.button.dropdown', this).on('click.fndtn', function (e) {
-      e.stopPropagation();
+      // Stops further propagation of the event up the DOM tree when clicked on the button.
+      // Events fired by its descendants are not being blocked.
+      if (e.target === this) {
+        e.stopPropagation();
+      }
     });
     $('.button.dropdown.split span', this).on('click.fndtn', function (e) {
       e.preventDefault();


### PR DESCRIPTION
Don't prevent the event from bubbling up the DOM tree when clicked on any descendant of the dropdown element.
