### PR TITLE
Default/custom class to disable custom JS inputs was not working

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -100,7 +100,7 @@
   $.foundation.customForms.appendCustomMarkup = function ( options ) {
 
     var defaults = {
-      disable_class: "js-disable-custom"
+      disable_class: "no-custom"
     };
 
     options = $.extend( defaults, options );
@@ -165,7 +165,7 @@
       //
       // Should we not create a custom list?
       //
-      if ( $this.hasClass( 'no-custom' ) ) return;
+      if ( $this.hasClass( options.disable_class ) ) return;
 
       //
       // Did we not create a custom select element yet?


### PR DESCRIPTION
The class to disable JS custom inputs was hard-coded, changed it to check options.disable_input and changed the default option to the one hard-coded (basically changed the default from js-disable-input to no-custom).
