### PR TITLE
remove infinite animation that triggers continious style recalculation...

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -125,10 +125,6 @@ $switch-label-outline:            1px dotted #888 !default;
   // Hiding custom form spans since we auto-create them
   span.custom { display: none !important; }
 
-  // Bugfix for older Webkit, including mobile Webkit. Adapted from:
-  // http://css-tricks.com/webkit-sibling-bug/
-  @if $experimental { -webkit-animation: webkitSiblingBugfix infinite 1s; }
-
   form.custom & .hidden-field {
     margin-left: auto;
     position: absolute;


### PR DESCRIPTION
It looks like this bugfix only applies to obsolete webkit browsers and causes continuous style recompilation (and therefore relatively high cpu load / power consumption) in modern webkit browsers.

The effect is currently quite pronounced on this page http://foundation.zurb.com/docs/components/switch.html (view in chrome or safari) vs the rest of the foundation docs. I'd suggest throwing a few switches on a clean page and tinkering with this animation setting if you have any doubts.
