### PR TITLE
Boosted .reveal-modal z-index to display it on top of its background.

### DIFF
--- a/scss/foundation/components/modules/_reveal.scss
+++ b/scss/foundation/components/modules/_reveal.scss
@@ -8,7 +8,7 @@
 
   .reveal-modal-bg { position: fixed; height: 100%; width: 100%; background: #000; background: rgba(#000, .45); z-index: 100; display: none; top: 0; #{$defaultFloat}: 0; }
 
-  .reveal-modal { background: #fff; visibility: hidden; display: none; top: 100px; #{$defaultFloat}: 50%; margin-#{$defaultFloat}: -260px; width: 520px; position: absolute; z-index: 41; padding: 30px; @include box-shadow(0 0 10px rgba(#000,.4));
+  .reveal-modal { background: #fff; visibility: hidden; display: none; top: 100px; #{$defaultFloat}: 50%; margin-#{$defaultFloat}: -260px; width: 520px; position: absolute; z-index: 101; padding: 30px; @include box-shadow(0 0 10px rgba(#000,.4));
     .close-reveal-modal:not(.button) {
       @include font-size(22);
       line-height: .5;


### PR DESCRIPTION
`.reveal-modal-bg` was showing on top of the modal due to a change in its `z-index` value which made it greater than the one specified for the `.reveal-modal` class (`100` > `41`).
As I suppose the change from `40` to `100` has a reason I'm not aware of, I decided to boost the modal's `z-index` to `101`.
