### PR TITLE
HTML5 Required w/ Custom Select

### DIFF
--- a/docs/components/custom-forms.html.erb
+++ b/docs/components/custom-forms.html.erb
@@ -279,6 +279,56 @@
         </form>
 
         <hr>
+        <h3><a name="errors"></a>Errors</h3>
+        <p>Foundation includes error states for labels, inputs and messaging that you can have your app generate programatically. You can attach a class of .error either to the individual elements (label, input, small) or to a column/div.</p>
+
+          <div class="row">
+            <div class="large-6 columns">
+<%= code_example '
+<label for="customDropdownError1">HTML5 Required Example</label>
+<select id="customDropdownError1" required>
+  <option value="">Invalid</option>
+  <option value="1">Valid</option>
+</select>', :html %>
+            </div>
+            <div class="large-6 columns">
+<%= code_example '
+<div class="large-6 columns error">
+  <label for="customDropdownError2">Custom Error Example</label>
+  <select id="customDropdownError2" required>
+    <option>Pineapples</option>
+    <option>Oranges</option>
+    <option>Kiwis</option>
+    <option>Guava</option>
+  </select>
+  <small>Pineapple is out of season.</small>
+</div>', :html %>
+            </div>
+          </div>
+        <form class="custom">
+          <div class="row">
+            <div class="large-6 columns">
+                <label for="customDropdownError1">HTML5 Required Example</label>
+                <select id="customDropdownError1" required>
+                  <option value="">Invalid</option>
+                  <option value="1">Valid</option>
+                </select>
+            </div>
+            <div class="large-6 columns error">
+              <label for="customDropdownError2">Custom Error Example</label>
+              <select id="customDropdownError2" required>
+                <option>Pineapples</option>
+                <option>Oranges</option>
+                <option>Kiwis</option>
+                <option>Guava</option>
+              </select>
+              <small>Pineapple is out of season.</small>
+            </div>
+          </div>
+          <input type="submit" value="Submit" class="button" />
+        </form>
+
+        <hr>
 
         <h3><a name="js"></a>Using the JavaScript</h3>
         <p>In order to get the custom forms to function, you'll need to include <code>foundation.forms.js</code>. You'll also need to make sure to include <code>zepto.js</code> and <code>foundation.js</code> above the forms plugin. Above your closing <code>&lt;/body&gt;</code> tag include the following line of code and make sure you have the JS in your directory.</p>
@@ -293,7 +343,8 @@
 
 <%= code_example "
 {
-  disable_class: 'no-custom'
+  disable_class: 'no-custom',
+  override_html5_errors: true
 }", :json %>
 
       </div>

--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -10,7 +10,7 @@
 
     settings : {
       disable_class: 'no-custom',
-      override_html5_errors: false
+      override_html5_errors: true
     },
 
     init : function (scope, method, options) {

--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -195,8 +195,9 @@
       // interrupt invalid event so as to avoid the unfocusable field error
       if(self.settings.override_html5_errors) {
         $this.on('invalid',function(e){
-          $this.siblings('label').addClass('error')
-          $customSelect.addClass('error').data('html5-error',true).after('<small class="error">This Field is Required</small>')
+          if($(this).next('div.custom.dropdown').data('html5-error')) return false; // block re-erroring
+          $(this).siblings('label').addClass('error')
+          $(this).next('div.custom.dropdown').addClass('error').data('html5-error',true).after('<small class="error">This Field is Required</small>')
           e.preventDefault();
           return false;
         })

--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -9,7 +9,8 @@
     version : '4.0.0',
 
     settings : {
-      disable_class: 'no-custom'
+      disable_class: 'no-custom',
+      override_html5_errors: false
     },
 
     init : function (scope, method, options) {
@@ -94,6 +95,13 @@
           var $this = $(this),
               $dropdown = $this.closest('div.custom.dropdown'),
               $select = $dropdown.prev();
+
+          // remove automatically added error classes from html5 `invalid` event
+          if(self.settings.override_html5_errors && $dropdown.data('html5-error')) {
+            $dropdown.removeClass('error').next('small.error').remove();
+            $dropdown.siblings('label.error').removeClass('error');
+            $dropdown.data('html5-error',false)
+          }
 
           // make sure other dropdowns close
           if(!$dropdown.hasClass('open'))
@@ -183,6 +191,16 @@
           $currentSelect = false;
 
       if ($this.hasClass(self.settings.disable_class)) return;
+
+      // interrupt invalid event so as to avoid the unfocusable field error
+      if(self.settings.override_html5_errors) {
+        $this.on('invalid',function(e){
+          $this.siblings('label').addClass('error')
+          $customSelect.addClass('error').data('html5-error',true).after('<small class="error">This Field is Required</small>')
+          e.preventDefault();
+          return false;
+        })
+      }
 
       if ($customSelect.length === 0) {
         var customSelectSize = $this.hasClass( 'small' )   ? 'small'   :

--- a/scss/foundation/components/_custom-forms.scss
+++ b/scss/foundation/components/_custom-forms.scss
@@ -15,7 +15,7 @@ $custom-select-border-color:            #ddd !default;
 $custom-select-triangle-color:          #aaa !default;
 $custom-select-triangle-color-open:     #222 !default;
 $custom-select-height:                  emCalc(13px) + ($form-spacing * 1.5) !default;
-$custom-select-margin-bottom:           emCalc(20px) !default;
+$custom-select-margin-bottom:           $form-spacing !default;
 $custom-select-font-color-selected:     #141414 !default;
 $custom-select-disabled-color:          #888 !default;
 
@@ -229,6 +229,15 @@ form.custom {
     }
 
     &.show { display: block; }
+
+  }
+  // error formatting with custom dropdowns
+  .error .custom.dropdown, .custom.dropdown.error {
+    border-color: $alert-color;
+    background: $custom-dropdown-bg;
+    background: -moz-linear-gradient(top, $custom-dropdown-bg 0%, lighten($alert-color,55%) 100%);
+    background: -webkit-linear-gradient(top, $custom-dropdown-bg 0%,lighten($alert-color,55%) 100%);
+    background: linear-gradient(to bottom, $custom-dropdown-bg 0%,lighten($alert-color,55%) 100%);
   }
 
   /* Custom input, disabled */


### PR DESCRIPTION
Fixes #1741

This adds support for errors with custom selects. Without this fix, a javascript error will be thrown when the browser can't focus to a `select` element with the attribute of `required`.

Examples and documentation have also been added. This is a work in progress as I'd like to refine the error styling (and settings for it).

![Screen Shot 2013-03-06 at 6 54 27 AM](https://f.cloud.github.com/assets/687594/227192/a0f25d1e-8654-11e2-8680-4f4c933895dc.png)
