### PR TITLE
Support Sprockets use outside of Rails.

### DIFF
--- a/lib/foundation/sprockets.rb
+++ b/lib/foundation/sprockets.rb
@@ -1,0 +1,4 @@
+require 'sprockets'
+
+Sprockets.append_path File.expand_path("../../../scss", __FILE__)
+Sprockets.append_path File.expand_path("../../../js", __FILE__)

--- a/lib/zurb-foundation.rb
+++ b/lib/zurb-foundation.rb
@@ -6,7 +6,11 @@ if defined?(Rails)
 end
 
 module Foundation
-  require "foundation/engine" if defined?(Rails)
+  if defined?(Rails)
+    require "foundation/engine"
+  elsif defined?(Sprockets)
+    require "foundation/sprockets"
+  end
 end
 
 if defined?(Compass)


### PR DESCRIPTION
This change registers the CSS and (most importantly) JavaScript paths directly with Sprockets when Rails is not loaded.

This makes Foundation work with Rack-based applications that use Sprockets but don't use Rails. I tested it with a middleman site I'm working on.

I'm not familiar with the foundation codebase, and I'll be happy to address any feedback on style / structure / tests. (I only did manual testing)

Thank you very much for foundation!
