### PR TITLE
Fix for font size setting on custom dropdown

### DIFF
--- a/scss/foundation/components/_custom-forms.scss
+++ b/scss/foundation/components/_custom-forms.scss
@@ -116,7 +116,7 @@ $custom-dropdown-width-large:           434px !default;
       background: linear-gradient(to bottom, $custom-dropdown-bg 0%,$custom-select-fade-to-color 100%);
       -webkit-box-shadow: none;
       box-shadow: none;
-      font-size: emCalc(14px);
+      font-size: $custom-dropdown-font-size;
       vertical-align: top;
   
       ul {


### PR DESCRIPTION
The custom dropdown should be using the available variable $custom-dropdown-font-size.
Otherwise the size is fixed which causes problems in the grid if you change the fontsize of the standard inputs
