### PR TITLE
Added Height Fix For Object and Embed Tags

### DIFF
--- a/stylesheets/foundation/components/_grid.scss
+++ b/stylesheets/foundation/components/_grid.scss
@@ -44,6 +44,7 @@
   }
 
   img, object, embed { max-width: 100%; height: auto; }
+  object, embed { height: 100%; }
   img { -ms-interpolation-mode: bicubic; }
   #map_canvas img, .map_canvas img {max-width: none!important;}
 


### PR DESCRIPTION
The issue was that strange height issues were happening and even in some instances, such as cases where in FireFox the entire object/embed tags were not being shown. 

The issue was the use of an auto height. Setting a 100% height for the object and embed tags solved the issue across all major browsers.

This fix has been tested across Google Chrome, various versions of Mozilla Firefox, Safari, Opera, and various versions of Internet Explorer.

This should also solve issues presented in #319
