### PR TITLE
Make Address Bar hiding conditional on no #Hash

### DIFF
--- a/vendor/assets/javascripts/foundation/app.js
+++ b/vendor/assets/javascripts/foundation/app.js
@@ -22,8 +22,8 @@
   // $('.block-grid.four-up>li:nth-child(4n+1)').css({clear: 'both'});
   // $('.block-grid.five-up>li:nth-child(5n+1)').css({clear: 'both'});
 
-  // Hide address bar on mobile devices
-  if (Modernizr.touch) {
+  // Hide address bar on mobile devices (except if #hash present, so we don't mess up deep linking).
+  if (Modernizr.touch && !window.location.hash) {
     $(window).load(function () {
       setTimeout(function () {
         window.scrollTo(0, 1);


### PR DESCRIPTION
If the user comes to a page via a deep link (eg, www.example.com/page/#anchor-on-page) we don't want the `scrollTo` to fire because it will prevent the page from staying at the anchor location (which is confusing, since the page would try to go to the anchor and then scroll up when the `scrollTo` fires). This commit remedies that via what should be a pretty standard, cross browser method (as far as I know). :)
