### PR TITLE
add bg color variable for progress bar

### DIFF
--- a/scss/foundation/components/_progress-bars.scss
+++ b/scss/foundation/components/_progress-bars.scss
@@ -4,6 +4,7 @@
 
 // We use this to se the prog bar height
 $progress-bar-height: emCalc(25px) !default;
+$progress-bar-color: transparent !default;
 
 // We use these to control the border styles
 $progress-bar-border-color: darken(#fff, 20%) !default;
@@ -28,6 +29,7 @@ $progress-meter-alert-color: $alert-color !default;
 
 // We use this to set up the progress bar container
 @mixin progress-container {
+  background-color: $progress-bar-color;
   height: $progress-bar-height;
   border: $progress-bar-border-size $progress-bar-border-style $progress-bar-border-color;
   padding: $progress-bar-pad;

--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -722,6 +722,7 @@
 
 // We use this to se the prog bar height
 // $progress-bar-height: emCalc(25px);
+// $progress-bar-color: transparent;
 
 // We use these to control the border styles
 // $progress-bar-border-color: darken(#fff, 20%);


### PR DESCRIPTION
This will allow developers more control to easily change the appearance of the default progress bars.

In my use case I removed padding and borders like so: `$progress-bar-border-size: 0;` and `$progress-bar-pad: 0;` and then wanted control over the bar color without adding extra classes. See screenshot for an idea of the result—which would be _super simple_ :grinning:  with this extra variable.

![Screen Shot 2013-03-06 at 1 17 18 PM](https://f.cloud.github.com/assets/196410/229302/e95ba98e-869a-11e2-93e8-0f1e75ad3439.png)
