### PR TITLE
Update _tables.scss

### DIFF
--- a/scss/foundation/components/_tables.scss
+++ b/scss/foundation/components/_tables.scss
@@ -75,6 +75,6 @@ $table-margin-bottom:    emCalc(20px) !default;
 
 
 /* Tables */
-table {
+table.table {
   @include table;
 }


### PR DESCRIPTION
Require a table to have a class of "table" for styling.

Fixes #1889
