### PR TITLE
Update grid.html.erb

### DIFF
--- a/docs/components/grid.html.erb
+++ b/docs/components/grid.html.erb
@@ -177,7 +177,7 @@
   <div class="small-6 large-centered columns">6 centered</div>
 </div>
 <div class="row">
-  <div class="small-9 small-centered columns">9 centered</div>
+  <div class="small-9 small-centered large-uncentered columns">9 centered</div>
 </div>
 <div class="row">
   <div class="small-11 small-centered columns">11 centered</div>


### PR DESCRIPTION
The 3rd row in the Centered Columns section example has the "large-uncentered" class applied in the code but not in the sample which is off-putting. This just adds it to the example as well.
