### PR TITLE
Update dropdown to remove top and bottom margins of only direct children.

### DIFF
--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -46,8 +46,8 @@ $f-dropdown-content-padding:      emCalc(20px) !default;
   top: -9999px;
   list-style: $f-dropdown-list-style;
 
-  *:first-child { margin-top: 0; }
-  *:last-child { margin-bottom: 0; }
+  > *:first-child { margin-top: 0; }
+  > *:last-child { margin-bottom: 0; }
 
   @if $content == list {
     width: 100%;


### PR DESCRIPTION
In order to use forms and other tags inside dropdowns, it may be better to remove the top and bottom margins of only direct children. This way, inputs will conserve their margins when inside a div.
