### PR TITLE
Only open clearing if img is clicked

### DIFF
--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -74,21 +74,24 @@
                 settings = self.get_data(current.parent()),
                 image = $(e.target);
 
-            e.preventDefault();
-            if (!settings) self.init();
+            // only open clearing if an image is clicked
+            if (image['context']['localName'] == 'img') {
+              e.preventDefault();
+              if (!settings) self.init();
 
-            // if clearing is open and the current image is
-            // clicked, go to the next image in sequence
-            if (target.hasClass('visible') && 
-              current[0] === target[0] && 
-              next.length > 0 && self.is_open(current)) {
-              target = next;
-              image = target.find('img');
+              // if clearing is open and the current image is
+              // clicked, go to the next image in sequence
+              if (target.hasClass('visible') && 
+                current[0] === target[0] && 
+                next.length > 0 && self.is_open(current)) {
+                target = next;
+                image = target.find('img');
+              }
+
+              // set current and target to the clicked li if not otherwise defined.
+              self.open(image, current, target);
+              self.update_paddles(target);
             }
-
-            // set current and target to the clicked li if not otherwise defined.
-            self.open(image, current, target);
-            self.update_paddles(target);
           })
 
         .on('click.fndtn.clearing', '.clearing-main-next',


### PR DESCRIPTION
Links don't work inside of clearing-thumbs, except the thumbnail.  This disables clearing for links other than links that have an img child.  There is probably a better way to do this, but it is working.
