### PR TITLE
Breadcrumbs: Do not set the global li font color

### DIFF
--- a/scss/foundation/components/_breadcrumbs.scss
+++ b/scss/foundation/components/_breadcrumbs.scss
@@ -56,7 +56,6 @@ $crumb-slash: "/" !default;
   float: $default-float;
   font-size: $crumb-font-size;
   text-transform: $crumb-font-transform;
-  color: $crumb-font-color;
 
   &:hover a, &:focus a { text-decoration: $crumb-link-decor; }
 


### PR DESCRIPTION
Less flexible than controlling on a per-selector basis
