### PR TITLE
Body padding should equal fixed top bar height plus margin-bottom.

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -46,7 +46,9 @@
           self.assemble();
 
           if (self.settings.$topbar.parent().hasClass('fixed')) {
-            $('body').css('padding-top', self.outerHeight(self.settings.$topbar));
+            var paddingTop = self.outerHeight(self.settings.$topbar);
+            paddingTop += parseInt(self.settings.$topbar.css('margin-bottom'));
+            $('body').css('padding-top', paddingTop);
           }
         });
 


### PR DESCRIPTION
When wrapping a top-bar in `<div class="fixed">`, the body's padding-top is set to the top-bar's outer height. However, this actually pushes content farther up, leaving less room between the content and the top-bar than when it's not fixed, due to the top-bar's `margin-bottom: 1.875em;`.

This patch adds the height and the bottom margin and sets the body's padding-top equal to the sum, meaning the content layout stays consistent.
