### PR TITLE
bugfix for custom forms with inline labels

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -288,7 +288,7 @@
   };
 
   var toggleCheckbox = function($element) {
-    var $input = $("#" + $element.attr('for')),
+    var $input = $element.prev(),
         input = $input[0];
 
     if (false === $input.is(':disabled')) {
@@ -348,6 +348,9 @@
         //the checkbox might be outside before the label
         if ($customCheckbox.length == 0) {
             $customCheckbox = $(this).prev('span.custom.checkbox');
+        }
+        if ($customCheckbox.length == 0) {
+          $customCheckbox = $("#" + $(event.currentTarget).attr('for')).next()
         }
         toggleCheckbox($customCheckbox);
       } else if ($associatedElement.attr('type') === 'radio') {

--- a/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.forms.js
@@ -288,7 +288,7 @@
   };
 
   var toggleCheckbox = function($element) {
-    var $input = $element.prev(),
+    var $input = $("#" + $element.attr('for')),
         input = $input[0];
 
     if (false === $input.is(':disabled')) {


### PR DESCRIPTION
The markup descriped in the Zurb Foundation 3.2 documentation under "Row Layouts" (inline labels in particular) does not work with custom form stylings.

This is because the assumption that the hidden checkbox input is the previous child of the styled input is not always correct.
In this pull request I've added a fall back using the for-attribute as a last resort lookup for the correct hidden input field.

Feedback?
