### PR TITLE
Fixes 't_top' is undefined error in foundation.topbar.js on window resize.

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -270,8 +270,9 @@
       var klass = '.' + this.settings.stickyClass;
       if ($(klass).length > 0) {
         var distance = $(klass).length ? $(klass).offset().top: 0,
-            $window = $(window);
-            var offst = this.outerHeight($('.top-bar'));
+            $window = $(window),
+            offst = this.outerHeight($('.top-bar')),
+            t_top;
         //Whe resize elements of the page on windows resize. Must recalculate distance
 		$(window).resize(function() {
             clearTimeout(t_top);


### PR DESCRIPTION
I'd like to resolve #2660 with this commit. It's a small fix, but by declaring t_top before it's passed to clearTimeout we can eliminate the numerous errors that are thrown when resizing the window.
