### PR TITLE
Easier Tooltip border-radius settings

### DIFF
--- a/scss/foundation/components/_tooltips.scss
+++ b/scss/foundation/components/_tooltips.scss
@@ -53,6 +53,7 @@ $tooltip-pip-size:            5px !default;
   width: 100%;
   color: $tooltip-font-color;
   background: $tooltip-bg;
+  @include radius($tooltip-radius);
 
   &>.nub {
     display: block;
@@ -68,8 +69,6 @@ $tooltip-pip-size:            5px !default;
     color: $has-tip-font-color-hover !important;
     border-bottom: $has-tip-border-bottom-hover !important;
   }
-
-  &.radius{ @include radius($tooltip-radius); }
 }
 
 .tap-to-close {


### PR DESCRIPTION
$tooltip-radius doesn't seeme to do anything.
Since the span.tooltip is created on page load there is no way to add the .radius to it.
Maby the tooltip-radius should be added to .tooltip instead. Then it would have $globalRadius as default.
