### PR TITLE
Allow tooltip content to be specified directly.

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -56,13 +56,13 @@
 
         });
       },
-      showOrCreateTip : function ($target) {
+      showOrCreateTip : function ($target, content) {
         var $tip = methods.getTip($target);
 
         if ($tip && $tip.length > 0) {
           methods.show($target);
         } else {
-          methods.create($target);
+          methods.create($target, content);
         }
       },
       getTip : function ($target) {
@@ -84,8 +84,9 @@
         }
         return (id) ? id : dataSelector;
       },
-      create : function ($target) {
-        var $tip = $(settings.tipTemplate(methods.selector($target), $('<div>').html($target.attr('title')).html())),
+      create : function ($target, content) {
+        var $tip = $(settings.tipTemplate(methods.selector($target),
+          $('<div>').html(content ? content : $target.attr('title')).html())),
           classes = methods.inheritable_classes($target);
 
         $tip.addClass(classes).appendTo('body');


### PR DESCRIPTION
This change allows a user to directly specify the content of a tooltip. This is particularly useful when using an MV\* framework and the text you want to use is in the model rather than the view.

**Example:**

```
model = {
    message: "my message"
}

$(document).foundationTooltips("showOrCreate", $(el), model.message);
```
