### PR TITLE
update breadcrumbs for semantic markup

### DIFF
--- a/scss/foundation/components/_breadcrumbs.scss
+++ b/scss/foundation/components/_breadcrumbs.scss
@@ -52,36 +52,40 @@ $crumb-slash: "/"                                              !default;
 
   // A normal state will make the links look and act like clickable breadcrumbs.
   margin: 0;
-  padding: 0 $crumb-side-padding 0 0;
   float: $default-float;
+  font-size: $crumb-font-size;
+  text-transform: $crumb-font-transform;
+  color: $crumb-font-color;
 
-  &:hover a,
-  &:focus a { text-decoration: $crumb-link-decor; }
+  &:hover a, &:focus a { text-decoration: $crumb-link-decor; }
 
   a,
   span {
-    font-size: $crumb-font-size;
-    padding-#{$default-float}: $crumb-side-padding;
     text-transform: $crumb-font-transform;
     color: $crumb-font-color;
   }
 
   // Current is for the link of the current page
   &.current {
+  	cursor: default;
+  	color: $crumb-font-color-current;
     a {
       cursor: default;
       color: $crumb-font-color-current;
     }
 
-    &:hover a,
-    &:focus a { text-decoration: none; }
+    &:hover, &:hover a,
+    &:focus, &:focus a { text-decoration: none; }
   }
 
   // Unavailable removed color and link styles so it looks inactive.
   &.unavailable {
+  	color: $crumb-font-color-unavailable;
     a { color: $crumb-font-color-unavailable; }
 
+    &:hover,
     &:hover a,
+    &:focus,
     a:focus {
       text-decoration: none;
       color: $crumb-font-color-unavailable;
@@ -92,12 +96,15 @@ $crumb-slash: "/"                                              !default;
   &:before {
     content: "#{$crumb-slash}";
     color: $crumb-slash-color;
+    margin: 0 $crumb-side-padding;
     position: relative;
     top: 1px;
   }
-  &:first-child a,
-  &:first-child span { padding-#{$default-float}: 0; }
-  &:first-child:before { content: " "; }
+  
+  &:first-child:before {
+	  content: " ";
+	  margin: 0;
+  }
 
 }
 
@@ -109,7 +116,7 @@ $crumb-slash: "/"                                              !default;
     @include crumb-container;
     @include radius($crumb-radius);
 
-    li {
+    &>* {
       @include crumbs;
     }
   }


### PR DESCRIPTION
With this update you can also use the breadcrumb layout:

``` HTML
<nav class="breadcrumbs">
  <a href="#">Parent</a>
  <a href="#">Child 1</a>
  <a href="#">Child 2</a>
 </nav>
```

with the negligible differences of $crumb-slash being slightly smaller due to inheriting the $crumb-font-size and losing the $crumb-link-decor because it would also apply to the $crumb-slash.
