### PR TITLE
Change the font-smoothing from antialiased to subpixel rendering.

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -153,7 +153,7 @@ $body-font-weight: normal !default;
 $body-font-style: normal !default;
 
 // We use this to control font-smoothing
-$font-smoothing: antialiased !default;
+$font-smoothing: subpixel-antialiased !default;
 
 // We use these to control text direction settings
 $text-direction: ltr !default;


### PR DESCRIPTION
The antialiased mode is generally less good at rendering fine or sharp edged fonts than with subpixel rendering.

Subpixel on top, bottom is the current setting. 

![zurb](https://f.cloud.github.com/assets/1137376/442050/a7298ddc-b134-11e2-821b-802539a765cb.png)
