### PR TITLE
Changed how change event is fired for dropdowns

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -150,7 +150,15 @@
 
             //store the old value in data
             $select.data('prevalue', $oldThis.html());
-            $select.trigger('change');
+            
+            // Kick off full DOM change event
+            if (typeof (document.createEvent) != 'undefined') {
+              var event = document.createEvent('HTMLEvents');
+              event.initEvent('change', true, true);
+              $select[0].dispatchEvent(event);
+            } else {
+              $select[0].fireEvent('onchange'); // for IE
+            }
           }
       });
 


### PR DESCRIPTION
Changed the way the change event is fired for $select to use the 
traditional DOM method for compatibility with Knockout.js.

Using $select.trigger('change'); does not create a full change event that is detectable by Knockout. However; using the traditional DOM approach of creating a new event and dispatching to the DOM element creates select lists that are compatible with Knockout and are compatible with Foundations custom forms.
