### PR TITLE
Reveal .small horizontal centering fix

### DIFF
--- a/scss/foundation/components/modules/_reveal.scss
+++ b/scss/foundation/components/modules/_reveal.scss
@@ -22,7 +22,7 @@
       font-weight: bold;
       cursor: pointer;
     }
-    &.small   { width: 30%; margin-left: -10%; }
+    &.small   { width: 30%; margin-left: -15%; }
     &.medium  { width: 40%; margin-left: -20%; }
     &.large   { width: 60%; margin-left: -30%; }
     &.xlarge  { width: 70%; margin-left: -35%; }


### PR DESCRIPTION
.reveal-modal.small is slightly off-center (too far right) due to an incorrect margin-left value.
