### PR TITLE
panal mixin is adding default style to headers, which is a bit annoying

### DIFF
--- a/scss/foundation/components/_panels.scss
+++ b/scss/foundation/components/_panels.scss
@@ -20,13 +20,14 @@ $panel-padding:         emCalc(20px) !default;
 $panel-font-color:      #333 !default;
 $panel-font-color-alt:  #fff !default;
 
+$panel-header-adjust:   true !default;
 
 //
 // Panel Mixins
 //
 
 // We use this mixin to create panels.
-@mixin panel($bg:$panel-bg, $padding:$panel-padding) {
+@mixin panel($bg:$panel-bg, $padding:$panel-padding, $adjust:$panel-header-adjust) {
 
   @if $bg {
     $bg-lightness: lightness($bg);
@@ -39,19 +40,21 @@ $panel-font-color-alt:  #fff !default;
 
     background: $bg;
 
-    // We set the font color based on the darkness of the bg.
-    @if $bg-lightness >= 50% and $bg == blue { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color-alt; } }
-    @else if $bg-lightness >= 50%            { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color; } }
-    @else                                    { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color-alt; } }
-
     // Respect the padding, fool.
     &>:first-child { margin-top: 0; }
     &>:last-child { margin-bottom: 0; }
 
-    // reset header line-heights for panels
-    h1,h2,h3,h4,h5,h6 {
-      line-height: 1; margin-bottom: emCalc(20px) / 2;
-      &.subheader { line-height: 1.4; }
+    @if $adjust {
+      // We set the font color based on the darkness of the bg.
+      @if $bg-lightness >= 50% and $bg == blue { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color-alt; } }
+      @else if $bg-lightness >= 50%            { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color; } }
+      @else                                    { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color-alt; } }
+
+      // reset header line-heights for panels
+      h1,h2,h3,h4,h5,h6 {
+        line-height: 1; margin-bottom: emCalc(20px) / 2;
+        &.subheader { line-height: 1.4; }
+      }
     }
   }
 }


### PR DESCRIPTION
I can understand the thought behind it, but it could be nicer, if we can have a control on it. I'd like to propose another argument to prevent adding styles to header tags.
