### PR TITLE
Fix typography compatibility with compass framework

### DIFF
--- a/scss/foundation/_foundation-global.scss
+++ b/scss/foundation/_foundation-global.scss
@@ -7,6 +7,10 @@
 // for compatibility with brower-based text zoom or user-set defaults.
 $base-font-size: 100% !default;
 
+// This maintains compatibility with compass framework since default compass
+// $base-line-height is 24px while $base-font-size is 16px
+$base-line-height: 150% !default;
+
 // Set your base font-size in pixels so emCalc can do its magic below
 $em-base: 16px !default;
 


### PR DESCRIPTION
### Problem

The change (https://github.com/zurb/foundation/commit/7c25193fd9ba8fcea37618bd5bc946515934b857) to use percentage size for `$base-font-size` broke compatibility with [`compass/typography/vertical_rhythm`](http://compass-style.org/reference/compass/typography/vertical_rhythm/) as the `$base-font-size` is now in `%` while `$base-line-height` is still in `px`. Refer to [line 36 of _vertical_rythm.scss](https://github.com/chriseppstein/compass/blob/stable/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss#L36).
### Symptom

I was seeing the following error on a project that made use of compass framework as well as foundation:

```
error scss/app.scss (Line 36 of _vertical_rhythm.scss: Incompatible units: '%' and 'px'.)
```
### Fix

I'm proposing to fix this by adding an appropriate default `$base-line-height` value to compliment the change of the `$base-font-size`. However, this `$base-line-height` is not used anywhere in the foundation codebase, so I'm not sure if this is ideal.
### Assumption

I'm assuming that the use of the `$base-font-size` variable was to maintain compatibility with the compass framework so I thought that this would be an issue. However, if this assumption is wrong, please feel free to drop a comment and disregard this issue.
