### PR TITLE
_semantic-grid.scss: changed how margins are set for centered column

### DIFF
--- a/scss/foundation/mixins/_semantic-grid.scss
+++ b/scss/foundation/mixins/_semantic-grid.scss
@@ -17,7 +17,7 @@
   // Columns mixin, syntax is ($columns, $behavior). Behavior can be 'centered' which centers things or 'collapse' which collapses the gutters. ex @include row(4,[center | collapse])
 
   @mixin column($columns:$columns, $behavior: false) {
-      @if      $behavior == center   { @extend %fl-n; margin: 0 auto !important; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; }
+      @if      $behavior == center   { @extend %fl-n; margin-left: auto; margin-right: auto; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; }
     } @else if $behavior == collapse { @extend %fl-l; @extend %c-base; padding: 0; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; }
     } @else                          { @extend %fl-l; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; } }
   }


### PR DESCRIPTION
No longer using !important; no longer setting top and bottom values.

Reasoning: 
1) If developers currently want to add top/bottom margins to a centered column, they have to use !important, to override the semantic grid's !important. This could result in lots of !importants.

2) If developers want to adjust left/right margins of a centered column - for example, if the design changes at a higher breakpoint - they would have to use !important, to override the semantic grid's !important. This could result in lots of !importants.
