### PR TITLE
Remove extra DOM query

### DIFF
--- a/vendor/assets/javascripts/foundation/app.js
+++ b/vendor/assets/javascripts/foundation/app.js
@@ -4,7 +4,7 @@
   var $doc = $(document),
       Modernizr = window.Modernizr;
 
-  $(document).ready(function() {
+  $doc.ready(function() {
     $.fn.foundationAlerts           ? $doc.foundationAlerts() : null;
     $.fn.foundationButtons          ? $doc.foundationButtons() : null;
     $.fn.foundationAccordion        ? $doc.foundationAccordion() : null;


### PR DESCRIPTION
This is utterly insignificant but it seems to me to be ever so slightly more tidy to use the cached reference to  `$doc` instead of wrapping it in jQuery again with `$(document)`.
