### PR TITLE
Added $include-html-top-bar-classes

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -76,6 +76,7 @@ $em-base: 16px !default;
 // $include-html-clearing-classes: $include-html-classes;
 // $include-html-alert-classes: $include-html-classes;
 // $include-html-nav-classes: $include-html-classes;
+// $include-html-top-bar-classes: $include-html-classes;
 // $include-html-label-classes: $include-html-classes;
 // $include-html-panel-classes: $include-html-classes;
 // $include-html-pricing-classes: $include-html-classes;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -61,7 +61,7 @@ $topbar-divider-border-top:            solid 1px darken($topbar-bg, 10%) !defaul
 // Sticky Class
 $topbar-sticky-class:                  ".sticky" !default;
 
-@if $include-html-nav-classes {
+@if $include-html-top-bar-classes != false {
 
   /* Wrapped around .top-bar to contain to grid width */
   .contain-to-grid {


### PR DESCRIPTION
Within _top-bar.scss there are no mixins. At the moment you can't use a topbar and have $include-html-nav-classes set to false.

I want to set $include-html-nav-classes to false and use the mixin'ss to achieve (more) semantic css and still be able to use a top-bar.
