### PR TITLE
give all slides opacity:0 to start

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -135,7 +135,7 @@
         this.$element.addClass('orbit-stack-on-small');
       }
 
-      this.$slides.addClass('orbit-slide');
+      this.$slides.addClass('orbit-slide').css({"opacity" : 0});
 
       this.setDimentionsFromLargestSlide();
       this.updateOptionsIfOnlyOneSlide();


### PR DESCRIPTION
Slides don't receive opacity attribute until cycled through once. If
first slide is transparent, other slides show through.
