### PR TITLE
Fix nil error on rails install generator by detecting application.coffee

### DIFF
--- a/lib/foundation/generators/install_generator.rb
+++ b/lib/foundation/generators/install_generator.rb
@@ -21,6 +21,7 @@ module Foundation
       end
 
       def detect_js_format
+        return ['.coffee', '#='] if File.exist?('app/assets/javascripts/application.coffee')
         return ['.js.coffee', '#='] if File.exist?('app/assets/javascripts/application.js.coffee')
         return ['.js', '//='] if File.exist?('app/assets/javascripts/application.js')
       end


### PR DESCRIPTION
...n install

The install generator currently fails with a nil error 
if an application.coffee exists because its presence is not 
detected from #detect_js_format. Since the asset pipeline handles 
straight .coffee files, we should support this during the install 
generator.
