### PR TITLE
New component: Switch.

### DIFF
--- a/scss/foundation/components/large-screen/_all.scss
+++ b/scss/foundation/components/large-screen/_all.scss
@@ -1,5 +1,6 @@
 @import "grid";
 @import "buttons";
+@import "switch";
 @import "navbar";
 // @import "topbar";
 // @import "orbit";

--- a/scss/foundation/components/large-screen/_switch.scss
+++ b/scss/foundation/components/large-screen/_switch.scss
@@ -1,0 +1,124 @@
+/* Styles for modern browsers */
+@media only screen {
+  
+  /* Multiple State Switch
+	 */
+  
+  /* Up-Down padding for the regular switch */
+  $regularBase: 10px;
+  
+  /* Class names for the multiple states */
+  $switchStates: 3, 4, 5; 
+  
+  /* Generate the class names for the multiple states */
+  $switchClasses: ();
+  @each $switch in $switchStates {
+    $switchClasses: join($switchClasses, unquote(".switch-#{$switch}"), comma);
+  }
+  
+  $switchClasses: join(unquote(".switch"), $switchClasses, comma);
+  
+  /* Two-state switch and shared styles between all states */
+  #{$switchClasses} {
+    position: relative;
+    padding: 0;
+    
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    
+    /* Sizes */
+    &.large label {
+      padding: $largeBtnBase 0;
+      font-size: ms(1);
+    }
+    &.small label { 
+    	font-size: ms(0) - 3; 
+      padding: $smallBtnBase 0;
+    }
+    &.tiny label { 
+    	font-size: ms(0) - 4; 
+      padding: $tinyBtnBase 0;
+    }
+    
+    label {
+      position: relative;
+      z-index: 2;
+      
+      float: left;
+      width: 50%;
+      height: 100%;
+      margin: 0;
+      padding: $regularBase 0;
+      
+      font-size: ms(0); 
+      font-weight: bold;
+      text-align: center;
+    }
+
+    .slide-button {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 1;
+
+      display: block;      
+      width: 50%;
+      height: 100%;
+      padding: 0;
+
+      @include transition-property(all);
+      @include transition-duration(0.3s);
+      @include transition-timing-function(ease-out);
+    }
+
+    input {
+      position: absolute;
+      opacity: 0;
+    }
+    
+    /* Outline the toggles when the inputs are focused */
+    input:focus + label {
+      outline: 1px dotted #888;
+    }
+
+    input:last-of-type:checked ~ .slide-button {
+      left: 50%;
+    }
+    
+    /* Bugfix for older Webkit, including mobile Webkit. Adapted from:
+     * http://css-tricks.com/webkit-sibling-bug/
+     */
+    -webkit-animation: webkitSiblingBugfix infinite 1s;
+    
+  }
+  
+  @-webkit-keyframes webkitSiblingBugfix { from { position: relative; } to { position: relative; } }
+  
+  /* Generate styles for the multiple states */
+  @for $i from 1 through length($switchStates) {
+    $state: nth($switchStates, $i);
+    $width: 100 / ($i + 2);
+    
+    .switch-#{$state} {
+      label,
+      .slide-button {
+        width: $width * 1%;
+      }
+    }
+    
+    @for $j from 2 through ($i + 1) {
+    
+      .switch-#{$state} input:checked:nth-of-type(#{$j}) ~ .slide-button {
+        left: $width * ($j - 1) * 1%;
+      }
+    
+    }
+    
+    .switch-#{$state} input:checked:last-of-type ~ .slide-button {
+      left: 100 - $width * 1%;
+    }
+    
+  }
+	
+}

