### PR TITLE
Fix for not removed modal-background in foundation.reveal({animation: "fade"})

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.reveal.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.reveal.js
@@ -543,10 +543,6 @@
               modal.trigger( 'reveal:closed' );
 
             } // end if !modalQueued
-            //
-            // Reset the modalQueued variable.
-            //
-            modalQueued = false;
 
           } // end if animation 'fadeAndPop'
 
@@ -639,7 +635,10 @@
             modal.trigger( 'reveal:closed' );
 
           } // end if not animating
-
+          //
+          // Reset the modalQueued variable.
+          //
+          modalQueued = false;
         } // end if !locked
 
       } // end closeAnimation


### PR DESCRIPTION
This might be a fix to be added.

Problem:
The Modal-Background (modalBg) was not removed after opening a number of "queued" dialogs with animation: "fade" and then closing the last one. Flag modalQueued must always be reset in closeAnimation() and there should be no difference between the different animation-modes in that respect.

Cheers
Jorg
