### PR TITLE
Add Foundation license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,11 @@
     "grunt": "~0.4.0",
     "grunt-contrib-watch": "~0.1.0",
     "grunt-contrib-qunit": "~0.1.1"
-  }
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/zurb/foundation/blob/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
NPM spec allows for the Foundation license in the package.json. For completeness, I added it in :)

https://npmjs.org/doc/json.html
