### PR TITLE
Media Query Mixins

### DIFF
--- a/scss/foundation/mixins/_all.scss
+++ b/scss/foundation/mixins/_all.scss
@@ -3,3 +3,4 @@
 @import "respond-to";
 @import "clearfix";
 @import "semantic-grid";
+@import "media-query"

--- a/scss/foundation/mixins/_media-query.scss
+++ b/scss/foundation/mixins/_media-query.scss
@@ -1,0 +1,19 @@
+// Inspired by http://thesassway.com/intermediate/responsive-web-design-in-sass-using-media-queries-in-sass-32
+
+@mixin mq($media) {
+  @if $media == large {
+    @media only screen and (min-width: 1441px) { @content; } 
+  }
+  @else if $media == medium {
+    @media only screen and (max-width: 1279px) and (min-width: 768px) { @content; } 
+  }
+  @else if $media == small {
+    @media only screen and (max-width: 767px) { @content; } 
+  }
+  @else if $media == landscape {
+    @media only screen and (orientation: landscape) { @content; } 
+  }
+  @else if $media == portrait {
+    @media only screen and (orientation: portrait) { @content; } 
+  }
+}


### PR DESCRIPTION
Hi Zurb Team,
My inspiration came from [The Sass Way](http://thesassway.com/intermediate/responsive-web-design-in-sass-using-media-queries-in-sass-32). Let me give you an example with Sass.

```
img
    padding-right: 1em
    @include mq(small)
        padding-right: 0
```

This is very useful for small tweaks. This is not the only way to implement media query mixins, but with Foundation's simple breakpoints, it is a good start.

I hope you like it,
Josh
