### PR TITLE
Don't explode when location.hash == "#/123"

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -103,7 +103,7 @@
       if (hash.length > 0 && this.settings.deep_linking) {
         $(this.scope)
           .find('[data-section]')
-          .find('.content[data-slug=' + hash + ']')
+          .find('.content[data-slug="' + hash + '"]')
           .closest('section, .section')
           .addClass('active');
       }


### PR DESCRIPTION
When location.hash is "#/123", section.js / jQuery errored with 
  "Error: Syntax error, unrecognized expression: .content[data-slug=/123]".
This fixes that.
