### PR TITLE
Introduced separate variable for custom form class generation

### DIFF
--- a/docs/sass.html.erb
+++ b/docs/sass.html.erb
@@ -267,6 +267,7 @@ $em-base: 16px !default;
 // $include-html-visibility-classes: $include-html-classes;
 // $include-html-button-classes: $include-html-classes;
 // $include-html-form-classes: $include-html-classes;
+// $include-html-custom-form-classes: $include-html-classes;
 // $include-html-media-classes: $include-html-classes;
 // $include-html-section-classes: $include-html-classes;
 // $include-html-reveal-classes: $include-html-classes;

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -63,6 +63,7 @@ $em-base: 16px !default;
 // $include-html-visibility-classes: $include-html-classes;
 // $include-html-button-classes: $include-html-classes;
 // $include-html-form-classes: $include-html-classes;
+// $include-html-custom-form-classes: $include-html-classes;
 // $include-html-media-classes: $include-html-classes;
 // $include-html-section-classes: $include-html-classes;
 // $include-html-reveal-classes: $include-html-classes;

--- a/scss/foundation/components/_custom-forms.scss
+++ b/scss/foundation/components/_custom-forms.scss
@@ -44,7 +44,7 @@ $custom-dropdown-width-large:           434px !default;
 // We may look at updating this in the future.
 
 // Only include these classes if the variable is true, otherwise they'll be left out.
-@if $include-html-button-classes != false {
+@if $include-html-custom-form-classes != false {
 
   /* Custom Checkbox and Radio Inputs */
   form.custom {

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -191,6 +191,7 @@ $include-html-grid-classes: $include-html-classes !default;
 $include-html-visibility-classes: $include-html-classes !default;
 $include-html-button-classes: $include-html-classes !default;
 $include-html-form-classes: $include-html-classes !default;
+$include-html-custom-form-classes: $include-html-classes !default;
 $include-html-media-classes: $include-html-classes !default;
 $include-html-section-classes: $include-html-classes !default;
 $include-html-reveal-classes: $include-html-classes !default;


### PR DESCRIPTION
The switch for generating the custom css classes was bound to the include-html-button-classes variable. This meant skipping the default button css class generation also stopped the custom forms from being styled. I add a new variable to break the dependancy.
