### PR TITLE
Adds horizontal-nav to section (replacement for Nav Bar in v3) 

### DIFF
--- a/docs/components/section.html.erb
+++ b/docs/components/section.html.erb
@@ -39,6 +39,32 @@
             </div>
           </div>
           <div class="large-9 columns">
+            <div class="section-container horizontal-nav" data-section data-options="deep_linking: false">
+              <section class="section">
+                <p class="title"><a href="#">Section 1</a></p>
+                <div class="content">
+                  <ul class="side-nav">
+                    <li><a href="#">Link 1</a></li>
+                    <li><a href="#">Link 2</a></li>
+                    <li><a href="#">Link 3</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#">Link 1</a></li>
+                  </ul>
+                </div>
+              </section>
+              <section class="section">
+                <p class="title"><a href="#">Section 2</a></p>
+                <div class="content">
+                  <ul class="side-nav">
+                    <li><a href="#">Link 1</a></li>
+                    <li><a href="#">Link 2</a></li>
+                    <li><a href="#">Link 3</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#">Link 1</a></li>
+                  </ul>
+                </div>
+              </section>
+            </div>            
             <div class="section-container tabs" data-section data-options="deep_linking: true">
               <section class="section">
                 <p class="title"><a href="#panel1">Section 1</a></p>
@@ -84,7 +110,7 @@
 
         <hr>
 
-        <h3>Sections Replace Accordion, Tabs &amp; Vertical Nav</h3>
+        <h3>Sections Replace Accordion, Tabs, Vertical Nav &amp; Nav Bar</h3>
         <p>Sections replace a few things that you are used to from Foundation 3. We've taken the accordion, the tabs and the vertical nav and combined them into this really flexible plugin that can handle all of those. The single JS file handles all the interactions, but the classes you add to the element control how it gets rendered and styled across our breakpoint.</p>
 
         <hr>
@@ -153,6 +179,48 @@
 <div class="row">
   <div class="large-3 columns">
     <div class="section-container vertical-nav" data-section>
+      <section class="section">
+        <p class="title"><a href="#">Section 1</a></p>
+        <div class="content">
+          <ul class="side-nav">
+            <li><a href="#">Link 1</a></li>
+            <li><a href="#">Link 2</a></li>
+            <li><a href="#">Link 3</a></li>
+            <li class="divider"></li>
+            <li><a href="#">Link 1</a></li>
+          </ul>
+        </div>
+      </section>
+      <section class="section">
+        <p class="title"><a href="#">Section 2</a></p>
+        <div class="content">
+          <ul class="side-nav">
+            <li><a href="#">Link 1</a></li>
+            <li><a href="#">Link 2</a></li>
+            <li><a href="#">Link 3</a></li>
+            <li class="divider"></li>
+            <li><a href="#">Link 1</a></li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </div>
+  <div class="large-9 columns">
+    <p>Content to the right of the navigation.</p>
+  </div>
+</div>', :html %>
+
+        <h6>Horizontal Nav/Nav Bar</h6>
+        <p>Adding a <code>horizontal-nav</code> class to the section container will enable horizontal navigation elements on large screens and show an accordion on small screens.</p>
+
+        <p>Horizontal navigation is a combination of the tab setting with vertical navigation drop downs.</p>
+
+        <p>Use the <code>side-nav</code> class on the list to apply the Foundation navigation styles</p>
+
+<%= code_example '
+<div class="row">
+  <div class="large-3 columns">
+    <div class="section-container horizontal-nav" data-section>
       <section class="section">
         <p class="title"><a href="#">Section 1</a></p>
         <div class="content">

--- a/docs/components/section.html.erb
+++ b/docs/components/section.html.erb
@@ -218,39 +218,33 @@
         <p>Use the <code>side-nav</code> class on the list to apply the Foundation navigation styles</p>
 
 <%= code_example '
-<div class="row">
-  <div class="large-3 columns">
-    <div class="section-container horizontal-nav" data-section>
-      <section class="section">
-        <p class="title"><a href="#">Section 1</a></p>
-        <div class="content">
-          <ul class="side-nav">
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link 2</a></li>
-            <li><a href="#">Link 3</a></li>
-            <li class="divider"></li>
-            <li><a href="#">Link 1</a></li>
-          </ul>
-        </div>
-      </section>
-      <section class="section">
-        <p class="title"><a href="#">Section 2</a></p>
-        <div class="content">
-          <ul class="side-nav">
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link 2</a></li>
-            <li><a href="#">Link 3</a></li>
-            <li class="divider"></li>
-            <li><a href="#">Link 1</a></li>
-          </ul>
-        </div>
-      </section>
+<div class="section-container horizontal-nav" data-section>
+  <section class="section">
+    <p class="title"><a href="#">Section 1</a></p>
+    <div class="content">
+      <ul class="side-nav">
+        <li><a href="#">Link 1</a></li>
+        <li><a href="#">Link 2</a></li>
+        <li><a href="#">Link 3</a></li>
+        <li class="divider"></li>
+        <li><a href="#">Link 1</a></li>
+      </ul>
     </div>
