### PR TITLE
making sure to return function object

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -189,6 +189,9 @@ if (typeof jQuery === "undefined" &&
           this.patch(this.libs[lib]);
           return this.libs[lib].init.apply(this.libs[lib], args);
         }
+        else {
+          return function () {};
+        }
       }.bind(this), lib);
     },
 


### PR DESCRIPTION
discussed in https://github.com/zurb/foundation/pull/2239

I had the similar issue as it's described above.  When I ran integration tests with Capybara::Poltergeist driver, I got the error on 

https://github.com/zurb/foundation/blob/master/js/foundation/foundation.js#L186

The reason why Poltergeist raising the error was because inside `init_lib()`, anonymous function inside the first argument of `this.trap`, which eventually chain-call `bind()` sometimes return undefined for some cases.  So I made sure it always returns function object.
