### PR TITLE
Remove fixed top bar bottom margin

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -342,6 +342,8 @@ $topbar-media-query: "only screen and (min-width:"#{$topbar-breakpoint}")" !defa
   }
 
   .contain-to-grid .top-bar { max-width: $row-width; margin: 0 auto; margin-bottom: $topbar-margin-bottom; }
+  
+  .fixed .top-bar { margin-bottom: 0; }
 
   .top-bar-section {
     @include single-transition(none,0,0);


### PR DESCRIPTION
Adding a bottom margin to a top bar with .fixed.contain-to-grid creates unwanted height. A bottom margin on a fixed div doesn't do much anyway :smile:
