### PR TITLE
Fixed augmented fourth

### DIFF
--- a/scss/foundation/common/_ratios.scss
+++ b/scss/foundation/common/_ratios.scss
@@ -11,7 +11,7 @@ $minor-seventh: (16 / 9);
 $major-sixth: (5 / 3);
 $minor-sixth: (8 / 5);
 $fifth: (3 / 2);
-$augfourth: (1 / 1.4142135623730950488);
+$augfourth: (1.414213562373);
 $fourth: (4 / 3);
 $major-third: (5 / 4);
 $minor-third: (6 / 5);


### PR DESCRIPTION
Augmented fourth used to be smaller than one, whereas all other ratios were larger. 
In addition, shortened the approximation of square root of 2 a bit
