### PR TITLE
Short pages with Joyride tips bounce to top when scrolling to the next tip

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -42,7 +42,7 @@
         expose  : '<div class="joyride-expose-wrapper"></div>',
         exposeCover: '<div class="joyride-expose-cover"></div>'
       },
-      exposeAddClass  	: ''		// One or more space-separated class names to be added to exposed element
+      exposeAddClass : '' // One or more space-separated class names to be added to exposed element
     },
 
     settings : {},
@@ -350,7 +350,13 @@
       if (!this.settings.modal) {
         $('.joyride-modal-bg').hide();
       }
-      this.settings.$current_tip.hide();
+
+      // Prevent scroll bouncing...wait to remove from layout
+      this.settings.$current_tip.css('visibility', 'hidden');
+      setTimeout($.proxy(function() {
+        this.hide();
+        this.css('visibility', 'visible');
+      }, this.settings.$current_tip), 0);
       this.settings.postStepCallback(this.settings.$li.index(),
         this.settings.$current_tip);
     },


### PR DESCRIPTION
When a page is short enough (or the tip is large enough), the Joyride tip can extend the length of the document.  When moving to the next tip, the element was removed from the layout causing a noticeable bounce to the top of the page before scrolling to the next location.

This change ensures that the element remains hidden in the layout until the scroll has occurred.
