### PR TITLE
Avoid Zepto check optimization

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -383,9 +383,9 @@ if (typeof jQuery === "undefined" &&
     },
 
     zj : function () {
-      try {
+      if (typeof Zepto !== 'undefined') {
         return Zepto;
-      } catch (e) {
+      } else {
         return jQuery;
       }
     }()


### PR DESCRIPTION
When using Foundation with closure js compiler, the Zepto try/catch gets optimized out to just a reference to Zepto (leading to an undefined reference error if using jquery). The code in this patch is equivalent but avoids errors when run through closure.
