### PR TITLE
Adds more flexible options for setting the row width of the grid

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -2,7 +2,12 @@
 
 // Grid Settings
 
-$rowWidth: 1000px !default;
+$maxRowWidth: 1400px !default;
+$xlargeRowWidth: 80% !default;
+$largeRowWidth: 80% !default;
+$mediumRowWidth: 100% !default;
+$smallRowWidth: 100% !default;
+
 $columnGutter: 30px !default;
 $totalColumns: 12 !default;
 $mobileTotalColumns: 4 !default;
@@ -259,7 +264,7 @@ $base-size: $baseFontSize $importantModNum;
 
 $screenSmall: 768px !default;
 $screenMedium: 1279px !default;
-$screenXlarge: 1441px !default;
+$screenLarge: 1441px !default;
 
 // Saving for better em-based testing
 // $screenSmall: 44em !default;

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -1,6 +1,7 @@
   /* The Grid ---------------------- */
 
-  .row { width: $rowWidth; max-width: 100%; min-width: $screenSmall; margin: 0 auto;
+  .row { 
+    @include outerRow;
     .row { width: auto; max-width: none; min-width: 0; margin: 0 (-($columnGutter/2)); }
 
     &.collapse {

--- a/scss/foundation/components/modules/_mqueries.scss
+++ b/scss/foundation/components/modules/_mqueries.scss
@@ -18,7 +18,7 @@
   .hide-for-print { display: inherit !important; }
 
   /* Very large display targeting */
-  @media only screen and (min-width: $screenXlarge) {
+  @media only screen and (min-width: $screenLarge) {
     .hide-for-small,
     .hide-for-medium,
     .hide-for-medium-down,

--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -25,7 +25,7 @@
   .top-bar { background: $topBarBgColor; height: $topBarHeight; line-height: $topBarHeight; margin: 0 0 $topBarBtmMargin; padding: 0; width: 100%; position: relative;
 
     /* Contain width to .row width */
-    .contain-to-grid & { max-width: $rowWidth; margin: 0 auto; }
+    .contain-to-grid & { @include outerRow; }
 
     /* First <ul> for branding, title, name, etc */
     &>ul {

--- a/scss/foundation/mixins/_respond-to.scss
+++ b/scss/foundation/mixins/_respond-to.scss
@@ -1,11 +1,13 @@
 // Mixin for Semantic Grid reponsiveness
 
   @mixin respondTo($media) {
-    @if $media == smallScreen {
+    @if $media == small {
       @media only screen and (max-width: $screenSmall - 1) { @content; }
-    } @else if $media == mediumScreen {
+    } @else if $media == medium {
       @media only screen and (max-width: $screenMedium) and (min-width: $screenSmall) { @content; }
-    } @else if $media == largeScreen {
-      @media only screen and (min-width: $screenXlarge) { @content; }
+    } @else if $media == large {
+      @media only screen and (min-width: $screenMedium) and (max-width: $screenLarge) { @content; }
+    } @else if $media == xlarge {
+      @media only screen and (min-width: $screenLarge) { @content; }
     }
   }

--- a/scss/foundation/mixins/_semantic-grid.scss
+++ b/scss/foundation/mixins/_semantic-grid.scss
@@ -2,9 +2,11 @@
 
   // Outer row mixin for container rows
 
-  @mixin outerRow() {
-    width: $rowWidth; max-width: 100%; min-width: $screenSmall; margin: 0 auto; @extend %clearfix;
-    @include respondTo(smallScreen) { width: auto; min-width: 0; margin-left: 0; margin-right: 0; }
+  @mixin outerRow($small: $smallRowWidth, $medium: $mediumRowWidth, $large: $largeRowWidth, $xlarge: $xlargeRowWidth) {
+    width: $xlarge; max-width: $maxRowWidth; margin: 0 auto; @extend %clearfix;
+    @include respondTo(large) { width: $large; }
+    @include respondTo(medium) { width: $medium; }
+    @include respondTo(small) { width: $small; }
   }
 
   // Inner row mixin for nested rows, must be a child of an outer-row element. $behavior can be 'collapse' to get rid of margins


### PR DESCRIPTION
Each responsive screen size from small, medium, large and xlarge can allow
for a different width setting. There is also a global maximum width
setting which constrains the overall proportions of the grid (and is
useful for legacy browser support)

This also changes the way the `respondTo` mixin works slightly. It now
uses small, medium, large and xlarge no longer skipping large as a
choice and dropping the 'Screen' suffix to make it more concise.

For comparison this is similar to the way the http://rdio.com responds going 
up to a max width of 1600px on very large monitors. Essentially what I'd like to do
is "really use the space" so to speak and make room for some more cowbell.
