### PR TITLE
Align cite element text to the right.

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -305,6 +305,7 @@ blockquote {
 
   cite {
     display: block;
+    text-align: right;
     font-size: $blockquote-cite-font-size;
     color: $blockquote-cite-font-color;
     &:before {


### PR DESCRIPTION
Added `text-align: right;` under the `cite` selector, as it tends to look better by default.
