### PR TITLE
Updated foundation.topbar.js for better control on parent-link

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -236,7 +236,7 @@
             url = $link.attr('href');
 
         if (url && url.length > 1) {
-          var $titleLi = $('<li class="title back js-generated"><h5><a href="#"></a></h5></li><li><a class="parent-link js-generated" href="' + url + '">' + $link.text() +'</a></li>');
+          var $titleLi = $('<li class="title back js-generated"><h5><a href="#"></a></h5></li><li class="parent-link js-generated"><a href="' + url + '">' + $link.text() +'</a></li>');
         } else {
           var $titleLi = $('<li class="title back js-generated"><h5><a href="#"></a></h5></li>');
         }


### PR DESCRIPTION
I was facing the problem in hiding the automatic generated parent-link `<li>` on larger screens through CSS, as the class "parent-link" was given to the `<a>` instead of its parent `<li>`

Updating this line worked for me. I think it gives more control as you can access a child element easily through CSS 
