### PR TITLE
Fix for non-links inside rounded button groups

### DIFF
--- a/scss/foundation/components/modules/_buttons.scss
+++ b/scss/foundation/components/modules/_buttons.scss
@@ -150,16 +150,14 @@
     }
 
     &.radius li {
-      a, input[type="submit"] {
-        &.button, &.button.radius, &.button-rounded { @include border-radius(0px); }
+      .button, .button.radius, .button-rounded { @include border-radius(0px); }
+      &:first-child {
+        .button, .button.radius { @include border-corner-radius(top, $defaultFloat, $buttonRadius); @include border-corner-radius(bottom, $defaultFloat, $buttonRadius); }
+        .button.rounded { @include border-corner-radius(top, $defaultFloat, 1000px); @include border-corner-radius(bottom, $defaultFloat, 1000px); }
       }
-      &:first-child a, &:first-child input[type="submit"] {
-        &.button, &.button.radius { @include border-corner-radius(top, $defaultFloat, $buttonRadius); @include border-corner-radius(bottom, $defaultFloat, $buttonRadius); }
-        &.button.rounded { @include border-corner-radius(top, $defaultFloat, 1000px); @include border-corner-radius(bottom, $defaultFloat, 1000px); }
-      }
-      &:last-child a, &:last-child input[type="submit"] {
-        &.button, &.button.radius { @include border-corner-radius(top, $defaultOpposite, $buttonRadius); @include border-corner-radius(bottom, $defaultOpposite, $buttonRadius); }
-        &.button.rounded { @include border-corner-radius(top, $defaultOpposite, 1000px); @include border-corner-radius(bottom, $defaultOpposite, 1000px); }
+      &:last-child {
+        .button, .button.radius { @include border-corner-radius(top, $defaultOpposite, $buttonRadius); @include border-corner-radius(bottom, $defaultOpposite, $buttonRadius); }
+        .button.rounded { @include border-corner-radius(top, $defaultOpposite, 1000px); @include border-corner-radius(bottom, $defaultOpposite, 1000px); }
       }
     }
 


### PR DESCRIPTION
If an element inside a rounded button groups is not a link (spans, button, etc) it still has full border radius. See issue #1189
