### PR TITLE
toggleRadio must only search for inputs in $input's form, not all over the DOM

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -376,11 +376,11 @@
 
   var toggleRadio = function($element) {
     var $input = $element.prev(),
+        $form = $input.closest('form.custom'),
         input = $input[0];
 
     if (false === $input.is(':disabled')) {
-
-      $('input:radio[name="' + $input.attr('name') + '"]').next().not($element).removeClass('checked');
+      $form.find('input:radio[name="' + $input.attr('name') + '"]').next().not($element).removeClass('checked');
       if ( !$element.hasClass('checked') ) {
         $element.toggleClass('checked');
       }


### PR DESCRIPTION
Hi!

Yesterday I came up with an annoying situation. I had two different forms using radios with the same names and everytime I picked one, the other one was unchecked.

Take a look: http://dev.vitoravelino.net/foundation/

I restricted the search for the input radios only for the input's form.

Thanks! 
