### PR TITLE
Fix broken 'Get Started' link

### DIFF
--- a/docs/_sidebar.html.erb
+++ b/docs/_sidebar.html.erb
@@ -3,7 +3,7 @@
     <p class="title"><a href="#">Using Foundation</a></p>
     <div class="content">
       <ul class="side-nav">
-        <li><a href="http://www.foundation.zurb.com/docs/">Get Started</a></li>
+        <li><a href="http://foundation.zurb.com/docs/">Get Started</a></li>
         <li><a href="javascript.html">Javascript</a></li>
         <li><a href="sass.html">Sass</a></li>
         <li><a href="rails.html">Rails</a></li>


### PR DESCRIPTION
www.foundation.zurb.com doesn't resolve and the 'Get Started' link int he sidebar uses it. This pull request just fixes that link.
