### PR TITLE
Orbit singleCycle, fix bug in conditional

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -650,7 +650,9 @@
         this.setCaption();
       }
 
-      if (this.$slides.last() && this.options.singleCycle) {
+      // if on last slide and singleCycle is true, don't loop through slides again
+      // .length is zero based so must minus 1 to match activeSlide index
+      if (this.activeSlide === this.$slides.length-1 && this.options.singleCycle) {
         this.stopClock();
       }
     }


### PR DESCRIPTION
```
if (this.$slides.last() && this.options.singleCycle) {
```

.last() returns a jQ object, not a boolean
fixed with:

```
 if (this.activeSlide === this.$slides.length-1 && this.options.singleCycle) {
```
