### PR TITLE
Fix dropdown positioning when close to the right edge of the screen

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -82,6 +82,10 @@
     },
 
     css : function (dropdown, target) {
+      if (target.parent().hasClass('button', 'split')) {
+        var target = target.parent();
+      }
+
       if (dropdown.parent()[0] === $('body')[0]) {
         var position = target.offset();
       } else {

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -97,10 +97,20 @@
           top: position.top + this.outerHeight(target)
         });
       } else {
+        var window_width = $(document).width();
+
+        if (window_width > this.outerWidth(dropdown) + target.offset().left) {
+          var left = position.left;
+        } else {
+          if (!dropdown.hasClass('right')) {
+            dropdown.addClass('right')
+          }
+          var left = position.left - (this.outerWidth(dropdown) - this.outerWidth(target));
+        }
         dropdown.attr('style', '').css({
           position : 'absolute',
           top: position.top + this.outerHeight(target),
-          left: position.left
+          left: left
         });
       }
 

--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -80,11 +80,20 @@ $f-dropdown-content-padding:      emCalc(20px) !default;
       z-index: 99;
     }
     &:after {
-      @include css-triangle($f-dropdown-triangle-size + 1,$f-dropdown-border-color,bottom);
+      @include css-triangle($f-dropdown-triangle-size + 1, $f-dropdown-border-color, bottom);
       position: absolute;
       top: -(($f-dropdown-triangle-size + 1) * 2);
       left: $f-dropdown-triangle-side-offset - 1;
       z-index: 98;
+    }
+
+    &.right:before {
+      left: auto;
+      right: $f-dropdown-triangle-side-offset;
+    }
+    &.right:after {
+      left: auto;
+      right: $f-dropdown-triangle-side-offset - 1;
     }
   }
 


### PR DESCRIPTION
This patch fixes the issue with dropdown buttons that are too close to the right edge of the screen and its menu becomes half off the screen.
## Before

![Before](http://f.cl.ly/items/2h2H1K3e0O1K1J3W1U3N/Screen%20Shot%202013-03-17%20at%2015.12.36.png)
## After

![After](http://f.cl.ly/items/2x072X2s1l0l3k1C2W1a/Screen%20Shot%202013-03-17%20at%2015.13.01.png)
