### PR TITLE
remove leading '#' from captionLocation in foundation.orbit.js

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -387,6 +387,10 @@
         if ($.trim($(captionLocation).text()).length < 1){
           return false;
         }
+        // if location selector starts with '#', remove it so we don't see id="#selector"
+        if (captionLocation.charAt(0) == '#') {
+            captionLocation = captionLocation.substring(1, captionLocation.length);
+        }
         captionHTML = $(captionLocation).html(); //get HTML from the matching HTML entity
         this.$caption
           .attr('id', captionLocation) // Add ID caption TODO why is the id being set?


### PR DESCRIPTION
If the caption for an orbit slider is set like

```
data-caption="#someDiv"
```

Then line 392 sets the `id` attribute of the element containing the caption to `#someDiv`.

This patch removes the leading `#` in the selector if it exists before applying it to the `id` attribute, so that any CSS rules designed to target a specific caption for a specific slider frame can work.
