### PR TITLE
Support Page Grammar Issues

### DIFF
--- a/docs/support.html.erb
+++ b/docs/support.html.erb
@@ -112,7 +112,7 @@
     <hr>
 
     <h5>Want IE8 Grid Support?</h5>
-    <p>We know it can be hard to get clients to ditch support for IE8. We're hoping with the auto-update to IE10 release from Microsoft, we won't need to worry about it anymore. Until then, here's a gist with a grid grid that will work in IE8, just like it did in Foundation 3.</p>
+    <p>We know it can be hard to get clients to ditch support for IE8. We're hoping with the auto-update to IE10 release from Microsoft, we won't need to worry about it anymore. Until then, here's a gist with a grid that will work in IE8, just like it did in Foundation 3.</p>
     <a class="small button" href="https://gist.github.com/zurbchris/5068210">Foundation IE8 Grid</a>
 
     <hr>


### PR DESCRIPTION
I removed duplicate "grid" wording in the IE8 section. 
