### PR TITLE
Upgrading modular vars for zero output

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -23,6 +23,8 @@ $em-base: 16px !default;
 
 //// Various global styles
 
+// $default-float: left;
+
 // $body-bg: #fff;
 // $body-font-color: #222;
 // $body-font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
@@ -59,13 +61,18 @@ $em-base: 16px !default;
 
 // $include-html-classes: true;
 // $include-print-styles: true;
+// $include-html-global-classes: $include-html-classes;
+// $include-html-type-classes: $include-html-classes;
 // $include-html-grid-classes: $include-html-classes;
 // $include-html-visibility-classes: $include-html-classes;
 // $include-html-button-classes: $include-html-classes;
 // $include-html-form-classes: $include-html-classes;
 // $include-html-media-classes: $include-html-classes;
 // $include-html-section-classes: $include-html-classes;
+// $include-html-orbit-classes: $include-html-classes;
 // $include-html-reveal-classes: $include-html-classes;
+// $include-html-joyride-classes: $include-html-classes;
+// $include-html-clearing-classes: $include-html-classes;
 // $include-html-alert-classes: $include-html-classes;
 // $include-html-nav-classes: $include-html-classes;
 // $include-html-label-classes: $include-html-classes;
@@ -73,6 +80,7 @@ $em-base: 16px !default;
 // $include-html-pricing-classes: $include-html-classes;
 // $include-html-progress-classes: $include-html-classes;
 // $include-html-magellan-classes: $include-html-classes;
+// $include-html-tooltip-classes: $include-html-classes;
 
 //// Media Queries
 

--- a/scss/foundation/components/_alert-boxes.scss
+++ b/scss/foundation/components/_alert-boxes.scss
@@ -1,6 +1,7 @@
 //
 // Alert Variables
 //
+$include-html-alert-classes: $include-html-classes !default;
 
 // We use this to control alert padding.
 $alert-padding-top:         emCalc(11px)                                   !default;

--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -1,13 +1,11 @@
 //
 // Block Grid Variables
 //
+$include-html-grid-classes: $include-html-classes !default;
 
 // We use this to control the maximum number of block grid elements per row
 $block-grid-elements: 12 !default;
 $block-grid-default-spacing: 10px !default;
-
-// Enables media queries for block-grid classes. Set to false if writing semantic HTML.
-$block-grid-media-queries: true !default;
 
 //
 // Block Grid Mixins
@@ -43,7 +41,7 @@ $block-grid-media-queries: true !default;
 
 }
 
