### PR TITLE
The `$button-border-color` was never used within the mixin

### DIFF
--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -118,7 +118,7 @@ $button-disabled-opacity: 0.6 !default;
     $bg-lightness: lightness($bg);
 
     background-color: $bg;
-    border-color: darken($bg, $button-function-factor);
+    border-color: $button-border-color;
     &:hover,
     &:focus { background-color: darken($bg, $button-function-factor); }
 

--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -99,7 +99,7 @@ $content-selector: ".content" !default;
     &:hover { background-color: $title-bg-hover; }
   }
 
-  #{$content-selector} {
+  > #{$content-selector} {
     display: none;
     padding: $content-padding;
     background-color: $content-bg;
@@ -149,7 +149,7 @@ $content-selector: ".content" !default;
     }
     &:last-child #{$title-selector} { border-#{$opposite-direction}: $section-border-style $section-border-size $section-border-color; }
 
-    #{$content-selector} {
+    > #{$content-selector} {
       border: $section-border-style $section-border-size $section-border-color;
       position: absolute;
       z-index: 10;
@@ -180,7 +180,7 @@ $content-selector: ".content" !default;
     }
     &:first-child #{$title-selector} { border-top: 0; }
 
-    #{$content-selector} {
+    > #{$content-selector} {
       // Display all content blocks to account for the scrollbar
       // in the outerWidth measurements. JavaScript will toggle the active tabs.
       display: block;
@@ -215,7 +215,7 @@ $content-selector: ".content" !default;
         width: 100%;
       }
     }
-    #{$content-selector} { display: none; }
+    > #{$content-selector} { display: none; }
     &:first-child #{$title-selector} { border-bottom: none; }
 
     &.active {
@@ -248,7 +248,7 @@ $content-selector: ".content" !default;
       a { width: 100%; }
     }
 
-    #{$content-selector} { display: none; }
+    > #{$content-selector} { display: none; }
 
     &.active {
       & > #{$content-selector} {
@@ -337,7 +337,7 @@ $content-selector: ".content" !default;
           border-right: 0;
         }
 
-        #{$content-selector} {
+        > #{$content-selector} {
           position: static;
           display: block;
           width: 100%;


### PR DESCRIPTION
Even though the `$button-border-color` is defined, it is nevery actually used in the mixin creating the buttons.  This makes it impossible to change the border-color using the settings.

See also #2192
