### PR TITLE
Updating path to _settings.scss for rails generator foundation:install

### DIFF
--- a/lib/foundation/generators/install_generator.rb
+++ b/lib/foundation/generators/install_generator.rb
@@ -7,7 +7,7 @@ module Foundation
       
       def add_assets                  
         insert_into_file "app/assets/javascripts/application#{detect_js_format[0]}", "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
-        settings_file = File.join(File.dirname(__FILE__),"..","..","..","templates","project","sass","_settings.scss")
+        settings_file = File.join(File.dirname(__FILE__),"..","..","..","templates","project","scss","_settings.scss")
         create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)
         append_to_file "app/assets/stylesheets/foundation_and_overrides.scss", "\n@import 'foundation';\n"
         insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "#{detect_css_format[1]} require foundation_and_overrides\n", :after => "require_self\n" 


### PR DESCRIPTION
This had been causing `rails g foundation:install` to fail when it could not locate `_settings.scss`

```
rails g foundation:install
      insert  app/assets/javascripts/application.js
/Users/sjungling/.rbenv/versions/1.9.3-p125/gemsets/my-gemset/gems/zurb-foundation-3.0.8/lib/foundation/generators/install_generator.rb:11:in `read': No such file or directory - /Users/sjungling/.rbenv/versions/1.9.3-p125/gemsets/my-gemset/gems/zurb-foundation-3.0.8/lib/foundation/generators/../../../templates/project/sass/_settings.scss (Errno::ENOENT)
    from /Users/sjungling/.rbenv/versions/1.9.3-p125/gemsets/my-gemset/gems/zurb-foundation-3.0.8/lib/foundation/generators/install_generator.rb:11:in `add_assets'
```
