### PR TITLE
Fixes improper placement of dropdown buttons

### DIFF
--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -26,7 +26,7 @@
   .sticky {
   	float: left;
   	overflow: hidden;
-  
+  }
   .sticky.fixed {
   	float: none;
   }   

--- a/vendor/assets/javascripts/foundation/index.js
+++ b/vendor/assets/javascripts/foundation/index.js
@@ -1,6 +1,7 @@
 /*
 =require foundation/modernizr.foundation
 =require foundation/jquery.placeholder
+=require foundation/jquery.foundation.utils
 =require foundation/jquery.foundation.alerts
 =require foundation/jquery.foundation.accordion
 =require foundation/jquery.foundation.buttons

--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -57,23 +57,27 @@
       }
     });
 
-    // Positioning the Flyout List
-    $doc.ready(function() {
-      var normalButtonHeight  = $('.button.dropdown:not(.large):not(.small):not(.tiny)', this).outerHeight() - 1,
-          largeButtonHeight   = $('.button.large.dropdown', this).outerHeight() - 1,
-          smallButtonHeight   = $('.button.small.dropdown', this).outerHeight() - 1,
-          tinyButtonHeight    = $('.button.tiny.dropdown', this).outerHeight() - 1;
+    // Make sure we calculate size of hidden elements properly.
+    var outerHeightHelper = $.foundation.utils.hiddenFix();
+    outerHeightHelper.adjust($('.button.dropdown'));
+    
+    var normalButtonHeight  = $('.button.dropdown:not(.large):not(.small):not(.tiny)', this).outerHeight() - 1,
+        largeButtonHeight   = $('.button.large.dropdown', this).outerHeight() - 1,
+        smallButtonHeight   = $('.button.small.dropdown', this).outerHeight() - 1,
+        tinyButtonHeight    = $('.button.tiny.dropdown', this).outerHeight() - 1;
 
-      $('.button.dropdown:not(.large):not(.small):not(.tiny) > ul', this).css('top', normalButtonHeight);
-      $('.button.dropdown.large > ul', this).css('top', largeButtonHeight);
-      $('.button.dropdown.small > ul', this).css('top', smallButtonHeight);
-      $('.button.dropdown.tiny > ul', this).css('top', tinyButtonHeight);
+    outerHeightHelper.reset();
+    
+    // Position flyout lists appropriately
+    $('.button.dropdown:not(.large):not(.small):not(.tiny) > ul', this).css('top', normalButtonHeight);
+    $('.button.dropdown.large > ul', this).css('top', largeButtonHeight);
+    $('.button.dropdown.small > ul', this).css('top', smallButtonHeight);
+    $('.button.dropdown.tiny > ul', this).css('top', tinyButtonHeight);
 
-      $('.button.dropdown.up:not(.large):not(.small):not(.tiny) > ul', this).css('top', 'auto').css('bottom', normalButtonHeight - 2);
-      $('.button.dropdown.up.large > ul', this).css('top', 'auto').css('bottom', largeButtonHeight - 2);
-      $('.button.dropdown.up.small > ul', this).css('top', 'auto').css('bottom', smallButtonHeight - 2);
-      $('.button.dropdown.up.tiny > ul', this).css('top', 'auto').css('bottom', tinyButtonHeight - 2);
-    });
+    $('.button.dropdown.up:not(.large):not(.small):not(.tiny) > ul', this).css('top', 'auto').css('bottom', normalButtonHeight - 2);
+    $('.button.dropdown.up.large > ul', this).css('top', 'auto').css('bottom', largeButtonHeight - 2);
+    $('.button.dropdown.up.small > ul', this).css('top', 'auto').css('bottom', smallButtonHeight - 2);
+    $('.button.dropdown.up.tiny > ul', this).css('top', 'auto').css('bottom', tinyButtonHeight - 2);
   };
 
 })( jQuery, this );

--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -31,8 +31,9 @@
         button = $el.closest('.button.dropdown'),
         dropdown = $('> ul', button);
 
-        // If the click is registered on an actual link then do not preventDefault which stops the browser from following the link
-        if (e.target.nodeName !== "A"){
+        // Make sure the click is for the button itself and not one of it's children
+        // before stopping event propagation.
+        if ($(e.originalEvent.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
           e.preventDefault();
         }
 

--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -58,21 +58,22 @@
     });
 
     // Positioning the Flyout List
-    var normalButtonHeight  = $('.button.dropdown:not(.large):not(.small):not(.tiny)', this).outerHeight() - 1,
-        largeButtonHeight   = $('.button.large.dropdown', this).outerHeight() - 1,
-        smallButtonHeight   = $('.button.small.dropdown', this).outerHeight() - 1,
-        tinyButtonHeight    = $('.button.tiny.dropdown', this).outerHeight() - 1;
+    $doc.ready(function() {
+      var normalButtonHeight  = $('.button.dropdown:not(.large):not(.small):not(.tiny)', this).outerHeight() - 1,
+          largeButtonHeight   = $('.button.large.dropdown', this).outerHeight() - 1,
+          smallButtonHeight   = $('.button.small.dropdown', this).outerHeight() - 1,
+          tinyButtonHeight    = $('.button.tiny.dropdown', this).outerHeight() - 1;
 
-    $('.button.dropdown:not(.large):not(.small):not(.tiny) > ul', this).css('top', normalButtonHeight);
-    $('.button.dropdown.large > ul', this).css('top', largeButtonHeight);
-    $('.button.dropdown.small > ul', this).css('top', smallButtonHeight);
-    $('.button.dropdown.tiny > ul', this).css('top', tinyButtonHeight);
+      $('.button.dropdown:not(.large):not(.small):not(.tiny) > ul', this).css('top', normalButtonHeight);
+      $('.button.dropdown.large > ul', this).css('top', largeButtonHeight);
+      $('.button.dropdown.small > ul', this).css('top', smallButtonHeight);
+      $('.button.dropdown.tiny > ul', this).css('top', tinyButtonHeight);
 
-    $('.button.dropdown.up:not(.large):not(.small):not(.tiny) > ul', this).css('top', 'auto').css('bottom', normalButtonHeight - 2);
-    $('.button.dropdown.up.large > ul', this).css('top', 'auto').css('bottom', largeButtonHeight - 2);
-    $('.button.dropdown.up.small > ul', this).css('top', 'auto').css('bottom', smallButtonHeight - 2);
-    $('.button.dropdown.up.tiny > ul', this).css('top', 'auto').css('bottom', tinyButtonHeight - 2);
-
+      $('.button.dropdown.up:not(.large):not(.small):not(.tiny) > ul', this).css('top', 'auto').css('bottom', normalButtonHeight - 2);
+      $('.button.dropdown.up.large > ul', this).css('top', 'auto').css('bottom', largeButtonHeight - 2);
+      $('.button.dropdown.up.small > ul', this).css('top', 'auto').css('bottom', smallButtonHeight - 2);
+      $('.button.dropdown.up.tiny > ul', this).css('top', 'auto').css('bottom', tinyButtonHeight - 2);
+    });
   };
 
 })( jQuery, this );

--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -8,95 +8,9 @@
 
 (function( $ ){
 
-  /**
-   * Helper object used to quickly adjust all hidden parent element's, display and visibility properties.
-   * This is currently used for the custom drop downs. When the dropdowns are contained within a reveal modal
-   * we cannot accurately determine the list-item elements width property, since the modal's display property is set
-   * to 'none'.
-   *
-   * This object will help us work around that problem.
-   *
-   * NOTE: This could also be plugin.
-   *
-   * @function hiddenFix
-   */
-  var hiddenFix = function() {
-
-    return {
-      /**
-       * Sets all hidden parent elements and self to visibile.
-       *
-       * @method adjust
-       * @param {jQuery Object} $child
-       */
-
-      // We'll use this to temporarily store style properties.
-      tmp : [],
-
-      // We'll use this to set hidden parent elements.
-      hidden : null,
-
-      adjust : function( $child ) {
-        // Internal reference.
-        var _self = this;
-
-        // Set all hidden parent elements, including this element.
-        _self.hidden = $child.parents().andSelf().filter( ":hidden" );
-
-        // Loop through all hidden elements.
-        _self.hidden.each( function() {
-
-          // Cache the element.
-          var $elem = $( this );
-
-          // Store the style attribute.
-          // Undefined if element doesn't have a style attribute.
-          _self.tmp.push( $elem.attr( 'style' ) );
-
-          // Set the element's display property to block,
-          // but ensure it's visibility is hidden.
-          $elem.css( { 'visibility' : 'hidden', 'display' : 'block' } );
-        });
-
-      }, // end adjust
-
-      /**
-       * Resets the elements previous state.
-       *
-       * @method reset
-       */
-      reset : function() {
-        // Internal reference.
-        var _self = this;
-        // Loop through our hidden element collection.
-        _self.hidden.each( function( i ) {
-          // Cache this element.
-          var $elem = $( this ),
-              _tmp = _self.tmp[ i ]; // Get the stored 'style' value for this element.
-
-          // If the stored value is undefined.
-          if( _tmp === undefined )
-            // Remove the style attribute.
-            $elem.removeAttr( 'style' );
-          else
-            // Otherwise, reset the element style attribute.
-            $elem.attr( 'style', _tmp );
-
-        });
-        // Reset the tmp array.
-        _self.tmp = [];
-        // Reset the hidden elements variable.
-        _self.hidden = null;
-
-      } // end reset
-
-    }; // end return
-
-  };
-
   jQuery.foundation = jQuery.foundation || {};
   jQuery.foundation.customForms = jQuery.foundation.customForms || {};
