### PR TITLE
#1254 - Converted hard-coded colors in the NavBar to variables

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -100,6 +100,22 @@ $tabTermFontSize: 12px;
 
 $navBarHeight: 40px !default;
 $navFlyoutBaseWidth: 250px !default;
+$navBarActiveColor: $mainColor !default;
+$navBarActiveBorderColor: darken($mainColor, 10%) !default;
+$navBarDarkBaseColor: $black !default;
+$navBarBorderColor: lighten($navBarDarkBaseColor, 20%) !default;
+$navBarBackgroundColor: lighten($navBarDarkBaseColor, 30%) !default;
+$navBarLightBaseColor: $white !default;
+$navBarFlyoutBackground: darken($navBarLightBaseColor, 5%) !default;
+$navBarFlyoutHover: darken($navBarLightBaseColor, 8%) !default;
+$navBarTextColor: darken($navBarLightBaseColor, 10%) !default;
+$navBarFlyoutBorder: darken($navBarLightBaseColor, 15%) !default;
+$navBarFlyoutActiveBorder: lighten($black, 10%) !default;
+$navBarFlyoutSideBorder: #CCC !default;
+$navBarFlyoutTextColor: #555 !default;
+$navBarFlyoutTextHover: #333 !default;
+$navBarFlyoutTextActive: $white !default;
+$navBarTouchFlyoutBorderColor: #666 !default;
 
 // Top Bar Settings
 

