### PR TITLE
Centered top and bottom tooltips above or below an element.

### DIFF
--- a/scss/foundation/components/modules/_ui.scss
+++ b/scss/foundation/components/modules/_ui.scss
@@ -62,7 +62,7 @@
 
     &>.nub { display: block; width: 0; height: 0; border: solid 5px; border-color: transparent transparent $tooltipBackgroundColor transparent; border-color: transparent transparent rgba($tooltipBackgroundColor,$tooltipBackgroundOpacity) transparent; position: absolute; top: -10px; #{$defaultFloat}: 10px; }
     &.tip-override>.nub { border-color: transparent transparent $tooltipBackgroundColor transparent !important; border-color: transparent transparent rgba($tooltipBackgroundColor,$tooltipBackgroundOpacity) transparent !important; top: -10px !important; }
-    &.tip-top>.nub { border-color: $tooltipBackgroundColor transparent transparent transparent; border-color: rgba($tooltipBackgroundColor,$tooltipBackgroundOpacity) transparent transparent transparent; top: auto; bottom: -10px; }
+    &.tip-top>.nub, &.tip-centered-top>.nub  { border-color: $tooltipBackgroundColor transparent transparent transparent; border-color: rgba($tooltipBackgroundColor,$tooltipBackgroundOpacity) transparent transparent transparent; top: auto; bottom: -10px; }
 
     &.tip-left, &.tip-right { float: none !important; }
 

--- a/test/elements.html
+++ b/test/elements.html
@@ -168,7 +168,7 @@
         </div>
         <br>
         <div class="eight columns">
-          <p>The tooltips can be positioned on the <span class="has-tip" data-width="210" title="I'm on bottom and the default position.">"tip-bottom"</span>, which is the default position, <span class="has-tip tip-top noradius" data-width="210" title="I'm on the top and I'm not rounded!">"tip-top" (hehe)</span>, <span class="has-tip tip-left" data-width="90" title="I'm on the left!">"tip-left"</span>, or <span class="has-tip tip-right" data-width="120" title="I'm on the right!">"tip-right"</span> of the target element. On a small device, the tooltips are full width and bottom aligned.</p>
+          <p>The tooltips can be positioned on the <span class="has-tip" data-width="210" title="I'm on bottom and the default position.">"tip-bottom"</span>, which is the default position, <span class="has-tip tip-top noradius" data-width="210" title="I'm on the top and I'm not rounded!">"tip-top" (hehe)</span>, <span class="has-tip tip-left" data-width="90" title="I'm on the left!">"tip-left"</span>, or <span class="has-tip tip-right" data-width="120" title="I'm on the right!">"tip-right"</span> of the target element. Centered tips are avaliable in bottom <span class="has-tip tip-centered-bottom" data-width="180" title="I'm a centered tip below the target element.">tip-centered-bottom</span> and in top <span class="has-tip tip-centered-top" data-width="120" title="I'm a centered tip above the target element.">tip-centered-top</span> flavors for an element. On a small device, the tooltips are full width and bottom aligned.</p>
 
           <h3>Custom Options</h3>
           <p>

--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -10,6 +10,7 @@
 
 ;(function ($, window, undefined) {
   'use strict';
+  
   var settings = {
       bodyHeight : 0,
       selector : '.has-tip',
@@ -160,6 +161,7 @@
                 return el;
               }
           }).join(' ') : '';
+          
         return $.trim(filtered);
       },
       show : function ($target) {

--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -10,7 +10,6 @@
 
 ;(function ($, window, undefined) {
   'use strict';
-
   var settings = {
       bodyHeight : 0,
       selector : '.has-tip',
@@ -141,19 +140,26 @@
             objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight), 'auto', 'auto', (target.offset().left + target.outerWidth() + 10), width)
               .removeClass('tip-override');
             objPos(nub, (tip.outerHeight() / 2) - (nubHeight / 2), 'auto', 'auto', -nubHeight);
+          } else if (classes && classes.indexOf('tip-centered-top') > -1) {
+            objPos(tip, (target.offset().top - tip.outerHeight() - nubHeight), 'auto', 'auto', (target.offset().left + ((target.outerWidth() - tip.outerWidth()) / 2) ), width)
+              .removeClass('tip-override');
+            objPos(nub, 'auto', ((tip.outerWidth() / 2) -(nubHeight / 2)), -nubHeight, 'auto');
+          } else if (classes && classes.indexOf('tip-centered-bottom') > -1) {
+            objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', (target.offset().left + ((target.outerWidth() - tip.outerWidth()) / 2) ), width)
+              .removeClass('tip-override');
+            objPos(nub, -nubHeight, ((tip.outerWidth() / 2) -(nubHeight / 2)), 'auto', 'auto');
           }
         }
         tip.css('visibility', 'visible').hide();
       },
       inheritable_classes : function (target) {
-        var inheritables = ['tip-top', 'tip-left', 'tip-bottom', 'tip-right', 'noradius'].concat(settings.additionalInheritableClasses),
+        var inheritables = ['tip-top', 'tip-left', 'tip-bottom', 'tip-right', 'tip-centered-top', 'tip-centered-bottom', 'noradius'].concat(settings.additionalInheritableClasses),
           classes = target.attr('class'),
           filtered = classes ? $.map(classes.split(' '), function (el, i) {
               if ($.inArray(el, inheritables) !== -1) {
                 return el;
               }
           }).join(' ') : '';
-
         return $.trim(filtered);
       },
       show : function ($target) {


### PR DESCRIPTION
Centered top and bottom tooltips by adding the classes tip-centered-top and tip-centered-bottom along side has-tip. The tooltip is positioned centered whether the tooltip is wider or narrower than the target element.  The nub is positioned in the middle of the tool tip. 

```
<span class="has-tip tip-centered-top" data-width="120" title="I'm a centered tip above the target element.">tip-centered-top</span>

<span class="has-tip tip-centered-bottom" data-width="120" title="I'm a centered tip below the target element.">tip-centered-top</span>
```

![centered-tooltip-bottom](https://f.cloud.github.com/assets/647691/44738/d9ba83ca-56f1-11e2-87ea-d9a3a2d95e9c.png)
