### PR TITLE
Missing : in $topbar-media-query

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -1189,4 +1189,4 @@ $em-base: 16px !default;
 
 // $topbar-transition-speed: 300ms;
 // $topbar-breakpoint: emCalc(940px); // Change to 9999px for always mobile layout
-// $topbar-media-query: "only screen and (min-width "#{$topbar-breakpoint}")";
+// $topbar-media-query: "only screen and (min-width: "#{$topbar-breakpoint}")";


### PR DESCRIPTION
Fixes an iPad landscape error, which didn't show topbar correct.
(kept the collapsed styles)
