### PR TITLE
Bind call causes js error

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -160,7 +160,7 @@ if (typeof jQuery === "undefined" &&
           this.patch(this.libs[lib]);
           return this.libs[lib].init.apply(this.libs[lib], args);
         }
-      }.bind(this), lib);
+      }.apply(this), lib);
     },
 
     trap : function (fun, lib) {


### PR DESCRIPTION
I'm using Poltergeist driver for running js code in my integration tests (Capybara).

When I ran it on project, where I'm using foundation, it was crashing on bind call here:
https://github.com/zurb/foundation/blob/master/js/foundation/foundation.js line 163

After I changed this to apply (as in this commit), js is compiling correctly, and Foundation is working.

I've reported this issue also in Poltergeist: https://github.com/jonleighton/poltergeist/issues/308 , as I'm not sure if it is Foundation or Poltergeist issue.
