### PR TITLE
Define standard initializer as well as assets initializer

### DIFF
--- a/lib/foundation/engine.rb
+++ b/lib/foundation/engine.rb
@@ -1,12 +1,20 @@
 module Foundation
   class Engine < Rails::Engine
-    # auto wire assets
-    initializer 'foundation.update_asset_paths', :group => :assets do |app|
+    # Save this block, we'll use it in two calls to .initializer
+    add_paths_block = lambda { |app|
       app.config.assets.paths << File.expand_path("../../../scss", __FILE__)
       app.config.assets.paths << File.expand_path("../../../js", __FILE__)
 
       # Ensure Zepto and Modernizr are precompiled in production
       app.config.assets.precompile += %w(vendor/zepto.js vendor/custom.modernizr.js)
-    end
+    }
+
+    # Standard initializer
+    initializer 'foundation.update_asset_paths', &add_paths_block
+
+    # Special initializer lets us precompile assets without fully initializing
+    initializer 'foundation.update_asset_paths', :group => :assets,
+                &add_paths_block
+
   end
 end


### PR DESCRIPTION
This way, we can happily precompile assets without needing to initialize the app, and assets still work when we do initialize the app.
