### PR TITLE
Updates andSelf to addBack, for jQuery 1.9

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -41,7 +41,7 @@
         var _self = this;
 
         // Set all hidden parent elements, including this element.
-        _self.hidden = $child.parents().andSelf().filter( ":hidden" );
+        _self.hidden = $child.parents().addBack().filter( ":hidden" );
 
         // Loop through all hidden elements.
         _self.hidden.each( function() {

--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -13,7 +13,7 @@
   $.fn.findFirstImage = function () {
     return this.first()
             .find('img')
-            .andSelf().filter('img')
+            .addBack().filter('img')
             .first();
   };
 


### PR DESCRIPTION
jquery 1.9.0's migrate script leaves a deprecation warning if you use andSelf instead of addBack, the accepted alias.
