### PR TITLE
fix custom form elements exclusion

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -411,7 +411,7 @@
   });
 
   $(document).on('click', 'form.custom label', function (event) {
-    var $associatedElement = $('#' + $(this).attr('for')),
+    var $associatedElement = $('#' + $(this).attr('for') + '[data-customforms!=disabled]'),
         $customCheckbox,
         $customRadio;
     if ($associatedElement.length !== 0) {


### PR DESCRIPTION
I went looking for (and found!) the undocumented feature of the Custom Forms that if you add `data-customforms="disabled"` to an element in a custom form it will not be converted into the Foundation Custom version.  This is useful for instances when the developer wishes to use a particular form field in a different manner (eg, apply some other kind of custom form code to the field, which in my case will be the FD Slider: https://github.com/freqdec/fd-slider).  However, I discovered that the change I've made for this Pull Request is necessary for it to fully work.  Without this change it only half-way works (the elements correctly are ignored for transformation, but the `click` event is still set which causes errors, etc.
