### PR TITLE
navBarHeightMobile hotfix

### DIFF
--- a/scss/foundation/components/modules/_mqueries.scss
+++ b/scss/foundation/components/modules/_mqueries.scss
@@ -351,7 +351,7 @@
   /* Topbar Specific Breakpoint that you can customize */
   @media only screen and (max-width: $topBarBreakPoint) {
 
-    .top-bar { margin-bottom: 0; overflow: hidden; height: $topBarHeightMobile; background: $topBarDropBgColor;
+    .top-bar { background: $topBarDropBgColor; margin-bottom: 0; min-height: $topBarHeightMobile; overflow: hidden;
       .js-generated { display: block; }
 
       /* Override contain to grid stuff for breakpoint */
@@ -443,7 +443,7 @@
           }
         }
       }
-      section > ul li a:not(.button) { padding-left: $topBarHeightMobile / 2 !important; }
+      section > ul li a:not(.button) { height: $topBarHeightMobile; line-height: $topBarHeightMobile; padding-left: $topBarHeightMobile / 2 !important; }
 
       /* When the Small Nav is Showing */
       &.expanded { height: 100%;


### PR DESCRIPTION
## Issue

``` css
$topBarHeight: 75px
$topBarHeightMobile: 45px
```

![navBarHeightMobile-hotfix](https://f.cloud.github.com/assets/222064/105582/1eb1cebe-69b9-11e2-9e91-d59d2991e313.jpg)

![navBarHeightMobile-hotfix-2](https://f.cloud.github.com/assets/222064/105585/6680f4cc-69b9-11e2-8002-4e5d0f037843.jpg)

When the css variable navBarHeightMobile is set, it does not work correctly. Height of topbar and items is never changed when responsive.
## Solution

The following code will fix the issue, and make it work as expected.

**Please test this code first.** I had issues testing my hotfix branch. I believe my system is using a cached version or something.

Look at the code in this pull request and you will see what I am doing.

What lead me to editing this gem was this monkeypatch that resolved the issue locally.

``` css
@media only screen and (max-width: $topBarBreakPoint)
  .top-bar
    min-height: $topBarHeightMobile
    & ul > li a:not(.button)
      height: $topBarHeightMobile
      line-height: $topBarHeightMobile
```

Signed-off-by: Keil Miller Jr keilmillerjr@me.com
