### PR TITLE
`nth-of-type` fix for block-grids

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -35,8 +35,9 @@ $block-grid-media-queries: true !default;
     &>li {
       width: 100%/$per-row;
       padding: 0 $spacing $spacing;
+      
+      &:nth-of-type(#{$per-row}n+1) { clear: both; }
     }
-    &:nth-of-type(#{$per-row}n+1) { clear: both; }
   }
 
 }


### PR DESCRIPTION
`nth-of-type` should be applied to the `li` to have the contents float correctly.
