### PR TITLE
fixed top bar active link selector

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -249,7 +249,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
     }
 
     // Apply the active link color when it has that class
-    &.active a { background: darken($topbar-dropdown-bg, 3%); }
+    &.active > a { background: darken($topbar-dropdown-bg, 3%); }
   }
 
   // Add some extra padding for list items contains buttons


### PR DESCRIPTION
Fix for active link selector to prevent links within the dropdown having an active appearance. #2095
