### PR TITLE
Altered the min-height value being applied to .top-bar on mobile

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -102,7 +102,8 @@
         .on('click.fndtn.topbar', '.top-bar .has-dropdown>a', function (e) {
           var topbar = $(this).closest('.top-bar'),
               section = topbar.find('section, .section'),
-              titlebar = topbar.children('ul').first();
+              titlebar = topbar.children('ul').first(),
+              dropdownHeight = $(this).next('.dropdown').outerHeight();
 
           if (Modernizr.touch || self.breakpoint()) {
             e.preventDefault();
@@ -121,6 +122,8 @@
               section.css({right: -(100 * topbar.data('index')) + '%'});
               section.find('>.name').css({right: 100 * topbar.data('index') + '%'});
             }
+
+            $('.top-bar').css('min-height', dropdownHeight);
 
             $this.siblings('ul')
               .height(topbar.data('height') + self.outerHeight(titlebar, true));


### PR DESCRIPTION
I noticed some unresolved issue from others where the min-height value would either be wrong or not be applied at all to the .top-bar element when a li.has-dropdown item was selected.

I added a dropdownHeight variable in the script to check the ul.dropdown that would become visible and apply that height as the min-height value to .top-bar.
