### PR TITLE
Add some simple styling to the .parent-link

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -324,6 +324,9 @@ $topbar-sticky-class: ".sticky" !default;
         a {
           font-weight: normal;
           padding: 8px $topbar-height / 3;
+          &.parent-link {
+            font-weight: $topbar-link-weight;
+          }
         }
 
         &.title h5 { margin-bottom: 0;


### PR DESCRIPTION
Add some simple styling to the `.parent-link` that is generated when you are looking at a drop down menu in mobile state.
I use the $topbar-link-weight that by default is set to `bold`. 

This is especially handy when you generate your topbar and can't add label's to your submenu's:
![image](https://f.cloud.github.com/assets/2445415/706227/913a0f0c-dde8-11e2-8e5d-fcac7b742288.png)
The "Item1" is now bold (normally it isn't).
