### PR TITLE
Support any Valid jQuery Selector for Tooltips

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -127,15 +127,15 @@
           tip.width(column.outerWidth() - 25).css('left', 15).addClass('tip-override');
           objPos(nub, -nubHeight, 'auto', 'auto', target.offset().left);
         } else {
-          if (classes.indexOf('tip-top') > -1) {
+          if (classes && classes.indexOf('tip-top') > -1) {
             objPos(tip, (target.offset().top - tip.outerHeight() - nubHeight), 'auto', 'auto', target.offset().left, width)
               .removeClass('tip-override');
             objPos(nub, 'auto', 'auto', -nubHeight, 'auto');
-          } else if (classes.indexOf('tip-left') > -1) {
+          } else if (classes && classes.indexOf('tip-left') > -1) {
             objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight), 'auto', 'auto', (target.offset().left - tip.outerWidth() - 10), width)
               .removeClass('tip-override');
             objPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), -nubHeight, 'auto', 'auto');
-          } else if (classes.indexOf('tip-right') > -1) {
+          } else if (classes && classes.indexOf('tip-right') > -1) {
             objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight), 'auto', 'auto', (target.offset().left + target.outerWidth() + 10), width)
               .removeClass('tip-override');
             objPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), 'auto', 'auto', -nubHeight);
@@ -145,11 +145,12 @@
       },
       inheritable_classes : function (target) {
         var inheritables = ['tip-top', 'tip-left', 'tip-bottom', 'tip-right', 'noradius'],
-          filtered = $.map(target.attr('class').split(' '), function (el, i) {
-            if ($.inArray(el, inheritables) !== -1) {
-              return el;
-            }
-          }).join(' ');
+          classes = target.attr('class'),
+          filtered = classes ? $.map(classes.split(' '), function (el, i) {
+              if ($.inArray(el, inheritables) !== -1) {
+                return el;
+              }
+          }).join(' ') : '';
 
         return $.trim(filtered);
       },

--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -13,7 +13,7 @@
 
   var settings = {
       bodyHeight : 0,
-      targetClass : '.has-tip',
+      selector : '.has-tip',
       tooltipClass : '.tooltip',
       tipTemplate : function (selector, content) {
         return '<span data-selector="' + selector + '" class="' + settings.tooltipClass.substring(1) + '">' + content + '<span class="nub"></span></span>';
@@ -23,11 +23,14 @@
       init : function (options) {
         settings = $.extend(settings, options);
 
+        // alias the old targetClass option
+        settings.selector = settings.targetClass ? settings.targetClass : settings.selector;
+
         return this.each(function () {
           var $body = $('body');
 
           if (Modernizr.touch) {
-            $body.on('click.tooltip touchstart.tooltip touchend.tooltip', settings.targetClass, function (e) {
+            $body.on('click.tooltip touchstart.tooltip touchend.tooltip', settings.selector, function (e) {
               e.preventDefault();
               $(settings.tooltipClass).hide();
               methods.showOrCreateTip($(this));
@@ -37,7 +40,7 @@
               $(this).fadeOut(150);
             });
           } else {
-            $body.on('mouseenter.tooltip mouseleave.tooltip', settings.targetClass, function (e) {
+            $body.on('mouseenter.tooltip mouseleave.tooltip', settings.selector, function (e) {
               var $this = $(this);
 
               if (e.type === 'mouseenter') {
@@ -169,9 +172,9 @@
       destroy : function () {
         return this.each(function () {
           $(window).off('.tooltip');
-          $(settings.targetClass).off('.tooltip');
+          $(settings.selector).off('.tooltip');
           $(settings.tooltipClass).each(function (i) {
-            $($(settings.targetClass).get(i)).attr('title', $(this).text());
+            $($(settings.selector).get(i)).attr('title', $(this).text());
           }).remove();
         });
       }


### PR DESCRIPTION
There are two commits here. One makes sure any references to the target element's classes are OK if there are no classes on the element, the other renames the `targetClass` option / setting to `selector` to make it clear it doesn't have to be a CSS class (the old option name is still supported).
