### PR TITLE
Fix Custom Select Arrow Box Height Issue

### DIFF
--- a/scss/foundation/common/_forms.scss
+++ b/scss/foundation/common/_forms.scss
@@ -114,6 +114,6 @@
 
   /* Correct FF custom dropdown height */
   @-moz-document url-prefix() {
-    form.custom div.custom.dropdown a.selector { height: 30px; }
+    form.custom div.custom.dropdown a.selector { height: 28px; }
   }
-  .lt-ie9 form.custom div.custom.dropdown a.selector { height: 30px; }
+  .lt-ie9 form.custom div.custom.dropdown a.selector { height: 28px; }


### PR DESCRIPTION
It seems that the following `30px` (which makes the little box with the dropdown arrow _taller_ than the rest of the dropdown) might be a mistake (perhaps missed during a previous change?):

``` css
/* Correct FF custom dropdown height */
@-moz-document url-prefix() {
  form.custom div.custom.dropdown a.selector { height: 30px; }
}
.lt-ie9 form.custom div.custom.dropdown a.selector { height: 30px; }
```

https://github.com/zurb/foundation/blob/master/scss/foundation/common/_forms.scss#L115

It looks like it should be `28px` as it is earlier in the code (eg, https://github.com/zurb/foundation/blob/master/scss/foundation/common/_forms.scss#L72 and following lines)?

This Pull Request fixes this.
