### PR TITLE
_orbit.scss: utilize $orbit-caption-font-color

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -53,7 +53,7 @@ $orbit-slide-number-padding: emCalc(5px) !default;
         padding: 10px 14px;
         font-size: emCalc(14px);
 
-        * { color: #fff; }
+        * { color: $orbit-caption-font-color; }
       }
     }
   }


### PR DESCRIPTION
Utilizing $orbit-caption-font-color in _orbit.scss. Otherwise that same variable in an individual project's _settings.scss does nothing.
