### PR TITLE
Fix "iterator.call is not a function" error when used with prototype js.

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -145,9 +145,9 @@ if (typeof jQuery === "undefined" &&
     },
 
     response_obj : function (response_arr, args) {
-      for (var callback in args) {
-        if (typeof args[callback] === 'function') {
-          return args[callback]({
+      for (var i = 0, len = args.length; i < len; i++) {
+        if (typeof args[i] === 'function') {
+          return args[i]({
             errors: response_arr.filter(function (s) {
               if (typeof s === 'string') return s;
             })


### PR DESCRIPTION
... or any library that extends native JavaScript arrays.

Switch for/in loop with a traditional for ;; loop to enumerate through an array. This will ignore prototype's enumerable method properties.

Sorry, I couldn't figure out a proper place to write tests.
