### PR TITLE
Fixed bug with different background for .button-group or any else ul in topbar.

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -215,7 +215,7 @@ $topbar-sticky-class:                  ".sticky" !default;
       width: 100%;
       height: auto;
       display: block;
-      background: $topbar-dropdown-bg;
+      background: $topbar-bg;
       font-size: $em-base;
       margin: 0;
     }


### PR DESCRIPTION
Fixed bug with different background for .button-group or any else ul in topbar.

When I added .button-group to .top-bar-section background of .button-group setted to $topbar-dropdown-bg and significantly stands out from the topbar background. 
