### PR TITLE
Missing Colon in _settings.scss for topbar-media-query variable.

### DIFF
--- a/templates/project/scss/_settings.scss
+++ b/templates/project/scss/_settings.scss
@@ -1014,5 +1014,5 @@
 // Transitions and breakpoint styles
 // $topbar-transition-speed: 300ms;
 // $topbar-breakpoint: emCalc(940px); // Change to 9999px for always mobile layout
-// $topbar-media-query: "only screen and (min-width "#{$topbar-breakpoint}")";
+// $topbar-media-query: "only screen and (min-width: "#{$topbar-breakpoint}")";
 


### PR DESCRIPTION
Caused about an hour of cursing.
