### PR TITLE
 Extends accordion feature to support ajax-loaded li's

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.accordion.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.accordion.js
@@ -2,7 +2,7 @@
 
   $.fn.foundationAccordion = function (options) {
 
-    $('.accordion li', this).on('click.fndtn', function () {
+    $('.accordion li', this).live('click.fndtn', function () {
     var p = $(this).parent(); //changed this
       var flyout = $(this).children('.content').first();
       $('.content', p).not(flyout).hide().parent('li').removeClass('active'); //changed this


### PR DESCRIPTION
This allows Foundation users to append li's to their accordions after page load with the expected functionality.

Current implentation does not support ajax loaded li's...

.live() should repair that problem.
