### PR TITLE
Allow foundationButtons method to be safely called on any element

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -2,60 +2,66 @@
   'use strict';
 
   $.fn.foundationButtons = function (options) {
-    var $doc = $(document),
-      config = $.extend({
+    var config = $.extend({
         dropdownAsToggle:true,
         activeClass:'active'
       }, options),
+      closeDropdowns,
+      resetToggles;
 
-    // close all dropdowns except for the dropdown passed
+    // Only bind events during initialization
+    if(this.is(document)) {
+      // close all dropdowns except for the dropdown passed
       closeDropdowns = function (dropdown) {
         $('.button.dropdown').find('ul').not(dropdown).removeClass('show-dropdown');
-      },
-    // reset all toggle states except for the button passed
+      };
+
+      // reset all toggle states except for the button passed
       resetToggles = function (button) {
         var buttons = $('.button.dropdown').not(button);
         buttons.add($('> span.' + config.activeClass, buttons)).removeClass(config.activeClass);
       };
 
-    // Prevent event propagation on disabled buttons
-    $doc.on('click.fndtn', '.button.disabled', function (e) {
-      e.preventDefault();
-    });
+      // Prevent event propagation on disabled buttons
+      this.on('click.fndtn', '.button.disabled', function (e) {
+        e.preventDefault();
+      });
 
-    $('.button.dropdown > ul', this).addClass('no-hover');
+      // reset other active states
+      this.on('click.fndtn', '.button.dropdown:not(.split), .button.dropdown.split span', function (e) {
+        var $el = $(this),
+          button = $el.closest('.button.dropdown'),
+          dropdown = $('> ul', button);
 
-    // reset other active states
-    $doc.on('click.fndtn', '.button.dropdown:not(.split), .button.dropdown.split span', function (e) {
-      var $el = $(this),
-        button = $el.closest('.button.dropdown'),
-        dropdown = $('> ul', button);
-
-        // If the click is registered on an actual link then do not preventDefault which stops the browser from following the link
-        if (e.target.nodeName !== "A"){
+        // If the click is registered on an actual link or descendent of a link then
+        // do not preventDefault which stops the browser from following the link
+        if (!$(e.target).closest('a').length) {
           e.preventDefault();
         }
 
-      // close other dropdowns
-      closeDropdowns(config.dropdownAsToggle ? dropdown : '');
-      dropdown.toggleClass('show-dropdown');
+        // close other dropdowns
+        closeDropdowns(config.dropdownAsToggle ? dropdown : '');
+        dropdown.toggleClass('show-dropdown');
 
-      if (config.dropdownAsToggle) {
-        resetToggles(button);
-        $el.toggleClass(config.activeClass);
-      }
-    });
-
-    // close all dropdowns and deactivate all buttons
-    $doc.on('click.fndtn', 'body, html', function (e) {
-      // check original target instead of stopping event propagation to play nice with other events
-      if (!$(e.originalEvent.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
-        closeDropdowns();
         if (config.dropdownAsToggle) {
-          resetToggles();
+          resetToggles(button);
+          $el.toggleClass(config.activeClass);
         }
-      }
-    });
+      });
+
+      // close all dropdowns and deactivate all buttons
+      this.on('click.fndtn', 'body, html', function (e) {
+        // check original target instead of stopping event propagation to play nice with other events
+        if (!$(e.originalEvent.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
+          closeDropdowns();
+          if (config.dropdownAsToggle) {
+            resetToggles();
+          }
+        }
+      });
+    }
+
+    $('.button.dropdown > ul', this).addClass('no-hover');
 
     // Positioning the Flyout List
     var normalButtonHeight  = $('.button.dropdown:not(.large):not(.small):not(.tiny)', this).outerHeight() - 1,
@@ -72,7 +78,6 @@
     $('.button.dropdown.up.large > ul', this).css('top', 'auto').css('bottom', largeButtonHeight - 2);
     $('.button.dropdown.up.small > ul', this).css('top', 'auto').css('bottom', smallButtonHeight - 2);
     $('.button.dropdown.up.tiny > ul', this).css('top', 'auto').css('bottom', tinyButtonHeight - 2);
-
   };
 
 })( jQuery, this );


### PR DESCRIPTION
Prevent duplicate event binding by only binding if the current element
is document.

This allows activation of dropdown buttons that were added to the DOM
after initialization by calling $('#myelement').foundationButtons()
after insertion.

Also, includes bugfix where preventDefault was being incorrectly called
when clicking a descendent of a link (e.g. an embedded `<img>`).
