### PR TITLE
Improving data-orbit-link to act as custom Orbit navigation

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -157,6 +157,8 @@
         if ($slide.length === 1) {
           self._reset_timer($slides_container, true);
           self._goto($slides_container, $slide.index(), function() {});
+          $(e.currentTarget).parents('ul').find('[data-orbit-link]').removeClass('active');
+          $(e.currentTarget).addClass('active');
         }
       });
 

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -183,6 +183,13 @@
         .on('orbit:after-slide-change.fndtn.orbit', function(e, orbit) {
           var $slide_number = $container.find('.' + self.settings.slide_number_class);
 
+          var dataOrbitSlide = $slides_container.children().eq(orbit.slide_number).attr('data-orbit-slide');
+          if(dataOrbitSlide) {
+            var dataOrbitLink = $('[data-orbit-link='+dataOrbitSlide.toString()+']');
+            $(dataOrbitLink).parents('ul').find('[data-orbit-link]').removeClass('active');
+            $(dataOrbitLink).addClass('active');
+          }
+
           if ($slide_number.length === 1) {
             $slide_number.replaceWith(self._slide_number_html(orbit.slide_number, orbit.total_slides));
           }


### PR DESCRIPTION
As I've mentioned in the commits I know my code may not be the best but it's the idea that counts. So please improve it / rewrite as needed :)

The idea here is to improve data-orbit-link so that it keeps up with Orbit slides. A class of 'active' is added (and removed) from the list of data-orbit-link elements as the slides are changed. This information can then be used to visually highlight the appropriate active link as I did on http://new.damir.com.au/ on the Testimonials section.

An even nicer visual improvement would be to immediately set the active link to the new slide as soon as it is clicked. Then animate in the new slide. Currently the slide is animated in and the appropriate link is changed after the slide has finished animating. This makes the effect appear a little laggy. However I didn't want to complicate the code any more until you have a look at it.
