### PR TITLE
Fix buttons target error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
-    fssm (0.2.9)
+    fssm (0.2.10)
     modular-scale (1.0.6)
       compass (>= 0.12.1)
       sass (>= 3.2.0)

--- a/scss/foundation/components/modules/_reveal.scss
+++ b/scss/foundation/components/modules/_reveal.scss
@@ -8,7 +8,7 @@
 
   .reveal-modal-bg { position: fixed; height: 100%; width: 100%; background: #000; background: rgba(#000, .45); z-index: 100; display: none; top: 0; #{$defaultFloat}: 0; }
 
-  .reveal-modal { background: #fff; visibility: hidden; display: none; top: 100px; #{$defaultFloat}: 50%; margin-#{$defaultFloat}: -260px; width: 520px; position: absolute; z-index: 41; padding: 30px; @include box-shadow(0 0 10px rgba(#000,.4));
+  .reveal-modal { background: #fff; visibility: hidden; display: none; top: 100px; #{$defaultFloat}: 50%; margin-#{$defaultFloat}: -260px; width: 520px; position: absolute; z-index: 101; padding: 30px; @include box-shadow(0 0 10px rgba(#000,.4));
     .close-reveal-modal:not(.button) {
       @include font-size(22);
       line-height: .5;

--- a/vendor/assets/javascripts/foundation/app.js
+++ b/vendor/assets/javascripts/foundation/app.js
@@ -2,20 +2,26 @@
   'use strict';
 
   var $doc = $(document),
-      Modernizr = window.Modernizr;
+      Modernizr = window.Modernizr,
+      defaults = {
+        tabs: {callback : $.foundation.customForms.appendCustomMarkup}
+      };
 
   $(document).ready(function() {
-    $.fn.foundationAlerts           ? $doc.foundationAlerts() : null;
-    $.fn.foundationButtons          ? $doc.foundationButtons() : null;
-    $.fn.foundationAccordion        ? $doc.foundationAccordion() : null;
-    $.fn.foundationNavigation       ? $doc.foundationNavigation() : null;
-    $.fn.foundationTopBar           ? $doc.foundationTopBar() : null;
-    $.fn.foundationCustomForms      ? $doc.foundationCustomForms() : null;
-    $.fn.foundationMediaQueryViewer ? $doc.foundationMediaQueryViewer() : null;
-    $.fn.foundationTabs             ? $doc.foundationTabs({callback : $.foundation.customForms.appendCustomMarkup}) : null;
-    $.fn.foundationTooltips         ? $doc.foundationTooltips() : null;
-    $.fn.foundationMagellan         ? $doc.foundationMagellan() : null;
-    $.fn.foundationClearing         ? $doc.foundationClearing() : null;
+    // Allow for setting per-plugin default options
+    var userDefaults = $.extend({}, defaults, $.foundationDefaults);
+    
+    $.fn.foundationAlerts           ? $doc.foundationAlerts(userDefaults.alerts) : null;
+    $.fn.foundationButtons          ? $doc.foundationButtons(userDefaults.buttons) : null;
+    $.fn.foundationAccordion        ? $doc.foundationAccordion(userDefaults.accordion) : null;
+    $.fn.foundationNavigation       ? $doc.foundationNavigation(userDefaults.navigation) : null;
+    $.fn.foundationTopBar           ? $doc.foundationTopBar(userDefaults.topBar) : null;
+    $.fn.foundationCustomForms      ? $doc.foundationCustomForms(userDefaults.customFonts) : null;
+    $.fn.foundationMediaQueryViewer ? $doc.foundationMediaQueryViewer(userDefaults.mediaQueryViewer) : null;
+    $.fn.foundationTabs             ? $doc.foundationTabs(userDefaults.tabs) : null;
+    $.fn.foundationTooltips         ? $doc.foundationTooltips(userDefaults.tooltips) : null;
+    $.fn.foundationMagellan         ? $doc.foundationMagellan(userDefaults.magellan) : null;
+    $.fn.foundationClearing         ? $doc.foundationClearing(userDefaults.clearing) : null;
 
     $.fn.placeholder                ? $('input, textarea').placeholder() : null;
   });

--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -55,7 +55,7 @@
       // close all dropdowns and deactivate all buttons
       this.on('click.fndtn', 'body, html', function (e) {
         // check original target instead of stopping event propagation to play nice with other events
-        if (typeof(e.originalEvent) === 'undefined' || !$(e.originalEvent.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
+        if (typeof(e.originalEvent) === 'undefined' || typeof(e.originalEvent.target) === 'undefined' || !$(e.originalEvent.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
           closeDropdowns();
           if (config.dropdownAsToggle) {
             resetToggles();


### PR DESCRIPTION
When including the Buttons plugin on any page, I got some weird error whenever a click event was triggered on an `<a>` element with a hash `href` attribute, like:

``` html
<a href="#some-id">Click me</a>
```

I would get a:

```
Fix for Uncaught TypeError: Cannot read property 'target' of undefined on line 58
```

Double checking for the `originalEvent`'s target did the trick for me.
