### PR TITLE
input[type=reset] doesn't expand for small devices

### DIFF
--- a/scss/foundation/components/modules/_mqueries.scss
+++ b/scss/foundation/components/modules/_mqueries.scss
@@ -259,7 +259,7 @@
 
     /* Basic overrides */
     .button { display: block; }
-    button.button, input[type="submit"].button { width: 100%; padding-#{$defaultFloat}: 0; padding-#{$defaultOpposite}: 0; }
+    button.button, input[type="submit"].button, input[type="reset"] { width: 100%; padding-#{$defaultFloat}: 0; padding-#{$defaultOpposite}: 0; }
     /* Button Groups */
     .button-group {
       button.button, input[type="submit"].button { width: auto; padding: $btnBase ($btnBase * 2) ($btnBase + 1);

--- a/scss/foundation/components/modules/_mqueries.scss
+++ b/scss/foundation/components/modules/_mqueries.scss
@@ -259,7 +259,7 @@
 
     /* Basic overrides */
     .button { display: block; }
-    button.button, input[type="submit"].button, input[type="reset"] { width: 100%; padding-#{$defaultFloat}: 0; padding-#{$defaultOpposite}: 0; }
+    button.button, input[type="submit"].button, input[type="reset"].button { width: 100%; padding-#{$defaultFloat}: 0; padding-#{$defaultOpposite}: 0; }
     /* Button Groups */
     .button-group {
       button.button, input[type="submit"].button { width: auto; padding: $btnBase ($btnBase * 2) ($btnBase + 1);


### PR DESCRIPTION
Added input[type="reset"] to expand 100% width for small devices
