### PR TITLE
delete unnecessary perfix and fix comma mistake

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -105,9 +105,9 @@
 
 // We use this to add a glowing effect to block elements
 @mixin block-glowing-effect($selector:focus, $fade-time:300ms, $glowing-effect-color:fade-out($primary-color, .25)) {
-  -webkit-transition: box-shadow, $fade-time, -moz-box-shadow, $fade-time, -webkit-box-shadow, $fade-time, border-color, $fade-time, ease-in-out;
-  -moz-transition: box-shadow, $fade-time, -moz-box-shadow, $fade-time, -webkit-box-shadow, $fade-time, border-color, $fade-time, ease-in-out;
-  transition: box-shadow, $fade-time, -moz-box-shadow, $fade-time, -webkit-box-shadow, $fade-time, border-color, $fade-time, ease-in-out;
+  -webkit-transition: -webkit-box-shadow $fade-time, border-color $fade-time ease-in-out;
+  -moz-transition: -moz-box-shadow $fade-time, border-color $fade-time ease-in-out;
+  transition: box-shadow $fade-time, border-color $fade-time ease-in-out;
 
   &:#{$selector} {
     -webkit-box-shadow: 0 0 5px $glowing-effect-color;


### PR DESCRIPTION
There are some unnecessary perfixes in  block-glowing-effect mixin, and even worse, the redundant comma makes some mistake in browser, which should be deleted.
