### PR TITLE
_semantic-grid.scss: changed columns on small screen to float:none; width:auto; (non mobile grid)

### DIFF
--- a/scss/foundation/mixins/_semantic-grid.scss
+++ b/scss/foundation/mixins/_semantic-grid.scss
@@ -17,9 +17,9 @@
   // Columns mixin, syntax is ($columns, $behavior). Behavior can be 'centered' which centers things or 'collapse' which collapses the gutters. ex @include row(4,[center | collapse])
 
   @mixin column($columns:$columns, $behavior: false) {
-      @if      $behavior == center   { @extend %fl-n; margin-left: auto; margin-right: auto; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; }
-    } @else if $behavior == collapse { @extend %fl-l; @extend %c-base; padding: 0; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; }
-    } @else                          { @extend %fl-l; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: left; width: 100%; } }
+      @if      $behavior == center   { @extend %fl-n; margin-left: auto; margin-right: auto; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: none; width: auto; }
+    } @else if $behavior == collapse { @extend %fl-l; @extend %c-base; padding: 0; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: none; width: auto; }
+    } @else                          { @extend %fl-l; @extend %c-base; width: gridCalc($columns, $totalColumns); @include respondTo(smallScreen) { float: none; width: auto; } }
   }
 
   // Offset Mixin, include after a column mixin to manipulate its grid offset.


### PR DESCRIPTION
Using {float:none; width:auto;} on non-mobile-grid columns at small screen. Changed from {float:left; width:100%;}

Reasoning: If Foundation user's aren't employing a mobile grid, columns should always stack on top of each other at small screen; they don't need to float. Changing width from 100% to auto allows additional left/right margin on the element without exceeding parent container's width.

It appears standard Foundation CSS does not have the problem (stylesheets/foundation.css uses {float:none; width:auto;} for non-mobile-grid columns at small screen). 

Minimal test case: http://toddwelstein.com/zurb/small-screen-widths/ 
More about width auto vs. 100%: http://www.456bereastreet.com/lab/width-auto/
