### PR TITLE
_init method now respects Foundation.rtl when activating the first slide

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -119,7 +119,7 @@
       $slides_container.append($slides.first().clone().attr('data-orbit-slide',''));
       $slides_container.prepend($slides.last().clone().attr('data-orbit-slide',''));
       // Make the first "real" slide active
-      $slides_container.css('marginLeft', '-100%');
+      $slides_container.css(Foundation.rtl ? 'marginRight' : 'marginLeft', '-100%');
       $slides.first().addClass(self.settings.active_slide_class);
 
       self._init_events($slides_container);


### PR DESCRIPTION
Hello,

I've fixed a minor bug in Orbit's _init method which cause invalid activation of the first slide on RTL sites.

Apologies if this contribution is not completely in line with your guidelines - this is my first time doing any contribution at all.

Regards,
Ilya A.
