### PR TITLE
Use e.target for the event's original target.

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.buttons.js
@@ -55,7 +55,7 @@
       // close all dropdowns and deactivate all buttons
       this.on('click.fndtn', 'body, html', function (e) {
         // check original target instead of stopping event propagation to play nice with other events
-        if (typeof(e.originalEvent) === 'undefined' || !$(e.originalEvent.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
+        if (!$(e.target).is('.button.dropdown:not(.split), .button.dropdown.split span')) {
           closeDropdowns();
           if (config.dropdownAsToggle) {
             resetToggles();


### PR DESCRIPTION
The 'originalEvent' property of a jQuery event object contains a browser-native event object. IE8's event objects do not have a 'target' property. (It uses 'srcElement' instead.) Because of this, as soon as a dropdown was opened on IE8, it would immediately be closed.

There's no reason to be using the 'originalEvent,' at all, in this code, since the 'target' property of a jQuery Event contains the element that initiated the event, which is exactly what this code is looking for.
