### PR TITLE
Add optional different side margin to no-bulleted lists.

### DIFF
--- a/docs/components/type.html.erb
+++ b/docs/components/type.html.erb
@@ -349,6 +349,7 @@ $hr-margin: emCalc(20);
 $list-style-position: outside;
 $list-side-margin: emCalc(20);
 $list-nested-margin: emCalc(20);
+$list-nobullet-side-margin: $list-side-margin;
 $definition-list-header-weight: bold;
 $definition-list-header-margin-bottom: .3em;
 $definition-list-margin-bottom: emCalc(12);

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -226,7 +226,7 @@ $default-float: left;
 // $list-style-position: outside;
 // $list-side-margin: emCalc(20);
 // $list-nested-margin: emCalc(20);
-// $list-nobullet-side-margin: $list-side-margin !default;
+// $list-nobullet-side-margin: $list-side-margin;
 // $definition-list-header-weight: bold;
 // $definition-list-header-margin-bottom: .3em;
 // $definition-list-margin-bottom: emCalc(12);

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -226,6 +226,7 @@ $default-float: left;
 // $list-style-position: outside;
 // $list-side-margin: emCalc(20);
 // $list-nested-margin: emCalc(20);
+// $list-nobullet-side-margin: $list-side-margin !default;
 // $definition-list-header-weight: bold;
 // $definition-list-header-margin-bottom: .3em;
 // $definition-list-margin-bottom: emCalc(12);

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -63,6 +63,7 @@ $hr-margin: emCalc(20) !default;
 $list-style-position: outside !default;
 $list-side-margin: 0 !default;
 $list-nested-margin: emCalc(20) !default;
+$list-nobullet-side-margin: $list-side-margin !default;
 $definition-list-header-weight: bold !default;
 $definition-list-header-margin-bottom: .3em !default;
 $definition-list-margin-bottom: emCalc(12) !default;
@@ -270,7 +271,12 @@ $microformat-abbr-font-decoration: none !default;
     &.square { list-style-type: square; }
     &.circle { list-style-type: circle; }
     &.disc { list-style-type: disc; }
-    &.no-bullet { list-style: none; }
+    &.no-bullet {
+      list-style: none;
+      @if $list-nobullet-side-margin != $list-side-margin {
+        margin-#{$default-float}: $list-nobullet-side-margin;
+      }
+    }
   }
 
   /* Ordered Lists */


### PR DESCRIPTION
Becomes essential for lists whose position is set to inside, aligning them to content with hanging indents. Lists given the no-bullet class then are pushed in even though they do not appear as lists.
