### PR TITLE
Removes duplicate code

### DIFF
--- a/scss/foundation/common/_forms.scss
+++ b/scss/foundation/common/_forms.scss
@@ -81,7 +81,7 @@
 
       a.current { display: block; width: auto; line-height: 26px; min-height: 28px; padding: 0; padding-#{$defaultFloat}: 6px; padding-#{$defaultOpposite}: 38px; border: solid 1px #ddd; color: #141414; background-color: #fff; white-space: nowrap; }
       a.selector { position: absolute; width: 27px; height: 28px; display: block; #{$defaultOpposite}: 0; top: 0; border: solid 1px #ddd;
-        &:after { content: ""; display: block; @include cssTriangle(5px, #aaa, top); position: absolute; #{$defaultFloat}: 50%; top: 50%; margin-top: -2px; margin-#{$defaultFloat}: -5px;  }
+        &:after { @include cssTriangle(5px, #aaa, top); position: absolute; #{$defaultFloat}: 50%; top: 50%; margin-top: -2px; margin-#{$defaultFloat}: -5px;  }
       }
       &:hover, &.open {
         a.selector { &:after { @include cssTriangle(5px, #222, top); } }


### PR DESCRIPTION
`content: ""; display: block;` is already included in `cssTriangle()`.
This patch removes duplicate output in CSS.
