### PR TITLE
Pass classes from options to li elements in custom dropdowns

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -272,7 +272,8 @@
           $customList = $customSelect.find("ul");
 
           liHtml = $options.map(function () {
-            return "<li>" + $(this).html() + "</li>";
+            var copyClasses = $(this).attr('class') ? $(this).attr('class') : '';
+            return "<li class='" + copyClasses + "'>" + $(this).html() + "</li>";
           }).get().join('');
 
           $customList.append(liHtml);


### PR DESCRIPTION
It would be REALLY nice to have classes from the options pull through to the li elements for custom dropdowns.  The classes from the select pull through to the div, but one of the advantages of these custom dropdowns is that they're more flexible when it comes to styling.
