### PR TITLE
Selector overwritten. Added :not to fix the bug.

### DIFF
--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -106,7 +106,7 @@ $content-selector: ".content" !default;
 
     &>*:last-child { margin-bottom: 0; }
     &>*:first-child { padding-top: 0; }
-    &>*:last-child { padding-bottom: 0; }
+    &>*:last-child:not(.flex-video) { padding-bottom: 0; }
   }
 
   &.active {


### PR DESCRIPTION
class flex-video was overwritten by other selectors reseting the padding-bottom. 
Added :not(.flex-video) to the selectors that is overwritten the property.
