### PR TITLE
Always append foundation to application stylesheet.

### DIFF
--- a/lib/foundation/generators/install_generator.rb
+++ b/lib/foundation/generators/install_generator.rb
@@ -17,7 +17,7 @@ module Foundation
         settings_file = File.join(File.dirname(__FILE__),"..","..","..","templates","project","scss","_settings.scss")
         create_file "app/assets/stylesheets/foundation_and_overrides.scss", File.read(settings_file)
         append_to_file "app/assets/stylesheets/foundation_and_overrides.scss", "\n@import 'foundation';\n"
-        insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "#{detect_css_format[1]} require foundation_and_overrides\n", :after => "require_self\n"
+        append_to_file "app/assets/stylesheets/application#{detect_css_format[0]}", "#{detect_css_format[1]} require foundation_and_overrides\n"
       end
 
       def detect_js_format


### PR DESCRIPTION
I removed the detection of require_self, since that might be gone
from an application that's written using Compass exclusively.
There is no need for the require to be appended immediately
after require_self, and this change makes the generator work
on more permutations of the application stylesheet.
