### PR TITLE
Support for using AJAX as data source for Reveal popups.

### DIFF
--- a/docs/components/reveal.html.erb
+++ b/docs/components/reveal.html.erb
@@ -60,6 +60,46 @@ $('#myModal').foundation('reveal', 'open');
 $('#myModal').foundation('reveal', 'close');
 ", :js %>
 
+        <h5>Firing a Reveal Modal with Ajax Content</h5>
+        <p>To launch a modal with content from another page, just add a <code>data-reveal-ajax</code> attribute pointing to the url of that page. When clicked, the Reveal modal will be opened with a content from that page. Beware, that content of the object from <code>data-reveal-id</code> attribute will be overwritten as a result.</p>
+        <p>To use an url from <code>href</code> attribute just add <code>data-reveal-ajax="true"</code> instead.</p>
+
+<%= code_example '
+<button data-reveal-id="myModal" data-reveal-ajax="http://some-url">
+    Click Me For A Modal
+</button>
+
+<a href="http://some-url" data-reveal-id="myModal" data-reveal-ajax="true">
+    Click Me For A Modal
+</a>
+', :html %>
+
+        <p>Ajax-based Reveal modals can also be opened via JavaScript:</p>
+
+<%= code_example "
+// just an url
+$('#myModal').foundation('reveal', 'open', 'http://some-url');
+
+// url with extra parameters
+$('#myModal').foundation('reveal', 'open', {
+    url: 'http://some-url',
+    data: {param1: 'value1', param2: 'value2'}
+});
+
+// url with custom callbacks
+$('#myModal').foundation('reveal', 'open', {
+    url: 'http://some-url',
+    success: function(data) {
+        alert('modal data loaded');
+    },
+    error: function() {
+        alert('failed loading modal');
+    }
+});
+", :js %>
+
+        <p>Please refer to <a href="http://api.jquery.com/jQuery.ajax/" target="_blank">http://api.jquery.com/jQuery.ajax/</a> for a complete list of possible parameters.</p>
+
         <hr>
 
         <h5>Default SCSS Variables</h5>


### PR DESCRIPTION
Reveal looks awesome, but it's missing AJAX support for a long time. Here is what I've did:
1. Added `data-reveal-ajax` attribute, which can be used in 2 ways, when placed on a DOM node with `data-reveal-id` present already:
   - when it's value is `true`, then `href` attribute of DOM node is used as url for an AJAX request (useful for A tags)
   - when it's value is not `true`, then this is an url for AJAX request (useful for non-A tags)
2. When used through `$('.reveal-div').foundation('reveal', 'open')` allows to pass 3 argument, that will act as `settings` argument for underlying `$.ajax(settings)` class (comes in handy when a POST data needs to be sent long with request). For example:

``` js
$('.reveal-div').foundation('reveal', 'open', {
  url: 'http://some-url',
  data: {param1: 'value1', param2: 'value2'}
});
```

Since Foundation also uses Zepto in some cases, then I'm not sure if following code is compatible with Zepto:
- https://github.com/aik099/foundation/commit/2e910dd343c68357da717efdae7f32cb4cf37c81#L0R103

Also based on code examples in #2088 I've added following `section` reflow for sections, that came from AJAX request (not sure if it's correct):
- https://github.com/aik099/foundation/commit/2e910dd343c68357da717efdae7f32cb4cf37c81#L0R142
