### PR TITLE
Fix active tabs color in Sections component

### DIFF
--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -278,7 +278,7 @@ $section-bottom-margin:             emCalc(20px) !default;
     @include section-container(false, tabs);
 
     &>section,
-    &>.section { @include section(tabs, $title-bg-active:#fff); }
+    &>.section { @include section(tabs, $title-bg-active:$section-title-bg-active-tabs); }
   }
 
   @media #{$small} {
@@ -287,7 +287,7 @@ $section-bottom-margin:             emCalc(20px) !default;
       @include section-container(false, tabs);
 
       &>section,
-      &>.section { @include section(tabs, $title-bg-active:#fff); }
+      &>.section { @include section(tabs, $title-bg-active:$section-title-bg-active-tabs); }
     }
     .section-container.accordion .section {
       padding-top: 0 !important;


### PR DESCRIPTION
Remove hardcoded bg color $title-bg-active:#fff, use $title-bg-active:$section-title-bg-active-tabs for active tabs.
