### PR TITLE
Minor syntax error

### DIFF
--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -90,7 +90,7 @@ $section-bottom-margin:          emCalc(20px) !default;
       padding: $section-padding;
       background-color: $section-content-bg;
 
-      *:last-child { margin-bottom: 0; }
+      &:last-child { margin-bottom: 0; }
     }
 
     &.active {

--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -64,8 +64,8 @@ $section-bottom-margin:          emCalc(20px) !default;
     border-top: $section-border-size $section-border-style $section-border-color;
     position: relative;
 
-    *>:first-child { padding-top: 0; }
-    *>:last-child { padding-bottom: 0; }
+    >*:first-child { padding-top: 0; }
+    >*:last-child { padding-bottom: 0; }
 
     .title {
       top: 0;


### PR DESCRIPTION
Current code says first and last child of everything (*) shall have no padding. Dwhaaaaat?

Should be direct children of section only. 

Fixed
