### PR TITLE
Sticky Top Bar

### DIFF
--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -25,7 +25,6 @@
   
   .sticky {
   	float: left;
-  	margin-bottom: 10px;
   
   .sticky.fixed {
   	float: none;

--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -123,7 +123,7 @@
       /* Right Side <ul> */
       &.right { float: right; width: auto; margin-bottom: 0;
         /* Dropdown Right Side Alignment */
-        .has-dropdown .dropdown { left: auto; right: -1px;
+        .has-dropdown .dropdown { left: auto; right: 0px;
           li.has-dropdown > .dropdown { right: 100%; left: auto; width: 100%; }
         }
       }

--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -25,6 +25,7 @@
   
   .sticky {
   	float: left;
+  	overflow: hidden;
   
   .sticky.fixed {
   	float: none;

--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -20,12 +20,22 @@
 
   /* Wrapped around .top-bar to make it fixed at the top */
   .fixed { width: 100%; left: 0; position: fixed; top: 0; z-index: 99; }
+  
+  /* Add .sticky class for using top bar as a sticky navigation when scrolling passed it. Add the class .sticky to a top bar using .contain-to-grid but leave off .fixed, javascript will take care of that */
+  
+  .sticky {
+  	float: left;
+  	margin-bottom: 10px;
+  
+  .sticky.fixed {
+  	float: none;
+  }   
 
   /* <nav> */
   .top-bar { background: $topBarBgColor; height: $topBarHeight; line-height: $topBarHeight; margin: 0 0 $topBarBtmMargin; padding: 0; width: 100%; position: relative;
 
     /* Contain width to .row width */
-    .contain-to-grid & { max-width: $rowWidth; margin: 0 auto; }
+    .contain-to-grid & { max-width: $rowWidth; margin: 0 auto; } 
 
     /* First <ul> for branding, title, name, etc */
     &>ul {

--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -154,5 +154,18 @@
       $.error('Method ' +  method + ' does not exist on jQuery.foundationTopBar');
     }
   };
+  
+  var distance = $('.sticky').offset().top,
+      $window = $(window);
+  
+  $window.scroll(function() {
+      if ( $window.scrollTop() >= distance ) {
+         $(".sticky").addClass("fixed");
+      }
+      
+     else if ( $window.scrollTop() < distance ) {
+        $(".sticky").removeClass("fixed");
+     }
+  });
 
 }(jQuery, this));


### PR DESCRIPTION
Using the top-bar with the class `.sticky` and `.contain-to-grid`, it can be placed anywhere in the document. For example, under a heading but before the main content starts. 

Once the page is scrolled to where the navigation is, the class .fixed is added automatically and it remains at the top of the page. When scrolling back up, the class .fixed is removed once it hits it's
original position.

A `float: left` was added to so there's no jump in element position once the `.fixed` class is added during scrolling which causes a jump in the browser when scrolling (as the top-bar is taken out of the page flow). 

Edit: It provides this type of feature found with the jQuery sticky plugin - http://stickyjs.com/ but requires no additional plugins and is supported by Foundation. 
