### PR TITLE
add overflow:hidden to .prefix class

### DIFF
--- a/scss/foundation/common/_forms.scss
+++ b/scss/foundation/common/_forms.scss
@@ -28,7 +28,7 @@
   a.button.prefix, a.button.postfix { padding-left: 0; padding-right: 0; text-align: center; }
   span.prefix, span.postfix { background: darken($white, 5%); border: 1px solid darken($white, 20%); }
 
-  .prefix { left: 2px; @include border-corner-radius(top, left, 2px); @include border-corner-radius(bottom, left, 2px); }
+  .prefix { left: 2px; @include border-corner-radius(top, left, 2px); @include border-corner-radius(bottom, left, 2px); overflow:hidden; }
   .postfix { right: 2px; @include border-corner-radius(top, right, 2px); @include border-corner-radius(bottom, right, 2px); }
 
   input[type="text"], input[type="password"], input[type="date"], input[type="datetime"], input[type="email"], input[type="number"], input[type="search"], input[type="tel"], input[type="time"], input[type="url"], textarea { border: 1px solid darken($white, 20%); @include border-radius(2px); @include box-shadow(inset 0 1px 2px rgba(0,0,0,0.1)); color: rgba(0,0,0,0.75); display: block; font-size: ms(0); margin: 0 0 $formSpacing 0; padding: ($formSpacing / 2); height: (ms(0) + ($formSpacing * 1.5)); width: 100%; @include transition(all 0.15s linear);


### PR DESCRIPTION
I noticed that if width of the browser window was such that the content of the `.prefix` element was too big for the element, then it was overflowing onto the adjacent element (ie, the `input`), obscuring the `input`.  Adding `overflow:hidden` to the `.prefix` class should fix that.  It may also be needed for the `.postfix` class, but I have not yet used that or tried that.