--- a/scss/foundation/components/modules/_navbar.scss
+++ b/scss/foundation/components/modules/_navbar.scss
@@ -1,28 +1,28 @@
-  .nav-bar { height: $navBarHeight; background: lighten($black, 30%); margin-left: 0; margin-top: $navBarHeight / 2; padding: 0;
+  .nav-bar { height: $navBarHeight; background: $navBarBackgroundColor; margin-left: 0; margin-top: $navBarHeight / 2; padding: 0;
 
-    &>li { float: $defaultFloat; display: block; position: relative; padding: 0; margin: 0; border: 1px solid lighten($black, 20%); border-#{$defaultOpposite}: none; line-height: $navBarHeight - 2; @include box-shadow(1px 0 0 fade-out($shinyEdge, .3) inset);
+    &>li { float: $defaultFloat; display: block; position: relative; padding: 0; margin: 0; border: 1px solid $navBarBorderColor; border-#{$defaultOpposite}: none; line-height: $navBarHeight - 2; @include box-shadow(1px 0 0 fade-out($shinyEdge, .3) inset);
 
       &:first-of-type { @include box-shadow(0 0 0); }
-      &:last-of-type { border-#{$defaultOpposite}: solid 1px lighten($black, 20%); @include box-shadow(1px 0 0 fade-out($shinyEdge, .3) inset, 1px 0 0 fade-out($shinyEdge, .3)); }
+      &:last-of-type { border-#{$defaultOpposite}: solid 1px $navBarBorderColor; @include box-shadow(1px 0 0 fade-out($shinyEdge, .3) inset, 1px 0 0 fade-out($shinyEdge, .3)); }
 
-      &.active { background: $mainColor; border-color: darken($mainColor, 10%);
-        &>a { color: $white; cursor: default; }
-        &:hover { background: $mainColor; cursor: default; }
+      &.active { background: $navBarActiveColor; border-color: $navBarActiveBorderColor;
+        &>a { color: $navBarLightBaseColor; cursor: default; }
+        &:hover { background: $navBarActiveColor; cursor: default; }
       }
-      &:hover { background: lighten($black, 20%); }
+      &:hover { background: $navBarBorderColor; }
 
-      &>a { color: darken($white, 10%); }
+      &>a { color: $navBarTextColor; }
       ul { margin-bottom: 0; }
       .flyout { display: none; }
 
       &.has-flyout {
         &>a:first-of-type { padding-#{$defaultOpposite}: $navBarHeight; position: relative;
-          &:after { @include cssTriangle(4px, darken($white, 10%), top); position: absolute; #{$defaultOpposite}: $navBarHeight / 2; top: ($navBarHeight / 2) - 3; }
+          &:after { @include cssTriangle(4px, $navBarTextColor, top); position: absolute; #{$defaultOpposite}: $navBarHeight / 2; top: ($navBarHeight / 2) - 3; }
         }
         &>a.flyout-toggle { border-#{$defaultFloat}: 0 !important; position: absolute; #{$defaultOpposite}: 0; top: 0; padding: ($navBarHeight / 2); z-index: 2; display: block; }
         &.is-touch {
           &>a:first-of-type { padding-#{$defaultOpposite}: 55px;}
-          &>a.flyout-toggle { border-#{$defaultFloat}: 1px dashed #666; }
+          &>a.flyout-toggle { border-#{$defaultFloat}: 1px dashed $navBarTouchFlyoutBorderColor; }
         }
         &:hover .dropdown { display: block; }
       }
@@ -33,20 +33,20 @@
 
     &.vertical { height: auto; margin-top: 0;
 
-      &>li { float: none; border-bottom: none; border-#{$defaultOpposite}: solid 1px lighten($black, 20%); @include box-shadow(none);
+      &>li { float: none; border-bottom: none; border-#{$defaultOpposite}: solid 1px $navBarBorderColor; @include box-shadow(none);
 
-        &.has-flyout>a:first-of-type:after { @include cssTriangle(4px, darken($white, 10%), $defaultFloat); }
+        &.has-flyout>a:first-of-type:after { @include cssTriangle(4px, $navBarTextColor, $defaultFloat); }
         .flyout { #{$defaultFloat}: 100%; top: -1px;
           &.right { #{$defaultFloat}: auto; #{$defaultOpposite}: 100%; }
         }
-        &.active { border-#{$defaultOpposite}: solid 1px darken($mainColor, 10%); }
-        &:last-of-type { border-bottom: solid 1px lighten($black, 20%);}
+        &.active { border-#{$defaultOpposite}: solid 1px $navBarActiveBorderColor; }
+        &:last-of-type { border-bottom: solid 1px $navBarBorderColor;}
       }
     }
 
   }
 
-  .flyout { background: darken($white, 5%); padding: $navBarHeight / 2; margin: 0; border: 1px solid darken($white, 15%); position: absolute; top: $navBarHeight - 1; #{$defaultFloat}: -1px; width: $navFlyoutBaseWidth; z-index: 40; @include box-shadow(0 1px 5px rgba(#000, .1));
+  .flyout { background: $navBarFlyoutBackground; padding: $navBarHeight / 2; margin: 0; border: 1px solid $navBarFlyoutBorder; position: absolute; top: $navBarHeight - 1; #{$defaultFloat}: -1px; width: $navFlyoutBaseWidth; z-index: 40; @include box-shadow(0 1px 5px rgba($black, .1));
 
     p { line-height: 1.2; font-size: ms(0) - 1; }
     *:first-of-type { margin-top: 0; } /* remove margin on any first-of-type element */
@@ -63,12 +63,12 @@
 
   ul.flyout, .nav-bar li ul { padding: 0; list-style: none;
 
-    li { border-#{$defaultFloat}: solid 3px #CCC;
-      a { background: darken($white, 5%); border: 1px solid darken($white, 10%); border-width: 1px 1px 0 0; color: #555; display: block; font-size: ms(0); height: auto; line-height: 1; padding: (($navBarHeight / 2) - 5) ($navBarHeight / 2); @include box-shadow(0 1px 0 $shinyEdge inset);
-        &:hover, &:focus { background: darken($white, 8%); color: #333; }
+    li { border-#{$defaultFloat}: solid 3px $navBarFlyoutSideBorder;
+      a { background: $navBarFlyoutBackground; border: 1px solid $navBarTextColor; border-width: 1px 1px 0 0; color: $navBarFlyoutTextColor; display: block; font-size: ms(0); height: auto; line-height: 1; padding: (($navBarHeight / 2) - 5) ($navBarHeight / 2); @include box-shadow(0 1px 0 $shinyEdge inset);
+        &:hover, &:focus { background: $navBarFlyoutHover; color: $navBarFlyoutTextHover; }
       }
-      &.active { margin-top: 0; border-top: 1px solid lighten($black, 30%); border-#{$defaultFloat}: 4px solid lighten($black, 10%);
-        a { background: lighten($black, 30%); border: none; color: #fff; height: auto; margin: 0; position: static; top: 0; @include box-shadow(0 0 0); }
+      &.active { margin-top: 0; border-top: 1px solid $navBarBackgroundColor; border-#{$defaultFloat}: 4px solid $navBarFlyoutActiveBorder;
+        a { background: $navBarBackgroundColor; border: none; color: $navBarFlyoutTextActive; height: auto; margin: 0; position: static; top: 0; @include box-shadow(0 0 0); }
       }
     }
 

--- a/test/scss/_settings.scss
+++ b/test/scss/_settings.scss
@@ -91,6 +91,22 @@
 
 // $navBarHeight: 40px;
 // $navFlyoutBaseWidth: 250px;
+// $navBarActiveColor: $mainColor;
+// $navBarActiveBorderColor: darken($mainColor, 10%);
+// $navBarDarkBaseColor: $black;
+// $navBarBorderColor: lighten($navBarDarkBaseColor, 20%);
+// $navBarBackgroundColor: lighten($navBarDarkBaseColor, 30%);
+// $navBarLightBaseColor: $white;
+// $navBarFlyoutBackground: darken($navBarLightBaseColor, 5%);
+// $navBarFlyoutHover: darken($navBarLightBaseColor, 8%);
+// $navBarTextColor: #F00;
+// $navBarFlyoutBorder: darken($navBarLightBaseColor, 15%);
+// $navBarFlyoutActiveBorder: lighten($black, 10%);
+// $navBarFlyoutSideBorder: #CCC;
+// $navBarFlyoutTextColor: #555;
+// $navBarFlyoutTextHover: #333;
+// $navBarFlyoutTextActive: $white;
+// $navBarTouchFlyoutBorderColor: #666;
 
 // Top Bar Settings
 


### PR DESCRIPTION
Instead of having to manually override all of the colors in the NavBar, I've abstracted all the colors out into variables accessible in _settings.scss.  
