### PR TITLE
Fixed collapse row styling effecting all nested rows.

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -117,8 +117,8 @@ $total-columns: 12 !default;
     @include grid-row;
 
     &.collapse {
-      .column,
-      .columns { @include grid-column($collapse:true); }
+      > .column,
+      > .columns { @include grid-column($collapse:true); }
     }
 
     .row { @include grid-row($behavior:nest);


### PR DESCRIPTION
Each row that should be collapsed should have its own .collapse class. (OR there should be an "uncollapse" class for nested rows to undo collapsing)
