### PR TITLE
Fix an issue with 'no-custom' select tags being affected by 'refreshCustomSelect'

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -404,6 +404,7 @@
   });
 
   $('form.custom select').on('change', function (event) {
+    if ($(this).hasClass('no-custom')) return;
     refreshCustomSelect($(this));
   });
 


### PR DESCRIPTION
The [Select2](http://ivaynberg.github.com/select2/) plugin replaces select tags with its own markup in much the same way as Foundation custom forms do. Adding the `no-custom` class to a select element on a custom form allows you to replace it with Select2 but it still triggers `refreshCustomSelect` on change which shrinks its width.

To get around this issue, I added one line to `jquery.foundation.forms.js` that prevents `refreshCustomSelect` from being called on a select tag with the `no-custom` class.

I'm submitting a pull request because I think it makes sense for `no-custom` to prevent any 'custom' behaviour :smile:
