### PR TITLE
Use max-width instead of width for tooltips

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -112,7 +112,7 @@
             'bottom' : bottom,
             'left' : left,
             'right' : right,
-            'width' : (width) ? width : 'auto'
+            'max-width' : (width) ? width : 'auto'
           }).end();
         };
 


### PR DESCRIPTION
Hey!

I caught another thing while I was working last week around the tooltips. Actually it's a suggestion instead of a bug.

Be possible to set a tooltip width is great, but not if its content is _dynamic_. 

**Attention!** If the intention of data-width is to have exactly a static width, forget about this. I just thought too loud.

Currently, we only have two possibilities:
### Default

![Automatic width based on the title length](http://dl.dropbox.com/u/27144161/Screenshots/z.png) 
### Static width

![Static width](http://dl.dropbox.com/u/27144161/Screenshots/-.png)

That's not a problem if we always have a title with a big length. See below what happen if we have a title with a smaller content:

![Using max-width having a smaller content](http://dl.dropbox.com/u/27144161/Screenshots/_.png)

My suggestion is to put a third state that fits the title length if it is less than the width chosen. That is only possible using max-width. See the examples below:

![Using max-width](http://dl.dropbox.com/u/27144161/Screenshots/~.png)

Of course that we could solve this problem not setting the data-width and putting a custom max-width for _.tooltip_. It's actually even faster to use a CSS solution but we can't limit that for a specific set of tooltips since we don't have a scope defined because the .tooltip divs are appended at the end of body.

If you want to see all of them in action, please visit [here](http://dev.vitoravelino.net/foundation2/).

Happy New Year!

Cheers.
