### PR TITLE
Add-in -webkit-font-smoothing variable

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -23,6 +23,7 @@ $darkEdge: rgba(#000, .2) !default;
 
 // Font Settings
 
+$fontSmoothing: antialiased;
 $headerFontFamily: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif !default;
 $headerFontWeight: bold !default;
 $headerFontStyle: normal !default;

--- a/scss/foundation/common/_globals.scss
+++ b/scss/foundation/common/_globals.scss
@@ -4,7 +4,7 @@
 
   * { @include box-sizing(border-box); }
   html { font-size: 62.5%; }
-  body { background: $white; font-family: $bodyFontFamily; font-weight: $bodyFontWeight; font-style: $bodyFontStyle; font-size: ms(0); line-height: 1; color: $bodyFontColor; position: relative; -webkit-font-smoothing: antialiased; }
+  body { background: $white; font-family: $bodyFontFamily; font-weight: $bodyFontWeight; font-style: $bodyFontStyle; font-size: ms(0); line-height: 1; color: $bodyFontColor; position: relative; -webkit-font-smoothing: $fontSmoothing; }
 
 /* Links ---------------------- */
 

--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -25,6 +25,7 @@
 
 // Font Settings
 
+// $fontSmoothing: antialiased;
 // $headerFontFamily: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
 // $headerFontWeight: bold;
 // $headerFontStyle: normal;

--- a/test/scss/_settings.scss
+++ b/test/scss/_settings.scss
@@ -25,6 +25,7 @@
 
 // Font Settings
 
+// $fontSmoothing: antialiased;
 // $headerFontFamily: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
 // $headerFontWeight: bold;
 // $headerFontStyle: normal;


### PR DESCRIPTION
This simply adds in a new variable to allow users to choose their preferred `-webkit-font-smoothing` attribute. [Tim Van Damme](http://maxvoltar.com/archive/-webkit-font-smoothing) started me on this venture a while ago - and personally, I'm a `subpixel-antialiased` kind of guy
