### PR TITLE
Fixed topbar.js auto height when the top bar is expanded

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -86,7 +86,7 @@
 
             topbar
               .toggleClass('expanded')
-              .css('min-height', '');
+              .css('max-height', '');
           }
 
           if (!topbar.hasClass('expanded')) {
@@ -164,14 +164,14 @@
               section.find('>.name').css({right: 100 * topbar.data('index') + '%'});
             }
 
-            topbar.css('min-height', self.height($this.siblings('ul')) + self.outerHeight(titlebar, true));
+            topbar.css('max-height', self.height($this.siblings('ul')) + self.outerHeight(titlebar, true));
           }
         });
 
       $(window).on('resize.fndtn.topbar', function () {
         if (!self.breakpoint()) {
           $('.top-bar, [data-topbar]')
-            .css('min-height', '')
+            .css('max-height', '')
             .removeClass('expanded')
             .find('li')
             .removeClass('hover');
@@ -210,9 +210,9 @@
         }
 
         if (topbar.data('index') === 0) {
-          topbar.css('min-height', 0);
+          topbar.css('max-height', '');
         } else {
-          topbar.css('min-height', self.height($previousLevelUl) + self.outerHeight(titlebar, true));
+          topbar.css('max-height', self.height($previousLevelUl) + self.outerHeight(titlebar, true));
         }
 
         setTimeout(function () {


### PR DESCRIPTION
Fixed topbar.js auto height when the top bar is expanded. (Changed min-height by max-height)

Now, when the top bar is expanded. The height is automatically resized to adapt it to the content.

Previously, the min-height of the expanded top bar was the height of the content of the first level.
