### PR TITLE
Move the padding to the anchor tag.

### DIFF
--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -106,14 +106,18 @@ $f-dropdown-content-padding:      emCalc(20px) !default;
 @mixin dropdown-style {
   font-size: $f-dropdown-font-size;
   cursor: pointer;
-  padding: $f-dropdown-list-padding;
+  
   line-height: $f-dropdown-line-height;
   margin: 0;
 
   &:hover,
   &:focus { background: $f-dropdown-list-hover-bg; }
 
-  a { color: $f-dropdown-font-color; }
+  a {
+    display: block;
+    padding: $f-dropdown-list-padding;
+    color: $f-dropdown-font-color;
+  }
 }
 
 


### PR DESCRIPTION
This allows the entire list element to be clickable, and gets rid of the issue of clicking on an li and having it close the dropdown but not activate the link.
