### PR TITLE
Fixed height and padding for lists with the .current-class applied and no anchor as ...

### DIFF
--- a/scss/foundation/components/_pagination.scss
+++ b/scss/foundation/components/_pagination.scss
@@ -64,6 +64,8 @@ $pagination-link-current-active-bg: $primary-color !default;
       &:focus { background: $pagination-link-current-active-bg; }
     }
   } @else {
+    height: auto;
+    padding: $pagination-link-pad;
     background: $pagination-link-current-background;
     color: $pagination-link-current-font-color;
     font-weight: $pagination-link-current-font-weight;


### PR DESCRIPTION
...a child.

See the height and padding difference here:
![image](https://f.cloud.github.com/assets/2445415/758832/7c164b0a-e75b-11e2-9908-deabe39ea2a3.png)
