### PR TITLE
Fix incorrect link to Abide docs

### DIFF
--- a/docs/index.html.erb
+++ b/docs/index.html.erb
@@ -137,7 +137,7 @@
     <div class="row">
       <div class="large-4 columns">
         <dl>
-          <dt><h5><a href="components/tooltips.html">Abide</a></h5></dt>
+          <dt><h5><a href="components/abide.html">Abide</a></h5></dt>
           <dd>Abide is an HTML5 form validation library that supports the native API by using patterns and required attributes.</dd>
         </dl>
       </div>


### PR DESCRIPTION
Just noticed that the link to the Abide docs was pointing at the Tooltip docs.

Thanks for an awesome project!
