### PR TITLE
Orbit - Added support for LI elements as slides

### DIFF
--- a/marketing/stylesheets/index.css
+++ b/marketing/stylesheets/index.css
@@ -607,15 +607,15 @@ ul.flyout li.active a, .nav-bar li ul li.active a { background: #4d4d4d; border:
 /* Container ---------------------- */
 div.orbit-wrapper { width: 1px; height: 1px; position: relative; }
 
-div.orbit { width: 1px; height: 1px; position: relative; overflow: hidden; margin-bottom: 17px; }
+.orbit { width: 1px; height: 1px; position: relative; overflow: hidden; margin-bottom: 17px; }
 
-div.orbit.with-bullets { margin-bottom: 40px; }
+.orbit.with-bullets { margin-bottom: 40px; }
 
-div.orbit .orbit-slide { max-width: 100%; position: absolute; top: 0; left: 0; }
+.orbit .orbit-slide { max-width: 100%; position: absolute; top: 0; left: 0; }
 
-div.orbit a.orbit-slide { border: none; line-height: 0; display: none; }
+.orbit a.orbit-slide { border: none; line-height: 0; display: none; }
 
-div.orbit div.orbit-slide { width: 100%; height: 100%; }
+.orbit .orbit-slide { width: 100%; height: 100%; }
 
 /* Note: If your slider only uses content or anchors, you're going to want to put the width and height declarations on the ".orbit>div" and "div.orbit>a" tags in addition to just the .orbit-wrapper */
 /* Timer ---------------------- */
@@ -664,9 +664,9 @@ ul.orbit-bullets li.has-thumb { background: none; width: 100px; height: 75px; }
 ul.orbit-bullets li.active.has-thumb { background-position: 0 0; border-top: 2px solid #000; }
 
 /* Fluid Layout ---------------------- */
-div.orbit img.fluid-placeholder { visibility: hidden; position: static; display: block; width: 100%; }
+.orbit img.fluid-placeholder { visibility: hidden; position: static; display: block; width: 100%; }
 
-div.orbit, div.orbit-wrapper { width: 100% !important; }
+.orbit, div.orbit-wrapper { width: 100% !important; }
 
 ul.orbit-bullets { position: absolute; z-index: 30; list-style: none; bottom: -50px; left: 50%; margin-left: -50px; padding: 0; }
 

--- a/test2.html
+++ b/test2.html
@@ -55,7 +55,12 @@
         <img src="http://placehold.it/500x300&text=image1" />
         <img src="http://placehold.it/500x300&text=image2" />
         <img src="http://placehold.it/500x300&text=image3" />
-      </div>      
+      </div>
+      <ul id="featuredLi">
+        <li><img src="http://placehold.it/500x300&text=image1" /></li>
+        <li><img src="http://placehold.it/500x300&text=image2" /></li>
+        <li><img src="http://placehold.it/500x300&text=image3" /></li>
+      </ul>      
     </div>
   </div>
       
@@ -313,6 +318,7 @@
 
      $(window).load(function() {
         $('#featured').orbit();
+        $('#featuredLi').orbit();
      });
 
 	</script>

--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -76,7 +76,7 @@
 
       this.$element = $(element);
       this.$wrapper = this.$element.wrap(this.wrapperHTML).parent();
-      this.$slides = this.$element.children('img, a, div');
+      this.$slides = this.$element.children('img, a, div, li');
 
       this.$element.bind('orbit.next', function () {
         self.shift('next');

--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -9,10 +9,10 @@
 
 (function ($) {
   'use strict';
-  $.fn.findFirstImage = function () {
+  $.fn.findFirstImage = function (selector) {
     return this.first()
-            .find('img')
-            .andSelf().filter('img')
+            .find(selector)
+            .andSelf().filter(selector)
             .first();
   };
 
@@ -39,7 +39,8 @@
       afterSlideChange: $.noop,   // empty function
       afterLoadComplete: $.noop, //callback to execute after everything has been loaded
       fluid: true,
-      centerBullets: true    // center bullet nav with js, turn this off if you want to position the bullet nav manually
+      centerBullets: true,    // center bullet nav with js, turn this off if you want to position the bullet nav manually
+      firstSelector: 'img'
     },
 
     activeSlide: 0,
@@ -157,13 +158,13 @@
       self.$element.add(self.$wrapper).height(this.$slides.first().height());
       self.orbitWidth = this.$slides.first().outerWidth();
       self.orbitHeight = this.$slides.first().height();
-      $fluidPlaceholder = this.$slides.first().findFirstImage().clone();
-
+      self.selector = this.options.firstSelector;
+      $fluidPlaceholder = this.$slides.first().findFirstImage(self.selector).clone();
 
       this.$slides.each(function () {
         var slide = $(this),
             slideWidth = slide.outerWidth(),
-            slideHeight = slide.height();
+            slideHeight = slide.find(self.selector).height();
 
         if (slideWidth > self.$element.outerWidth()) {
           self.$element.add(self.$wrapper).width(slideWidth);
@@ -172,7 +173,7 @@
         if (slideHeight > self.$element.height()) {
           self.$element.add(self.$wrapper).height(slideHeight);
           self.orbitHeight = self.$element.height();
-          $fluidPlaceholder = $(this).findFirstImage().clone();
+          $fluidPlaceholder = $(this).findFirstImage(self.selector).clone();
         }
         self.numberSlides += 1;
       });


### PR DESCRIPTION
This change adds functionality for an 'li' element to be allowed as a child selector for Orbit slides.  It also makes the .orbit CSS more general and there's a quick example of it working in test2.html.
