### PR TITLE
Update _clearing.scss

### DIFF
--- a/scss/foundation/components/_clearing.scss
+++ b/scss/foundation/components/_clearing.scss
@@ -39,7 +39,7 @@ $clearing-carousel-thumb-active-border: 4px solid rgb(255,255,255) !default;
 
   li {
     float: $default-float;
-    margin-#{$opposite-direction}: 10px;
+    //margin-#{$opposite-direction}: 10px; If you create the gallery using block-grid, this causes a mess
   }
 }
 
@@ -105,6 +105,7 @@ $clearing-carousel-thumb-active-border: 4px solid rgb(255,255,255) !default;
 
 .clearing-assembled .clearing-container { height: 100%;
   .carousel > ul { display: none; }
+  .carousel > ul li { clear: none; } // Needed to prevent block-grid nth-of-type selector to clear the 5 element
 }
 
 


### PR DESCRIPTION
When creating a clearing gallery using block-grid for presentation, some styles interfere with the presentation of clearing.
Example:

``` html
<ul class="large-block-grid-4 clearing-thumbs" data-clearing>
<li><a href="#" class="th"><img src="myimage.jpg"></a></li>
<li><a href="#" class="th"><img src="myimage.jpg"></a></li>
<li><a href="#" class="th"><img src="myimage.jpg"></a></li>
<li><a href="#" class="th"><img src="myimage.jpg"></a></li>
<li><a href="#" class="th"><img src="myimage.jpg"></a></li> <!-- This thumbnail will appear on second line -->
<li><a href="#" class="th"><img src="myimage.jpg"></a></li>
<li><a href="#" class="th"><img src="myimage.jpg"></a></li>
</ul>
```

The style for the block-grid break the presentation of the clearing thumbnails with this selector .large-block-grid-4 > li:nth-of-type(4n+1) because the fith thumbnail will be cleared and floated to the left.
