### PR TITLE
Fixed Top Bar not showing menu inline on large screens

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -61,7 +61,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
 }
 
 .top-bar {
-  overflow: hidden;
+  overflow: visible;
   height: $topbar-height;
   line-height: $topbar-height;
   position: relative;
@@ -190,7 +190,7 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
   @include single-transition($default-float, $topbar-transition-speed);
 
   ul {
-    width: 100%;
+    width: auto;
     height: auto;
     display: block;
     background: $topbar-dropdown-bg;
@@ -282,8 +282,8 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
   // Styling elements inside of dropdowns
   .dropdown {
     position: absolute;
-    #{$default-float}: 100%;
-    top: 0;
+    #{$default-float}: 0;
+    top: 100%;
     visibility: hidden;
     z-index: 99;
 


### PR DESCRIPTION
Changed the CSS to match the example CSS on http://foundation.zurb.com/docs/components/top-bar.html . Menu items now display inline on large screens and the dropdowns behave normally.
