### PR TITLE
Fix front-page typo

### DIFF
--- a/docs/index.html.erb
+++ b/docs/index.html.erb
@@ -108,7 +108,7 @@
       <div class="large-4 columns">
         <dl>
           <dt><h5><a href="components/joyride.html">Joyride</a></h5></dt>
-          <dd>This plugin lets you give users a tour of your site our app. Joyride is easy to customize using CSS or our Scss variables.</dd>
+          <dd>This plugin lets you give users a tour of your site or app. Joyride is easy to customize using CSS or our Scss variables.</dd>
         </dl>
       </div>
     </div>


### PR DESCRIPTION
"site our app" becomes "site or app".

Probably a good idea to fix these little issues throughout!
