### PR TITLE
tooltips now support html, such as <br>

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -81,7 +81,7 @@
         return (id) ? id : dataSelector;
       },
       create : function ($target) {
-        var $tip = $(settings.tipTemplate(methods.selector($target), $('<div>').text($target.attr('title')).html())),
+        var $tip = $(settings.tipTemplate(methods.selector($target), $('<div>').html($target.attr('title')).html())),
           classes = methods.inheritable_classes($target);
 
         $tip.addClass(classes).appendTo('body');


### PR DESCRIPTION
This was bothering me a little bit. Not sure if this is the best way to go about it, but this now supports line-breaks inside tooltips. 

Again, not sure if it's semantic - but it works.
