### PR TITLE
Mixin font-size should work with ms()

### DIFF
--- a/stylesheets/foundation/mixins/_font-size.scss
+++ b/stylesheets/foundation/mixins/_font-size.scss
@@ -1,6 +1,8 @@
   // Font size mixin to include px and rem
 
   @mixin font-size($size, $is-important: false) {
+    $size: if(unitless($size), $size, $size / 1px);
+    
     @if $is-important {
       font-size: $size + px !important;
       font-size: ($size / 10) + rem !important;


### PR DESCRIPTION
``` scss
@include font-size(ms(0));
```

does currently not work, because `ms` returns a pixel number and `font-size` does only work with unitless numbers. This pull request should fix that.
