### PR TITLE
jQuery 1.9 live die error

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -42,7 +42,7 @@
             $('body').css('padding-top',settings.$topbar.outerHeight())
           }
 
-          $('.top-bar .toggle-topbar').die('click.fndtn').live('click.fndtn', function (e) {
+          $('.top-bar').off('click.fndtn', '.toggle-topbar').on('click.fndtn','.toggle-topbar', function (e) {
             e.preventDefault();
 
             if (methods.breakpoint()) {
@@ -59,7 +59,7 @@
           });
 
           // Show the Dropdown Levels on Click
-          $('.top-bar .has-dropdown>a').die('click.fndtn').live('click.fndtn', function (e) {
+          $('.top-bar').off('click.fndtn','.has-dropdown>a').on('click.fndtn','.has-dropdown>a', function (e) {
             if (Modernizr.touch || methods.breakpoint())
               e.preventDefault();
 
@@ -84,7 +84,7 @@
           });
 
           // Go up a level on Click
-          $('.top-bar .has-dropdown .back').die('click.fndtn').live('click.fndtn', function (e) {
+          $('.top-bar').off('click.fndtn','.has-dropdown .back').on('click.fndtn','.has-dropdown .back', function (e) {
             e.preventDefault();
 
             var $this = $(this),


### PR DESCRIPTION
.live() and .die() are deprecated. This rewrite maintains the ability to subscribe to events on dynamically added elements as mentioned in https://github.com/zurb/foundation/issues/1407
