### PR TITLE
Fixed wrong check for reveal css-top property.

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -90,7 +90,7 @@
 
       var open_modal = $('.reveal-modal.open');
 
-      if (!modal.data('css-top')) {
+      if (typeof modal.data('css-top') === 'undefined') {
         modal.data('css-top', parseInt(modal.css('top'), 10))
           .data('offset', this.cache_offset(modal));
       }


### PR DESCRIPTION
When the reveal modal checks if it has the `css-top` data attribute set, it would assume a `0` to mean that it is not set, while it actually means it is set and its value is `0`.

Just changed the check to fix this wrong assumption.

![Celebrate!](http://www.reactiongifs.com/wp-content/uploads/2013/02/anigif_enhanced-buzz-31994-1359473038-6.gif)
