### PR TITLE
Update _top_bar.css to respect font-size overrides

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -209,7 +209,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
       width: 100%;
       padding: 12px 0 12px $topbar-height / 3;
       color: $topbar-link-color;
-      font-size: emCalc(13px);
+      font-size: $topbar-link-font-size;
       font-weight: bold;
       background: $topbar-dropdown-bg;
 
@@ -218,7 +218,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
 
       &.button {
         background: $primary-color;
-        font-size: emCalc(13px);
+        font-size: $topbar-link-font-size;
         &:hover {
           background: darken($primary-color, 10%);
         }


### PR DESCRIPTION
The font-size of links in a top-bar section was hard set to 13px and did not respect any overrides set by the user.
