### PR TITLE
Fix column float for rtl

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -61,7 +61,7 @@ $total-columns: 12 !default;
 
 
 // For creating columns - @include these inside a media query to control small vs. large grid layouts
-@mixin grid-column($columns:false, $last-column:false, $center:false, $offset:false, $push:false, $pull:false, $collapse:false, $float:$default-float) {
+@mixin grid-column($columns:false, $last-column:false, $center:false, $offset:false, $push:false, $pull:false, $collapse:false, $float:true) {
 
   position: relative;
 


### PR DESCRIPTION
fix column float for rtl

Noted: $default-float == right when $text-direction == rtl, this cause the following to output the opposite of what we want:

```
@mixin grid-column($columns:false, $last-column:false, $center:false, $offset:false, $push:false, $pull:false, $collapse:false, $float:$default-float) {

  ...

  @if $float {
    @if $float == left or $float == true { float: $default-float; }
    @else if $float == right { float: $opposite-direction; }
    @else { float: none; }
  }
```

because the condition of `$float == right` is matched, and thus will output `float: $opposite-direction;`, which is `float: left` for the case of rtl, but we really want `float: right` when `$text-direction == rtl`
