### PR TITLE
fix breakPoint issues regarding multiple topbars

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -38,9 +38,11 @@
           self.settings.$titlebar = self.settings.$topbar.children('ul').first();
           self.settings.$topbar.data('index', 0);
 
-          var breakpoint = $("<div class='top-bar-js-breakpoint'/>").insertAfter(self.settings.$topbar);
-          self.settings.breakPoint = breakpoint.width();
-          breakpoint.remove();
+          if (!self.settings.breakPoint) {
+            var breakpoint = $("<div class='top-bar-js-breakpoint'/>").insertAfter(self.settings.$topbar);
+            self.settings.breakPoint = breakpoint.width();
+            breakpoint.remove();
+          }
 
           self.assemble();
 


### PR DESCRIPTION
Hi, I dealt with a bug happening to me because I have two top-bars into my site, they look exactly the same, but one was in the top, and the second one in the bottom, but the bottom one is hidden for small displays.

The issue was that because the second one was hidden, and was the last one, when it tried to calculate the width it end up reseting it to zero (since it can't calculate invisible elements).

To avoid the issue I made it only calculates the breakPoint if it wasn't calculated yet. This way you can have many topbars as you want, if at least one of them is visible it will work.
