### PR TITLE
Adjust .switch to only apply to div tags

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -219,7 +219,7 @@ $switch-label-outline:            1px dotted #888 !default;
   @media only screen {
 
     // Containing element for the radio switch
-    .switch {
+    div.switch {
       @include switch;
 
       // Large radio switches


### PR DESCRIPTION
This makes it match [the docs](http://foundation.zurb.com/docs/components/switch.html) and also less likely to conflict with 3rd party plugins that utilize the switch class on other tags like `th` or `td`.
