### PR TITLE
Remove Top-bar background color conflicts for small screens

### DIFF
--- a/scss/foundation/components/modules/_mqueries.scss
+++ b/scss/foundation/components/modules/_mqueries.scss
@@ -363,7 +363,7 @@
         &>li { float: none;
           &.active, &:hover { background: darken($topBarDropBgColor, 5%); }
           /* Branding and name */
-          &.name { background: darken($topBarBgColor, 20%); height: $topBarHeightMobile;
+          &.name { height: $topBarHeightMobile;
             h1 { line-height: 1;
               a { color: $topBarLinkColor; display: block; line-height: $topBarHeightMobile !important; padding-left: $topBarHeightMobile / 2; height: $topBarHeightMobile; }
             }


### PR DESCRIPTION
Remove a background color darkening for Top Bar, introduced at ac45fddf0dd1014d879c149852c1ae4752fda11f.

Test: Set a custom `$topBarBgColor`, and `$topBarDropBgColor`, and resize your browser
