### PR TITLE
fixed broken links to support and changelog page

### DIFF
--- a/docs/faq.html.erb
+++ b/docs/faq.html.erb
@@ -43,7 +43,7 @@
     <div class="panel">
       <h3>What's Changed Recently?</h3>
       <h5 class="subheader">Foundation is the most advanced front-end framework in existence. We've ditched IE7 so that we can do more awesome things and push the web to where it needs to be. Take a look at our changelog to know what's recently been changed or updated.</h5>
-      <a class="button" href="support.php">Browser Support &raquo;</a> <a class="secondary button" href="changelog.php">See the Version Changelog &raquo;</a>
+      <a class="button" href="support.html">Browser Support &raquo;</a> <a class="secondary button" href="changelog.html">See the Version Changelog &raquo;</a>
     </div>
 
   </div>


### PR DESCRIPTION
links to to support and changelog had `.php` as extension, where all other links in the doc where using `.html`

links also broken in the current http://foundation.zurb.com/docs/faq.html
