### PR TITLE
Make Section support RTL

### DIFF
--- a/docs/components/section.html.erb
+++ b/docs/components/section.html.erb
@@ -394,6 +394,7 @@ $section-bottom-margin:          emCalc(20px);
 {
   deep_linking: false,
   one_up: true,
+  rtl: false,
   callback: function (){}
 }", :js %>
 

--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -11,6 +11,7 @@
     settings : {
       deep_linking: false,
       one_up: true,
+      rtl: false,
       callback: function (){}
     },
 
@@ -207,15 +208,24 @@
     position_titles : function (section, off) {
       var titles = section.find('.title'),
           previous_width = 0,
-          self = this;
+          self = this,
+          settings = $.extend({}, self.settings, self.data_options(section));
 
       if (typeof off === 'boolean') {
         titles.attr('style', '');
 
       } else {
+        var attr = 'left';
+        if (settings.rtl === true)
+          attr = 'right';
+
         titles.each(function () {
-          $(this).css('left', previous_width);
+          $(this).css(attr, previous_width);
           previous_width += self.outerWidth($(this));
+
+          // Strangely, in RTL mode there is
+          if (settings.rtl === true)
+            previous_width++;
         });
       }
     },
@@ -223,7 +233,8 @@
     position_content : function (section, off) {
       var titles = section.find('.title'),
           content = section.find('.content'),
-          self = this;
+          self = this,
+          settings = $.extend({}, self.settings, self.data_options(section));
 
       if (typeof off === 'boolean') {
         content.attr('style', '');
@@ -233,10 +244,17 @@
           var title = $(this).find('.title'),
               content = $(this).find('.content');
 
-          content.css({left: title.position().left - 1, top: self.outerHeight(title) - 2});
+          if (settings.rtl === true)
+            if (typeof Zepto === 'function')
+              content.css({right: section.width() - title.position().left - self.outerWidth(title) - 4, 'top': self.outerHeight(title) - 2});
+            else
+              content.css({right: section.width() - title.position().left - self.outerWidth(title) - 2, 'top': self.outerHeight(title) - 2});
+          else
+            content.css({left: title.position().left - 1, top: self.outerHeight(title) - 2});
         });
 
         // temporary work around for Zepto outerheight calculation issues.
+        console.log(this.outerHeight(titles.first()));
         if (typeof Zepto === 'function') {
           section.height(this.outerHeight(titles.first()));
         } else {

--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -117,14 +117,14 @@ $section-bottom-margin:          emCalc(20px) !default;
     .title {
       width: auto;
       border: $section-border-size $section-border-style $section-border-color;
-      border-right: 0;
+      border-#{$default-opposite}: 0;
       border-bottom: 0;
       position: absolute;
       z-index: 1;
 
       a { width: 100%; }
     }
-    &:last-child .title { border-right: $section-border-size $section-border-style $section-border-color; }
+    &:last-child .title { border-#{$default-opposite}: $section-border-size $section-border-style $section-border-color; }
 
     .content {
       border: $section-border-size $section-border-style $section-border-color;
@@ -157,7 +157,7 @@ $section-bottom-margin:          emCalc(20px) !default;
       .content {
         display: block;
         position: absolute;
-        left: 100%;
+        #{$default-float}: 100%;
         top: -1px;
         z-index: 999;
         min-width: $section-vertical-nav-min-width;
@@ -175,7 +175,7 @@ $section-bottom-margin:          emCalc(20px) !default;
     .title {
       width: auto;
       border: $section-border-size $section-border-style $section-border-color;
-      border-left: 0;
+      border-#{$default-float}: 0;
       top: -1px;
       position: absolute;
       z-index: 1;
@@ -190,7 +190,7 @@ $section-bottom-margin:          emCalc(20px) !default;
         display: block;
         position: absolute;
         z-index: 999;
-        left: 0;
+        #{$default-float}: 0;
         top: -2px;
         min-width: $section-vertical-nav-min-width;
         border: $section-border-size $section-border-style $section-border-color;
@@ -245,5 +245,4 @@ $section-bottom-margin:          emCalc(20px) !default;
       .section { @include section(horizontal-nav); }
     }
   }
-
 }


### PR DESCRIPTION
Currently `foundation.section.js` doesn't support RTL layout. I propose a boolean `rtl` option in `data-options` that defaults to `false`. `_section.scss` has also been modified to support RTL mode.
