### PR TITLE
Basic margin for form elements

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -317,6 +317,7 @@ $input-error-message-font-color-alt: #333 !default;
   /* Adjust margin for form elements below */
   input[type="file"],
   input[type="checkbox"],
+  input[type="radio"],
   select {
     margin: 0 0 $form-spacing 0;
   }

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -314,6 +314,13 @@ $input-error-message-font-color-alt: #333 !default;
     @include single-transition(all, 0.15s, linear);
   }
 
+  /* Adjust margin for form elements below */
+  input[type="file"],
+  input[type="checkbox"],
+  select {
+    margin: 0 0 $form-spacing 0;
+  }
+
   /* We add basic fieldset styling */
   fieldset {
     @include fieldset;


### PR DESCRIPTION
Some form elements looked strange without margin when not using custom forms. This adds basic margin for checkboxes, radios, select-elements and fileinputs.
