### PR TITLE
Dont overwrite padding-left and padding-right (you can use grid-column()...

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -134,7 +134,8 @@ $glowing-effect-color: $input-focus-border-color !default;
   }
   @else if $alignment == inline {
     margin: 0 0 $form-spacing 0;
-    padding: $form-spacing / 2 + emCalc($input-border-width * 2) 0;
+    padding-top: $form-spacing / 2 + emCalc($input-border-width * 2);
+    padding-bottom: $form-spacing / 2 + emCalc($input-border-width * 2);
   }
 }
 


### PR DESCRIPTION
... after this commit.)

I have the fallowing problem in my project:

``` scss
label {
    @include grid-column($columns:3, $collapse:false, $float:false);
    text-align: right;
    //@include form-label($alignment:inline, $base-style:false);
    margin: 0 0 $form-spacing 0;
    padding-top: $form-spacing / 2 + emCalc($input-border-width * 2);
    padding-bottom: $form-spacing / 2 + emCalc($input-border-width * 2);
}
```

I can't use the form-label mixin, because it would set `padding: $form-spacing / 2 + emCalc($input-border-width * 2);`. But because the grid-column() mixin uses padding-left and padding-right those would get cancelled out.

Not really sure if I should apply grid-column on a label in the first place?
