### PR TITLE
Added 'fixed' class to Magellan when in fixed position state

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -79,8 +79,10 @@
             if ($expedition.data("magellan-fixed-position") != fixed_position) {
               $expedition.data("magellan-fixed-position", fixed_position);
               if (fixed_position) {
+                $expedition.addClass('fixed');
                 $expedition.css({position:"fixed", top:0});
               } else {
+                $expedition.removeClass('fixed');
                 $expedition.css({position:"", top:""});
               }
               if (fixed_position && typeof attr != 'undefined' && attr != false) {


### PR DESCRIPTION
The idea behind this is that you can style the Magellan element
differently when it is fixed as opposed to in its normal state.

The 'fixed' class is already declared by Foundation but I have found no
issues when using it in this instance.
