### PR TITLE
Adding role attribute selector to top bar dividers

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -197,7 +197,8 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
     margin: 0;
   }
 
-  .divider {
+  .divider,
+  [role="separator"] {
     border-bottom: solid 1px lighten($topbar-dropdown-bg, 10%);
     border-top: solid 1px darken($topbar-dropdown-bg, 10%);
     clear: both;
@@ -428,7 +429,8 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
       }
     }
 
-    & > ul > .divider {
+    & > ul > .divider,
+    & > ul > [role="separator"] {
       border-bottom: none;
       border-top: none;
       border-#{$opposite-direction}: solid 1px lighten($topbar-bg, 10%);


### PR DESCRIPTION
Looking through some aria documentation, I noticed there was a role for separators within menus. Adding the role would help screen readers realize the .divider li elements are not part of the actual menu outline. Writing li class="divider" role="separator" everywhere seemed redundant, however. This change adds a [role="separator"] selector to the existing .divider selectors, allowing the markup to be shortened to simply li role="separator".
