### PR TITLE
Rails 2 compatability

### DIFF
--- a/lib/zurb-foundation.rb
+++ b/lib/zurb-foundation.rb
@@ -1,12 +1,12 @@
 root = File.join(File.dirname(__FILE__), "..")
 require "foundation/version"
 
-if defined?(Rails)
+if defined?(Rails::Generators::Base)
   require "foundation/generators/install_generator"
 end
 
 module Foundation
-  if defined?(Rails)
+  if defined?(Rails::Engine)
     require "foundation/engine"
   elsif defined?(Sprockets)
     require "foundation/sprockets"


### PR DESCRIPTION
Tightened up Rails feature detection so that Rails 2 apps that have Sprockets installed but are using Zurb can boot and bypass loading all of the Rails 3 integration code.
