### PR TITLE
Fix for $topbar-bg assuming only solid color for topbar background, now allows gradients, images, transparency, etc

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -1227,7 +1227,8 @@ $default-float: left;
 
 // Background color for the top bar
 
-// $topbar-bg: #111 !default;
+// $topbar-bg-color: #111;
+// $topbar-bg: $topbar-bg-color;
 
 // Height and margin
 
@@ -1247,7 +1248,7 @@ $default-float: left;
 
 // $topbar-dropdown-bg: #222;
 // $topbar-dropdown-link-color: #fff;
-// $topbar-dropdown-link-bg: lighten($topbar-bg, 5%);
+// $topbar-dropdown-link-bg: lighten($topbar-bg-color, 5%);
 // $topbar-dropdown-toggle-size: 5px;
 // $topbar-dropdown-toggle-color: #fff;
 // $topbar-dropdown-toggle-alpha: 0.5;
@@ -1260,13 +1261,14 @@ $default-float: left;
 // $topbar-link-weight: bold;
 // $topbar-link-font-size: emCalc(13);
 // $topbar-link-hover-lightness: -30%; // Darken by 30%
-// $topbar-link-bg-hover: darken($topbar-bg, 3%);
-// $topbar-link-bg-active: darken($topbar-bg, 3%);
+// $topbar-link-bg-hover: darken($topbar-bg-color, 3%);
+// $topbar-link-bg-active: darken($topbar-bg-color, 3%);
 
 // $topbar-dropdown-label-color: #555;
 // $topbar-dropdown-label-text-transform: uppercase;
 // $topbar-dropdown-label-font-weight: bold;
 // $topbar-dropdown-label-font-size: emCalc(10);
+// $topbar-dropdown-label-bg: lighten($topbar-bg-color, 5%);
 
 // Top menu icon styles
 
@@ -1286,8 +1288,8 @@ $default-float: left;
 
 // Divider Styles
 
-// $topbar-divider-border-bottom: solid 1px lighten($topbar-bg, 10%);
-// $topbar-divider-border-top: solid 1px darken($topbar-bg, 10%);
+// $topbar-divider-border-bottom: solid 1px lighten($topbar-bg-color, 10%);
+// $topbar-divider-border-top: solid 1px darken($topbar-bg-color, 10%);
 
 // Sticky Class
 

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -4,7 +4,8 @@
 $include-html-top-bar-classes: $include-html-classes !default;
 
 // Background color for the top bar
-$topbar-bg: #111 !default;
+$topbar-bg-color: #111 !default;
+$topbar-bg: $topbar-bg-color !default;
 
 // Height and margin
 $topbar-height: 45px !default;
@@ -20,7 +21,7 @@ $topbar-title-font-size: emCalc(17) !default;
 // Style the top bar dropdown elements
 $topbar-dropdown-bg: #222 !default;
 $topbar-dropdown-link-color: #fff !default;
-$topbar-dropdown-link-bg: lighten($topbar-bg, 5%) !default;
+$topbar-dropdown-link-bg: lighten($topbar-bg-color, 5%) !default;
 $topbar-dropdown-toggle-size: 5px !default;
 $topbar-dropdown-toggle-color: #fff !default;
 $topbar-dropdown-toggle-alpha: 0.5 !default;
@@ -32,13 +33,14 @@ $topbar-link-color-active: #fff !default;
 $topbar-link-weight: bold !default;
 $topbar-link-font-size: emCalc(13) !default;
 $topbar-link-hover-lightness: -30% !default; // Darken by 30%
-$topbar-link-bg-hover: darken($topbar-bg, 3%) !default;
-$topbar-link-bg-active: darken($topbar-bg, 3%) !default;
+$topbar-link-bg-hover: darken($topbar-bg-color, 3%) !default;
+$topbar-link-bg-active: darken($topbar-bg-color, 3%) !default;
 
 $topbar-dropdown-label-color: #555 !default;
 $topbar-dropdown-label-text-transform: uppercase !default;
 $topbar-dropdown-label-font-weight: bold !default;
 $topbar-dropdown-label-font-size: emCalc(10) !default;
+$topbar-dropdown-label-bg: lighten($topbar-bg-color, 5%) !default;
 
 // Top menu icon styles
 $topbar-menu-link-transform: uppercase !default;
@@ -55,8 +57,8 @@ $topbar-breakpoint: emCalc(940) !default; // Change to 9999px for always mobile 
 $topbar-media-query: "only screen and (min-width: #{$topbar-breakpoint})" !default;
 
 // Divider Styles
-$topbar-divider-border-bottom: solid 1px lighten($topbar-bg, 10%) !default;
-$topbar-divider-border-top: solid 1px darken($topbar-bg, 10%) !default;
+$topbar-divider-border-bottom: solid 1px lighten($topbar-bg-color, 10%) !default;
+$topbar-divider-border-top: solid 1px darken($topbar-bg-color, 10%) !default;
 
 // Sticky Class
 $topbar-sticky-class: ".sticky" !default;
@@ -463,7 +465,7 @@ $topbar-sticky-class: ".sticky" !default;
 
           label {
             white-space: nowrap;
-            background: lighten($topbar-bg, 5%);
+            background: $topbar-dropdown-label-bg;
           }
 
           // Second Level Dropdowns


### PR DESCRIPTION
modified $topbar-bg definition to split color definition from background definition, replaced all references to $topbar-bg with $topbar-bg-color, added new variable for $topbar-dropdown-label-bg

Fixes https://github.com/zurb/foundation/issues/2111 by allowing any valid background CSS to be set for $topbar-bg, including gradients, images, transparency, etc.
