### PR TITLE
setting img to inline-block as setting it to block for all images breaks most website layouts

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -49,7 +49,7 @@ img { -ms-interpolation-mode: bicubic; }
 .hide         { display: none; }
 
 // Get rid of gap under images by making them display: block; by default
-img { display: block; }
+img { display: inline-block; }
 
 //
 // Global resets for forms

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -48,7 +48,7 @@ img { -ms-interpolation-mode: bicubic; }
 .text-justify { text-align: justify; }
 .hide         { display: none; }
 
-// Get rid of gap under images by making them display: block; by default
+// Get rid of gap under images by making them display: inline-block; by default
 img { display: inline-block; }
 
 //

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -49,7 +49,7 @@ img { -ms-interpolation-mode: bicubic; }
 .hide         { display: none; }
 
 // Get rid of gap under images by making them display: block; by default
-img { display: inline-block; }
+img { display: inline-block;}
 
 //
 // Global resets for forms

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -49,7 +49,7 @@ img { -ms-interpolation-mode: bicubic; }
 .hide         { display: none; }
 
 // Get rid of gap under images by making them display: block; by default
-img { display: inline-block;}
+img { display: inline-block; }
 
 //
 // Global resets for forms


### PR DESCRIPTION
Images are inline elements and therefore they should not be set "display: block;" by default. Settings them to "display: inline-block;" will also fixing the gap under the images but it will not break the layouts of probably all website out there.