-
+ 
   $.foundation.customForms.appendCustomMarkup = function ( options ) {
 
     var defaults = {
@@ -119,7 +33,7 @@
     }
 
     function appendCustomSelect(idx, sel) {
-      var hiddenFixObj = hiddenFix();
+      var hiddenFixObj = $.foundation.utils.hiddenFix();
           //
           // jQueryify the <select> element and cache it.
           //

--- a/vendor/assets/javascripts/foundation/jquery.foundation.utils.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.utils.js
@@ -1,0 +1,92 @@
+;(function ($, window, undefined) {
+  'use strict';
+  
+  $.foundation = $.foundation || {};
+  $.foundation.utils = $.foundation.utils || {};
+  
+   /**
+   * Helper object used to quickly adjust all hidden parent element's, display and visibility properties.
+   * This is currently used for the custom drop downs. When the dropdowns are contained within a reveal modal
+   * we cannot accurately determine the list-item elements width property, since the modal's display property is set
+   * to 'none'.
+   *
+   * This object will help us work around that problem.
+   *
+   * @function hiddenFix
+   */
+  $.foundation.utils.hiddenFix = function() {
+
+    return {
+      /**
+       * Sets all hidden parent elements and self to visibile.
+       *
+       * @method adjust
+       * @param {jQuery Object} $child
+       */
+
+      // We'll use this to temporarily store style properties.
+      tmp : [],
+
+      // We'll use this to set hidden parent elements.
+      hidden : null,
+
+      adjust : function( $child ) {
+        // Internal reference.
+        var _self = this;
+
+        // Set all hidden parent elements, including this element.
+        _self.hidden = $child.parents().andSelf().filter( ":hidden" );
+
+        // Loop through all hidden elements.
+        _self.hidden.each( function() {
+
+          // Cache the element.
+          var $elem = $( this );
+
+          // Store the style attribute.
+          // Undefined if element doesn't have a style attribute.
+          _self.tmp.push( $elem.attr( 'style' ) );
+
+          // Set the element's display property to block,
+          // but ensure it's visibility is hidden.
+          $elem.css( { 'visibility' : 'hidden', 'display' : 'block' } );
+        });
+
+      }, // end adjust
+
+      /**
+       * Resets the elements previous state.
+       *
+       * @method reset
+       */
+      reset : function() {
+        // Internal reference.
+        var _self = this;
+        // Loop through our hidden element collection.
+        _self.hidden.each( function( i ) {
+          // Cache this element.
+          var $elem = $( this ),
+              _tmp = _self.tmp[ i ]; // Get the stored 'style' value for this element.
+
+          // If the stored value is undefined.
+          if( _tmp === undefined )
+            // Remove the style attribute.
+            $elem.removeAttr( 'style' );
+          else
+            // Otherwise, reset the element style attribute.
+            $elem.attr( 'style', _tmp );
+
+        });
+        // Reset the tmp array.
+        _self.tmp = [];
+        // Reset the hidden elements variable.
+        _self.hidden = null;
+
+      } // end reset
+
+    }; // end return
+
+  };
+
+
+})( jQuery, this );


### PR DESCRIPTION
When dropdown buttons are hidden on the page, their outerHeight calculation is incorrect, resulting in bad placement of the dropdown list. This fixes that. See commit notes for more information.
