### PR TITLE
Better topbar .active and :hover bg control + text-decoration for a:hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ WordPress
 * [Yeti](https://github.com/modlearning/Yeti) by Modular Learning
 * [Foundation](https://github.com/drewsymo/Foundation) by Drewsymo
 * [required+ Themes](http://themes.required.ch/) by required+
+* [WPF](https://github.com/MekZii/WPF/) by MekZii
 
 Joomla
 

--- a/docs/components/top-bar.html.erb
+++ b/docs/components/top-bar.html.erb
@@ -241,6 +241,10 @@ $topbar-dropdown-toggle-color: #fff;
 $topbar-dropdown-toggle-alpha: 0.5;
 $dropdown-label-color: #555;
 
+/* Style the top bar active and hover states */
+$topbar-hover-bg: darken($topbar-dropdown-bg, 3%);
+$topbar-active-bg: $topbar-hover-bg;
+
 /* Top menu icon styles */
 $topbar-menu-link-transform: uppercase;
 $topbar-menu-link-font-size: emCalc(13px);

--- a/docs/components/type.html.erb
+++ b/docs/components/type.html.erb
@@ -309,6 +309,7 @@ $code-font-weight:                     bold;
 $anchor-text-decoration:               none;
 $anchor-font-color:                    $primary-color;
 $anchor-font-color-hover:              darken($primary-color, 5%);
+$anchor-text-decoration-hover:         none;
 
 /* We use these to style the <hr> element */
 $hr-border-width:                      1px;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -22,7 +22,7 @@ $topbar-link-weight: bold !default;
 $topbar-link-font-size: emCalc(13px) !default;
 
 // Style the top bar dropdown elements
-$topbar-dropdown-bg: #333 !default; /* this effects the colors for the divider, hover and active elements */
+$topbar-dropdown-bg: #333 !default;
 $topbar-dropdown-link-color: #fff !default;
 $topbar-dropdown-toggle-size: 5px !default;
 $topbar-dropdown-toggle-color: #fff !default;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -22,12 +22,16 @@ $topbar-link-weight: bold !default;
 $topbar-link-font-size: emCalc(13px) !default;
 
 // Style the top bar dropdown elements
-$topbar-dropdown-bg: #333 !default;
+$topbar-dropdown-bg: #333 !default; /* this effects the colors for the divider, hover and active elements */
 $topbar-dropdown-link-color: #fff !default;
 $topbar-dropdown-toggle-size: 5px !default;
 $topbar-dropdown-toggle-color: #fff !default;
 $topbar-dropdown-toggle-alpha: 0.5 !default;
 $dropdown-label-color: #555 !default;
+
+// Style the top bar active and hover states
+$topbar-hover-bg: darken($topbar-dropdown-bg, 3%) !default;
+$topbar-active-bg: $topbar-hover-bg !default;
 
 // Top menu icon styles
 $topbar-menu-link-transform: uppercase !default;
@@ -44,7 +48,7 @@ $topbar-breakpoint: emCalc(940px) !default; // Change to 9999px for always mobil
 $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !default;
 
 
-/* Wrapped around .top-bar to contain to grid width */
+// Wrapped around .top-bar to contain to grid width
 .contain-to-grid {
   width: 100%;
   background: $topbar-bg;
@@ -216,8 +220,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
       font-weight: $topbar-link-weight;
       background: $topbar-dropdown-bg;
 
-      &:hover { background: darken($topbar-dropdown-bg, 3%); }
-
+      &:hover { background: $topbar-hover-bg; }
 
       &.button {
         background: $primary-color;
@@ -248,7 +251,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
     }
 
     // Apply the active link color when it has that class
-    &.active a { background: darken($topbar-dropdown-bg, 3%); }
+    &.active > a { background: $topbar-active-bg; }
   }
 
   // Add some extra padding for list items contains buttons
@@ -317,7 +320,6 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
 }
 .js-generated { display: block; }
 
-
 // Top Bar styles intended for screen sizes above the breakpoint.
 @media #{$topbar-media-query} {
   .top-bar { background: $topbar-bg; @include clearfix; overflow: visible;
@@ -361,7 +363,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
         padding: 0 $topbar-height / 3;
         line-height: $topbar-height;
         background: $topbar-bg;
-        &:hover { background: darken($topbar-dropdown-bg, 30%); }
+        &:hover { background: $topbar-hover-bg; }
       }
     }
 

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -51,6 +51,7 @@ $code-font-weight:                     bold !default;
 $anchor-text-decoration:               none !default;
 $anchor-font-color:                    $primary-color !default;
 $anchor-font-color-hover:              darken($primary-color, 5%) !default;
+$anchor-text-decoration-hover:         none !default;
 
 // We use these to style the <hr> element
 $hr-border-width:                      1px !default;
@@ -149,7 +150,10 @@ a {
   line-height: inherit;
 
   &:hover,
-  &:focus { color: $anchor-font-color-hover; }
+  &:focus {
+    color: $anchor-font-color-hover;
+    text-decoration: $anchor-text-decoration-hover;
+  }
 
   img { border:none; }
 }

--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -994,6 +994,10 @@
 // $topbar-dropdown-toggle-alpha: 0.5;
 // $dropdown-label-color: #555;
 
+// Style the top bar active and hover states
+// $topbar-hover-bg: darken($topbar-dropdown-bg, 3%);
+// $topbar-active-bg: $topbar-hover-bg;;
+
 // Top menu icon styles
 // $topbar-menu-link-transform: uppercase;
 // $topbar-menu-link-font-size: emCalc(13px);

--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -132,6 +132,7 @@
 // $anchor-text-decoration: none;
 // $anchor-font-color: $primary-color;
 // $anchor-font-color-hover: darken($primary-color, 5%);
+// $anchor-text-decoration-hover: none;
 
 // We use these to style the <hr> element
 // $hr-border-width: 1px;


### PR DESCRIPTION
- Better topbar .active and :hover bg control. (added 2 new variables for topbar)
- Placed a '>' in topbar that was needed to get the right result (the .active bg color was given to every link in the dropdown/childs).
- text-decoration for a:hover (added a new variable for typography)
- Added the wordpress theme WPF to readme
