### PR TITLE
The `$button-border-color` was never used within the mixin

### DIFF
--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -118,7 +118,7 @@ $button-disabled-opacity: 0.6 !default;
     $bg-lightness: lightness($bg);
 
     background-color: $bg;
-    border-color: darken($bg, $button-function-factor);
+    border-color: $button-border-color;
     &:hover,
     &:focus { background-color: darken($bg, $button-function-factor); }
 


### PR DESCRIPTION
Even though the $button-border-color is defined, it is nevery actually used in the mixin creating the buttons. This makes it impossible to change the border-color using the settings.

This is a replacement for #2773 because it was using the `master` branch.
