### PR TITLE
_grid.scss: remove height for object and embed tags

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -43,8 +43,8 @@
     .pull-#{convert-number-to-word($i)} { #{$defaultOpposite}: gridCalc($i, $totalColumns); }
   }
 
-  img, object, embed { max-width: 100%; height: auto; }
-  object, embed { height: 100%; }
+  img { height: auto; }
+  img, object, embed { max-width: 100%; }
   img { -ms-interpolation-mode: bicubic; }
   #map_canvas img, .map_canvas img {max-width: none!important;}
 


### PR DESCRIPTION
Currently, object and embed tags have their height set in _grid.scss to height:auto; and height:100%;

However, height:auto and height:100% on those tags alter the content dimensions, and - as far as I've found - there is no way to unset those values without inline styles. This is a problem when dealing with ad servers because the content should always be rendered full size. Therefore I have removed height for both object and embed tags.

If some Foundation users require height:auto; and height:100%; on object and embed tags, how about attaching that to a helper class?

Further details with minimal test case:
http://toddwelstein.com/zurb/flash-ads/
