### PR TITLE
Add an example for accordion on both small and large screens

### DIFF
--- a/docs/components/section.html.erb
+++ b/docs/components/section.html.erb
@@ -150,6 +150,24 @@
         <hr>
 
         <h3>Variations</h3>
+        <h6>Accordion</h6>
+        <p>Adding an <code>accordion</code> class to the section container will show an accordion on both small and large screens.</p>
+<%= code_example '
+<div class="section-container accordion" data-section>
+  <section class="section">
+    <p class="title"><a href="#">Section 1</a></p>
+    <div class="content">
+      <p>Content of section 1.</p>
+    </div>
+  </section>
+  <section class="section">
+    <p class="title"><a href="#">Section 2</a></p>
+    <div class="content">
+      <p>Content of section 2.</p>
+    </div>
+  </section>
+</div>', :html %>
+        
         <h6>Tabs/Accordion</h6>
         <p>Adding a <code>tabs</code> class to the section container will enable tabs on large screens and show an accordion on small screens.</p>
 <%= code_example '


### PR DESCRIPTION
If you want accordion functionality on both small and large screens, without tabs, the `accordion` class is required. Without the accordion class, the [javascript](https://github.com/zurb/foundation/blob/master/js/foundation/foundation.section.js#L138) will add top padding to the section element.

![when-no-accordion-class](https://f.cloud.github.com/assets/379519/257164/1a150120-8c49-11e2-9c32-ae671003fdc6.png)
