### PR TITLE
Fix tooltips in IE8 that doesn't implement Array#map.

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -136,7 +136,7 @@
       },
       inheritable_classes : function (target) {
         var inheritables = ['tip-top', 'tip-left', 'tip-bottom', 'tip-right', 'noradius'],
-          filtered = target.attr('class').split(' ').map(function (el, i) {
+          filtered = $.map(target.attr('class').split(' '), function (el, i) {
             if ($.inArray(el, inheritables) !== -1) {
               return el;
             }


### PR DESCRIPTION
Use $.map instead of Array#map that is not implemented in Internet Explorer 8.
