### PR TITLE
Fix typo in scss/foundation/_variables.scss

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -3,7 +3,7 @@
 //
 
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
-// for compatibility with brower-based text zoom or user-set defaults.
+// for compatibility with browser-based text zoom or user-set defaults.
 $base-font-size: 100% !default;
 
 // $base-line-height is 24px while $base-font-size is 16px


### PR DESCRIPTION
'Browser' vs “brower”
