### PR TITLE
Bring back jQuery show() and toggle()

### DIFF
--- a/scss/foundation/common/_globals.scss
+++ b/scss/foundation/common/_globals.scss
@@ -21,7 +21,7 @@
   .text-left   { text-align: left; }
   .text-right  { text-align: right; }
   .text-center { text-align: center; }
-  .hide        { display: none !important; }
+  .hide        { display: none; }
   .highlight   { background: $highlightColor; }
 
   #googlemap img, object, embed { max-width: none; }


### PR DESCRIPTION
Breaks jQuery show() & toggle() which rely on setting the inline style display=block.

The jQuery inline style will be overridden by the important! display: none style in this commit.

This reverts commit 06151af561e9cee0b937651066d4e5038c21f0e9.
