### PR TITLE
Calculate topbar distance on window resize

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -272,7 +272,13 @@
         var distance = $(klass).length ? $(klass).offset().top: 0,
             $window = $(window);
             var offst = this.outerHeight($('.top-bar'));
-
+        //Whe resize elements of the page on windows resize. Must recalculate distance
+		$(window).resize(function() {
+            clearTimeout(t_top);
+			t_top = setTimeout (function() {
+				distance = $(klass).offset().top;
+			},105);
+		});
           $window.scroll(function() {
             if ($window.scrollTop() >= (distance)) {
               $(klass).addClass("fixed");


### PR DESCRIPTION
If a element of the page is resized on window resize, distance must be recalculated when sticky is enabled
