### PR TITLE
Quote selector in tooltips.js

### DIFF
--- a/js/foundation/foundation.tooltips.js
+++ b/js/foundation/foundation.tooltips.js
@@ -86,7 +86,7 @@
           tip = null;
 
       if (selector) {
-        tip = $('span[data-selector=' + selector + ']' + this.settings.tooltipClass);
+        tip = $('span[data-selector="' + selector + '"]' + this.settings.tooltipClass);
       }
 
       return (typeof tip === 'object') ? tip : false;


### PR DESCRIPTION
Fix the case when `selector` has a space char in it (e.g. id attribute of the element with tooltip has a space). Or, actually, any other "interesting" character, like `|`.

This can happen if your ids are autogenerated, for example, and you have no control over them, and also cannot just remove them. Regardless of the nature of such situation and validity of such ids, I think it's better to be on a safe side, so there.
