### PR TITLE
added storing prev value in dropdown

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -474,10 +474,11 @@
     event.stopPropagation();
     $('div.dropdown').removeClass('open');
 
-    $this
+    $oldThis= $this
       .closest('ul')
-      .find('li')
-      .removeClass('selected');
+      .find('li.selected');
+    $oldThis.removeClass('selected');
+
     $this.addClass('selected');
 
     $customDropdown
@@ -493,8 +494,12 @@
     });
     $select[0].selectedIndex = selectedIndex;
 
-    $select.trigger('change');
+	//store the old value in data
+	console.log($select);
+	$select.data('prevalue', $oldThis.html());
+  $select.trigger('change');
   });
+
 
 
   $.fn.foundationCustomForms = $.foundation.customForms.appendCustomMarkup;


### PR DESCRIPTION
CAUTION!!!! I've just realized i've left a console.log();    :s 

Added store the old select value in data('prevalue').

So you can use it, later; since you can't grab it via the option.focus event
