### PR TITLE
Update docs with example for ul.no-bullet.

### DIFF
--- a/docs/components/type.html.erb
+++ b/docs/components/type.html.erb
@@ -152,6 +152,21 @@
 
         <div class="row">
           <div class="large-4 columns">
+            <h6>ul.no-bullet</h6>
+            <ul class="no-bullet">
+              <li>List item with a much longer description or more content.</li>
+              <li>List item</li>
+              <li>List item
+                <ul>
+                  <li>Nested List Item</li>
+                  <li>Nested List Item</li>
+                  <li>Nested List Item</li>
+                </ul>
+              </li>
+              <li>List item</li>
+            </ul>
+          </div>
+          <div class="large-4 columns">
             <h6>Ordered Lists</h6>
             <ol>
               <li>List Item 1</li>
@@ -165,7 +180,7 @@
               <li>List Item 3</li>
             </ol>
           </div>
-          <div class="large-8 columns">
+          <div class="large-4 columns">
             <h6>Defition Lists</h6>
             <dl>
               <dt>Definition Title</dt>
@@ -188,6 +203,20 @@
   </li>
   <li>List item</li>
   <li>List item</li>
+  <li>List item</li>
+</ul>
+
+<!-- Sometimes you don\'t want bullets at all -->
+<ul class="no-bullet">
+  <li>List item with a much longer description or more content.</li>
+  <li>List item</li>
+  <li>List item
+    <ul>
+      <li>Nested List Item</li>
+      <li>Nested List Item</li>
+      <li>Nested List Item</li>
+    </ul>
+  </li>
   <li>List item</li>
 </ul>
 


### PR DESCRIPTION
I had to dig into the source code to find out about the ul.no-bullet class, so I think it would be an improvement to have it in the docs.
