### PR TITLE
Add missing units into default tooltip font sizes

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -144,10 +144,10 @@ $tooltipBackgroundOpacity: 0.85 !default;
 $tooltipFontSize: 12px !default;
 $tooltipFontWeight: bold !default;
 $tooltipFontColor: #fff !default;
-$tapToCloseFontSize: 10 !default;
+$tapToCloseFontSize: 10px !default;
 $tapToCloseFontWeight: normal !default;
 $tapToCloseFontColor: #888 !default;
-$tooltipFontSizeScreenSm: 14 !default;
+$tooltipFontSizeScreenSm: 14px !default;
 $tooltipBgOpacityScreenSm: 0.85 !default;
 $tooltipBorderRadius: 4px !default;
 


### PR DESCRIPTION
Spotted this one through the w3c validator!
