### PR TITLE
Make these two values configurable via settings

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -59,6 +59,7 @@ $formSpacing: 12px !default;
 // Tab Settings
 
 $tabHeight: 40px !default;
+$tabTermFontSize: ms(0) -2px;
 
 // Nav Bar Settings
 
@@ -120,6 +121,9 @@ $topBarDropToggleSize: 5px !default;
 $topBarSearchWidth: 200px !default;
 $topBarBreakPoint: 940px !default; // Change to 9999px for always mobile layout
 $topBarNavToggleSize: 8px !default;
+
+// UI Link Lists
+$linkListBottomMargin: ms(1) -22px;
 
 // Media Queries
 

--- a/scss/foundation/components/modules/_tabs.scss
+++ b/scss/foundation/components/modules/_tabs.scss
@@ -7,7 +7,7 @@
   dl.tabs { border-bottom: solid 1px darken($white, 10%); display: block; height: $tabHeight; padding: 0; margin-bottom: 20px;
     &.contained { margin-bottom: 0; }
 
-    dt { color: darken($white, 30%); cursor: default; display: block; float: $defaultFloat; font-size: ms(0) - 2px; height: $tabHeight; line-height: $tabHeight; padding: 0; padding-#{$defaultOpposite}: 9px; padding-#{$defaultFloat}: 20px; width: auto; text-transform: uppercase;
+    dt { color: darken($white, 30%); cursor: default; display: block; float: $defaultFloat; font-size: $tabTermFontSize; height: $tabHeight; line-height: $tabHeight; padding: 0; padding-#{$defaultOpposite}: 9px; padding-#{$defaultFloat}: 20px; width: auto; text-transform: uppercase;
       &:first-child { padding: 0; padding-#{$defaultOpposite}: 9px; }
     }
 

--- a/scss/foundation/components/modules/_ui.scss
+++ b/scss/foundation/components/modules/_ui.scss
@@ -315,7 +315,7 @@
   }
 
   /* Link List */
-  ul.link-list { margin: 0 0 ms(1) -22px; padding: 0; list-style: none; overflow: hidden;
+  ul.link-list { margin: 0 0 $linkListBottomMargin; padding: 0; list-style: none; overflow: hidden;
 
     li { list-style: none; float: $defaultFloat; margin-#{$defaultFloat}: 22px; display: block;
 


### PR DESCRIPTION
These two values are originally hard-coded which causes a failure if you want
to use relative font-sizes.  Moving these to settings allows the developer to
specify them however they see fit, including as a relative value.
