### PR TITLE
Added command-line JS testing with Grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ marketing/.sass-cache/*
 test/.sass-cache/*
 test/stylesheets/styles.css
 *.orig
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,27 @@ This is the Foundation project.  We love making super awesome stuff, but even mo
 
 ## Testing
 
+### Styles
+
 Go into the test/ directory.  Run `bundle exec compass compile` or `bundle exec compass watch` if you're making changes and want to see them reflected on-the-fly.
 
 Want to add a feature to Foundation?  Either update one of the test/*.html files or copy `test/template.html` to a new file, add your markup to it and check it in.
+
+### JavaScript
+
+The Foundation JS libraries are tested with qUnit. You can run the tests in your browser by opening up the respective `.html` files in `test/javascripts/tests/`.
+
+For more convenient testing using the command line and watcher functionality, you can also run the tests through Grunt with PhantomJS.
+
+**Setting up Grunt for command line testing. **
+
+1. Install [PhantomJS](http://phantomjs.org/)
+2. Install [Node.js](http://nodejs.org/)
+3. You may need to reboot your machine to make sure your PATH is up to date.
+4. From the root of the project, `npm install`. This will install the grunt tasks locally.
+5. Install the grunt command line interface with `npm install -g grunt-cli`.
+
+Now you should have two new commands available. `grunt qunit` will execute all of the qUnit tests. `grunt watch` will watch for changes to the JS files and test files, and execute the tests when something changes.
 
 ## Compass Project
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The Foundation JS libraries are tested with qUnit. You can run the tests in your
 
 For more convenient testing using the command line and watcher functionality, you can also run the tests through Grunt with PhantomJS.
 
-**Setting up Grunt for command line testing. **
+**Setting up Grunt for command line testing.**
 
 1. Install [PhantomJS](http://phantomjs.org/)
 2. Install [Node.js](http://nodejs.org/)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,27 @@
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks('grunt-contrib-qunit');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+
+    grunt.initConfig({
+      qunit: {
+        all: ['test/javascripts/tests/**/*.html']
+      },
+      watch: {
+        all: {
+            files: [
+                'test/javascripts/tests/**/*.html',
+                'test/javascripts/tests/**/*.js',
+                'lib/assets/javascripts/foundation/*.js'
+            ],
+            tasks: 'default',
+            options: {
+                interrupt: true
+            }
+        }
+      }
+    });
+
+    // Default task.
+    grunt.registerTask('default', ['qunit']);
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "zurb-foundation",
+  "version": "4.0.0-wip",
+  "devDependencies": {
+    "grunt": "~0.4.0",
+    "grunt-contrib-watch": "~0.1.0",
+    "grunt-contrib-qunit": "~0.1.1"
+  }
+}


### PR DESCRIPTION
As previously mentioned in #1369.

In addition to giving us a nicer way to run unit tests, using grunt means that we could easily add other sorts of quality/build steps easily in the future. For instance, it would be trivial to add a lint task that would also run in the watcher.

Just let me know if you have any questions or see anything you'd like for me to change.
