### PR TITLE
Orbit bullet color variables fix

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -166,14 +166,14 @@ $stack-on-small-margin-bottom: emCalc(20px) !default;
     display: block;
     width: 18px;
     height: 18px;
-    background: #fff;
+    background: $orbit-bullet-nav-color;
     float: $default-float;
     margin-#{$opposite-direction}: 6px;
-    border: solid 2px #000;
+    border: solid 2px $orbit-bullet-nav-color-active;
     @include radius(1000px);
 
     &.active {
-      background: #000;
+      background: $orbit-bullet-nav-color-active;
     }
 
     &:last-child { margin-#{$opposite-direction}: 0; }


### PR DESCRIPTION
$orbit-bullet-nav-color and $orbit-bullet-nav-color-active we're not
used anywhere so I applied them to the orbit bullets which I'm assuming
they were for.
