### PR TITLE
Fix touch handling when using jQuery

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -177,6 +177,7 @@
           }
         })
         .on('touchstart.fndtn.orbit', function(e) {
+          if (!e.touches) { e = e.originalEvent; }
           var data = {
             start_page_x: e.touches[0].pageX,
             start_page_y: e.touches[0].pageY,
@@ -188,6 +189,7 @@
           e.stopPropagation();
         })
         .on('touchmove.fndtn.orbit', function(e) {
+          if (!e.touches) { e = e.originalEvent; }
           // Ignore pinch/zoom events
           if(e.touches.length > 1 || e.scale && e.scale !== 1) return;
 


### PR DESCRIPTION
When using jQuery, events seem to get "fixed" to work around some browser bugs, but this doesn't work perfectly for touches. See (http://www.the-xavi.com/articles/trouble-with-touch-events-jquery) for more details. This meant that if someone used orbit with jQuery rather than zepto, touch handling would be broken due to e.touches being undefined.

This fixes that case.
