### PR TITLE
Update andSelf call (deprecated in jQuery 1.8+) to addBack

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -448,7 +448,7 @@
           var _self = this;
 
           // Set all hidden parent elements, including this element.
-          _self.hidden = $child.parents().andSelf().filter(":hidden");
+          _self.hidden = $child.parents().addBack().filter(":hidden");
 
           // Loop through all hidden elements.
           _self.hidden.each(function () {


### PR DESCRIPTION
The `$.andSelf` call (deprecated as of jQuery 1.8) in `foundation.forms.js` forces one to use the jQuery Migrate plugin in conjunction with jQuery 1.9 or newer to avoid errors. The `$.addBack` method is equivalent and non-deprecated.
