### PR TITLE
Fix three/four/five-up tab styling on ul>li

### DIFF
--- a/scss/foundation/components/modules/_tabs.scss
+++ b/scss/foundation/components/modules/_tabs.scss
@@ -49,9 +49,9 @@
       dt a, dd a, li a { padding: 0 ms(1); text-align: center; overflow: hidden; }
     }
     &.two-up dt, &.two-up dd, &.two-up li      { width: 50%; }
-    &.three-up dt, &.three-up dd, &.two-up li  { width: 33.33%; }
-    &.four-up dt, &.four-up dd, &.two-up li    { width: 25%; }
-    &.five-up dt, &.five-up dd, &.two-up li    { width: 20%; }
+    &.three-up dt, &.three-up dd, &.three-up li  { width: 33.33%; }
+    &.four-up dt, &.four-up dd, &.four-up li    { width: 25%; }
+    &.five-up dt, &.five-up dd, &.five-up li    { width: 20%; }
   }
 
   ul.tabs-content { display: block; margin: 0 0 20px; padding: 0;


### PR DESCRIPTION
I just noticed that three-up, four-up and five-up dont work on ul > li lists.

Looks like a simple copy-paste typo
