### PR TITLE
Add tab support for use as a navigation element

### DIFF
--- a/test/tabs.html
+++ b/test/tabs.html
@@ -23,7 +23,7 @@
 	<![endif]-->
 </head>
 <body>
-  
+
 	<div class="row">
     <div class="twelve columns">
       <p><a href="index.html">&laquo; Back</a></p>
@@ -32,16 +32,17 @@
       <dl class="sub-nav">
         <dt>Go to:</dt>
         <dd><a href="#simple-tabs">Simple Tabs</a></dd>
+        <dd><a href="#absolute-tabs">Absolutely Linked Tabs</a></dd>
         <dd><a href="#tab-sizing">Tab Sizing</a></dd>
         <dd><a href="#contained-tabs">Contained Tabs</a></dd>
         <dd><a href="#pill-style-tables">Pill-Style Tabs</a></dd>
         <dd><a href="#vertical-tabs">Vertical Tabs</a></dd>
         <dd><a href="#mobile-tabs">Mobile Tabs</a></dd>
-        
+
       </dl>
     </div>
   </div>
-	
+
 	<!-- Test Foundation Components Here -->
   <div class="row">
     <div class="twelve columns">
@@ -70,7 +71,25 @@
           </ul>
         </div>
       </div>
-      
+
+      <br><br>
+
+      <div class="row">
+        <div class="four columns">
+          <a name="absolute-tabs"></a>
+          <h4>Absolutely Linked Tabs</h4>
+          <p>Tabs can be linked to a path and used as navigation.</p>
+        </div>
+        <br>
+        <div class="eight columns">
+          <dl class="tabs">
+            <dd class="active"><a href="tabs.html">Tabs</a></dd>
+            <dd><a href="forms.html">Forms</a></dd>
+            <dd class="hide-for-small"><a href="elements.html">Elements</a></dd>
+          </dl>
+        </div>
+      </div>
+
       <br><br>
 
       <div class="row">
@@ -96,7 +115,7 @@
           </dl>
         </div>
       </div>
-      
+
       <br><br>
 
       <div class="row">
@@ -121,7 +140,7 @@
           </ul>
         </div>
       </div>
-      
+
       <br><br>
 
       <div class="row">
@@ -139,7 +158,7 @@
           </dl>
         </div>
       </div>
-      
+
       <div class="row">
         <div class="four columns">
           <a name="vertical-tabs"></a>
@@ -154,15 +173,15 @@
           </dl>
         </div>
       </div>
-      
-      
+
+
       <a name="mobile-tabs"></a>
   		<h4>Mobile Tabs</h4>
   		<p>If you want a standard, horizontal tab group to act vertical on small devices, adding a class of "mobile" to a standard (not vertical) tab group will switch them to full width nav bars on small screens.</p>
 
   	</div>
   </div>
-	
+
 	<!-- Included JS Files -->
 	<script src="../vendor/assets/javascripts/foundation/jquery.js"></script>
   <script src="../vendor/assets/javascripts/foundation/jquery.foundation.mediaQueryToggle.js"></script>
@@ -179,6 +198,6 @@
 	<script src="../vendor/assets/javascripts/foundation/app.js"></script>
   <script type="text/javascript">
     // Page-Specific JavaScript Goes Here
-  </script>	
+  </script>
 </body>
 </html>

--- a/vendor/assets/javascripts/foundation/jquery.foundation.tabs.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tabs.js
@@ -8,18 +8,24 @@
 
     var activateTab = function ($tab) {
       var $activeTab = $tab.closest('dl').find('dd.active'),
-          contentLocation = $tab.children('a').attr("href") + 'Tab';
+          target = $tab.children('a').attr("href"),
+          hasHash = /^#/.test(target),
+          contentLocation = '';
 
-      // Strip off the current url that IE adds
-      contentLocation = contentLocation.replace(/^.+#/, '#');
+      if (hasHash) {
+        contentLocation = target + 'Tab';
+
+        // Strip off the current url that IE adds
+        contentLocation = contentLocation.replace(/^.+#/, '#');
+
+        //Show Tab Content
+        $(contentLocation).closest('.tabs-content').children('li').removeClass('active').hide();
+        $(contentLocation).css('display', 'block').addClass('active');
+      }
 
       //Make Tab Active
       $activeTab.removeClass('active');
       $tab.addClass('active');
-
-      //Show Tab Content
-      $(contentLocation).closest('.tabs-content').children('li').removeClass('active').hide();
-      $(contentLocation).css('display', 'block').addClass('active');
     };
 
     $(document).on('click.fndtn', 'dl.tabs dd a', function (event){


### PR DESCRIPTION
A simple check for the hash prevents JavaScript errors, else it proceeds as normal.
