### PR TITLE
Fixed deep linking for nested content and improved selected hash checking

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -246,15 +246,16 @@
               var content = $(self.settings.content_selector, this),
                   content_slug = content.data('slug');
 
-              if (new RegExp(content_slug, 'i').test(hash)) 
+              if (new RegExp('^' + content_slug + '$', 'i').test(hash)) {
                 return content;
+              }
             });
 
 
           var count = hash_regions.length;
 
           for (var i = count - 1; i >= 0; i--) {
-            $(hash_regions[i]).parent().addClass('active');
+            $(hash_regions[i]).parents(self.settings.region_selector).addClass('active');
           }
         }
       });


### PR DESCRIPTION
The regular expression for the selected hash wasn't checking for an exact match causing "subtab" to match on "subsubtab", for instance.

Additionally, the logic to set the section active was only setting it for the immediate parent causing the deep linking to not work correctly for deeply nested items, so I fixed it.  :)
