### PR TITLE
fix input height calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 InstalledFiles
 _yardoc
 coverage

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -97,7 +97,7 @@ $glowing-effect-color: $input-focus-border-color !default;
   font-size: $input-font-size;
   margin: 0 0 $form-spacing 0;
   padding: $form-spacing / 2;
-  height: emCalc(13) + ($form-spacing * 1.5);
+  height: ($input-font-size + ($form-spacing * 1.5) - emCalc(1));
   width: 100%;
   @include box-sizing(border-box);
   @if $input-include-glowing-effect {


### PR DESCRIPTION
without this fix input and .postfix elements with same font size(for example $label-font-size = $label-font-size = emCalc(16px)) had different height