-  </div>
-  <div class="large-9 columns">
-    <p>Content to the right of the navigation.</p>
-  </div>
-</div>', :html %>
+  </section>
+  <section class="section">
+    <p class="title"><a href="#">Section 2</a></p>
+    <div class="content">
+      <ul class="side-nav">
+        <li><a href="#">Link 1</a></li>
+        <li><a href="#">Link 2</a></li>
+        <li><a href="#">Link 3</a></li>
+        <li class="divider"></li>
+        <li><a href="#">Link 1</a></li>
+      </ul>
+    </div>
+  </section>
+</div>
+', :html %>
 
 
         <h6>Deep Linking</h6>

--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -6,7 +6,7 @@
   Foundation.libs.section = {
     name: 'section',
 
-    version : '4.0.3',
+    version : '4.0.4',
 
     settings : {
       deep_linking: false,
@@ -49,6 +49,7 @@
     toggle_active : function (e, self) {
       var $this = $(this),
           section = $this.closest('section, .section'),
+          title = section.find('.title'),
           content = section.find('.content'),
           parent = section.closest('[data-section]'),
           self = Foundation.libs.section;
@@ -60,6 +61,7 @@
       if (section.hasClass('active')) {
         if (self.small(parent)
           || self.is_vertical(parent)
+          || self.is_horizontal(parent)
           || self.is_accordion(parent)) {
           section
             .removeClass('active')
@@ -81,6 +83,9 @@
         }
 
         section.addClass('active');
+
+        if (self.is_horizontal(parent))
+          content.css({left: title.position().left, top: title.outerHeight()});
       }
 
       self.settings.callback();
@@ -100,6 +105,7 @@
             .attr('style', '');
         } else if (active_section.length < 1
           && !self.is_vertical($this)
+          && !self.is_horizontal($this)
           && !self.is_accordion($this)) {
           var first = $this.find('section, .section').first();
           first.addClass('active');
@@ -122,6 +128,10 @@
 
     is_vertical : function (el) {
       return el.hasClass('vertical-nav');
+    },
+
+    is_horizontal : function (el) {
+      return el.hasClass('horizontal-nav');
     },
 
     is_accordion : function (el) {

--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -53,6 +53,12 @@ $section-bottom-margin:          emCalc(20px) !default;
   @else if $section-type == vertical-nav {
 
   }
+
+  // Horizontal Nav container border styles
+  @else if $section-type == horizontal-nav {
+    border: 0;
+    position: relative;
+  }
 }
 
 // We use this mixin to create the styles for sections as accordions.
@@ -157,6 +163,37 @@ $section-bottom-margin:          emCalc(20px) !default;
       }
     }
   }
+
+  // Horizontal Nav Styles
+  @else if $section-type == horizontal-nav {
+    padding-top: 0;
+    border: 0;
+    position: static;
+    
+    .title {
+      top: 1px;
+      width: auto;
+      border: $section-border-size $section-border-style $section-border-color;
+      border-right: 0;
+      position: absolute;
+      z-index: 1;
+
+      a { width: 100%; }
+    }
+    &:last-child .title { border-right: $section-border-size $section-border-style $section-border-color; }
+
+    .content { display: none; }
+
+    &.active {
+      .content {
+        display: block;
+        position: absolute;
+        z-index: 999;
+        min-width: $section-vertical-nav-min-width;
+        border: $section-border-size $section-border-style $section-border-color;
+      }
+    }
+  }
 }
 
 
@@ -181,6 +218,13 @@ $section-bottom-margin:          emCalc(20px) !default;
 
       section,
       .section { @include section(vertical-nav); }
+    }
+
+    .section-container.horizontal-nav {
+      @include section-container(false, horizontal-nav);
+
+      section,
+      .section { @include section(horizontal-nav); }
     }
 
     .section-container.tabs {


### PR DESCRIPTION
After upgrading a site I noticed there was no suitable replacement for the Nav Bar used in Foundation 3. The top bar is overkill for simple or secondary menus.

I've kept the code clean and succinct. The docs will need to be updated to include the extra use case:

`<div class="section-container horizontal-nav" data-section>`

Enjoy
