### PR TITLE
Removed unnecessary CSS for sticky top bar

### DIFF
--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -21,16 +21,6 @@
   /* Wrapped around .top-bar to make it fixed at the top */
   .fixed { width: 100%; left: 0; position: fixed; top: 0; z-index: 99; }
   
-  /* Add .sticky class for using top bar as a sticky navigation when scrolling passed it. Add the class .sticky to a top bar using .contain-to-grid but leave off .fixed, javascript will take care of that */
-  
-  .sticky {
-  	float: left;
-  	overflow: hidden;
-  
-  .sticky.fixed {
-  	float: none;
-  }   
-
   /* <nav> */
   .top-bar { background: $topBarBgColor; height: $topBarHeight; line-height: $topBarHeight; margin: 0 0 $topBarBtmMargin; padding: 0; width: 100%; position: relative;
 

--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -155,17 +155,23 @@
     }
   };
   
-  var distance = $('.sticky').offset().top,
-      $window = $(window);
-  
-  $window.scroll(function() {
-      if ( $window.scrollTop() >= distance ) {
-         $(".sticky").addClass("fixed");
-      }
-      
-     else if ( $window.scrollTop() < distance ) {
-        $(".sticky").removeClass("fixed");
-     }
-  });
-
+   // Monitor scroll position for sticky
+   if ($('.sticky').length > 0) {
+     var distance = $('.sticky').length ? $('.sticky').offset().top: 0,
+         $window = $(window);
+         var offst = $('nav.top-bar').outerHeight()+20;
+ 
+       $window.scroll(function() {
+         if ( $window.scrollTop() >= ( distance ) ) {
+            $(".sticky").addClass("fixed");
+              $('body').css('padding-top',offst);
+         }
+ 
+        else if ( $window.scrollTop() < distance ) {
+           $(".sticky").removeClass("fixed");
+           $('body').css('padding-top','0');
+        }
+     });
+   }
+   
 }(jQuery, this));

--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -155,23 +155,17 @@
     }
   };
   
-   // Monitor scroll position for sticky
-   if ($('.sticky').length > 0) {
-     var distance = $('.sticky').length ? $('.sticky').offset().top: 0,
-         $window = $(window);
-         var offst = $('nav.top-bar').outerHeight()+20;
- 
-       $window.scroll(function() {
-         if ( $window.scrollTop() >= ( distance ) ) {
-            $(".sticky").addClass("fixed");
-              $('body').css('padding-top',offst);
-         }
- 
-        else if ( $window.scrollTop() < distance ) {
-           $(".sticky").removeClass("fixed");
-           $('body').css('padding-top','0');
-        }
-     });
-   }
-   
+  var distance = $('.sticky').offset().top,
+      $window = $(window);
+  
+  $window.scroll(function() {
+      if ( $window.scrollTop() >= distance ) {
+         $(".sticky").addClass("fixed");
+      }
+      
+     else if ( $window.scrollTop() < distance ) {
+        $(".sticky").removeClass("fixed");
+     }
+  });
+
 }(jQuery, this));


### PR DESCRIPTION
Removed now-redundant CSS for the .sticky class which was causing some layout issues with dropdown menus. Behaviour tested in different browsers using default Foundation tempaltes. 
