### PR TITLE
Foundation.topbar fix

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -64,6 +64,7 @@
       var self = this;
       var offst = this.outerHeight($('.top-bar, [data-topbar]'));
       $(this.scope)
+        .off('.fndtn.topbar')
         .on('click.fndtn.topbar', '.top-bar .toggle-topbar, [data-topbar] .toggle-topbar', function (e) {
           var topbar = $(this).closest('.top-bar, [data-topbar]'),
               section = topbar.find('section, .section'),


### PR DESCRIPTION
I made a little fix on Foundation topbar calling .off('fndtn.topbar') before the on() calls. This is useful in the case of javascript generated content, for example a Backbone view that writes the entire body element (including a topbar) after the execution of $(document).foundation(). Before the fix, consecutive executions of $(document).foundation() alternatively enabled and disabled the topbar events. Now, after every execution of $(document).foundation() the topbar works perfectly.
