### PR TITLE
Update _grid.scss

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -57,8 +57,15 @@ $total-columns: 12 !default;
 
   position: relative;
 
+  // If collapsed, get rid of gutter padding
+  @if $collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   // Gutter padding whenever a column isn't set to collapse
-  @if $collapse == false {
+  // (use $collapse:null to do nothing)
+  @else if $collapse == false {
     padding-left: $column-gutter / 2;
     padding-right: $column-gutter / 2;
   }
@@ -70,12 +77,7 @@ $total-columns: 12 !default;
     // If last column, float naturally instead of to the right
     @if $last-column { float: $default-opposite; }
 
-    // if collapsed, get rid of gutter padding
-    @else if $collapse { padding-left: 0; padding-right: 0; }
-
   }
-
-  @if $collapse { padding-left: 0; padding-right: 0; }
 
   // If offset, calculate appropriate margins
   @if $offset { margin-#{$default-float}: gridCalc($offset, $total-columns); }


### PR DESCRIPTION
Clean up code and prevent possible duplicated output:
- the mixin `grid-column` produced duplicated output if called with `$columns:x, $last-column:false, $collapse:true`
- the implicit option of `$collapse:null` to skip the padding properties remains

Tests done: successfully compiled to grid HTML classes identical to before the change. (Duplicated output did not occur in the HTML classes generation because the given parameter combination was never used.)
