### PR TITLE
handle multiple css classes for previous/next links

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -185,12 +185,12 @@
             $slide_number.replaceWith(self._slide_number_html(orbit.slide_number, orbit.total_slides));
           }
         })
-        .on('orbit:next-slide.fndtn.orbit click.fndtn.orbit', '.' + self.settings.next_class, function(e) {
+        .on('orbit:next-slide.fndtn.orbit click.fndtn.orbit', '.' + self.settings.next_class.split(" ").join("."), function(e) {
           e.preventDefault();
           self._reset_timer($slides_container, true);
           self._goto($slides_container, 'next', function() {});
         })
-        .on('orbit:prev-slide.fndtn.orbit click.fndtn.orbit', '.' + self.settings.prev_class, function(e) {
+        .on('orbit:prev-slide.fndtn.orbit click.fndtn.orbit', '.' + self.settings.prev_class.split(" ").join("."), function(e) {
           e.preventDefault();
           self._reset_timer($slides_container, true);
           self._goto($slides_container, 'prev', function() {});


### PR DESCRIPTION
For Orbit module, whenever more than 1 css class is defined for `next_class` and `prev_class`, the onclik event is not triggered.

Example: you define the options as follow: `data-options="next_class:orbit-next-button button;"`. The selector to get the element is: `.orbit-next-button button` instead of `.orbit-next-button.button`
