### PR TITLE
Addresses #959 & #571: Conditionally preventDefault for dropdown buttons. 

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -30,7 +30,11 @@
       var $el = $(this),
         button = $el.closest('.button.dropdown'),
         dropdown = $('> ul', button);
-      e.preventDefault();
+
+        // If the click is registered on an actual link then do not preventDefault which stops the browser from following the link
+        if (e.target.nodeName !== "A"){
+          e.preventDefault();
+        }
 
       // close other dropdowns
       closeDropdowns(config.dropdownAsToggle ? dropdown : '');


### PR DESCRIPTION
We were having issues with Foundation 3.2 and being able to actually follow links contained within Dropdown Buttons. Conditionally checking the click target and preventing default seems to have resolved the issue for us but you'll understand the larger picture and whether or not this is an acceptable solution.
