### PR TITLE
Fixed wrong css class name for caption workaround in IE

### DIFF
--- a/scss/foundation/components/modules/_orbit.scss
+++ b/scss/foundation/components/modules/_orbit.scss
@@ -76,7 +76,7 @@
 
   /* Correct timer in IE */
   .lt-ie9 .timer { display: none !important; }
-  .lt-ie9 div.caption { background: $orbitCaptionBgColorOldBrowser; filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#99000000,endColorstr=#99000000);zoom: 1; }
+  .lt-ie9 div.orbit-caption { background: $orbitCaptionBgColorOldBrowser; filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#99000000,endColorstr=#99000000);zoom: 1; }
 
 // Allow slides to be stacked on mobile devices
 @media only screen and (max-width: $screenSmall - 1) {


### PR DESCRIPTION
The class of the caption div was `caption`, but I think it should be `orbit-caption`.
