### PR TITLE
Allows to scroll long select box without selecting the last touched item on the ipad

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -139,7 +139,7 @@
 
             $customDropdown.removeClass('open')
               .find('a.current')
-              .text($this.text());
+              .html($this.html());
 
             $this.closest('ul').find('li').each(function (index) {
               if ($this[0] === this) {

--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -119,7 +119,7 @@
             return false;
           }
         })
-        .on('click.fndtn.forms touchend.fndtn.forms', 'form.custom div.custom.dropdown li', function (e) {
+        .on('click.fndtn.forms', 'form.custom div.custom.dropdown li', function (e) {
           var $this = $(this),
               $customDropdown = $this.closest('div.custom.dropdown'),
               $select = getFirstPrevSibling($customDropdown, 'select'),
@@ -270,7 +270,7 @@
           $customSelect = $('<div class="' + ['custom', 'dropdown', customSelectSize].concat(copyClasses).filter(function (item, idx, arr) {
             if (item === '') return false;
             return arr.indexOf(item) === idx;
-          }).join(' ') + '"><a href="#" class="selector"></a><ul /></div>');
+          }).join(' ') + '"><a href="#" class="selector"></a><a href="#"><ul /></a></div>');
 
           $selector = $customSelect.find(".selector");
           $customList = $customSelect.find("ul");


### PR DESCRIPTION
When using select long enough to need to be scrolled,
the scolling ends with selecting the last item under ones
finger on an ipad (tested for iOS 6).
This fix removes the binding on the "touchend"
event for selecting the options and wraps the dropdown in a
<a> tag to receive a proper "click" event instead.
