### PR TITLE
Fixed typo that caused reveals to remain open when linked to another reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -103,7 +103,7 @@
         if (open_modal.length < 1) {
           this.toggle_bg(modal);
         }
-        this.hide(open_modal, this.settings.css.open);
+        this.hide(open_modal, this.settings.css.close);
         this.show(modal, this.settings.css.open);
       }
     },


### PR DESCRIPTION
how to reproduce (this works on foundations site as well) click through a chained set of modals and all previous modals except the last will still have display block
