### PR TITLE
Changes in foundation-orbit changes for switching to auto height orbit (without JS height calculation) with table layout

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -131,17 +131,6 @@
       var self = this,
           $container = $slides_container.parent();
 
-      $(window)
-        .on('load.fndtn.orbit', function() {
-          $slides_container.height('');
-          $slides_container.height($slides_container.height($container.height()));
-          $slides_container.trigger('orbit:ready');
-        })
-        .on('resize.fndtn.orbit', function() {
-          $slides_container.height('');
-          $slides_container.height($slides_container.height($container.height()));
-        });
-
       $(document).on('click.fndtn.orbit', '[data-orbit-link]', function(e) {
         e.preventDefault();
         var id = $(e.currentTarget).attr('data-orbit-link'),
@@ -238,7 +227,6 @@
 
       $slides_container.css('width', $slides.length * 100 + '%');
       $slides.css('width', 100 / $slides.length + '%');
-      $slides_container.height($container.height());
       $slides_container.css('width', $slides.length * 100 + '%');
     },
 

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -120,15 +120,15 @@ $preloader-class: "preloader" !default;
       list-style: none;
       margin: 0;
       padding: 0;
-      position: relative;
+      display: table;
 
       img { display: block; }
+      
+      & > li {
+        display: table-cell;
+      }
 
       &>* {
-        position: relative;
-        float: $default-float;
-        height: auto;
-
         .orbit-caption {
           position: absolute;
           bottom: 0;


### PR DESCRIPTION
#### Changes in foundation-orbit for switching to auto height orbit (without JS height calculation) with table layout

All changes are in the orbit-table-layout branch. The change will make the LI's into a uniform height aligning to the parent UL. The UL will become a `display: table` and the LI will become `display: table-cell` making it always 100% of the parent. If the size of different carousel items is different, the LI's will always have the height of the biggest LI. The table-cell's also allow easy vertical align. Height management between orbit container and orbit is not needed anymore (no js for adjusting height) and the carousel will uniformly scale as needed.
- Removed on load  event (deprecated in jQuery 1.8)
- Removed any height manipulation on orbit UL
- Added Table layout style to UL and LI of orbit
