### PR TITLE
Moved minus sign inside parens, so calc would work.

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -21,7 +21,7 @@ $block-grid-media-queries: true !default;
   @if $base-style {
     display: block;
     padding: 0;
-    margin: 0 -($spacing/2);
+    margin: 0 (-$spacing/2);
     @include clearfix;
 
     &>li {


### PR DESCRIPTION
Top and bottom margins on `block-grid-*` where being overridden by side margins because the minus sign was outside of the parenthesis, causing the calculation to eat up to `0px` top and bottom value:

Base code:
`margin: 0 -($spacing/2);`

Results in:
`margin: -0.625em;`

New code:
`margin: 0 (-$spacing/2);`

Results in:
`margin: 0 -0.625em;`
