### PR TITLE
Add check for Scroll Position before Scroll

### DIFF
--- a/vendor/assets/javascripts/foundation/app.js
+++ b/vendor/assets/javascripts/foundation/app.js
@@ -30,7 +30,10 @@
   if (Modernizr.touch && !window.location.hash) {
     $(window).load(function () {
       setTimeout(function () {
-        window.scrollTo(0, 1);
+        // At load, if user hasn't scrolled more than 20px or so...
+  			if( $(window).scrollTop() < 20 ) {
+          window.scrollTo(0, 1);
+        }
       }, 0);
     });
   }


### PR DESCRIPTION
I came across this recently and it seems like a good idea (eg, I've added it to my own site). This checks the scroll position before scrolling in order to avoid doing the "hide address bar" scroll when the user has already begun scrolling (which would then be quite annoying to get forced back to the top of the page). This code also has the additional benefit that if the page is scrolled part way and then manually refreshed/reloaded it should refresh at its proper scroll position instead of jumping back to the top.

Credits:
https://gist.github.com/1183357
http://24ways.org/2011/raising-the-bar-on-mobile
