### PR TITLE
Reveal sizing classes don't reflect the docs

### DIFF
--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -116,11 +116,11 @@ $reveal-border-color:    #666 !default;
     .reveal-modal {
       @include reveal-modal-style(false, emCalc(30px), false, $box-shadow: false, $top-offset: emCalc(100px));
 
-      &.small  { @include reveal-modal-base(false, 30%); }
-      &.medium { @include reveal-modal-base(false, 40%); }
-      &.large  { @include reveal-modal-base(false, 60%); }
-      &.xlarge { @include reveal-modal-base(false, 70%); }
-      &.expand { @include reveal-modal-base(false, 95%); }
+      &.tiny  { @include reveal-modal-base(false, 30%); }
+      &.small { @include reveal-modal-base(false, 40%); }
+      &.medium  { @include reveal-modal-base(false, 60%); }
+      &.large { @include reveal-modal-base(false, 70%); }
+      &.xlarge { @include reveal-modal-base(false, 95%); }
     }
   }
 


### PR DESCRIPTION
It appears as though the sizes for reveal modals were using the syntax from Foundation 3, while the docs for Foundation 4 indicate new names for these. This patch makes Foundation  reveal styles match the documentation. 
