### PR TITLE
Configure the Top Bar hover color lightness

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -20,6 +20,7 @@ $topbar-title-font-size: emCalc(17px) !default;
 $topbar-link-color: #fff !default;
 $topbar-link-weight: bold !default;
 $topbar-link-font-size: emCalc(13px) !default;
+$topbar-link-hover-lightness: -30% !default; // Darken by 30%
 
 // Style the top bar dropdown elements
 $topbar-dropdown-bg: #333 !default;
@@ -361,7 +362,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
         padding: 0 $topbar-height / 3;
         line-height: $topbar-height;
         background: $topbar-bg;
-        &:hover { background: darken($topbar-dropdown-bg, 30%); }
+        &:hover { background: adjust-color($topbar-dropdown-bg, $lightness: $topbar-link-hover-lightness); }
       }
     }
 

--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -993,6 +993,7 @@
 // $topbar-link-color: #fff;
 // $topbar-link-weight: bold;
 // $topbar-link-font-size: emCalc(13px);
+// $topbar-link-hover-lightness: -30%;  // Darken by 30%
 
 // Style the top bar dropdown elements
 // $topbar-dropdown-bg: #333;


### PR DESCRIPTION
Allow user to configure the lightness or darkness of the top-bar menu item hover color. Backwards compatibility was maintained.
