### PR TITLE
Minor fix to custom drop down in Firefox

### DIFF
--- a/scss/foundation/components/_custom-forms.scss
+++ b/scss/foundation/components/_custom-forms.scss
@@ -111,6 +111,7 @@ form.custom {
     -webkit-box-shadow: none;
     box-shadow: none;
     font-size: emCalc(14px);
+    vertical-align: top;
 
     ul {
       overflow-y: auto;


### PR DESCRIPTION
If a custom drop down is displayed as inline, it doesn't align with the text property in FF. Eg:

```
<form class="custom">
   <p>Bla bla bla <select></select> bla bla bla</p>
   <style> .custom.dropdown { display:inline-block; width:100px; } </style>
</form>
```

As per http://stackoverflow.com/questions/5373400/why-does-setting-line-height-for-one-of-two-inline-block-sibling-divs-effect-bot `vertical-align:top` fixes it.
