### PR TITLE
Fix dropdown positionning

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -82,11 +82,9 @@
     },
 
     css : function (dropdown, target) {
-      if (dropdown.parent()[0] === $('body')[0]) {
-        var position = target.offset();
-      } else {
-        var position = target.position();
-      }
+      var position = target.position();
+      position.top += target.offsetParent().scrollTop();
+      position.left += target.offsetParent().scrollLeft();
 
       if (this.small()) {
         dropdown.css({


### PR DESCRIPTION
This should fix positioning of Dropdown menus for all cases, no need to check if parent is body (the need came from the scroll bug, witch was present in any scrollable element)
