### PR TITLE
Fix large-uncetered to set correctly float position

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -169,11 +169,17 @@ $total-columns: 12 !default;
     .columns.large-centered { @include grid-column($center:true, $collapse:null, $float:false); }
 
     .column.large-uncentered,
-    .columns.large-uncentered, {
+    .columns.large-uncentered {
       margin-#{$default-float}: 0;
       margin-#{$opposite-direction}: 0;
-      float: none;
+      float: $default-float !important;
     }
+
+    .column.large-uncentered.opposite,
+    .columns.large-uncentered.opposite {
+      float: $opposite-direction;
+    }
+
 
   }
 

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -177,7 +177,7 @@ $total-columns: 12 !default;
 
     .column.large-uncentered.opposite,
     .columns.large-uncentered.opposite {
-      float: $opposite-direction;
+      float: $opposite-direction !important;
     }
 
 


### PR DESCRIPTION
See the code bellow:

``` html
<div class="row">
        <div class="panel small-centered small-10 large-5 large-uncentered push-7 columns">
        </div>

        <div class="hide-for-small large-7 pull-5 columns">
        </div>
    </div>
```

in this example the columns are not aligned in large screen because the large-uncentered not correct the float, which is removed by small-centered.

I put the large-uncentered to force the float: left and large-uncentered.opposite to float: right.

And it solve the problem.
