### PR TITLE
Update vendor/assets/javascripts/foundation/jquery.foundation.topbar.js

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -42,7 +42,7 @@
             $('body').css('padding-top',settings.$topbar.outerHeight())
           }
 
-          $('.top-bar .toggle-topbar').die('click.fndtn').live('click.fndtn', function (e) {
+          $('.top-bar .toggle-topbar').off('click.fndtn').on('click.fndtn', function (e) {
             e.preventDefault();
 
             if (methods.breakpoint()) {
@@ -59,7 +59,7 @@
           });
 
           // Show the Dropdown Levels on Click
-          $('.top-bar .has-dropdown>a').die('click.fndtn').live('click.fndtn', function (e) {
+          $('.top-bar .has-dropdown>a').off('click.fndtn').on('click.fndtn', function (e) {
             if (Modernizr.touch || methods.breakpoint())
               e.preventDefault();
 
@@ -84,7 +84,7 @@
           });
 
           // Go up a level on Click
-          $('.top-bar .has-dropdown .back').die('click.fndtn').live('click.fndtn', function (e) {
+          $('.top-bar .has-dropdown .back').off('click.fndtn').on('click.fndtn', function (e) {
             e.preventDefault();
 
             var $this = $(this),


### PR DESCRIPTION
.die() and .live are being deprecated
Replace .die and .live with .off and .on respectively 

JQuery can then be updated to 1.9.0 full tested working
