### PR TITLE
Fix for Reveal scroll issue on touch devices

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -77,7 +77,7 @@
             }
           }
         })
-        .on('click.fndtn.reveal touchend.click.fndtn.reveal', this.close_targets(), function (e) {
+        .on('click.fndtn.reveal click.fndtn.reveal', this.close_targets(), function (e) {
           e.preventDefault();
           if (!self.locked) {
             var settings = $.extend({}, self.settings, self.data_options($('.reveal-modal.open')));


### PR DESCRIPTION
If you open a reveal modal on a touch device and scroll using your
thumb over .reveal-modal-bg (not .reveal-modal itself), it ends up
closing the reveal as soon as your thumb leaves the touch screen (on
touchend).

From a UX standpoint this seems buggy as I didn't tap the background. I
only placed my thumb on it to scroll the reveal modal, not to close it.