--- a/test/switch.html
+++ b/test/switch.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<!-- paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/ -->
+<!--[if IE 8]>    <html class="no-js lt-ie9" lang="en"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8" />
+
+  <!-- Set the viewport width to device width for mobile -->
+  <meta name="viewport" content="width=device-width" />
+
+  <title>Foundation Switch Testing</title>
+
+  <!-- Included CSS Files -->
+  <link rel="stylesheet" href="stylesheets/styles.css">
+
+  <script src="../vendor/assets/javascripts/foundation/modernizr.foundation.js"></script>
+
+</head>
+<body>
+
+  <div class="row">
+    <div class="twelve columns">
+      <p><a href="index.html">&laquo; Back</a></p>
+      <h2>Foundation Switch Testing</h2>
+      <hr />
+      <dl class="sub-nav">
+        <dt>Go to:</dt>
+        <dd><a href="#sizes">Sizes</a></dd>
+        <dd><a href="#styles">Styles</a></dd>
+        <dd><a href="#multiple-states">Multiple States</a></dd>
+      </dl>
+    </div>
+  </div>
+
+  <!-- Test Foundation Components Here -->
+  <div class="row">
+    <div class="large-12">
+
+      <h3>Switches</h3>
+      <h4 class="subheader">Switches can be used instead of regular radio buttons, to switch between two or more options. They are very customizable and use styles from other components such as buttons or panels. </h4>
+      <br>
+
+      <div class="row">
+        <div class="large-4">
+          <a name="sizes"></a>
+          <h4>Sizes</h4>
+          <p>The switches include the same size styles as buttons, so you can add the additional <code>.tiny</code>, <code>.small</code> or <code>.large</code> classes to change the regular size of the switch. </p>
+        </div>
+        <br>
+        
+        <div class="large-8">
+
+          <div class="row">
+            <label>Tiny switch: </label>
+
+            <div class="switch panel tiny">
+              <input id="o11" name="switch-tiny" type="radio" checked>
+              <label for="o11" onclick="">Option 1</label>
+
+              <input id="o12" name="switch-tiny" type="radio">	
+              <label for="o12" onclick="">Option 2</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Small switch: </label>
+
+            <div class="switch panel small">
+              <input id="o21" name="switch-small" type="radio" checked>
+              <label for="o21" onclick="">Option 1</label>
+
+              <input id="o22" name="switch-small" type="radio">	
+              <label for="o22" onclick="">Option 2</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Regular switch: </label>
+
+            <div class="switch panel">
+              <input id="o31" name="switch" type="radio" checked>
+              <label for="o31" onclick="">Option 1</label>
+
+              <input id="o32" name="switch" type="radio">	
+              <label for="o32" onclick="">Option 2</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Large switch: </label>
+
+            <div class="switch panel large">
+              <input id="o41" name="switch-large" type="radio" checked>
+              <label for="o41" onclick="">Option 1</label>
+
+              <input id="o42" name="switch-large" type="radio">	
+              <label for="o42" onclick="">Option 2</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+      
+      <div class="row">
+        <div class="large-4">
+          <a name="styles"></a>
+          <h4>Styles</h4>
+          <p>Switches use styles from other components, so you can use the classes from buttons, alerts or panels, among others. </p>
+        </div>
+        <br>
+        
+        <div class="large-8">
+
+          <div class="row">
+            <label>Secondary switch: </label>
+
+            <div class="switch panel">
+              <input id="o51" name="switch-secondary" type="radio" checked>
+              <label for="o51" onclick="">Option 1</label>
+
+              <input id="o52" name="switch-secondary" type="radio">	
+              <label for="o52" onclick="">Option 2</label>
+
+              <span class="slide-button button secondary"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Success switch: </label>
+
+            <div class="switch panel">
+              <input id="o61" name="switch-success" type="radio" checked>
+              <label for="o61" onclick="">Option 1</label>
+
+              <input id="o62" name="switch-success" type="radio">	
+              <label for="o62" onclick="">Option 2</label>
+
+              <span class="slide-button button success"></span>
+            </div>
+          </div>
+
+          <div class="row">
+            <label>Alert switch: </label>
+
+            <div class="switch panel">
+              <input id="o71" name="switch-alert" type="radio" checked>
+              <label for="o71" onclick="">Option 1</label>
+
+              <input id="o72" name="switch-alert" type="radio">	
+              <label for="o72" onclick="">Option 2</label>
+
+              <span class="slide-button button alert"></span>
+            </div>
+          </div>
+
+          <div class="row">
+            <label>Radius switch: </label>
+
+            <div class="switch panel">
+              <input id="o91" name="switch-radius" type="radio" checked>
+              <label for="o91" onclick="">Option 1</label>
+
+              <input id="o92" name="switch-radius" type="radio">	
+              <label for="o92" onclick="">Option 2</label>
+
+              <span class="slide-button button radius"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Invert switch: </label>
+
+            <div class="switch panel callout radius">
+              <input id="o141" name="switch-invert" type="radio" checked>
+              <label for="o141" onclick="">Option 1</label>
+
+              <input id="o142" name="switch-invert" type="radio">	
+              <label for="o142" onclick="">Option 2</label>
+
+              <span class="slide-button button radius"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Round switch: </label>
+
+            <div class="switch button secondary round">
+              <input id="o101" name="switch-round" type="radio" checked>
+              <label for="o101" onclick="">Option 1</label>
+
+              <input id="o102" name="switch-round" type="radio">	
+              <label for="o102" onclick="">Option 2</label>
+
+              <span class="slide-button button round"></span>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+      
+      <div class="row">
+        <div class="large-4">
+          <a name="multiple-states"></a>
+          <h4>Multiple States</h4>
+          <p>You can add up to five options in a switch, using the <code>.switch-3</code>, <code>.switch-4</code> or <code>.switch-5</code> classes. If you've got more than five options, it's probably best to use other forms of interaction. </p>
+        </div>
+        <br>
+        
+        <div class="large-8">
+
+          <div class="row">
+            <label>Three-state switch: </label>
+
+            <div class="switch-3 panel">
+              <input id="o111" name="switch-three" type="radio" checked>
+              <label for="o111" onclick="">Option 1</label>
+
+              <input id="o112" name="switch-three" type="radio">	
+              <label for="o112" onclick="">Option 2</label>
+              
+              <input id="o113" name="switch-three" type="radio">	
+              <label for="o113" onclick="">Option 3</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Four-state switch: </label>
+
+            <div class="switch-4 panel">
+              <input id="o121" name="switch-four" type="radio" checked>
+              <label for="o121" onclick="">Option 1</label>
+
+              <input id="o122" name="switch-four" type="radio">	
+              <label for="o122" onclick="">Option 2</label>
+              
+              <input id="o123" name="switch-four" type="radio">	
+              <label for="o123" onclick="">Option 3</label>
+              
+              <input id="o124" name="switch-four" type="radio">	
+              <label for="o124" onclick="">Option 4</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+          <div class="row">
+            <label>Five-state switch: </label>
+
+            <div class="switch-5 panel">
+              <input id="o131" name="switch-five" type="radio" checked>
+              <label for="o131" onclick="">Option 1</label>
+
+              <input id="o132" name="switch-five" type="radio">	
+              <label for="o132" onclick="">Option 2</label>
+              
+              <input id="o133" name="switch-five" type="radio">	
+              <label for="o133" onclick="">Option 3</label>
+              
+              <input id="o134" name="switch-five" type="radio">	
+              <label for="o134" onclick="">Option 4</label>
+              
+              <input id="o135" name="switch-five" type="radio">	
+              <label for="o135" onclick="">Option 5</label>
+
+              <span class="slide-button button"></span>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- Included JS Files -->
+  <script src="../vendor/assets/javascripts/foundation/jquery.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.mediaQueryToggle.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.placeholder.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.alerts.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.accordion.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.buttons.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.tooltips.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.forms.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.tabs.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.navigation.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.reveal.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/jquery.foundation.orbit.js"></script>
+  <script src="../vendor/assets/javascripts/foundation/app.js"></script>
+  <script type="text/javascript">
+    // Page-Specific JavaScript Goes Here
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Switches can be used instead of regular radio buttons, to switch between two or more options. They are very customizable and use styles from other components such as buttons or panels.

The switches are CSS-only, and only show-up only modern browsers. Browsers without support for media queries get standard form elements.

The class names used are similar to the ones used by F4 classes for grids (`.switch`, `.switch-3`, `.switch-4`, `.switch-5`).
