### PR TITLE
Remove tip guides on end

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -810,6 +810,7 @@
       this.settings.$current_tip.hide();
       this.settings.postStepCallback(this.settings.$li.index(), this.settings.$current_tip);
       this.settings.postRideCallback(this.settings.$li.index(), this.settings.$current_tip);
+      $('.joyride-tip-guide').remove();
     },
 
     outerHTML : function (el) {


### PR DESCRIPTION
I have a couple of joyrides on my page and I launch them on different situations. I needed to remove existing tip guides to prevent old ones from showing when second joyride starts.

This tiny edit seems to fix the problem.

Code sample:

JS:
$(document).foundation();

function fire1() { $('#first').foundation('joyride', 'start', { ...settings... }); }

function fire2() { $('#second').foundation('joyride', 'start', { ...settings... }); }

HTML:
<snip>

<div id="first"><ol data-joyride>....</ol></div>

<div id="second"><ol data-joyride>....</ol></div>

</snip>
