### PR TITLE
Fixes extra space when thumbnail is within a paragraph.

### DIFF
--- a/scss/foundation/components/_thumbs.scss
+++ b/scss/foundation/components/_thumbs.scss
@@ -19,6 +19,7 @@ $thumb-transition-speed: 200ms !default;
 
 // We use this to create image thumbnail styles.
 @mixin thumb($border-width:$thumb-border-width, $box-shadow:$thumb-box-shadow, $box-shadow-hover:$thumb-box-shadow-hover) {
+  line-height: 0;
   display: inline-block;
   border: $thumb-border-style $border-width $thumb-border-color;
   -webkit-box-shadow: $box-shadow;


### PR DESCRIPTION
When a thumbnail image is used within a paragraph tag, you get an extra little bit of space below the image.

![Screen Shot 2013-04-02 at 6 41 07 PM](https://f.cloud.github.com/assets/624446/331296/a1fe63e0-9be6-11e2-8c79-376061f07c0a.png)

No Space

``` html
<a class="th" href="../img/demos/demo1.jpg"><img src="../img/demos/demo1-th.jpg"></a>
```

Extra Space

``` html
<p><a class="th" href="../img/demos/demo3.jpg"><img src="../img/demos/demo3-th.jpg"></a></p>
```
