### PR TITLE
Make Foundation's topbar support Turbolinks

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -28,15 +28,23 @@
 
           methods.attachEventListeners();
 
-          if (window.Turbolinks) {
-            $(window).on('page:change', function(e) {
-              console.log('change!');
+          var page_change = null;
+          var page_load   = null;
+          if (window.Turbolinks !== undefined) {
+            page_change = 'page:change';
+            page_load   = 'page:load';
+          } else if ($.fn.pjax !== undefined) {
+            page_change = 'pjax:begin';
+            page_load   = 'pjax:end';
+          }
+
+          if (page_change !== null) {
+            $(window).on(page_change, function(e) {
               methods.detachEventListeners();
               settings.initialized = false;
             });
 
-            $(window).on('page:load', function(e) {
-              console.log('restore!');
+            $(window).on(page_load, function(e) {
               methods.initializeSettings();
               methods.assemble();
               settings.initialized = true;


### PR DESCRIPTION
This PR does a couple things to the Foundation topbar:

1/ Convert jQuery .live() calls to .on(), because live is deprecated.
2/ Detach and re-attach topbar's event handlers when Turbolinks is changing pages.

I had to shuffle some initialization code around. Let me know if there is anything you'd rather this PR do differently and I'd be happy to change it.
