### PR TITLE
Fixed orbit single cycle feature

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -642,7 +642,7 @@
         this.setCaption();
       }
 
-      if (this.$slides.last() && this.options.singleCycle) {
+      if (this.currentSlide().is(":last-child") && this.options.singleCycle) {
         this.stopClock();
       }
     }


### PR DESCRIPTION
Sadly, the orbit single cycle feature actually never really worked. The if clause `this.$slides.last()` was always true, because `.last()` just returns the last object of the list `this.$slides`.

Not sure whether `this.currentSlide().is(":last-child")` is the nicest solution, but it works. Open for feedback.
