### PR TITLE
mobile columns should also float on end

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -81,6 +81,7 @@
       .row {
         .mobile-#{convert-number-to-word($i)} { width: gridCalc($i, $mobileTotalColumns) !important; float: $defaultFloat; padding: 0 ($columnGutter/2);
           &:last-child { float: $defaultOpposite; }
+          &.end { float: $defaultFloat; }
         }
         &.collapse {
           .mobile-#{convert-number-to-word($i)} { padding: 0; }


### PR DESCRIPTION
On mobile-columns, the end class doesn't make a column float left, as it get's overwritten by the mobile attributes. This adds the end that to the mobile attributes.
