### PR TITLE
Show DIVs for @media print

### DIFF
--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -126,6 +126,6 @@ $reveal-border-color:    #666 !default;
 
   // Reveal Print Styles
   @media print {
-    div:not(.reveal-modal) { display: none; }
+    .reveal-modal {background: #fff !important;}
   }
 }


### PR DESCRIPTION
Fixes #2139
Don't remove all DIVs except .reveal-modal.
Make .reveal-modal's background white to aviod overlaying transparent DIVs
