### PR TITLE
Nested side_nav items corrected styles

### DIFF
--- a/scss/foundation/components/_side-nav.scss
+++ b/scss/foundation/components/_side-nav.scss
@@ -44,7 +44,7 @@ $side-nav-divider-color:     darken(#fff, 10%) !default;
       color: $link-color;
     }
 
-    &.active a {
+    &.active > a:first-child {
       color: $side-nav-link-color-active;
       font-weight: $side-nav-font-weight;
     }


### PR DESCRIPTION
When nesting side_nav items (ul) only the direct first-child should get
a different style.
