### PR TITLE
Added placeholder selector to fix extra output of invisible classes

### DIFF
--- a/scss/foundation/mixins/_semantic-grid.scss
+++ b/scss/foundation/mixins/_semantic-grid.scss
@@ -62,5 +62,5 @@
   %c-base { @include columnBase(); }
 
   @for $i from 1 through $totalColumns {
-    .c-#{$i} { @include column($i); }
+    %c-#{$i} { @include column($i); }
   }


### PR DESCRIPTION
This should get rid of the following invisible placeholder classes that are getting compiled into the css output.

```
.c-1, .c-2, .c-3, .c-4, .c-5, .c-6, .c-7, .c-8, .c-9, .c-10, .c-11, .c-12 { float: left; }

.c-1, .c-2, .c-3, .c-4, .c-5, .c-6, .c-7, .c-8, .c-9, .c-10, .c-11, .c-12 { position: relative; min-height: 1px; padding: 0 15px; }

.c-1 { width: 8.33333%; }

.c-2 { width: 16.66667%; }

.c-3 { width: 25%; }

.c-4 { width: 33.33333%; }

.c-5 { width: 41.66667%; }

.c-6 { width: 50%; }

.c-7 { width: 58.33333%; }

.c-8 { width: 66.66667%; }

.c-9 { width: 75%; }

.c-10 { width: 83.33333%; }

.c-11 { width: 91.66667%; }

.c-12 { width: 100%; }
```
