### PR TITLE
Fixes bug that prevents opening custom dropdown when currently selected option is blank

### DIFF
--- a/scss/foundation/common/_forms.scss
+++ b/scss/foundation/common/_forms.scss
@@ -75,7 +75,7 @@
 
     @include box-shadow(none);
       ul { overflow-y: auto; max-height: $custSelectDropHeight;  }
-      a.current { cursor:default; white-space: nowrap; line-height: (ms(0) + ($formSpacing * 1.5)) - ($inputBorderWidth * 2);  color: $inputFontColor;text-decoration: none; overflow: hidden;display: block;margin-left:($formSpacing / 2);margin-right:((ms(0) + ($formSpacing * 1.5))/2)+5;}
+      a.current { cursor:default; white-space: nowrap; height: 100%; line-height: (ms(0) + ($formSpacing * 1.5)) - ($inputBorderWidth * 2);  color: $inputFontColor;text-decoration: none; overflow: hidden;display: block;margin-left:($formSpacing / 2);margin-right:((ms(0) + ($formSpacing * 1.5))/2)+5;}
       a.selector { cursor:default;position: absolute;width: ((ms(0) + ($formSpacing * 1.5))/2)+5; height: (ms(0) + ($formSpacing * 1.5)) - ($inputBorderWidth * 2); display: block; #{$defaultOpposite}: 0; top: 0;
         &:after { content: ""; display: block; @include cssTriangle(5px, $custSelectTriangleColor, top); position: absolute; left: 3px; top: 50%; margin-top: -2px;  }
       }


### PR DESCRIPTION
When a select option is empty/blank and currently selected, the custom foundation dropdown won't allow you to actually open the dropdown (unless you click the arrow). This is due to there be no height on the empty a.current element, resulting in nothing to trigger the click event. Give a.current a height and it will work properly.

This fix simply applies height: 100% to a.current.
