### PR TITLE
Auto-size the height of a dropdown li element to accommodate multi-block content

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -314,7 +314,10 @@ $topbar-sticky-class:                  ".sticky" !default;
       visibility: hidden;
       z-index: 99;
 
-      li { width: 100%;
+      li {
+        width: 100%;
+        height: auto;
+
         a {
           font-weight: normal;
           padding: 8px $topbar-height / 3;


### PR DESCRIPTION
For example, a sign-in login form is displayed when hovering over the top-level "Sign in" link.

``` html
  <li id="main-menu-user-login" class="has-dropdown">
                <a title="Sign into your account" href="">Sign in</a>
                <ul class="dropdown">
                  <li class="has-form">';
                     <!-- Enter username and password form labels and inputs, and the submit button -->
                  </li>
                </ul>
              </li>
```
