### PR TITLE
Remove confusing "h1." from header example for h5 and h6.

### DIFF
--- a/docs/components/type.html.erb
+++ b/docs/components/type.html.erb
@@ -23,16 +23,16 @@
         <h2>h2. This is a large header.</h2>
         <h3>h3. This is a medium header.</h3>
         <h4>h4. This is a moderate header.</h4>
-        <h5>h5. This is a small header. h1.</h5>
-        <h6>h6. This is a tiny header. h1.</h6>
+        <h5>h5. This is a small header.</h5>
+        <h6>h6. This is a tiny header.</h6>
 
 <%= code_example '
 <h1>h1. This is a very large header.</h1>
 <h2>h2. This is a large header.</h2>
 <h3>h3. This is a medium header.</h3>
 <h4>h4. This is a moderate header.</h4>
-<h5>h5. This is a small header. h1.</h5>
-<h6>h6. This is a tiny header. h1.</h6>
+<h5>h5. This is a small header.</h5>
+<h6>h6. This is a tiny header.</h6>
 ', :html %>
 
         <hr>


### PR DESCRIPTION
Can't believe they are supposed to be there.
