### PR TITLE
Fixed mobile topbar: nested ULs

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -165,7 +165,7 @@
               section.find('>.name').css({right: 100 * topbar.data('index') + '%'});
             }
 
-            topbar.css('height', self.outerHeight($this.siblings('ul'), true) + self.outerHeight(titlebar, true));
+            topbar.css('height', self.outerHeight($this.siblings('ul'), true) + self.height(titlebar));
           }
         });
 
@@ -213,7 +213,7 @@
         if (topbar.data('index') === 0) {
           topbar.css('height', '');
         } else {
-          topbar.css('height', self.outerHeight($previousLevelUl, true) + self.outerHeight(titlebar, true));
+          topbar.css('height', self.outerHeight($previousLevelUl, true) + self.height(titlebar));
         }
 
         setTimeout(function () {


### PR DESCRIPTION
Second level topbar gets an injected li-h5-a element (back button)
--> outerHeigt(titlebar, true) does not calculate the correct block-element height. Fixed with self.height(titlebar);
