### PR TITLE
Fix for #1648 - Button with postfix or prefix does not render text at correct height

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -183,6 +183,8 @@ $input-error-message-font-color-alt: #333 !default;
   @if $is-button {
     padding-#{$default-float}: 0;
     padding-#{$default-opposite}: 0;
+    padding-top: 0;
+    padding-bottom: 0;
     text-align: center;
     line-height: emCalc(34px);
   }


### PR DESCRIPTION
As above. I'm not 100% familiar with Zurb's patterns, so unsure if this overriding of an override is considered good practice or not - but it appears to fix the issue.
