### PR TITLE
Fix for $.fn.foundationTooltips('destroy')

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js
@@ -182,11 +182,17 @@
       },
       destroy : function () {
         return this.each(function () {
-          $(window).off('.tooltip');
-          $(settings.selector).off('.tooltip');
-          $(settings.tooltipClass).each(function (i) {
-            $($(settings.selector).get(i)).attr('title', $(this).text());
+          var $selector = $(settings.selector);
+          
+          $('body').off('.tooltip', settings.selector);
+          
+          $(settings.tooltipClass).each(function () {
+            var $this = $(this),
+              dataFilter = '[data-selector=' + $this.data('selector') + ']';
+              
+            $selector.filter(dataFilter).attr('title', $this.text());
           }).remove();
+          
         });
       }
     };


### PR DESCRIPTION
The `destroy` function uses the index of the tooltip to re-populate the title attribute of the target element with the matching index.
This is incorrect because tooltips are added to the DOM on mouseenter, therefore each tooltip may not have the same index as the target element.

Patch attached.
