### PR TITLE
Adding support for configurable label font colors.

### DIFF
--- a/docs/components/forms.html.erb
+++ b/docs/components/forms.html.erb
@@ -415,11 +415,11 @@ $is-button: false
 $form-spacing:                       emCalc(16px);
 
 /* We use these to style the labels in different ways */
-$label-pointer:                      pointer;
-$label-font-size:                    emCalc(14px);
-$label-font-weight:                  500;
-$label-font-color:                   lighten(#000, 30%);
-$label-bottom-margin:                emCalc(3px);
+$form-label-pointer:                 pointer;
+$form-label-font-size:               emCalc(14px);
+$form-label-font-weight:             500;
+$form-label-font-color:              lighten(#000, 30%);
+$form-label-bottom-margin:           emCalc(3px);
 $input-font-color:                   rgba(0,0,0,0.75);
 $input-font-size:                    emCalc(14px);
 $input-bg-color:                     #fff;

--- a/docs/components/labels.html.erb
+++ b/docs/components/labels.html.erb
@@ -86,7 +86,9 @@ $label-radius:      $global-radius;
 
 /* We use these to style the label text */
 $label-font-sizing: emCalc(14px);
-$label-font-weight: bold;', :css %>
+$label-font-weight: bold;
+$label-font-color: #333;
+$label-font-color-alt: #fff;', :css %>
 
         <p><strong>Note:</strong> <code>emCalc();</code> is a function we wrote to convert <code>px</code> to <code>em</code>. It is included in <strong>_foundation-global.scss</strong>.</p>
 

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -6,11 +6,11 @@
 $form-spacing:                       emCalc(16px) !default;
 
 // We use these to style the labels in different ways
-$label-pointer:                      pointer !default;
-$label-font-size:                    emCalc(14px) !default;
-$label-font-weight:                  500 !default;
-$label-font-color:                   lighten(#000, 30%) !default;
-$label-bottom-margin:                emCalc(3px) !default;
+$form-label-pointer:                      pointer !default;
+$form-label-font-size:                    emCalc(14px) !default;
+$form-label-font-weight:                  500 !default;
+$form-label-font-color:                   lighten(#000, 30%) !default;
+$form-label-bottom-margin:                emCalc(3px) !default;
 $input-font-family:                  inherit !default;
 $input-font-color:                   rgba(0,0,0,0.75) !default;
 $input-font-size:                    emCalc(14px) !default;
@@ -108,12 +108,12 @@ $input-error-message-font-color-alt: #333 !default;
 
   // Control whether or not the base styles come through.
   @if $base-style {
-    font-size: $label-font-size;
-    color: $label-font-color;
-    cursor: $label-pointer;
+    font-size: $form-label-font-size;
+    color: $form-label-font-color;
+    cursor: $form-label-pointer;
     display: block;
-    font-weight: $label-font-weight;
-    margin-bottom: $label-bottom-margin;
+    font-weight: $form-label-font-weight;
+    margin-bottom: $form-label-bottom-margin;
   }
 
   // Alignment options
@@ -139,9 +139,9 @@ $input-error-message-font-color-alt: #333 !default;
   border-style: $input-prefix-border-type;
   border-width: $input-prefix-border-size;
   overflow: $input-prefix-overflow;
-  font-size: $label-font-size;
-  height: ($label-font-size + ($form-spacing * 1.5) - emCalc(1px));
-  line-height: ($label-font-size + ($form-spacing * 1.5) - emCalc(1px));
+  font-size: $form-label-font-size;
+  height: ($form-label-font-size + ($form-spacing * 1.5) - emCalc(1px));
+  line-height: ($form-label-font-size + ($form-spacing * 1.5) - emCalc(1px));
 }
 
 // We use this mixin to create prefix label styles

--- a/scss/foundation/components/_labels.scss
+++ b/scss/foundation/components/_labels.scss
@@ -9,6 +9,8 @@ $label-radius:      $global-radius !default;
 // We use these to style the label text
 $label-font-sizing:   emCalc(14px) !default;
 $label-font-weight: bold !default;
+$label-font-color: #333 !default;
+$label-font-color-alt: #fff !default;
 
 //
 // Label Mixins
@@ -43,8 +45,8 @@ $label-font-weight: bold !default;
     background-color: $bg;
 
     // We control the text color for you based on the background color.
-    @if $bg-lightness < 70% { color: #fff; }
-    @else { color: #333; }
+    @if $bg-lightness < 70% { color: $label-font-color-alt; }
+    @else { color: $label-font-color; }
   }
 
   // We use this to control the radius on labels.

--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -188,11 +188,11 @@
 // $form-spacing: emCalc(16px);
 
 // We use these to style the labels in different ways
-// $label-pointer: pointer;
-// $label-font-size: emCalc(14px);
-// $label-font-weight: 500;
-// $label-font-color: lighten(#000, 30%);
-// $label-bottom-margin: emCalc(3px);
+// $form-label-pointer: pointer;
+// $form-label-font-size: emCalc(14px);
+// $form-label-font-weight: 500;
+// $form-label-font-color: lighten(#000, 30%);
+// $form-label-bottom-margin: emCalc(3px);
 // $input-font-family: inherit;
 // $input-font-color: rgba(0,0,0,0.75);
 // $input-font-size: emCalc(14px);
@@ -601,6 +601,8 @@
 // We use these to style the label text
 // $label-font-sizing: emCalc(14px);
 // $label-font-weight: bold;
+// $label-font-color: #333;
+// $label-font-color-alt: #fff;
 
 //
 // Magellan Variables


### PR DESCRIPTION
Font colors we're previously hardcoded within _labels.scss.

I've added two new variables named $label-font-color and
$label-font-color-alt.

Since form labels used the variable prefix within _forms.scss, $label-, I've renamed these
to $form-label-
