### PR TITLE
Fix breadcrumbs first element bug

### DIFF
--- a/scss/foundation/components/_breadcrumbs.scss
+++ b/scss/foundation/components/_breadcrumbs.scss
@@ -97,7 +97,7 @@ $crumb-slash: "/"                                              !default;
   }
   &:first-child a,
   &:first-child span { padding-#{$default-float}: 0; }
-  &:first-child:before { content: ""; }
+  &:first-child:before { content: " "; }
 
 }
 


### PR DESCRIPTION
Fixes issue #1876 (for foundation 4.x) and #415 (for same issue in F3). 

The first element is out of breadcrumbs is not inline with the
supplemental elements in the list.
