### PR TITLE
Configured the Foundation initialization script to run in noConflict() and default mode

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -8,11 +8,21 @@
 
 /*jslint unparam: true, browser: true, indent: 2 */
 
-// Accommodate running jQuery in noConflict() mode by
-// using an anonymous function to redefine the jQuery $
-// shorthand name. See http://docs.jquery.com/Using_jQuery_with_Other_Libraries
-if (jQuery == null) {
-    var jQuery = $;
+// Accommodate running jQuery or Zepto in noConflict() mode by
+// using an anonymous function to redefine the $ shorthand name.
+// See http://docs.jquery.com/Using_jQuery_with_Other_Libraries
+// and http://zeptojs.com/
+var libFuncName = null;
+if (typeof jQuery === "undefined" &&
+    typeof Zepto === "undefined" &&
+    typeof $ === "function") {
+    libFuncName = $;
+} else if (typeof jQuery === "function") {
+    libFuncName = jQuery;
+} else if (typeof Zepto === "function") {
+    libFuncName = Zepto;
+} else {
+    throw new TypeError();
 }
 
 (function ($) {
@@ -339,4 +349,4 @@ if (jQuery == null) {
 
 }(this, this.document));
 
-})(jQuery);
+})(libFuncName);

--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -8,6 +8,15 @@
 
 /*jslint unparam: true, browser: true, indent: 2 */
 
+// Accommodate running jQuery in noConflict() mode by
+// using an anonymous function to redefine the jQuery $
+// shorthand name. See http://docs.jquery.com/Using_jQuery_with_Other_Libraries
+if (jQuery == null) {
+    var jQuery = $;
+}
+
+(function ($) {
+
 (function () {
   // add dusty browser stuff
   if (!Array.prototype.filter) {
@@ -329,3 +338,5 @@
   };
 
 }(this, this.document));
+
+})(jQuery);


### PR DESCRIPTION
The purpose of this commit is to facilitate Foundation running in jQuery noConflict() mode in which the $ shorthand is globally replaced with the "jQuery" long-form function name. The commit supports running in noConflict() and default ("$" shorthand is available) modes.

I tested in both modes using the code referenced in the [Getting Started Guide](http://foundation.zurb.com/docs/) and the [Top Bar Guide](http://foundation.zurb.com/docs/components/top-bar.html)
