### PR TITLE
Enables styling the Orbit extension via the orbit scss-variables as documented in the Foundation Orbit manuals

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -169,11 +169,12 @@ $stack-on-small-margin-bottom: emCalc(20px) !default;
     background: $orbit-bullet-nav-color;
     float: $default-float;
     margin-#{$opposite-direction}: 6px;
-    border: solid 2px $orbit-bullet-nav-color-active;
+    border: solid 2px $orbit-bullet-nav-color;
     @include radius(1000px);
 
     &.active {
       background: $orbit-bullet-nav-color-active;
+      border: solid 2px $orbit-bullet-nav-color-active;
     }
 
     &:last-child { margin-#{$opposite-direction}: 0; }

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -20,7 +20,7 @@ $orbit-bullet-nav-color: #999 !default;
 $orbit-bullet-nav-color-active: #222 !default;
 
 // We use thes to controls the style of slide numbers
-$orbit-slide-number-bg: rgb(0,0,0) !default;
+$orbit-slide-number-bg: rgba(0,0,0,0) !default;
 $orbit-slide-number-font-color: #fff !default;
 $orbit-slide-number-padding: emCalc(5px) !default;
 
@@ -67,7 +67,9 @@ $stack-on-small-margin-bottom: emCalc(20px) !default;
     top: 10px;
     #{$default-float}: 10px;
     font-size: 12px;
-    span { font-weight: 700; }
+    span { font-weight: 700; padding: $orbit-slide-number-padding;}
+    color: $orbit-slide-number-font-color;
+    background: $orbit-slide-number-bg;
   }
 
   .orbit-timer {

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -166,14 +166,14 @@ $stack-on-small-margin-bottom: emCalc(20px) !default;
     display: block;
     width: 18px;
     height: 18px;
-    background: #fff;
+    background: $orbit-bullet-nav-color;
     float: $default-float;
     margin-#{$opposite-direction}: 6px;
-    border: solid 2px #000;
+    border: solid 2px $orbit-bullet-nav-color-active;
     @include radius(1000px);
 
     &.active {
-      background: #000;
+      background: $orbit-bullet-nav-color-active;
     }
 
     &:last-child { margin-#{$opposite-direction}: 0; }


### PR DESCRIPTION
Fix to make the following foundation scss-variables work for the Orbit extension:

```
$orbit-bullet-nav-color 
$orbit-bullet-nav-color-active
$orbit-slide-number-bg (and set default to use rgb-alpha)
$orbit-slide-number-font-color
$orbit-slide-number-padding
```
