### PR TITLE
Fix typo in Definition Lists example.

### DIFF
--- a/docs/components/type.html.erb
+++ b/docs/components/type.html.erb
@@ -166,7 +166,7 @@
             </ol>
           </div>
           <div class="large-8 columns">
-            <h6>Defition Lists</h6>
+            <h6>Definition Lists</h6>
             <dl>
               <dt>Definition Title</dt>
               <dd>Definition Cras justo odio, dapibus ac facilisis in, egestas eget quam. Nullam id dolor id nibh ultricies vehicula ut id elit.</dd>


### PR DESCRIPTION
Tiny typo.
