### PR TITLE
Close a Reveal modal with a button by adding the "close-reveal-modal" class (no additional javascript required)

### DIFF
--- a/scss/foundation/components/modules/_reveal.scss
+++ b/scss/foundation/components/modules/_reveal.scss
@@ -9,7 +9,7 @@
   .reveal-modal-bg { position: fixed; height: 100%; width: 100%; background: #000; background: rgba(#000, .45); z-index: 40; display: none; top: 0; #{$defaultFloat}: 0; }
 
   .reveal-modal { background: #fff; visibility: hidden; display: none; top: 100px; #{$defaultFloat}: 50%; margin-#{$defaultFloat}: -260px; width: 520px; position: absolute; z-index: 41; padding: 30px; @include box-shadow(0 0 10px rgba(#000,.4));
-    .close-reveal-modal {
+    .close-reveal-modal:not(.button) {
       @include font-size(22);
       line-height: .5;
       position: absolute;


### PR DESCRIPTION
Allows you to assign the .close-reveal-modal class to a .button within a
.reveal-modal, allowing the user to close the modal by clicking the
button.

Example: 

``` html
<div id="myModal" class="reveal-modal">
    <a class="close-reveal-modal">&#215;</a>
    <p>
        Click the button below to close me.
    </p>
    <a href="#" class="button close-reveal-modal">Close</a>
</div>
```

Utilizes the CSS :not() selector to ensure that the styles applied to
the close "x" displayed in the top right (or left depending on your
$defaultOpposite variable) corner of the modal are not applied to the
button.
