### PR TITLE
[Design Flaw] Certain variables cannot be overridden.

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -2,6 +2,7 @@
 @charset "UTF-8";
 
 // This includes all of the foundation global elements that are needed to work with any of the other files.
+@import "foundation/foundation-global-functions";
 @import "foundation/foundation-global";
 
 // Foundation Components

--- a/scss/foundation/_foundation-global-functions.scss
+++ b/scss/foundation/_foundation-global-functions.scss
@@ -1,0 +1,22 @@
+
+// Set your base font-size in pixels so emCalc can do its magic below
+$em-base: 16px !default;
+
+//
+// Functions
+//
+
+// Working in ems is annoying. Think in pixels by using this handy function, emCalc(#px)
+@function emCalc($pxWidth) {
+  @return $pxWidth / $em-base * 1em;
+}
+
+// Creating rems and pixels
+@function remCalc($pxWidth) {
+  @return $pxWidth / $em-base * 1rem;
+}
+
+// Grid Calculation for Percentages
+@function gridCalc($colNumber, $totalColumns) {
+  @return percentage(($colNumber / $totalColumns));
+}

--- a/scss/foundation/_foundation-global.scss
+++ b/scss/foundation/_foundation-global.scss
@@ -7,9 +7,6 @@
 // for compatibility with brower-based text zoom or user-set defaults.
 $base-font-size: 100% !default;
 
-// Set your base font-size in pixels so emCalc can do its magic below
-$em-base: 16px !default;
-
 // We use these to control various global styles
 $body-bg: #fff !default;
 $body-font-color: #222 !default;
@@ -63,25 +60,6 @@ $include-html-panel-classes: $include-html-classes !default;
 $include-html-pricing-classes: $include-html-classes !default;
 $include-html-progress-classes: $include-html-classes !default;
 $include-html-magellan-classes: $include-html-classes !default;
-
-//
-// Functions
-//
-
-// Working in ems is annoying. Think in pixels by using this handy function, emCalc(#px)
-@function emCalc($pxWidth) {
-  @return $pxWidth / $em-base * 1em;
-}
-
-// Creating rems and pixels
-@function remCalc($pxWidth) {
-  @return $pxWidth / $em-base * 1rem;
-}
-
-// Grid Calculation for Percentages
-@function gridCalc($colNumber, $totalColumns) {
-  @return percentage(($colNumber / $totalColumns));
-}
 
 
 //


### PR DESCRIPTION
If you want to override the media query variables:

```
$small-screen: emCalc(768px) !default;
$medium-screen: emCalc(1280px) !default;
$large-screen: emCalc(1440px) !default;
```

you need to define them before loading `_foundation-global.scss`. The problem here is that you will need the `emCalc()` function if you are to do this correctly.
