### PR TITLE
Allow user-specified default options for app.js

### DIFF
--- a/vendor/assets/javascripts/foundation/app.js
+++ b/vendor/assets/javascripts/foundation/app.js
@@ -2,20 +2,26 @@
   'use strict';
 
   var $doc = $(document),
-      Modernizr = window.Modernizr;
+      Modernizr = window.Modernizr,
+      defaults = {
+        tabs: {callback : $.foundation.customForms.appendCustomMarkup}
+      };
 
   $(document).ready(function() {
-    $.fn.foundationAlerts           ? $doc.foundationAlerts() : null;
-    $.fn.foundationButtons          ? $doc.foundationButtons() : null;
-    $.fn.foundationAccordion        ? $doc.foundationAccordion() : null;
-    $.fn.foundationNavigation       ? $doc.foundationNavigation() : null;
-    $.fn.foundationTopBar           ? $doc.foundationTopBar() : null;
-    $.fn.foundationCustomForms      ? $doc.foundationCustomForms() : null;
-    $.fn.foundationMediaQueryViewer ? $doc.foundationMediaQueryViewer() : null;
-    $.fn.foundationTabs             ? $doc.foundationTabs({callback : $.foundation.customForms.appendCustomMarkup}) : null;
-    $.fn.foundationTooltips         ? $doc.foundationTooltips() : null;
-    $.fn.foundationMagellan         ? $doc.foundationMagellan() : null;
-    $.fn.foundationClearing         ? $doc.foundationClearing() : null;
+    // Allow for setting per-plugin default options
+    var userDefaults = $.extend({}, defaults, $.foundationDefaults);
+    
+    $.fn.foundationAlerts           ? $doc.foundationAlerts(userDefaults.alerts) : null;
+    $.fn.foundationButtons          ? $doc.foundationButtons(userDefaults.buttons) : null;
+    $.fn.foundationAccordion        ? $doc.foundationAccordion(userDefaults.accordion) : null;
+    $.fn.foundationNavigation       ? $doc.foundationNavigation(userDefaults.navigation) : null;
+    $.fn.foundationTopBar           ? $doc.foundationTopBar(userDefaults.topBar) : null;
+    $.fn.foundationCustomForms      ? $doc.foundationCustomForms(userDefaults.customFonts) : null;
+    $.fn.foundationMediaQueryViewer ? $doc.foundationMediaQueryViewer(userDefaults.mediaQueryViewer) : null;
+    $.fn.foundationTabs             ? $doc.foundationTabs(userDefaults.tabs) : null;
+    $.fn.foundationTooltips         ? $doc.foundationTooltips(userDefaults.tooltips) : null;
+    $.fn.foundationMagellan         ? $doc.foundationMagellan(userDefaults.magellan) : null;
+    $.fn.foundationClearing         ? $doc.foundationClearing(userDefaults.clearing) : null;
 
     $.fn.placeholder                ? $('input, textarea').placeholder() : null;
   });


### PR DESCRIPTION
I came across an issue where I needed the automatic initialization at `app.js` to pick up a particular option for the `foundationTabs` plugin, but I found no way of doing this but getting rid of this automatic behavior and doing everything by hand -- which kind of took away some of the magic of using Foundation :disappointed:

So, I'm sending this PR with a sort of new feature: allowing for user-specified default options that will be picked up by `app.js`.
## Here's how it works:
1. Have a script executed **before** the on-ready callback at `app.js` which sets a hash at `$.foundationDefaults` with the desired defaults. More on how to do this later.
2. Once `app.js` executes its on-ready callback, it will try to pick up the settings and initialize each plugin with the defaults specified for it.
### Specifying per-plugin defaults

All plugin defaults are namespaced under their plugin name (without the `foundation` prefix, as it would be dreadfully repeating). Defaults for any plugin can be specified without having to specify anything the rest of them:

``` javascript
// Before jQuery.ready callbacks are executed
$.foundationDefaults = {
  tooltip: { tooltipClass: '.not-your-mamas-tooltip' }
}
```
### What about the _default defaults_?

`app.js` also has a `defaults` variable which is currently set to the only _default default_ option I found: `callback` for `tabs` plugin:

``` javascript
defaults = {
  tabs: {callback : $.foundation.customForms.appendCustomMarkup}
}
```
### An example (Rails app)

With a simple Rails project, you might add the user default settings at (for the sake of this example's simplicity) `application.js`:

``` javascript
//
// application.js: Application-wide scripts.
//
//= require jquery
//= require jquery_ujs
//= require foundation
//= require_tree .

jQuery.foundationDefaults = {
  tooltip: { tooltipClass: '.not-your-mamas-tooltip' }
};
```

![:)](http://www.reactiongifs.com/wp-content/uploads/2012/10/pleased.gif)
