### PR TITLE
Sticky now prevents any page flow jump when it triggers

### DIFF
--- a/scss/foundation/components/modules/_topbar.scss
+++ b/scss/foundation/components/modules/_topbar.scss
@@ -134,6 +134,11 @@
 
     .js-generated { display: none; }
   }
+  
+  // Specifies the height of the sticky padding to prevent any page flow jump when sticky is enabled
+  .top-bar-sticky-padding {
+	  height: $topBarHeight;	
+}
 
   /* Firefox Fixes */
   @-moz-document url-prefix() {

--- a/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.topbar.js
@@ -159,17 +159,15 @@
   if ($('.sticky').length > 0) {
       var distance = $('.sticky').length ? $('.sticky').offset().top: 0,
           $window = $(window);
-          var offst = $('nav.top-bar').outerHeight()+20;
+          (".sticky").after("<div class='top-bar-sticky-padding'></div>");
   
         $window.scroll(function() {
           if ( $window.scrollTop() >= ( distance ) ) {
              $(".sticky").addClass("fixed");
-               $('body').css('padding-top',offst);
           }
   
          else if ( $window.scrollTop() < distance ) {
             $(".sticky").removeClass("fixed");
-            $('body').css('padding-top','0');
          }
       });
     }


### PR DESCRIPTION
Sticky JS adds a padding element of the same height as the top-bar when
scrolling. Once sticky triggers and the top-bar is taken out of the
page flow, the padder prevents a 45px jump.
