### PR TITLE
Update vendor/assets/javascripts/foundation/jquery.foundation.orbit.js

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -392,7 +392,7 @@
         if (captionLocation.charAt(0) == '#') {
             captionLocation = captionLocation.substring(1, captionLocation.length);
         }
-        captionHTML = $(captionLocation).html(); //get HTML from the matching HTML entity
+        captionHTML = $('#' + captionLocation).html(); //get HTML from the matching HTML entity
         this.$caption
           .attr('id', captionLocation) // Add ID caption TODO why is the id being set?
           .html(captionHTML); // Change HTML in Caption


### PR DESCRIPTION
I found an error on the jQuery lookup for the caption to display in an orbit slider.

The code was stripping the '#' off of the captionLocation thus the lookup was failing.

I think this fixes #1268
