### PR TITLE
Font cleanup

### DIFF
--- a/scss/foundation/_foundation-global.scss
+++ b/scss/foundation/_foundation-global.scss
@@ -17,9 +17,6 @@ $body-font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif !
 $body-font-weight: normal !default;
 $body-font-style: normal !default;
 
-// We use this to control font-smoothing
-$font-smoothing: antialiased !default;
-
 // We use these to control text direction settings
 $text-direction: ltr !default; // Controls default global text direction, 'rtl' or 'ltr'
 $default-float: left !default;

--- a/scss/foundation/_foundation-global.scss
+++ b/scss/foundation/_foundation-global.scss
@@ -3,7 +3,11 @@
 // Variables
 //
 
-// This is the default html and body font-size for the base em value.
+// The default font-size is set to 100% of the browser style sheet (usually 16px) 
+// for compatibility with brower-based text zoom or user-set defaults. 
+$base-font-size: 100% !default;
+
+// Set your base font-size in pixels so emCalc can do its magic below
 $em-base: 16px !default;
 
 // We use these to control various global styles

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -6,7 +6,7 @@
 }
 
 html,
-body { font-size: $em-base; }
+body { font-size: $base-font-size; }
 
 // Default body styles
 body {
@@ -50,6 +50,12 @@ img { -ms-interpolation-mode: bicubic; }
 .text-center  { text-align: center !important; }
 .text-justify { text-align: justify !important; }
 .hide         { display: none; }
+
+// Font smoothing
+// Antialiased font smoothing works best for light text on a dark background.
+// Apply to single elements instead of globally to body. 
+// Note this only applies to webkit-based desktop browsers on the Mac.
+.antialiased { -webkit-font-smoothing: antialiased; }
 
 // Get rid of gap under images by making them display: inline-block; by default
 img { display: inline-block; }

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -19,7 +19,6 @@ body {
   font-style: $body-font-style;
   line-height: 1;
   position: relative;
-  -webkit-font-smoothing: $font-smoothing;
 }
 
 // Override outline from normalize, we don't like it


### PR DESCRIPTION
# Global font-size

Changed the font-size property for html/body elements from 16px to 100%. While most browsers default to 16px, this ensures compatibility with brower-based text zoom and user-set defaults. 
# Font smoothing

Restored font smoothing settings to browser defaults. This property only works in one family of browsers and only on the desktop and only on the Mac. Changed from global setting on body element to class based setting. Also, some folks consider this property harmful. (see http://www.usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/)
