### PR TITLE
Fixes #1845 Span with label clips when wrapped on mobile

### DIFF
--- a/scss/foundation/components/_labels.scss
+++ b/scss/foundation/components/_labels.scss
@@ -21,7 +21,7 @@ $label-font-weight: bold !default;
   text-decoration: none;
   line-height: 1;
   white-space: nowrap;
-  display: inline;
+  display: inline-block;
   position: relative;
 }
 


### PR DESCRIPTION
`.label` had `display: inline`, which doesn't work with `box-sizing: border-box`. Padding on the label therefore pushes the background past the baseline.

This fix has the potential to break existing layouts.
