### PR TITLE
A top bar that is wrapped in .contain-to-grid does not have a margin-bottom

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -68,7 +68,7 @@ $topbar-sticky-class: ".sticky" !default;
     width: 100%;
     background: $topbar-bg;
 
-    .top-bar { margin-bottom: 0; }
+    .top-bar { margin-bottom: $topbar-margin-bottom; }
   }
 
   // Wrapped around .top-bar to make it stick to the top
@@ -382,6 +382,7 @@ $topbar-sticky-class: ".sticky" !default;
     .contain-to-grid .top-bar {
       max-width: $row-width;
       margin: 0 auto;
+      margin-bottom: $topbar-margin-bottom;
     }
 
     .top-bar-section {


### PR DESCRIPTION
I tried to use  `.contain-to-grid` on my top bar but the results were not as expected, the top bar is lacking a bottom margin.

![Max width top bar](http://f.cl.ly/items/2V401P2I2g2z472j3g1z/foundation-max.jpg)

![Mobile top bar](http://f.cl.ly/items/440c2u1E0q1H2Y3A0C2a/foundation-mobile.jpg)

Normally the top bar has a margin bottom taken from the `$topbar-margin-bottom` variable, however the `.contain-to-grid` class resets `margin-bottom` to zero.

This issue appears to have been fixed in PR #2178 which was accepted a couple of months ago. However it seems to have been removed again, perhaps [here](https://github.com/zurb/foundation/commit/2f9b746db42b2b1849a775ab3ad9da49c5f87a4b#L0R373) and/or elsewhere.

This pull request aims to fix this again, although I am unsure if there is any knock-on effect with the `.fixed` or `.sticky` classes, and would have to defer to someone else that is a bit more familiar with foundation than I.
