### PR TITLE
Fix for topbar dropdown arrow position when height of topbar is increased.

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -369,11 +369,12 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
 
     .has-dropdown {
       & > a {
-        padding-#{$opposite-direction}: $topbar-dropdown-toggle-size * 7 !important;
+        padding-#{$opposite-direction}: $topbar-height / 3 + 20 !important;
 
         &:after {
           @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), top);
           margin-top: -($topbar-dropdown-toggle-size / 2);
+          top: $topbar-height / 2;
         }
       }
 


### PR DESCRIPTION
The topbar dropdown arrow has a `top` position of 22px. This is
hardcoded assuming the default topbar height of 45px hasn't changed.
This fix, fixes the position of the topbar dropdown arrow so that its
top position is `$topbar-height / 2`. It also fixes maintains
consistent padding as the topbar height is changed.

Issue can be seen here (topbar is set to 90px):
http://lukebussey.com/foundation-topbar-dropdown-arrow-bug/

Fix can be seen here:
http://lukebussey.com/foundation-topbar-dropdown-arrow-fix/
