### PR TITLE
Fixes recent pull request causing $topbar-link-color to be ignored 

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -208,7 +208,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
     & > a {
       display: block;
       width: 100%;
-      color: $topbar-dropdown-link-color;
+      color: $topbar-link-color;
       padding: 12px 0 12px 0;
       padding-#{$default-float}: $topbar-height / 3;
       font-size: $topbar-link-font-size;
@@ -405,6 +405,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
 
       li {
         a {
+          color: $topbar-dropdown-link-color;
           line-height: 1;
           white-space: nowrap;
           padding: 7px $topbar-height / 3;


### PR DESCRIPTION
A recent pull request (https://github.com/zurb/foundation/pull/1730) which causes $topbar-link-color to be ignored but
$topbar-dropdown-link-color to be used instead for the topbar link color.  These changes honor the intention of $topbar-link-color and $topbar-dropdown-link-color.
