### PR TITLE
Fix for grid mixin $float:right

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -92,7 +92,7 @@ $total-columns: 12 !default;
   }
 
   @if $float {
-    @if $float == left or true { float: $default-float; }
+    @if $float == left or $float == true { float: $default-float; }
     @else if $float == right { float: $opposite-direction; }
     @else { float: none; }
   }


### PR DESCRIPTION
This fixes the problem where all @include grid-columns would float left even if $float:right was declared.