-@if $block-grid-media-queries {
+@if $include-html-grid-classes {
   /* Foundation Block Grids for below small breakpoint */
   @media only screen {
     [class*="block-grid-"] { @include block-grid; }

--- a/scss/foundation/components/_breadcrumbs.scss
+++ b/scss/foundation/components/_breadcrumbs.scss
@@ -1,6 +1,7 @@
 //
 // Breadcrumb Variables
 //
+$include-html-nav-classes: $include-html-classes !default;
 
 // We use this to set the background color for the breadcrumb container.
 $crumb-bg: lighten($secondary-color, 5%)                       !default;

--- a/scss/foundation/components/_button-groups.scss
+++ b/scss/foundation/components/_button-groups.scss
@@ -1,6 +1,7 @@
 //
 // Button Group Variables
 //
+$include-html-button-classes: $include-html-classes !default;
 
 // Sets the margin for the right side by default, and the left margin if right-to-left direction is used
 $button-bar-margin-opposite: emCalc(10px) !default;

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -1,6 +1,7 @@
 //
 // Button Variables
 //
+$include-html-button-classes: $include-html-classes !default;
 
 // We use these to build padding for buttons.
 $button-med:              emCalc(12px) !default;

--- a/scss/foundation/components/_clearing.scss
+++ b/scss/foundation/components/_clearing.scss
@@ -1,6 +1,7 @@
 //
 // Clearing Variables
 //
+$include-html-clearing-classes: $include-html-classes !default;
 
 // We use these to set the background colors for parts of Clearing.
 $clearing-bg:                           #111 !default;
@@ -26,192 +27,194 @@ $clearing-carousel-height:              150px !default;
 $clearing-carousel-thumb-width:         175px !default;
 $clearing-carousel-thumb-active-border: 4px solid rgb(255,255,255) !default;
 
-
-// We decided to not create a mixin for Clearing because it relies
-// on predefined classes and structure to work properly.
-// The variables above should give enough control.
-
-/* Clearing Styles */
-[data-clearing] {
-  @include clearfix;
-  margin-bottom: 0;
-  list-style: none;
-
-  li {
-    float: $default-float;
-    margin-#{$opposite-direction}: 10px;
+@if $include-html-clearing-classes {
+  // We decided to not create a mixin for Clearing because it relies
+  // on predefined classes and structure to work properly.
+  // The variables above should give enough control.
+  
+  /* Clearing Styles */
+  [data-clearing] {
+    @include clearfix;
+    margin-bottom: 0;
+    list-style: none;
+  
+    li {
+      float: $default-float;
+      margin-#{$opposite-direction}: 10px;
+    }
   }
-}
-
-.clearing-blackout {
-  background: $clearing-bg;
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  #{$default-float}: 0;
-  z-index: 998;
-
-  .clearing-close { display: block; }
-}
-
-.clearing-container {
-  position: relative;
-  z-index: 998;
-  height: 100%;
-  overflow: hidden;
-  margin: 0;
-}
-
-.visible-img {
-  height: 95%;
-  position: relative;
-
-  img {
-    position: absolute;
-    #{$default-float}: 50%;
-    top: 50%;
-    margin-#{$default-float}: -50%;
-    max-height: 100%;
-    max-width: 100%;
-  }
-}
-
-.clearing-caption {
-  color: $clearing-caption-font-color;
-  line-height: 1.3;
-  margin-bottom: 0;
-  text-align: center;
-  bottom: 0;
-  background: $clearing-caption-bg;
-  width: 100%;
-  padding: $clearing-caption-padding;
-  position: absolute;
-  #{$default-float}: 0;
-}
-
-.clearing-close {
-  z-index: 999;
-  padding-#{$default-float}: 20px;
-  padding-top: 10px;
-  font-size: $clearing-close-size;
-  line-height: 1;
-  color: $clearing-close-color;
-  display: none;
-
-  &:hover,
-  &:focus { color: #ccc; }
-}
-
-.clearing-assembled .clearing-container { height: 100%;
-  .carousel > ul { display: none; }
-}
-
-
-// Large screen overrides
-@media #{$small} {
-  .clearing-main-prev,
-  .clearing-main-next {
-    position: absolute;
+  
+  .clearing-blackout {
+    background: $clearing-bg;
+    position: fixed;
+    width: 100%;
     height: 100%;
-    width: 40px;
     top: 0;
-    & > span {
-      position: absolute;
-      top: 50%;
-      display: block;
-      width: 0;
-      height: 0;
-      border: solid $clearing-arrow-size;
-    }
-  }
-  .clearing-main-prev {
     #{$default-float}: 0;
-    & > span {
-      #{$default-float}: 5px;
-      border-color: transparent;
-      border-#{$opposite-direction}-color: $clearing-arrow-color;
+    z-index: 998;
+  
+    .clearing-close { display: block; }
+  }
+  
+  .clearing-container {
+    position: relative;
+    z-index: 998;
+    height: 100%;
+    overflow: hidden;
+    margin: 0;
+  }
+  
+  .visible-img {
+    height: 95%;
+    position: relative;
+  
+    img {
+      position: absolute;
+      #{$default-float}: 50%;
+      top: 50%;
+      margin-#{$default-float}: -50%;
+      max-height: 100%;
+      max-width: 100%;
     }
   }
-  .clearing-main-next {
-    #{$opposite-direction}: 0;
-    & > span {
-      border-color: transparent;
-      border-#{$default-float}-color: $clearing-arrow-color;
-    }
+  
+  .clearing-caption {
+    color: $clearing-caption-font-color;
+    line-height: 1.3;
+    margin-bottom: 0;
+    text-align: center;
+    bottom: 0;
+    background: $clearing-caption-bg;
+    width: 100%;
+    padding: $clearing-caption-padding;
+    position: absolute;
+    #{$default-float}: 0;
   }
-
-  .clearing-main-prev.disabled,
-  .clearing-main-next.disabled { opacity: 0.5; }
-
-  // If you want to show a lightbox, but only have a single image come through as the thumbnail
-  .clearing-feature ~ li { display: none; }
-
-  .clearing-assembled .clearing-container {
-
-    .carousel {
-      background: $clearing-carousel-bg;
-      height: $clearing-carousel-height;
-      margin-top: 5px;
-
-      & > ul {
+  
+  .clearing-close {
+    z-index: 999;
+    padding-#{$default-float}: 20px;
+    padding-top: 10px;
+    font-size: $clearing-close-size;
+    line-height: 1;
+    color: $clearing-close-color;
+    display: none;
+  
+    &:hover,
+    &:focus { color: #ccc; }
+  }
+  
+  .clearing-assembled .clearing-container { height: 100%;
+    .carousel > ul { display: none; }
+  }
+  
+  
+  // Large screen overrides
+  @media #{$small} {
+    .clearing-main-prev,
+    .clearing-main-next {
+      position: absolute;
+      height: 100%;
+      width: 40px;
+      top: 0;
+      & > span {
+        position: absolute;
+        top: 50%;
         display: block;
-        z-index: 999;
-        width: 200%;
-        height: 100%;
-        margin-#{$default-float}: 0;
-        position: relative;
-        #{$default-float}: 0;
-
-        li {
-          display: block;
-          width: $clearing-carousel-thumb-width;
-          height: inherit;
-          padding: 0;
-          float: $default-float;
-          overflow: hidden;
-          margin-#{$opposite-direction}: 1px;
-          position: relative;
-          cursor: pointer;
-          opacity: 0.4;
-
-          &.fix-height {
-            img {
-              min-height: 100%;
-              height: 100%;
-              max-width: none;
-            }
-          }
-
-          a.th {
-            border: none;
-            -webkit-box-shadow: none;
-                    box-shadow: none;
-            display: block;
-          }
-
-          img {
-            cursor: pointer !important;
-            min-width: 100% !important;
-          }
-
-          &.visible { opacity: 1; }
-        }
+        width: 0;
+        height: 0;
+        border: solid $clearing-arrow-size;
       }
     }
-
-    .visible-img {
-      background: $clearing-img-bg;
-      overflow: hidden;
-      height: $clearing-active-img-height;
+    .clearing-main-prev {
+      #{$default-float}: 0;
+      & > span {
+        #{$default-float}: 5px;
+        border-color: transparent;
+        border-#{$opposite-direction}-color: $clearing-arrow-color;
+      }
+    }
+    .clearing-main-next {
+      #{$opposite-direction}: 0;
+      & > span {
+        border-color: transparent;
+        border-#{$default-float}-color: $clearing-arrow-color;
+      }
+    }
+  
+    .clearing-main-prev.disabled,
+    .clearing-main-next.disabled { opacity: 0.5; }
+  
+    // If you want to show a lightbox, but only have a single image come through as the thumbnail
+    .clearing-feature ~ li { display: none; }
+  
+    .clearing-assembled .clearing-container {
+  
+      .carousel {
+        background: $clearing-carousel-bg;
+        height: $clearing-carousel-height;
+        margin-top: 5px;
+  
+        & > ul {
+          display: block;
+          z-index: 999;
+          width: 200%;
+          height: 100%;
+          margin-#{$default-float}: 0;
+          position: relative;
+          #{$default-float}: 0;
+  
+          li {
+            display: block;
+            width: $clearing-carousel-thumb-width;
+            height: inherit;
+            padding: 0;
+            float: $default-float;
+            overflow: hidden;
+            margin-#{$opposite-direction}: 1px;
+            position: relative;
+            cursor: pointer;
+            opacity: 0.4;
+  
+            &.fix-height {
+              img {
+                min-height: 100%;
+                height: 100%;
+                max-width: none;
+              }
+            }
+  
+            a.th {
+              border: none;
+              -webkit-box-shadow: none;
+                      box-shadow: none;
+              display: block;
+            }
+  
+            img {
+              cursor: pointer !important;
+              min-width: 100% !important;
+            }
+  
+            &.visible { opacity: 1; }
+          }
+        }
+      }
+  
+      .visible-img {
+        background: $clearing-img-bg;
+        overflow: hidden;
+        height: $clearing-active-img-height;
+      }
+    }
+  
+    .clearing-close {
+      position: absolute;
+      top: 10px;
+      #{$opposite-direction}: 20px;
+      padding-#{$default-float}: 0;
+      padding-top: 0;
     }
   }
 
-  .clearing-close {
-    position: absolute;
-    top: 10px;
-    #{$opposite-direction}: 20px;
-    padding-#{$default-float}: 0;
-    padding-top: 0;
-  }
 }

--- a/scss/foundation/components/_custom-forms.scss
+++ b/scss/foundation/components/_custom-forms.scss
@@ -1,6 +1,7 @@
 //
 // Custom Form Variables
 //
+$include-html-form-classes: $include-html-classes !default;
 
 // We use these to control the basic form styles input styles
 $custom-form-border-color:              #ccc !default;
@@ -43,8 +44,7 @@ $custom-dropdown-width-large:           434px !default;
 // they rely on a very specific class naming structure.
 // We may look at updating this in the future.
 
-// Only include these classes if the variable is true, otherwise they'll be left out.
-@if $include-html-button-classes != false {
+@if $include-html-form-classes {
 
   /* Custom Checkbox and Radio Inputs */
   form.custom {

--- a/scss/foundation/components/_dropdown-buttons.scss
+++ b/scss/foundation/components/_dropdown-buttons.scss
@@ -1,6 +1,7 @@
 //
 // Dropdown Button Variables
 //
+$include-html-button-classes: $include-html-classes !default;
 
 // We use these to set the color of the pip in dropdown buttons
 $dropdown-button-pip-color:     #fff !default;
@@ -101,7 +102,7 @@ $dropdown-button-pip-top-lrg:   -$button-lrg / 2 + emCalc(3px) !default;
 }
 
 
-@if $include-html-button-classes != false {
+@if $include-html-button-classes {
 
   /* Dropdown Button */
   .dropdown.button { @include dropdown-button;

--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -1,6 +1,7 @@
 //
 // Dropdown Variables
 //
+$include-html-button-classes: $include-html-classes !default;
 
 // We use these to controls height and width styles.
 $f-dropdown-max-width:            200px !default;
@@ -120,7 +121,7 @@ $f-dropdown-content-padding:      emCalc(20px) !default;
 }
 
 
-@if $include-html-nav-classes != false {
+@if $include-html-button-classes != false {
 
   @media only screen and (max-width: 767px) {
     .f-dropdown {

--- a/scss/foundation/components/_flex-video.scss
+++ b/scss/foundation/components/_flex-video.scss
@@ -1,6 +1,7 @@
 //
 // Flex Video Variables
 //
+$include-html-media-classes: $include-html-classes !default;
 
 // We use these to control video container padding and margins
 $flex-video-padding-top:               emCalc(25px) !default;

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -1,6 +1,7 @@
 //
 // Form Variables
 //
+$include-html-form-classes: $include-html-classes !default;
 
 // We use this to set the base for lots of form spacing and positioning styles
 $form-spacing:                       emCalc(16px) !default;

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -187,20 +187,7 @@ $shiny-edge-active-color: rgba(#000, .2) !default;
 // We use this to control whether or not CSS classes come through in the gem files.
 $include-html-classes: true !default;
 $include-print-styles: true !default;
-$include-html-grid-classes: $include-html-classes !default;
-$include-html-visibility-classes: $include-html-classes !default;
-$include-html-button-classes: $include-html-classes !default;
-$include-html-form-classes: $include-html-classes !default;
-$include-html-media-classes: $include-html-classes !default;
-$include-html-section-classes: $include-html-classes !default;
-$include-html-reveal-classes: $include-html-classes !default;
-$include-html-alert-classes: $include-html-classes !default;
-$include-html-nav-classes: $include-html-classes !default;
-$include-html-label-classes: $include-html-classes !default;
-$include-html-panel-classes: $include-html-classes !default;
-$include-html-pricing-classes: $include-html-classes !default;
-$include-html-progress-classes: $include-html-classes !default;
-$include-html-magellan-classes: $include-html-classes !default;
+$include-html-global-classes: $include-html-classes !default;
 
 // Media Queries
 $small-screen: emCalc(768px) !default;
@@ -214,76 +201,80 @@ $large: "only screen and (min-width:"#{$large-screen}")" !default;
 $landscape: "only screen and (orientation: landscape)" !default;
 $portrait: "only screen and (orientation: portrait)" !default;
 
-// Set box-sizing globally to handle padding and border widths
-*,
-*:before,
-*:after {
-  @include box-sizing(border-box);
-}
-
-html,
-body { font-size: $base-font-size; }
-
-// Default body styles
-body {
-  background: $body-bg;
-  color: $body-font-color;
-  padding: 0;
-  margin: 0;
-  font-family: $body-font-family;
-  font-weight: $body-font-weight;
-  font-style: $body-font-style;
-  line-height: 1; // Set to $base-line-height to take on browser default of 150%
-  position: relative;
-}
-
-// Override outline from normalize, we don't like it
-a:focus { outline: none; }
-
-// Grid Defaults to get images and embeds to work properly
-img,
-object,
-embed { max-width: 100%; height: auto; }
-
-object,
-embed { height: 100%; }
-img { -ms-interpolation-mode: bicubic; }
-
-#map_canvas,
-.map_canvas {
-  img,
-  embed,
-  object { max-width: none !important;
+@if $include-html-global-classes {
+  
+  // Set box-sizing globally to handle padding and border widths
+  *,
+  *:before,
+  *:after {
+    @include box-sizing(border-box);
   }
+  
+  html,
+  body { font-size: $base-font-size; }
+  
+  // Default body styles
+  body {
+    background: $body-bg;
+    color: $body-font-color;
+    padding: 0;
+    margin: 0;
+    font-family: $body-font-family;
+    font-weight: $body-font-weight;
+    font-style: $body-font-style;
+    line-height: 1; // Set to $base-line-height to take on browser default of 150%
+    position: relative;
+  }
+  
+  // Override outline from normalize, we don't like it
+  a:focus { outline: none; }
+  
+  // Grid Defaults to get images and embeds to work properly
+  img,
+  object,
+  embed { max-width: 100%; height: auto; }
+  
+  object,
+  embed { height: 100%; }
+  img { -ms-interpolation-mode: bicubic; }
+  
+  #map_canvas,
+  .map_canvas {
+    img,
+    embed,
+    object { max-width: none !important;
+    }
+  }
+  
+  // Miscellaneous useful HTML classes
+  .left         { float: left !important; }
+  .right        { float: right !important; }
+  .text-left    { text-align: left !important; }
+  .text-right   { text-align: right !important; }
+  .text-center  { text-align: center !important; }
+  .text-justify { text-align: justify !important; }
+  .hide         { display: none; }
+  
+  // Font smoothing
+  // Antialiased font smoothing works best for light text on a dark background.
+  // Apply to single elements instead of globally to body.
+  // Note this only applies to webkit-based desktop browsers on the Mac.
+  .antialiased { -webkit-font-smoothing: antialiased; }
+  
+  // Get rid of gap under images by making them display: inline-block; by default
+  img {
+    display: inline-block;
+    vertical-align: middle;
+  }
+  
+  //
+  // Global resets for forms
+  //
+  
+  // Make sure textarea takes on height automatically
+  textarea { height: auto; min-height: 50px; }
+  
+  // Make select elements 100% width by default
+  select { width: 100%; }
+
 }
-
-// Miscellaneous useful HTML classes
-.left         { float: left !important; }
-.right        { float: right !important; }
-.text-left    { text-align: left !important; }
-.text-right   { text-align: right !important; }
-.text-center  { text-align: center !important; }
-.text-justify { text-align: justify !important; }
-.hide         { display: none; }
-
-// Font smoothing
-// Antialiased font smoothing works best for light text on a dark background.
-// Apply to single elements instead of globally to body.
-// Note this only applies to webkit-based desktop browsers on the Mac.
-.antialiased { -webkit-font-smoothing: antialiased; }
-
-// Get rid of gap under images by making them display: inline-block; by default
-img {
-  display: inline-block;
-  vertical-align: middle;
-}
-
-//
-// Global resets for forms
-//
-
-// Make sure textarea takes on height automatically
-textarea { height: auto; min-height: 50px; }
-
-// Make select elements 100% width by default
-select { width: 100%; }

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -1,6 +1,8 @@
 //
 // Grid Variables
 //
+$include-html-grid-classes: $include-html-classes !default;
+
 $row-width:     emCalc(1000px) !default;
 $column-gutter: emCalc(30px) !default;
 $total-columns: 12 !default;
@@ -109,9 +111,8 @@ $total-columns: 12 !default;
 }
 
 
-/* Grid HTML Classes */
 @if $include-html-grid-classes != false {
-
+	/* Grid HTML Classes */
   .row {
     @include grid-row;
 

--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -1,6 +1,7 @@
 //
 // Inline List Variables
 //
+$include-html-global-classes: $include-html-classes !default;
 
 // We use this to control the margins and padding of the inline list.
 $inline-list-top-margin: 0 !default;
@@ -42,7 +43,7 @@ $inline-list-children-display: block !default;
 }
 
 
-@if $include-html-grid-classes != false {
+@if $include-html-global-classes != false {
 
   /* Inline Lists */
   .inline-list {

--- a/scss/foundation/components/_joyride.scss
+++ b/scss/foundation/components/_joyride.scss
@@ -1,6 +1,7 @@
 //
 // Joyride Variables
 //
+$include-html-joyride-classes: $include-html-classes !default;
 
 // Controlling default Joyride styles
 $joyride-tip-bg:              rgb(0,0,0) !default;
@@ -34,177 +35,181 @@ $joyride-screenfill:          rgba(0,0,0,0.5) !default;
 
 // We decided not to make a mixin for this because it relies on predefined classes to work properly.
 
-/* Foundation Joyride */
-.joyride-list { display: none; }
+@if $include-html-joyride-classes != false {
 
-/* Default styles for the container */
-.joyride-tip-guide {
-  display: none;
-  position: absolute;
-  background: $joyride-tip-bg;
-  color: $joyride-tip-font-color;
-  z-index: 101;
-  top: 0;
-  #{$default-float}: 2.5%;
-  font-family: inherit;
-  font-weight: normal;
-  width: 95%;
-}
-
-.lt-ie9 .joyride-tip-guide {
-  max-width:800px;
-  #{$default-float}: 50%;
-  margin-#{$default-float}:-400px;
-}
-
-.joyride-content-wrapper {
-  width: 100%;
-
-  padding: $joyride-tip-padding;
-
-  .button { margin-bottom: 0 !important; }
-}
-
-/* Add a little css triangle pip, older browser just miss out on the fanciness of it */
-.joyride-tip-guide {
-  .joyride-nub {
-    display: block;
+  /* Foundation Joyride */
+  .joyride-list { display: none; }
+  
+  /* Default styles for the container */
+  .joyride-tip-guide {
+    display: none;
     position: absolute;
-    #{$default-float}: $joyride-tip-position-offset;
-    width: 0;
-    height: 0;
-    border: inset $joyride-tip-nub-size;
-
-    &.top {
-      border-top-style: solid;
-      border-color: $joyride-tip-bg;
-      border-top-color: transparent !important;
-      border-#{$default-float}-color: transparent !important;
-      border-#{$opposite-direction}-color: transparent !important;
-      top: -($joyride-tip-nub-size*2);
-    }
-    &.bottom {
-      border-bottom-style: solid;
-      border-color: $joyride-tip-bg !important;
-      border-bottom-color: transparent !important;
-      border-#{$default-float}-color: transparent !important;
-      border-#{$opposite-direction}-color: transparent !important;
-      bottom: -($joyride-tip-nub-size*2);
-    }
-
-    &.right { right: -($joyride-tip-nub-size*2); }
-    &.left { left: -($joyride-tip-nub-size*2); }
+    background: $joyride-tip-bg;
+    color: $joyride-tip-font-color;
+    z-index: 101;
+    top: 0;
+    #{$default-float}: 2.5%;
+    font-family: inherit;
+    font-weight: normal;
+    width: 95%;
   }
-}
-
-/* Typography */
-.joyride-tip-guide h1,
-.joyride-tip-guide h2,
-.joyride-tip-guide h3,
-.joyride-tip-guide h4,
-.joyride-tip-guide h5,
-.joyride-tip-guide h6 {
-  line-height: 1.25;
-  margin: 0;
-  font-weight: $joyride-tip-header-weight;
-  color: $joyride-tip-font-color;
-}
-.joyride-tip-guide p {
-  margin: 0 0 emCalc(18px) 0;
-  font-size: $joyride-tip-font-size;
-  line-height: 1.3;
-}
-
-.joyride-timer-indicator-wrap {
-  width: $joyride-tip-timer-width;
-  height: $joyride-tip-timer-height;
-  border: $joyride-tip-border;
-  position: absolute;
-  #{$opposite-direction}: emCalc(17px);
-  bottom: emCalc(16px);
-}
-.joyride-timer-indicator {
-  display: block;
-  width: 0;
-  height: inherit;
-  background: $joyride-tip-timer-color;
-}
-
-.joyride-close-tip {
-  position: absolute;
-  #{$opposite-direction}: 12px;
-  top: 10px;
-  color: $joyride-tip-close-color !important;
-  text-decoration: none;
-  font-size: $joyride-tip-close-size;
-  font-weight: $joyride-tip-close-weight;
-  line-height: .5 !important;
-
-  &:hover,
-  &:focus { color: #eee !important; }
-}
-
-.joyride-modal-bg {
-  position: fixed;
-  height: 100%;
-  width: 100%;
-  background: transparent;
-  background: $joyride-screenfill;
-  z-index: 100;
-  display: none;
-  top: 0;
-  #{$default-float}: 0;
-  cursor: pointer;
-}
-
-.joyride-expose-wrapper {
-  background-color: #ffffff;
-  position: absolute;
-  border-radius: 3px;
-  z-index: 102;
-  -moz-box-shadow: 0px 0px 30px #ffffff;
-  -webkit-box-shadow: 0px 0px 15px #ffffff;
-  box-shadow: 0px 0px 15px #ffffff;
-}
-
-.joyride-expose-cover {
-  background: transparent;
-  border-radius: 3px;
-  position: absolute;
-  z-index: 9999;
-  top: 0px;
-  left: 0px;
-}
-
-
-/* Styles for screens that are atleast 768px; */
-@media #{$small} {
-  .joyride-tip-guide { width: $joyride-tip-default-width; #{$default-float}: inherit;
+  
+  .lt-ie9 .joyride-tip-guide {
+    max-width:800px;
+    #{$default-float}: 50%;
+    margin-#{$default-float}:-400px;
+  }
+  
+  .joyride-content-wrapper {
+    width: 100%;
+  
+    padding: $joyride-tip-padding;
+  
+    .button { margin-bottom: 0 !important; }
+  }
+  
+  /* Add a little css triangle pip, older browser just miss out on the fanciness of it */
+  .joyride-tip-guide {
     .joyride-nub {
+      display: block;
+      position: absolute;
+      #{$default-float}: $joyride-tip-position-offset;
+      width: 0;
+      height: 0;
+      border: inset $joyride-tip-nub-size;
+  
+      &.top {
+        border-top-style: solid;
+        border-color: $joyride-tip-bg;
+        border-top-color: transparent !important;
+        border-#{$default-float}-color: transparent !important;
+        border-#{$opposite-direction}-color: transparent !important;
+        top: -($joyride-tip-nub-size*2);
+      }
       &.bottom {
+        border-bottom-style: solid;
         border-color: $joyride-tip-bg !important;
         border-bottom-color: transparent !important;
         border-#{$default-float}-color: transparent !important;
         border-#{$opposite-direction}-color: transparent !important;
         bottom: -($joyride-tip-nub-size*2);
       }
-      &.right {
-        border-color: $joyride-tip-bg !important;
-        border-top-color: transparent !important;
-        border-right-color: transparent !important; border-bottom-color: transparent !important;
-        top: $joyride-tip-position-offset;
-        left: auto;
-        right: -($joyride-tip-nub-size*2);
-      }
-      &.left {
-        border-color: $joyride-tip-bg !important;
-        border-top-color: transparent !important;
-        border-left-color: transparent !important;
-        border-bottom-color: transparent !important;
-        top: $joyride-tip-position-offset;
-        left: -($joyride-tip-nub-size*2);
-        right: auto;
+  
+      &.right { right: -($joyride-tip-nub-size*2); }
+      &.left { left: -($joyride-tip-nub-size*2); }
+    }
+  }
+  
+  /* Typography */
+  .joyride-tip-guide h1,
+  .joyride-tip-guide h2,
+  .joyride-tip-guide h3,
+  .joyride-tip-guide h4,
+  .joyride-tip-guide h5,
+  .joyride-tip-guide h6 {
+    line-height: 1.25;
+    margin: 0;
+    font-weight: $joyride-tip-header-weight;
+    color: $joyride-tip-font-color;
+  }
+  .joyride-tip-guide p {
+    margin: 0 0 emCalc(18px) 0;
+    font-size: $joyride-tip-font-size;
+    line-height: 1.3;
+  }
+  
+  .joyride-timer-indicator-wrap {
+    width: $joyride-tip-timer-width;
+    height: $joyride-tip-timer-height;
+    border: $joyride-tip-border;
+    position: absolute;
+    #{$opposite-direction}: emCalc(17px);
+    bottom: emCalc(16px);
+  }
+  .joyride-timer-indicator {
+    display: block;
+    width: 0;
+    height: inherit;
+    background: $joyride-tip-timer-color;
+  }
+  
+  .joyride-close-tip {
+    position: absolute;
+    #{$opposite-direction}: 12px;
+    top: 10px;
+    color: $joyride-tip-close-color !important;
+    text-decoration: none;
+    font-size: $joyride-tip-close-size;
+    font-weight: $joyride-tip-close-weight;
+    line-height: .5 !important;
+  
+    &:hover,
+    &:focus { color: #eee !important; }
+  }
+  
+  .joyride-modal-bg {
+    position: fixed;
+    height: 100%;
+    width: 100%;
+    background: transparent;
+    background: $joyride-screenfill;
+    z-index: 100;
+    display: none;
+    top: 0;
+    #{$default-float}: 0;
+    cursor: pointer;
+  }
+  
+  .joyride-expose-wrapper {
+    background-color: #ffffff;
+    position: absolute;
+    border-radius: 3px;
+    z-index: 102;
+    -moz-box-shadow: 0px 0px 30px #ffffff;
+    -webkit-box-shadow: 0px 0px 15px #ffffff;
+    box-shadow: 0px 0px 15px #ffffff;
+  }
+  
+  .joyride-expose-cover {
+    background: transparent;
+    border-radius: 3px;
+    position: absolute;
+    z-index: 9999;
+    top: 0px;
+    left: 0px;
+  }
+  
+  
+  /* Styles for screens that are atleast 768px; */
+  @media #{$small} {
+    .joyride-tip-guide { width: $joyride-tip-default-width; #{$default-float}: inherit;
+      .joyride-nub {
+        &.bottom {
+          border-color: $joyride-tip-bg !important;
+          border-bottom-color: transparent !important;
+          border-#{$default-float}-color: transparent !important;
+          border-#{$opposite-direction}-color: transparent !important;
+          bottom: -($joyride-tip-nub-size*2);
+        }
+        &.right {
+          border-color: $joyride-tip-bg !important;
+          border-top-color: transparent !important;
+          border-right-color: transparent !important; border-bottom-color: transparent !important;
+          top: $joyride-tip-position-offset;
+          left: auto;
+          right: -($joyride-tip-nub-size*2);
+        }
+        &.left {
+          border-color: $joyride-tip-bg !important;
+          border-top-color: transparent !important;
+          border-left-color: transparent !important;
+          border-bottom-color: transparent !important;
+          top: $joyride-tip-position-offset;
+          left: -($joyride-tip-nub-size*2);
+          right: auto;
+        }
       }
     }
   }
+
 }

--- a/scss/foundation/components/_keystrokes.scss
+++ b/scss/foundation/components/_keystrokes.scss
@@ -1,6 +1,7 @@
 //
 // Keystroke Variables
 //
+$include-html-type-classes: $include-html-classes !default;
 
 // We use these to control text styles.
 $keystroke-font:            "Consolas", "Menlo", "Courier", monospace !default;
@@ -44,7 +45,7 @@ $keystroke-radius:          $global-radius !default;
 }
 
 
-@if $include-html-media-classes != false {
+@if $include-html-type-classes != false {
 
   /* Keystroke Characters */
   .keystroke,

--- a/scss/foundation/components/_labels.scss
+++ b/scss/foundation/components/_labels.scss
@@ -1,6 +1,7 @@
 //
 // Label Variables
 //
+$include-html-label-classes: $include-html-classes !default;
 
 // We use these to style the labels
 $label-padding:     emCalc(3px) emCalc(10px) emCalc(4px) !default;

--- a/scss/foundation/components/_magellan.scss
+++ b/scss/foundation/components/_magellan.scss
@@ -1,6 +1,8 @@
 //
 // Magellan Variables
 //
+$include-html-magellan-classes: $include-html-classes !default;
+
 $magellan-bg: #fff !default;
 $magellan-padding: 10px !default;
 

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -1,4 +1,5 @@
 // Orbit Settings
+$include-html-orbit-classes: $include-html-classes !default;
 
 // We use these to control the caption styles
 $orbit-container-bg: #f5f5f5 !default;
@@ -27,183 +28,186 @@ $orbit-slide-number-padding: emCalc(5px) !default;
 // Margin for when Orbit is stacked on small screens
 $stack-on-small-margin-bottom: emCalc(20px) !default;
 
-
-.orbit-container {
-  overflow: hidden;
-  width: 100%;
-  position: relative;
-  background: $orbit-container-bg;
-
-  .orbit-slides-container {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+@if $include-html-orbit-classes != false {
+  
+  .orbit-container {
+    overflow: hidden;
+    width: 100%;
     position: relative;
-
-    img { display: block; }
-
-    &>* {
+    background: $orbit-container-bg;
+  
+    .orbit-slides-container {
+      list-style: none;
+      margin: 0;
+      padding: 0;
       position: relative;
-      float: $default-float;
-      height: 100%;
-
-      .orbit-caption {
-        position: absolute;
-        bottom: 0;
-        background-color: $orbit-caption-bg-old;
-        background-color: $orbit-caption-bg;
-        color: #fff;
-        width: 100%;
-        padding: 10px 14px;
-        font-size: emCalc(14px);
-
-        * { color: $orbit-caption-font-color; }
+  
+      img { display: block; }
+  
+      &>* {
+        position: relative;
+        float: $default-float;
+        height: 100%;
+  
+        .orbit-caption {
+          position: absolute;
+          bottom: 0;
+          background-color: $orbit-caption-bg-old;
+          background-color: $orbit-caption-bg;
+          color: #fff;
+          width: 100%;
+          padding: 10px 14px;
+          font-size: emCalc(14px);
+  
+          * { color: $orbit-caption-font-color; }
+        }
       }
     }
-  }
-
-  .orbit-slide-number {
-    position: absolute;
-    top: 10px;
-    #{$default-float}: 10px;
-    font-size: 12px;
-    span { font-weight: 700; padding: $orbit-slide-number-padding;}
-    color: $orbit-slide-number-font-color;
-    background: $orbit-slide-number-bg;
-  }
-
-  .orbit-timer {
-    position: absolute;
-    top: 10px;
-    #{$opposite-direction}: 10px;
-    height: 6px;
-    width: 100px;
-    .orbit-progress {
-      height: 100%;
-      background-color: $orbit-timer-bg-old;
-      background-color: $orbit-timer-bg;
-      display: block;
-      width: 0%;
-    }
-
-    & > span {
-      display: none;
+  
+    .orbit-slide-number {
       position: absolute;
       top: 10px;
-      #{$opposite-direction}: 0px;
-      width: 11px;
-      height: 14px;
-      border: solid 4px #000;
-      border-top: none;
-      border-bottom: none;
+      #{$default-float}: 10px;
+      font-size: 12px;
+      span { font-weight: 700; padding: $orbit-slide-number-padding;}
+      color: $orbit-slide-number-font-color;
+      background: $orbit-slide-number-bg;
     }
-
-    &.paused {
+  
+    .orbit-timer {
+      position: absolute;
+      top: 10px;
+      #{$opposite-direction}: 10px;
+      height: 6px;
+      width: 100px;
+      .orbit-progress {
+        height: 100%;
+        background-color: $orbit-timer-bg-old;
+        background-color: $orbit-timer-bg;
+        display: block;
+        width: 0%;
+      }
+  
       & > span {
-        #{$opposite-direction}: -6px;
-        top: 9px;
+        display: none;
+        position: absolute;
+        top: 10px;
+        #{$opposite-direction}: 0px;
         width: 11px;
         height: 14px;
-        border: inset 8px;
-        border-right-style: solid;
-        border-color: transparent transparent transparent #000;
+        border: solid 4px #000;
+        border-top: none;
+        border-bottom: none;
+      }
+  
+      &.paused {
+        & > span {
+          #{$opposite-direction}: -6px;
+          top: 9px;
+          width: 11px;
+          height: 14px;
+          border: inset 8px;
+          border-right-style: solid;
+          border-color: transparent transparent transparent #000;
+        }
+      }
+    }
+  
+    &:hover .orbit-timer > span { display: block; }
+  
+    // Let's get those controls to be right in the center on each side
+    .orbit-prev,
+    .orbit-next {
+      position: absolute;
+      top: 50%;
+      margin-top: -25px;
+      background-color: $orbit-nav-bg-old;
+      background-color: $orbit-nav-bg;
+      width: 50px;
+      height: 60px;
+      line-height: 50px;
+      color: white;
+      text-indent: -9999px !important;
+  
+      & > span {
+        position: absolute;
+        top: 50%;
+        margin-top: -16px;
+        display: block;
+        width: 0;
+        height: 0;
+        border: inset 16px;
+      }
+    }
+    .orbit-prev { #{$default-float}: 0;
+      & > span {
+        border-#{$opposite-direction}-style: solid;
+        border-color: transparent;
+        border-#{$opposite-direction}-color: #fff;
+      }
+      &:hover > span {
+        border-#{$opposite-direction}-color: #ccc;
+      }
+    }
+    .orbit-next { #{$opposite-direction}: 0;
+      & > span {
+        border-color: transparent;
+        border-#{$default-float}-style: solid;
+        border-#{$default-float}-color: #fff;
+        #{$default-float}: 50%;
+        margin-#{$default-float}: -8px;
+      }
+      &:hover > span {
+        border-#{$default-float}-color: #ccc;
       }
     }
   }
-
-  &:hover .orbit-timer > span { display: block; }
-
-  // Let's get those controls to be right in the center on each side
-  .orbit-prev,
-  .orbit-next {
-    position: absolute;
-    top: 50%;
-    margin-top: -25px;
-    background-color: $orbit-nav-bg-old;
-    background-color: $orbit-nav-bg;
-    width: 50px;
-    height: 60px;
-    line-height: 50px;
-    color: white;
-    text-indent: -9999px !important;
-
-    & > span {
-      position: absolute;
-      top: 50%;
-      margin-top: -16px;
+  
+  .orbit-bullets {
+    margin: 0 auto 30px auto;
+    overflow: hidden;
+    position: relative;
+    top: 10px;
+  
+    li {
       display: block;
-      width: 0;
-      height: 0;
-      border: inset 16px;
+      width: 18px;
+      height: 18px;
+      background: $orbit-bullet-nav-color;
+      float: $default-float;
+      margin-#{$opposite-direction}: 6px;
+      border: solid 2px $orbit-bullet-nav-color-active;
+      @include radius(1000px);
+  
+      &.active {
+        background: $orbit-bullet-nav-color-active;
+      }
+  
+      &:last-child { margin-#{$opposite-direction}: 0; }
     }
   }
-  .orbit-prev { #{$default-float}: 0;
-    & > span {
-      border-#{$opposite-direction}-style: solid;
-      border-color: transparent;
-      border-#{$opposite-direction}-color: #fff;
-    }
-    &:hover > span {
-      border-#{$opposite-direction}-color: #ccc;
-    }
-  }
-  .orbit-next { #{$opposite-direction}: 0;
-    & > span {
-      border-color: transparent;
-      border-#{$default-float}-style: solid;
-      border-#{$default-float}-color: #fff;
-      #{$default-float}: 50%;
-      margin-#{$default-float}: -8px;
-    }
-    &:hover > span {
-      border-#{$default-float}-color: #ccc;
-    }
-  }
-}
-
-.orbit-bullets {
-  margin: 0 auto 30px auto;
-  overflow: hidden;
-  position: relative;
-  top: 10px;
-
-  li {
-    display: block;
-    width: 18px;
-    height: 18px;
-    background: $orbit-bullet-nav-color;
-    float: $default-float;
-    margin-#{$opposite-direction}: 6px;
-    border: solid 2px $orbit-bullet-nav-color-active;
-    @include radius(1000px);
-
-    &.active {
-      background: $orbit-bullet-nav-color-active;
-    }
-
-    &:last-child { margin-#{$opposite-direction}: 0; }
-  }
-}
-
-.touch {
-  .orbit-container {
-    .orbit-prev,
-    .orbit-next { display: none; }
-  }
-
-  .orbit-bullets { display: none; }
-}
-
-
-@media #{$small} {
-
+  
   .touch {
     .orbit-container {
       .orbit-prev,
-      .orbit-next { display: inherit; }
+      .orbit-next { display: none; }
     }
-
-    .orbit-bullets { display: block; }
+  
+    .orbit-bullets { display: none; }
+  }
+  
+  
+  @media #{$small} {
+  
+    .touch {
+      .orbit-container {
+        .orbit-prev,
+        .orbit-next { display: inherit; }
+      }
+  
+      .orbit-bullets { display: block; }
+    }
+  
   }
 
 }

--- a/scss/foundation/components/_pagination.scss
+++ b/scss/foundation/components/_pagination.scss
@@ -1,6 +1,7 @@
 //
 // Pagination Variables
 //
+$include-html-nav-classes: $include-html-classes !default;
 
 // We use these to control the pagination container
 $pagination-height:                      emCalc(24px) !default;

--- a/scss/foundation/components/_panels.scss
+++ b/scss/foundation/components/_panels.scss
@@ -1,6 +1,7 @@
 //
 // Panel Variables
 //
+$include-html-panel-classes: $include-html-classes !default;
 
 // We use these to control the background and border styles
 $panel-bg:              darken(#fff, 5%) !default;

--- a/scss/foundation/components/_pricing-tables.scss
+++ b/scss/foundation/components/_pricing-tables.scss
@@ -1,6 +1,7 @@
 //
 // Pricing Table Variables
 //
+$include-html-pricing-classes: $include-html-classes !default;
 
 // We use this to control the border color
 $price-table-border:        solid 1px #ddd !default;

--- a/scss/foundation/components/_progress-bars.scss
+++ b/scss/foundation/components/_progress-bars.scss
@@ -1,6 +1,7 @@
 //
 // Progress Bar Variables
 //
+$include-html-media-classes: $include-html-classes !default;
 
 // We use this to se the prog bar height
 $progress-bar-height: emCalc(25px) !default;

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -1,4 +1,5 @@
 // NEED TO FINISH THE LOGIC HERE
+$include-html-reveal-classes: $include-html-classes !default;
 
 //
 // Reveal Variables

--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -1,6 +1,7 @@
 //
 // Section Variables
 //
+$include-html-section-classes: $include-html-classes !default;
 
 // We use these to set padding and hover factor
 $section-padding:                emCalc(15px) !default;

--- a/scss/foundation/components/_side-nav.scss
+++ b/scss/foundation/components/_side-nav.scss
@@ -1,6 +1,7 @@
 //
 // Side Nav Variables
 //
+$include-html-nav-classes: $include-html-classes !default;
 
 // We use this to control padding.
 $side-nav-padding:           emCalc(14px) 0 !default;

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -1,6 +1,7 @@
 //
 // Split Button Variables
 //
+$include-html-button-classes: $include-html-classes !default;
 
 // We use these to control different shared styles for Split Buttons
 $split-button-function-factor: 15% !default;

--- a/scss/foundation/components/_sub-nav.scss
+++ b/scss/foundation/components/_sub-nav.scss
@@ -1,6 +1,7 @@
 //
 // Sub Nav Variables
 //
+$include-html-nav-classes: $include-html-classes !default;
 
 // We use these to control margin and padding
 $sub-nav-list-margin:        emCalc(-4px) 0 emCalc(18px) !default;

--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -1,6 +1,7 @@
 //
 // Switch Variables
 //
+$include-html-form-classes: $include-html-classes !default;
 
 // Controlling border styles and background colors for the switch container
 $switch-border-color:             darken(#fff, 20%) !default;
@@ -212,7 +213,7 @@ $switch-label-outline:            1px dotted #888 !default;
   @include switch-style($paddle-bg, $positive-color, $negative-color, $radius, $base-style);
 }
 
-@if $include-html-button-classes != false {
+@if $include-html-form-classes != false {
 
   /* Foundation Switches */
   @media only screen {

--- a/scss/foundation/components/_tables.scss
+++ b/scss/foundation/components/_tables.scss
@@ -1,6 +1,7 @@
 //
 // Table Variables
 //
+$include-html-table-classes: $include-html-classes !default;
 
 // These control the background color for the table and even rows
 $table-bg:               #fff !default;
@@ -73,8 +74,11 @@ $table-margin-bottom:    emCalc(20px) !default;
   tfoot tr td { display: $table-display; line-height: $table-line-height; }
 }
 
+@if $include-html-table-classes {
 
-/* Tables */
-table {
-  @include table;
+  /* Tables */
+  table {
+    @include table;
+  }
+
 }

--- a/scss/foundation/components/_thumbs.scss
+++ b/scss/foundation/components/_thumbs.scss
@@ -1,6 +1,7 @@
 //
 // Image Thumbnail Variables
 //
+$include-html-media-classes: $include-html-classes !default;
 
 // We use these to control border styles
 $thumb-border-style:     solid !default;

--- a/scss/foundation/components/_tooltips.scss
+++ b/scss/foundation/components/_tooltips.scss
@@ -1,6 +1,8 @@
 //
 // Tooltip Variables
 //
+$include-html-tooltip-classes: $include-html-classes !default;
+
 $has-tip-border-bottom:       dotted 1px #ccc !default;
 $has-tip-font-weight:         bold !default;
 $has-tip-font-color:          #333 !default;
@@ -21,93 +23,95 @@ $tooltip-font-size-sml:       emCalc(14px) !default;
 $tooltip-radius:              $global-radius !default;
 $tooltip-pip-size:            5px !default;
 
-
-/* Tooltips */
-
-.has-tip {
-  border-bottom: $has-tip-border-bottom;
-  cursor: $has-tip-cursor-type;
-  font-weight: $has-tip-font-weight;
-  color: $has-tip-font-color;
-
-  &:hover,
-  &:focus {
-    border-bottom: $has-tip-border-bottom-hover;
-    color: $has-tip-font-color-hover;
+@if $include-html-tooltip-classes != false {
+  
+  /* Tooltips */
+  .has-tip {
+    border-bottom: $has-tip-border-bottom;
+    cursor: $has-tip-cursor-type;
+    font-weight: $has-tip-font-weight;
+    color: $has-tip-font-color;
+  
+    &:hover,
+    &:focus {
+      border-bottom: $has-tip-border-bottom-hover;
+      color: $has-tip-font-color-hover;
+    }
+  
+    &.tip-left,
+    &.tip-right { float: none !important; }
   }
-
-  &.tip-left,
-  &.tip-right { float: none !important; }
-}
-
-.tooltip {
-  display: none;
-  position: absolute;
-  z-index: 999;
-  font-weight: $tooltip-font-weight;
-  font-size: $tooltip-font-size;
-  line-height: $tooltip-line-height;
-  padding: $tooltip-padding;
-  max-width: 85%;
-  #{$default-float}: 50%;
-  width: 100%;
-  color: $tooltip-font-color;
-  background: $tooltip-bg;
-  @include radius($tooltip-radius);
-
-  &>.nub {
-    display: block;
-    #{$default-float}: $tooltip-pip-size;
-    position: absolute;
-    width: 0;
-    height: 0;
-    border: solid $tooltip-pip-size;
-    border-color: transparent transparent $tooltip-bg transparent;
-    top: -($tooltip-pip-size * 2);
-  }
-
-  &.opened {
-    color: $has-tip-font-color-hover !important;
-    border-bottom: $has-tip-border-bottom-hover !important;
-  }
-}
-
-.tap-to-close {
-  display: block;
-  font-size: $tooltip-close-font-size;
-  color: $tooltip-close-font-color;
-  font-weight: $tooltip-close-font-weight;
-}
-
-@media #{$small} {
+  
   .tooltip {
+    display: none;
+    position: absolute;
+    z-index: 999;
+    font-weight: $tooltip-font-weight;
+    font-size: $tooltip-font-size;
+    line-height: $tooltip-line-height;
+    padding: $tooltip-padding;
+    max-width: 85%;
+    #{$default-float}: 50%;
+    width: 100%;
+    color: $tooltip-font-color;
+    background: $tooltip-bg;
+    @include radius($tooltip-radius);
+  
     &>.nub {
+      display: block;
+      #{$default-float}: $tooltip-pip-size;
+      position: absolute;
+      width: 0;
+      height: 0;
+      border: solid $tooltip-pip-size;
       border-color: transparent transparent $tooltip-bg transparent;
       top: -($tooltip-pip-size * 2);
     }
-    &.tip-top>.nub {
-      border-color: $tooltip-bg transparent transparent transparent;
-      top: auto;
-      bottom: -($tooltip-pip-size * 2);
+  
+    &.opened {
+      color: $has-tip-font-color-hover !important;
+      border-bottom: $has-tip-border-bottom-hover !important;
     }
-
-    &.tip-left,
-    &.tip-right { float: none !important; }
-
-    &.tip-left>.nub {
-      border-color: transparent transparent transparent $tooltip-bg;
-      right: -($tooltip-pip-size * 2);
-      left: auto;
-      top: 50%;
-      margin-top: -$tooltip-pip-size;
-    }
-    &.tip-right>.nub {
-      border-color: transparent $tooltip-bg transparent transparent;
-      right: auto;
-      left: -($tooltip-pip-size * 2);
-      top: 50%;
-      margin-top: -$tooltip-pip-size;
-    }
-
   }
+  
+  .tap-to-close {
+    display: block;
+    font-size: $tooltip-close-font-size;
+    color: $tooltip-close-font-color;
+    font-weight: $tooltip-close-font-weight;
+  }
+  
+  @media #{$small} {
+    .tooltip {
+      &>.nub {
+        border-color: transparent transparent $tooltip-bg transparent;
+        top: -($tooltip-pip-size * 2);
+      }
+      &.tip-top>.nub {
+        border-color: $tooltip-bg transparent transparent transparent;
+        top: auto;
+        bottom: -($tooltip-pip-size * 2);
+      }
+  
+      &.tip-left,
+      &.tip-right { float: none !important; }
+  
+      &.tip-left>.nub {
+        border-color: transparent transparent transparent $tooltip-bg;
+        right: -($tooltip-pip-size * 2);
+        left: auto;
+        top: 50%;
+        margin-top: -$tooltip-pip-size;
+      }
+      &.tip-right>.nub {
+        border-color: transparent $tooltip-bg transparent transparent;
+        right: auto;
+        left: -($tooltip-pip-size * 2);
+        top: 50%;
+        margin-top: -$tooltip-pip-size;
+      }
+  
+    }
+  }
+
 }

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -1,6 +1,7 @@
 //
 // Top Bar Variables
 //
+$include-html-nav-classes: $include-html-classes !default;
 
 // Background color for the top bar
 $topbar-bg: #111 !default;
@@ -44,419 +45,422 @@ $topbar-transition-speed: 300ms !default;
 $topbar-breakpoint: emCalc(940px) !default; // Change to 9999px for always mobile layout
 $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !default;
 
-
-/* Wrapped around .top-bar to contain to grid width */
-.contain-to-grid {
-  width: 100%;
-  background: $topbar-bg;
-}
-
-// Wrapped around .top-bar to make it fixed at the top
-.fixed {
-  width: 100%;
-  #{$default-float}: 0;
-  position: fixed;
-  top: 0;
-  z-index: 99;
-}
-
-.top-bar {
-  overflow: hidden;
-  height: $topbar-height;
-  line-height: $topbar-height;
-  position: relative;
-  background: $topbar-bg;
-  margin-bottom: $topbar-margin-bottom;
-
-  // Topbar Global list Styles
-  ul {
-    margin-bottom: 0;
-    list-style: none;
+@if $include-html-nav-classes {
+  
+  /* Wrapped around .top-bar to contain to grid width */
+  .contain-to-grid {
+    width: 100%;
+    background: $topbar-bg;
   }
-
-  .row { max-width: none; }
-
-  form,
-  input { margin-bottom: 0; }
-
-  input { height: $topbar-input-height; }
-
-  .button { padding-top: .5em; padding-bottom: .5em; margin-bottom: 0; }
-
-  // Title Area
-  .title-area { position: relative; }
-
-  .name {
+  
+  // Wrapped around .top-bar to make it fixed at the top
+  .fixed {
+    width: 100%;
+    #{$default-float}: 0;
+    position: fixed;
+    top: 0;
+    z-index: 99;
+  }
+  
+  .top-bar {
+    overflow: hidden;
     height: $topbar-height;
-    margin: 0;
-    font-size: $em-base;
-
-    h1 {
-      line-height: $topbar-height;
-      font-size: $topbar-title-font-size;
+    line-height: $topbar-height;
+    position: relative;
+    background: $topbar-bg;
+    margin-bottom: $topbar-margin-bottom;
+  
+    // Topbar Global list Styles
+    ul {
+      margin-bottom: 0;
+      list-style: none;
+    }
+  
+    .row { max-width: none; }
+  
+    form,
+    input { margin-bottom: 0; }
+  
+    input { height: $topbar-input-height; }
+  
+    .button { padding-top: .5em; padding-bottom: .5em; margin-bottom: 0; }
+  
+    // Title Area
+    .title-area { position: relative; }
+  
+    .name {
+      height: $topbar-height;
       margin: 0;
+      font-size: $em-base;
+  
+      h1 {
+        line-height: $topbar-height;
+        font-size: $topbar-title-font-size;
+        margin: 0;
+        a {
+          font-weight: $topbar-title-weight;
+          color: $topbar-link-color;
+          width: 50%;
+          display: block;
+          padding: 0 $topbar-height / 3;
+        }
+      }
+    }
+  
+    // Menu toggle button on small devices
+    .toggle-topbar {
+      position: absolute;
+      #{$opposite-direction}: 0;
+      top: 0;
+  
       a {
-        font-weight: $topbar-title-weight;
         color: $topbar-link-color;
-        width: 50%;
+        text-transform: $topbar-menu-link-transform;
+        font-size: $topbar-menu-link-font-size;
+        font-weight: $topbar-menu-link-weight;
+        position: relative;
         display: block;
         padding: 0 $topbar-height / 3;
-      }
-    }
-  }
-
-  // Menu toggle button on small devices
-  .toggle-topbar {
-    position: absolute;
-    #{$opposite-direction}: 0;
-    top: 0;
-
-    a {
-      color: $topbar-link-color;
-      text-transform: $topbar-menu-link-transform;
-      font-size: $topbar-menu-link-font-size;
-      font-weight: $topbar-menu-link-weight;
-      position: relative;
-      display: block;
-      padding: 0 $topbar-height / 3;
-      height: $topbar-height;
-      line-height: $topbar-height;
-    }
-
-    // Adding the class "menu-icon" will add the 3-line icon people love and adore.
-    &.menu-icon {
-      #{$opposite-direction}: $topbar-height / 3;
-      top: 50%;
-      margin-top: -16px;
-      padding-#{$default-float}: 40px;
-
-      a {
-        text-indent: -48px;
-        width: 34px;
-        height: 34px;
-        line-height: 33px;
-        padding: 0;
-        color: $topbar-menu-link-color;
-
-        span {
-          position: absolute;
-          #{$opposite-direction}: 0;
-          display: block;
-          width: 16px;
-          height: 0;
-          // Shh, don't tell, but box-shadows create the menu icon :)
-          -webkit-box-shadow: 0 10px 0 1px $topbar-menu-icon-color,
-                              0 16px 0 1px $topbar-menu-icon-color,
-                              0 22px 0 1px $topbar-menu-icon-color;
-
-          box-shadow:         0 10px 0 1px $topbar-menu-icon-color,
-                              0 16px 0 1px $topbar-menu-icon-color,
-                              0 22px 0 1px $topbar-menu-icon-color;
-        }
-      }
-    }
-  }
-
-  // Change things up when the top-bar is expanded
-  &.expanded {
-    height: auto;
-    background: transparent;
-
-    .title-area { background: $topbar-bg; }
-
-    .toggle-topbar {
-      a { color: $topbar-menu-link-color-toggled;
-        span {
-          // Shh, don't tell, but box-shadows create the menu icon :)
-          -webkit-box-shadow: 0 10px 0 1px $topbar-menu-icon-color-toggled,
-                              0 16px 0 1px $topbar-menu-icon-color-toggled,
-                              0 22px 0 1px $topbar-menu-icon-color-toggled;
-
-          box-shadow:         0 10px 0 1px $topbar-menu-icon-color-toggled,
-                              0 16px 0 1px $topbar-menu-icon-color-toggled,
-                              0 22px 0 1px $topbar-menu-icon-color-toggled;
-        }
-      }
-    }
-  }
-
-}
-
-// Right and Left Navigation that stacked by default
-.top-bar-section {
-  #{$default-float}: 0;
-  position: relative;
-  width: auto;
-  @include single-transition($default-float, $topbar-transition-speed);
-
-  ul {
-    width: 100%;
-    height: auto;
-    display: block;
-    background: $topbar-dropdown-bg;
-    font-size: $em-base;
-    margin: 0;
-  }
-
-  .divider,
-  [role="separator"] {
-    border-bottom: solid 1px lighten($topbar-dropdown-bg, 10%);
-    border-top: solid 1px darken($topbar-dropdown-bg, 10%);
-    clear: both;
-    height: 1px;
-    width: 100%;
-  }
-
-  ul li {
-    & > a {
-      display: block;
-      width: 100%;
-      color: $topbar-link-color;
-      padding: 12px 0 12px 0;
-      padding-#{$default-float}: $topbar-height / 3;
-      font-size: $topbar-link-font-size;
-      font-weight: $topbar-link-weight;
-      background: $topbar-dropdown-bg;
-
-      &:hover { background: darken($topbar-dropdown-bg, 3%); }
-
-
-      &.button {
-        background: $primary-color;
-        font-size: $topbar-link-font-size;
-        &:hover {
-          background: darken($primary-color, 10%);
-        }
-      }
-      &.button.secondary {
-        background: $secondary-color;
-        &:hover {
-          background: darken($secondary-color, 10%);
-        }
-      }
-      &.button.success {
-        background: $success-color;
-        &:hover {
-          background: darken($success-color, 10%);
-        }
-      }
-      &.button.alert {
-        background: $alert-color;
-        &:hover {
-          background: darken($alert-color, 10%);
-        }
-      }
-
-    }
-
-    // Apply the active link color when it has that class
-    &.active > a { background: darken($topbar-dropdown-bg, 3%); }
-  }
-
-  // Add some extra padding for list items contains buttons
-  .has-form { padding: $topbar-height / 3; }
-
-  // Styling for list items that have a dropdown within them.
-  .has-dropdown {
-    position: relative;
-
-    & > a {
-      &:after {
-        @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), $default-float);
-        margin-#{$opposite-direction}: $topbar-height / 3;
-        margin-top: -($topbar-dropdown-toggle-size / 2) - 2;
-        position: absolute;
-        top: 22px;
-        #{$opposite-direction}: 0;
-      }
-    }
-
-    &.moved { position: static;
-      & > .dropdown {
-        visibility: visible;
-      }
-    }
-  }
-
-  // Styling elements inside of dropdowns
-  .dropdown {
-    position: absolute;
-    #{$default-float}: 100%;
-    top: 0;
-    visibility: hidden;
-    z-index: 99;
-
-    li { width: 100%;
-      a {
-        font-weight: normal;
-        padding: 8px $topbar-height / 3;
-      }
-
-      &.title h5 { margin-bottom: 0;
-        a {
-          color: $topbar-link-color;
-          line-height: $topbar-height / 2;
-          display: block;
-        }
-      }
-    }
-
-    label {
-      padding: 8px $topbar-height / 3 2px;
-      margin-bottom: 0;
-      text-transform: uppercase;
-      color: $dropdown-label-color;
-      font-weight: bold;
-      font-size: emCalc(10px);
-    }
-  }
-}
-
-// Element that controls breakpoint, no need to change this ever
-.top-bar-js-breakpoint {
-  width: $topbar-breakpoint !important;
-  visibility: hidden;
-}
-.js-generated { display: block; }
-
-
-// Top Bar styles intended for screen sizes above the breakpoint.
-@media #{$topbar-media-query} {
-  .top-bar { background: $topbar-bg; @include clearfix; overflow: visible;
-    .toggle-topbar { display: none; }
-
-    .title-area { float: $default-float; }
-    .name h1 a { width: auto; }
-
-    input,
-    .button {
-      line-height: 2em;
-      font-size: emCalc(14px);
-      height: 2em;
-      padding: 0 10px;
-      position: relative;
-      top: 8px;
-    }
-
-    &.expanded { background: $topbar-bg; }
-  }
-
-  .contain-to-grid .top-bar { max-width: $row-width; margin: 0 auto; margin-bottom: $topbar-margin-bottom; }
-
-  .top-bar-section {
-    @include single-transition(none,0,0);
-    #{$default-float}: 0 !important;
-
-    ul {
-      width: auto;
-      height: auto !important;
-      display: inline;
-
-      li {
-        float: $default-float;
-        .js-generated { display: none; }
-      }
-    }
-
-    li {
-      a:not(.button) {
-        padding: 0 $topbar-height / 3;
+        height: $topbar-height;
         line-height: $topbar-height;
-        background: $topbar-bg;
-        &:hover { background: adjust-color($topbar-dropdown-bg, $lightness: $topbar-link-hover-lightness); }
       }
-    }
-
-    .has-dropdown {
-      & > a {
-        padding-#{$opposite-direction}: $topbar-height / 3 + 20 !important;
-
-        &:after {
-          @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), top);
-          margin-top: -($topbar-dropdown-toggle-size / 2);
-          top: $topbar-height / 2;
+  
+      // Adding the class "menu-icon" will add the 3-line icon people love and adore.
+      &.menu-icon {
+        #{$opposite-direction}: $topbar-height / 3;
+        top: 50%;
+        margin-top: -16px;
+        padding-#{$default-float}: 40px;
+  
+        a {
+          text-indent: -48px;
+          width: 34px;
+          height: 34px;
+          line-height: 33px;
+          padding: 0;
+          color: $topbar-menu-link-color;
+  
+          span {
+            position: absolute;
+            #{$opposite-direction}: 0;
+            display: block;
+            width: 16px;
+            height: 0;
+            // Shh, don't tell, but box-shadows create the menu icon :)
+            -webkit-box-shadow: 0 10px 0 1px $topbar-menu-icon-color,
+                                0 16px 0 1px $topbar-menu-icon-color,
+                                0 22px 0 1px $topbar-menu-icon-color;
+  
+            box-shadow:         0 10px 0 1px $topbar-menu-icon-color,
+                                0 16px 0 1px $topbar-menu-icon-color,
+                                0 22px 0 1px $topbar-menu-icon-color;
+          }
         }
       }
-
-      &.moved { position: relative;
-        & > .dropdown { visibility: hidden; }
+    }
+  
+    // Change things up when the top-bar is expanded
+    &.expanded {
+      height: auto;
+      background: transparent;
+  
+      .title-area { background: $topbar-bg; }
+  
+      .toggle-topbar {
+        a { color: $topbar-menu-link-color-toggled;
+          span {
+            // Shh, don't tell, but box-shadows create the menu icon :)
+            -webkit-box-shadow: 0 10px 0 1px $topbar-menu-icon-color-toggled,
+                                0 16px 0 1px $topbar-menu-icon-color-toggled,
+                                0 22px 0 1px $topbar-menu-icon-color-toggled;
+  
+            box-shadow:         0 10px 0 1px $topbar-menu-icon-color-toggled,
+                                0 16px 0 1px $topbar-menu-icon-color-toggled,
+                                0 22px 0 1px $topbar-menu-icon-color-toggled;
+          }
+        }
       }
-
-      &:hover,
-      &:active {
+    }
+  
+  }
+  
+  // Right and Left Navigation that stacked by default
+  .top-bar-section {
+    #{$default-float}: 0;
+    position: relative;
+    width: auto;
+    @include single-transition($default-float, $topbar-transition-speed);
+  
+    ul {
+      width: 100%;
+      height: auto;
+      display: block;
+      background: $topbar-dropdown-bg;
+      font-size: $em-base;
+      margin: 0;
+    }
+  
+    .divider,
+    [role="separator"] {
+      border-bottom: solid 1px lighten($topbar-dropdown-bg, 10%);
+      border-top: solid 1px darken($topbar-dropdown-bg, 10%);
+      clear: both;
+      height: 1px;
+      width: 100%;
+    }
+  
+    ul li {
+      & > a {
+        display: block;
+        width: 100%;
+        color: $topbar-link-color;
+        padding: 12px 0 12px 0;
+        padding-#{$default-float}: $topbar-height / 3;
+        font-size: $topbar-link-font-size;
+        font-weight: $topbar-link-weight;
+        background: $topbar-dropdown-bg;
+  
+        &:hover { background: darken($topbar-dropdown-bg, 3%); }
+  
+  
+        &.button {
+          background: $primary-color;
+          font-size: $topbar-link-font-size;
+          &:hover {
+            background: darken($primary-color, 10%);
+          }
+        }
+        &.button.secondary {
+          background: $secondary-color;
+          &:hover {
+            background: darken($secondary-color, 10%);
+          }
+        }
+        &.button.success {
+          background: $success-color;
+          &:hover {
+            background: darken($success-color, 10%);
+          }
+        }
+        &.button.alert {
+          background: $alert-color;
+          &:hover {
+            background: darken($alert-color, 10%);
+          }
+        }
+  
+      }
+  
+      // Apply the active link color when it has that class
+      &.active > a { background: darken($topbar-dropdown-bg, 3%); }
+    }
+  
+    // Add some extra padding for list items contains buttons
+    .has-form { padding: $topbar-height / 3; }
+  
+    // Styling for list items that have a dropdown within them.
+    .has-dropdown {
+      position: relative;
+  
+      & > a {
+        &:after {
+          @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), $default-float);
+          margin-#{$opposite-direction}: $topbar-height / 3;
+          margin-top: -($topbar-dropdown-toggle-size / 2) - 2;
+          position: absolute;
+          top: 22px;
+          #{$opposite-direction}: 0;
+        }
+      }
+  
+      &.moved { position: static;
         & > .dropdown {
           visibility: visible;
         }
       }
-
-      .dropdown li.has-dropdown {
-        & > a {
-          &:after {
-            border: none;
-            content: "\00bb";
-            margin-top: -15px;
-            #{$opposite-direction}: 5px;
+    }
+  
+    // Styling elements inside of dropdowns
+    .dropdown {
+      position: absolute;
+      #{$default-float}: 100%;
+      top: 0;
+      visibility: hidden;
+      z-index: 99;
+  
+      li { width: 100%;
+        a {
+          font-weight: normal;
+          padding: 8px $topbar-height / 3;
+        }
+  
+        &.title h5 { margin-bottom: 0;
+          a {
+            color: $topbar-link-color;
+            line-height: $topbar-height / 2;
+            display: block;
           }
         }
       }
-
+  
+      label {
+        padding: 8px $topbar-height / 3 2px;
+        margin-bottom: 0;
+        text-transform: uppercase;
+        color: $dropdown-label-color;
+        font-weight: bold;
+        font-size: emCalc(10px);
+      }
     }
-
-    .dropdown {
-      #{$default-float}: 0;
-      top: auto;
-      background: transparent;
-      min-width: 100%;
-
+  }
+  
+  // Element that controls breakpoint, no need to change this ever
+  .top-bar-js-breakpoint {
+    width: $topbar-breakpoint !important;
+    visibility: hidden;
+  }
+  .js-generated { display: block; }
+  
+  
+  // Top Bar styles intended for screen sizes above the breakpoint.
+  @media #{$topbar-media-query} {
+    .top-bar { background: $topbar-bg; @include clearfix; overflow: visible;
+      .toggle-topbar { display: none; }
+  
+      .title-area { float: $default-float; }
+      .name h1 a { width: auto; }
+  
+      input,
+      .button {
+        line-height: 2em;
+        font-size: emCalc(14px);
+        height: 2em;
+        padding: 0 10px;
+        position: relative;
+        top: 8px;
+      }
+  
+      &.expanded { background: $topbar-bg; }
+    }
+  
+    .contain-to-grid .top-bar { max-width: $row-width; margin: 0 auto; margin-bottom: $topbar-margin-bottom; }
+  
+    .top-bar-section {
+      @include single-transition(none,0,0);
+      #{$default-float}: 0 !important;
+  
+      ul {
+        width: auto;
+        height: auto !important;
+        display: inline;
+  
+        li {
+          float: $default-float;
+          .js-generated { display: none; }
+        }
+      }
+  
       li {
-        a {
-          color: $topbar-dropdown-link-color;
-          line-height: 1;
-          white-space: nowrap;
-          padding: 7px $topbar-height / 3;
-          background: lighten($topbar-bg, 5%);
-        }
-
-        label {
-          white-space: nowrap;
-          background: lighten($topbar-bg, 5%);
-        }
-
-        // Second Level Dropdowns
-        .dropdown {
-          #{$default-float}: 100%;
-          top: 0;
+        a:not(.button) {
+          padding: 0 $topbar-height / 3;
+          line-height: $topbar-height;
+          background: $topbar-bg;
+          &:hover { background: adjust-color($topbar-dropdown-bg, $lightness: $topbar-link-hover-lightness); }
         }
       }
-    }
-
-    & > ul > .divider,
-    & > ul > [role="separator"] {
-      border-bottom: none;
-      border-top: none;
-      border-#{$opposite-direction}: solid 1px lighten($topbar-bg, 10%);
-      border-#{$default-float}: solid 1px darken($topbar-bg, 10%);
-      clear: none;
-      height: $topbar-height;
-      width: 0px;
-    }
-
-    .has-form {
-      background: $topbar-bg;
-      padding: 0 $topbar-height / 3;
-      height: $topbar-height;
-    }
-
-    // Position overrides for ul.right
-    ul.right {
-      li .dropdown {
-        left: auto;
-        right: 0;
-
-        li .dropdown { right: 100%; }
+  
+      .has-dropdown {
+        & > a {
+          padding-#{$opposite-direction}: $topbar-height / 3 + 20 !important;
+  
+          &:after {
+            @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), top);
+            margin-top: -($topbar-dropdown-toggle-size / 2);
+            top: $topbar-height / 2;
+          }
+        }
+  
+        &.moved { position: relative;
+          & > .dropdown { visibility: hidden; }
+        }
+  
+        &:hover,
+        &:active {
+          & > .dropdown {
+            visibility: visible;
+          }
+        }
+  
+        .dropdown li.has-dropdown {
+          & > a {
+            &:after {
+              border: none;
+              content: "\00bb";
+              margin-top: -15px;
+              #{$opposite-direction}: 5px;
+            }
+          }
+        }
+  
       }
+  
+      .dropdown {
+        #{$default-float}: 0;
+        top: auto;
+        background: transparent;
+        min-width: 100%;
+  
+        li {
+          a {
+            color: $topbar-dropdown-link-color;
+            line-height: 1;
+            white-space: nowrap;
+            padding: 7px $topbar-height / 3;
+            background: lighten($topbar-bg, 5%);
+          }
+  
+          label {
+            white-space: nowrap;
+            background: lighten($topbar-bg, 5%);
+          }
+  
+          // Second Level Dropdowns
+          .dropdown {
+            #{$default-float}: 100%;
+            top: 0;
+          }
+        }
+      }
+  
+      & > ul > .divider,
+      & > ul > [role="separator"] {
+        border-bottom: none;
+        border-top: none;
+        border-#{$opposite-direction}: solid 1px lighten($topbar-bg, 10%);
+        border-#{$default-float}: solid 1px darken($topbar-bg, 10%);
+        clear: none;
+        height: $topbar-height;
+        width: 0px;
+      }
+  
+      .has-form {
+        background: $topbar-bg;
+        padding: 0 $topbar-height / 3;
+        height: $topbar-height;
+      }
+  
+      // Position overrides for ul.right
+      ul.right {
+        li .dropdown {
+          left: auto;
+          right: 0;
+  
+          li .dropdown { right: 100%; }
+        }
+      }
+  
     }
-
+  
   }
 
 }

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -1,6 +1,7 @@
 //
 // Typography Variables
 //
+$include-html-type-classes: $include-html-classes !default;
 
 // We use these to control header font styles
 $header-font-family:                   "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif !default;
@@ -116,307 +117,310 @@ $microformat-abbr-font-decoration:     none !default;
   margin-bottom: $subheader-bottom-margin;
 }
 
-
-/* Typography resets */
-div,
-dl,
-dt,
-dd,
-ul,
-ol,
-li,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-pre,
-form,
-p,
-blockquote,
-th,
-td {
-  margin:0;
-  padding:0;
-  direction: $text-direction;
-}
-
-/* Default Link Styles */
-a {
-  color: $anchor-font-color;
-  text-decoration: $anchor-text-decoration;
-  line-height: inherit;
-
-  &:hover,
-  &:focus { color: $anchor-font-color-hover; }
-
-  img { border:none; }
-}
-
-/* Default paragraph styles */
-p {
-  font-family: $paragraph-font-family;
-  font-weight: $paragraph-font-weight;
-  font-size: $paragraph-font-size;
-  line-height: $paragraph-line-height;
-  margin-bottom: $paragraph-margin-bottom;
-  text-rendering: $paragraph-text-rendering;
-
-  &.lead { @extend %lead; }
-
-  & aside {
-    font-size: $paragraph-aside-font-size;
-    line-height: $paragraph-aside-line-height;
-    font-style: $paragraph-aside-font-style;
+@if $include-html-type-classes != false {
+  
+  /* Typography resets */
+  div,
+  dl,
+  dt,
+  dd,
+  ul,
+  ol,
+  li,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  pre,
+  form,
+  p,
+  blockquote,
+  th,
+  td {
+    margin:0;
+    padding:0;
+    direction: $text-direction;
   }
-}
-
-/* Default header styles */
-h1, h2, h3, h4, h5, h6 {
-  font-family: $header-font-family;
-  font-weight: $header-font-weight;
-  font-style: $header-font-style;
-  color: $header-font-color;
-  text-rendering: $header-text-rendering;
-  margin-top: $header-top-margin;
-  margin-bottom: $header-bottom-margin;
-  line-height: $header-line-height - emCalc(3px);
-
+  
+  /* Default Link Styles */
+  a {
+    color: $anchor-font-color;
+    text-decoration: $anchor-text-decoration;
+    line-height: inherit;
+  
+    &:hover,
+    &:focus { color: $anchor-font-color-hover; }
+  
+    img { border:none; }
+  }
+  
+  /* Default paragraph styles */
+  p {
+    font-family: $paragraph-font-family;
+    font-weight: $paragraph-font-weight;
+    font-size: $paragraph-font-size;
+    line-height: $paragraph-line-height;
+    margin-bottom: $paragraph-margin-bottom;
+    text-rendering: $paragraph-text-rendering;
+  
+    &.lead { @extend %lead; }
+  
+    & aside {
+      font-size: $paragraph-aside-font-size;
+      line-height: $paragraph-aside-line-height;
+      font-style: $paragraph-aside-font-style;
+    }
+  }
+  
+  /* Default header styles */
+  h1, h2, h3, h4, h5, h6 {
+    font-family: $header-font-family;
+    font-weight: $header-font-weight;
+    font-style: $header-font-style;
+    color: $header-font-color;
+    text-rendering: $header-text-rendering;
+    margin-top: $header-top-margin;
+    margin-bottom: $header-bottom-margin;
+    line-height: $header-line-height - emCalc(3px);
+  
+    small {
+      font-size: $small-font-size;
+      color: $small-font-color;
+      line-height: 0;
+    }
+  }
+  
+  h1 { font-size: $h1-font-size - emCalc(10px); }
+  h2 { font-size: $h2-font-size - emCalc(10px); }
+  h3 { font-size: $h3-font-size - emCalc(5px); }
+  h4 { font-size: $h4-font-size - emCalc(5px); }
+  h5 { font-size: $h5-font-size; }
+  h6 { font-size: $h6-font-size; }
+  
+  .subheader { @extend %subheader; }
+  
+  hr {
+    border: $hr-border-style $hr-border-color;
+    border-width: $hr-border-width 0 0;
+    clear: both;
+    margin: $hr-margin 0 ($hr-margin - emCalc(1px));
+    height: 0;
+  }
+  
+  /* Helpful Typography Defaults */
+  em,
+  i {
+    font-style: italic;
+    line-height: inherit;
+  }
+  
+  strong,
+  b {
+    font-weight: bold;
+    line-height: inherit;
+  }
+  
   small {
     font-size: $small-font-size;
-    color: $small-font-color;
-    line-height: 0;
+    line-height: inherit;
   }
-}
-
-h1 { font-size: $h1-font-size - emCalc(10px); }
-h2 { font-size: $h2-font-size - emCalc(10px); }
-h3 { font-size: $h3-font-size - emCalc(5px); }
-h4 { font-size: $h4-font-size - emCalc(5px); }
-h5 { font-size: $h5-font-size; }
-h6 { font-size: $h6-font-size; }
-
-.subheader { @extend %subheader; }
-
-hr {
-  border: $hr-border-style $hr-border-color;
-  border-width: $hr-border-width 0 0;
-  clear: both;
-  margin: $hr-margin 0 ($hr-margin - emCalc(1px));
-  height: 0;
-}
-
-/* Helpful Typography Defaults */
-em,
-i {
-  font-style: italic;
-  line-height: inherit;
-}
-
-strong,
-b {
-  font-weight: bold;
-  line-height: inherit;
-}
-
-small {
-  font-size: $small-font-size;
-  line-height: inherit;
-}
-
-code {
-  font-family: $code-font-family;
-  font-weight: $code-font-weight;
-  color: $code-color;
-}
-
-/* Lists */
-ul,
-ol,
-dl {
-  font-size: $paragraph-font-size;
-  line-height: $paragraph-line-height;
-  margin-bottom: $paragraph-margin-bottom;
-  list-style-position: $list-style-position;
-  font-family: $paragraph-font-family;
-}
-
-/* Unordered Lists */
-ul {
-  li {
-    ul,
-    ol {
-      margin-#{$default-float}: $list-side-margin;
-      margin-bottom: 0;
-      font-size: 1em; /* Override nested font-size change */
+  
+  code {
+    font-family: $code-font-family;
+    font-weight: $code-font-weight;
+    color: $code-color;
+  }
+  
+  /* Lists */
+  ul,
+  ol,
+  dl {
+    font-size: $paragraph-font-size;
+    line-height: $paragraph-line-height;
+    margin-bottom: $paragraph-margin-bottom;
+    list-style-position: $list-style-position;
+    font-family: $paragraph-font-family;
+  }
+  
+  /* Unordered Lists */
+  ul {
+    li {
+      ul,
+      ol {
+        margin-#{$default-float}: $list-side-margin;
+        margin-bottom: 0;
+        font-size: 1em; /* Override nested font-size change */
+      }
+    }
+    &.square,
+    &.circle,
+    &.disc {
+      li ul { list-style: inherit; }
+    }
+  
+    &.square { list-style-type: square; }
+    &.circle { list-style-type: circle; }
+    &.disc { list-style-type: disc; }
+    &.no-bullet { list-style: none; }
+  }
+  
+  /* Ordered Lists */
+  ol {
+    li {
+      ul,
+      ol {
+        margin-#{$default-float}: $list-side-margin;
+        margin-bottom: 0;
+      }
     }
   }
-  &.square,
-  &.circle,
-  &.disc {
-    li ul { list-style: inherit; }
-  }
-
-  &.square { list-style-type: square; }
-  &.circle { list-style-type: circle; }
-  &.disc { list-style-type: disc; }
-  &.no-bullet { list-style: none; }
-}
-
-/* Ordered Lists */
-ol {
-  li {
-    ul,
-    ol {
-      margin-#{$default-float}: $list-side-margin;
-      margin-bottom: 0;
+  
+  /* Definition Lists */
+  dl {
+    dt {
+      margin-bottom: $definition-list-header-margin-bottom;
+      font-weight: $definition-list-header-weight;
     }
+    dd { margin-bottom: $definition-list-margin-bottom; }
   }
-}
-
-/* Definition Lists */
-dl {
-  dt {
-    margin-bottom: $definition-list-header-margin-bottom;
-    font-weight: $definition-list-header-weight;
+  
+  /* Abbreviations */
+  abbr,
+  acronym {
+    text-transform: uppercase;
+    font-size: 90%;
+    color: $body-font-color;
+    border-bottom: $acronym-underline;
+    cursor: help;
   }
-  dd { margin-bottom: $definition-list-margin-bottom; }
-}
-
-/* Abbreviations */
-abbr,
-acronym {
-  text-transform: uppercase;
-  font-size: 90%;
-  color: $body-font-color;
-  border-bottom: $acronym-underline;
-  cursor: help;
-}
-abbr {
-  text-transform: none;
-}
-
-/* Blockquotes */
-blockquote {
-  margin: 0 0 $paragraph-margin-bottom;
-  padding: $blockquote-padding;
-  border-#{$default-float}: $blockquote-border;
-
-  cite {
-    display: block;
-    font-size: $blockquote-cite-font-size;
-    color: $blockquote-cite-font-color;
-    &:before {
-      content: "\2014 \0020";
-    }
-
-    a,
-    a:visited {
-      color: $blockquote-cite-link-color;
-    }
-  }
-}
-blockquote,
-blockquote p {
-  line-height: $paragraph-line-height;
-  color: $blockquote-font-color;
-}
-
-/* Microformats */
-.vcard {
-  display: inline-block;
-  margin: $microformat-margin;
-  border: $microformat-border-width $microformat-border-style $microformat-border-color;
-  padding: $microformat-padding;
-
-  li {
-    margin: 0;
-    display: block;
-  }
-  .fn {
-    font-weight: $microformat-fullname-font-weight;
-    font-size: $microformat-fullname-font-size;
-  }
-}
-
-.vevent {
-  .summary { font-weight: $microformat-summary-font-weight; }
-
   abbr {
-    cursor: default;
-    text-decoration: $microformat-abbr-font-decoration;
-    font-weight: $microformat-abbr-font-weight;
-    border: none;
-    padding: $microformat-abbr-padding;
+    text-transform: none;
   }
-}
-
-
-@media #{$small} {
-  h1,h2,h3,h4,h5,h6 { line-height: $header-line-height; }
-  h1 { font-size: $h1-font-size; }
-  h2 { font-size: $h2-font-size; }
-  h3 { font-size: $h3-font-size; }
-  h4 { font-size: $h4-font-size; }
-}
-
-// Only include these styles if you want them.
-@if $include-print-styles {
-  /*
-   * Print styles.
-   *
-   * Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/
-   * Credit to Paul Irish and HTML5 Boilerplate (html5boilerplate.com)
-  */
-  .print-only { display: none !important; }
-  @media print {
-    * {
-      background: transparent !important;
-      color: #000 !important; /* Black prints faster: h5bp.com/s */
-      box-shadow: none !important;
-      text-shadow: none !important;
+  
+  /* Blockquotes */
+  blockquote {
+    margin: 0 0 $paragraph-margin-bottom;
+    padding: $blockquote-padding;
+    border-#{$default-float}: $blockquote-border;
+  
+    cite {
+      display: block;
+      font-size: $blockquote-cite-font-size;
+      color: $blockquote-cite-font-color;
+      &:before {
+        content: "\2014 \0020";
+      }
+  
+      a,
+      a:visited {
+        color: $blockquote-cite-link-color;
+      }
     }
-
-    a,
-    a:visited { text-decoration: underline;}
-    a[href]:after { content: " (" attr(href) ")"; }
-
-    abbr[title]:after { content: " (" attr(title) ")"; }
-
-    // Don't show links for images, or javascript/internal links
-    .ir a:after,
-    a[href^="javascript:"]:after,
-    a[href^="#"]:after { content: ""; }
-
-    pre,
-    blockquote {
-      border: 1px solid #999;
-      page-break-inside: avoid;
-    }
-
-    thead { display: table-header-group; /* h5bp.com/t */ }
-
-    tr,
-    img { page-break-inside: avoid; }
-
-    img { max-width: 100% !important; }
-
-    @page { margin: 0.5cm; }
-
-    p,
-    h2,
-    h3 {
-      orphans: 3;
-      widows: 3;
-    }
-
-    h2,
-    h3 { page-break-after: avoid; }
-
-    .hide-on-print { display: none !important; }
-    .print-only { display: block !important; }
-    .hide-for-print { display: none !important; }
-    .show-for-print { display: inherit !important; }
   }
+  blockquote,
+  blockquote p {
+    line-height: $paragraph-line-height;
+    color: $blockquote-font-color;
+  }
+  
+  /* Microformats */
+  .vcard {
+    display: inline-block;
+    margin: $microformat-margin;
+    border: $microformat-border-width $microformat-border-style $microformat-border-color;
+    padding: $microformat-padding;
+  
+    li {
+      margin: 0;
+      display: block;
+    }
+    .fn {
+      font-weight: $microformat-fullname-font-weight;
+      font-size: $microformat-fullname-font-size;
+    }
+  }
+  
+  .vevent {
+    .summary { font-weight: $microformat-summary-font-weight; }
+  
+    abbr {
+      cursor: default;
+      text-decoration: $microformat-abbr-font-decoration;
+      font-weight: $microformat-abbr-font-weight;
+      border: none;
+      padding: $microformat-abbr-padding;
+    }
+  }
+  
+  
+  @media #{$small} {
+    h1,h2,h3,h4,h5,h6 { line-height: $header-line-height; }
+    h1 { font-size: $h1-font-size; }
+    h2 { font-size: $h2-font-size; }
+    h3 { font-size: $h3-font-size; }
+    h4 { font-size: $h4-font-size; }
+  }
+  
+  // Only include these styles if you want them.
+  @if $include-print-styles {
+    /*
+     * Print styles.
+     *
+     * Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/
+     * Credit to Paul Irish and HTML5 Boilerplate (html5boilerplate.com)
+    */
+    .print-only { display: none !important; }
+    @media print {
+      * {
+        background: transparent !important;
+        color: #000 !important; /* Black prints faster: h5bp.com/s */
+        box-shadow: none !important;
+        text-shadow: none !important;
+      }
+  
+      a,
+      a:visited { text-decoration: underline;}
+      a[href]:after { content: " (" attr(href) ")"; }
+  
+      abbr[title]:after { content: " (" attr(title) ")"; }
+  
+      // Don't show links for images, or javascript/internal links
+      .ir a:after,
+      a[href^="javascript:"]:after,
+      a[href^="#"]:after { content: ""; }
+  
+      pre,
+      blockquote {
+        border: 1px solid #999;
+        page-break-inside: avoid;
+      }
+  
+      thead { display: table-header-group; /* h5bp.com/t */ }
+  
+      tr,
+      img { page-break-inside: avoid; }
+  
+      img { max-width: 100% !important; }
+  
+      @page { margin: 0.5cm; }
+  
+      p,
+      h2,
+      h3 {
+        orphans: 3;
+        widows: 3;
+      }
+  
+      h2,
+      h3 { page-break-after: avoid; }
+  
+      .hide-on-print { display: none !important; }
+      .print-only { display: block !important; }
+      .hide-for-print { display: none !important; }
+      .show-for-print { display: inherit !important; }
+    }
+  }
+
 }

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -1,6 +1,8 @@
 //
 // Foundation Visibility Classes
 //
+$include-html-visibility-classes: $include-html-classes !default;
+
 @if $include-html-visibility-classes != false {
 
   /* Foundation Visibility HTML Classes */


### PR DESCRIPTION
This will change the current behavior so that setting `$include-html-classes: false;` and `$include-print-styles: false;` will produce an empty css file.

This way users can add in only the pieces they want to include by setting: `$include-html-classes: false;` and `$include-html-XYZ-classes: true;`
