### PR TITLE
Fix to ensure that cached images are available before use - fixes issue #2663

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -10,6 +10,8 @@
 
     cache : {},
 
+    images_loaded : false,
+
     settings : {
       load_attr : 'interchange',
 
@@ -71,6 +73,11 @@
     resize : function () {
       var cache = this.cache;
 
+      if(!this.images_loaded) {
+        setTimeout($.proxy(this.resize, this), 50);
+        return;
+      }
+
       for (var uuid in cache) {
         if (cache.hasOwnProperty(uuid)) {
           var passed = this.results(uuid, cache[uuid]);
@@ -85,18 +92,17 @@
     },
 
     results : function (uuid, scenarios) {
-      var count = scenarios.length,
-          results_arr = [];
+      var count = scenarios.length;
 
       if (count > 0) {
         var el = $('[data-uuid="' + uuid + '"]');
 
         for (var i = count - 1; i >= 0; i--) {
-          var rule = scenarios[i][2];
+          var mq, rule = scenarios[i][2];
           if (this.settings.named_queries.hasOwnProperty(rule)) {
-            var mq = matchMedia(this.settings.named_queries[rule]);
+            mq = matchMedia(this.settings.named_queries[rule]);
           } else {
-            var mq = matchMedia(scenarios[i][2]);
+            mq = matchMedia(rule);
           }
           if (mq.matches) {
             return {el: el, scenario: scenarios[i]};
@@ -118,12 +124,15 @@
     update_images : function () {
       var images = document.getElementsByTagName('img'),
           count = images.length,
+          loaded_count = 0,
           data_attr = 'data-' + this.settings.load_attr;
 
       this.cached_images = [];
+      this.images_loaded = false;
 
       for (var i = count - 1; i >= 0; i--) {
-        this.loaded($(images[i]), (i === 0), function (image, last) {
+        this.loaded($(images[i]), function (image) {
+          loaded_count++;
           if (image) {
             var str = image.getAttribute(data_attr) || '';
 
@@ -132,8 +141,10 @@
             }
           }
 
-          if (last) this.enhance();
-
+          if(loaded_count === count) {
+            this.images_loaded = true;
+            this.enhance();
+          }
         }.bind(this));
       }
 
@@ -143,9 +154,9 @@
     // based on jquery.imageready.js
     // @weblinc, @jsantell, (c) 2012
 
-    loaded : function (image, last, callback) {
+    loaded : function (image, callback) {
       function loaded () {
-        callback(image[0], last);
+        callback(image[0]);
       }
 
       function bindLoad () {


### PR DESCRIPTION
This change ensures that all of the images have been accounted for before executing the resize logic.  Prior to this change, you could get in a situation where things would occur before all the images had been processed causing behaviors such as individual images showing only the initial src value.
