### PR TITLE
Use $global-radius as the default setting for side-radius()

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -15,7 +15,7 @@ $experimental: true !default;
 }
 
 // We use this to create equal side border radius on elements.
-@mixin side-radius($side, $radius) {
+@mixin side-radius($side, $radius:$global-radius) {
   @if $side == left {
     @if $experimental {
       -moz-border-radius-bottomleft: $radius;


### PR DESCRIPTION
Use $global-radius as the default setting for side-radius().
This way you can:

``` scss
div {
  @include side-radius(bottom);
}
```

Instead of:

``` scss
div {
  @include side-radius(bottom, $global-radius);
}
```
