### PR TITLE
Normalize file input width to 100% to prevent overflow on mobile layouts...

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -324,6 +324,11 @@ $input-error-message-font-color-alt: #333 !default;
   select {
     margin: 0 0 $form-spacing 0;
   }
+  
+  /* Normalize file input width */
+  input[type="file"] {
+    width:100%;
+  }
 
   /* We add basic fieldset styling */
   fieldset {


### PR DESCRIPTION
The default width for file inputs varies between browsers but all will cause overflow on a 320px width. This normalizes the file input width to 100% to match other input types.
