### PR TITLE
Fix for invalid $em-base setting in 4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 InstalledFiles
 _yardoc
 coverage

--- a/docs/components/abide.html.erb
+++ b/docs/components/abide.html.erb
@@ -167,7 +167,7 @@
             </tr>
             <tr>
               <td>card</td>
-              <td>visa, ames, mastercard</td>
+              <td>visa, amex, mastercard</td>
             </tr>
             <tr>
               <td>cvv</td>
@@ -250,7 +250,7 @@ $(document)
       dashes_only: /^[0-9-]*$/,
       ip_address: /^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/
     }
-  })
+  });
 ", :js %>
         
         <p>You can then use these custom patterns like you would the predfined patterns in your markup:</p>
@@ -292,7 +292,7 @@ $(document)
 
         <h3>Events</h3>
 
-        <p>If a submit event is fired, a <code>valid</code> event is fired if the form is valid and an <code>invalid</code> event is fired if the form is invalid.</p>
+        <p>If a submit event is fired, a <code>valid</code> event is triggered if the form is valid and an <code>invalid</code> event is triggered if the form is invalid.</p>
 
         <p>You can bind to these events and fire your own callback:</p>
 

--- a/docs/components/abide.html.erb
+++ b/docs/components/abide.html.erb
@@ -63,9 +63,9 @@
 
             <div class="row">
               <div class="large-6 columns">
-                <label for="radio1"><input name="radio1" type="radio" id="radio1" required><span class="custom radio"></span> Radio Button 1</label>
-                <label for="radio1"><input name="radio1" type="radio" id="radio1" required><span class="custom radio"></span> Radio Button 2</label>
-                <label for="radio1"><input name="radio1" type="radio" id="radio1" required><span class="custom radio"></span> Radio Button 3</label>
+                <label for="radio1"><input name="radio1" type="radio" id="radio1" style="display:none;" required><span class="custom radio"></span> Radio Button 1</label>
+                <label for="radio1"><input name="radio1" type="radio" id="radio1" style="display:none;" required><span class="custom radio"></span> Radio Button 2</label>
+                <label for="radio1"><input name="radio1" type="radio" id="radio1" style="display:none;" required><span class="custom radio"></span> Radio Button 3</label>
               </div>
               <div class="large-6 columns">
                 <label for="checkbox1"><input type="checkbox" id="checkbox1" style="display: none;" required><span class="custom checkbox"></span> Label for Checkbox</label>

--- a/docs/components/abide.html.erb
+++ b/docs/components/abide.html.erb
@@ -63,9 +63,9 @@
 
             <div class="row">
               <div class="large-6 columns">
-                <label for="radio1"><input name="radio1" type="radio" id="radio1" style="display:none;" required><span class="custom radio"></span> Radio Button 1</label>
-                <label for="radio1"><input name="radio1" type="radio" id="radio1" style="display:none;" required><span class="custom radio"></span> Radio Button 2</label>
-                <label for="radio1"><input name="radio1" type="radio" id="radio1" style="display:none;" required><span class="custom radio"></span> Radio Button 3</label>
+                <label for="radio1"><input name="radio1" type="radio" id="radio1" required><span class="custom radio"></span> Radio Button 1</label>
+                <label for="radio1"><input name="radio1" type="radio" id="radio1" required><span class="custom radio"></span> Radio Button 2</label>
+                <label for="radio1"><input name="radio1" type="radio" id="radio1" required><span class="custom radio"></span> Radio Button 3</label>
               </div>
               <div class="large-6 columns">
                 <label for="checkbox1"><input type="checkbox" id="checkbox1" style="display: none;" required><span class="custom checkbox"></span> Label for Checkbox</label>

--- a/docs/components/buttons.html.erb
+++ b/docs/components/buttons.html.erb
@@ -202,7 +202,6 @@ $button-function-factor: 10%;
 /* We use these to control button border styles. */
 $button-border-width: 1px;
 $button-border-style: solid;
-$button-border-color: darken($primary-color, $button-function-factor);
 
 /* We use this to set the default radius used throughout the core. */
 $button-radius: $global-radius;

--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -50,6 +50,7 @@
 
     events: function () {
       var self = this;
+          selectScrolled = false;
 
       $(this.scope)
         .on('click.fndtn.forms', 'form.custom span.custom.checkbox', function (e) {
@@ -119,45 +120,60 @@
             return false;
           }
         })
-        .on('click.fndtn.forms touchend.fndtn.forms', 'form.custom div.custom.dropdown li', function (e) {
+        .on('click.fndtn.forms touchend.fndtn.forms touchmove.fndtn.forms', 'form.custom div.custom.dropdown li', function (e) {
           var $this = $(this),
               $customDropdown = $this.closest('div.custom.dropdown'),
               $select = getFirstPrevSibling($customDropdown, 'select'),
               selectedIndex = 0;
 
-          e.preventDefault();
-          e.stopPropagation();
+          if (e.type == 'touchmove') {
+            selectScrolled = true;
+          }
 
-          if (!$(this).hasClass('disabled')) {
-            $('div.dropdown').not($customDropdown).removeClass('open');
+          if (e.type == 'touchend') {
+            if (selectScrolled) {
+              selectScrolled = false;
+            }
+            else if (!selectScrolled) {
+              selectItem();
+            }
+          }
+          else if (e.type == 'click') {
+            selectItem();
+          }
+          
+          function selectItem() {
+            if (!$(this).hasClass('disabled')) {
+              $('div.dropdown').not($customDropdown).removeClass('open');
 
-            var $oldThis = $this.closest('ul')
-              .find('li.selected');
-            $oldThis.removeClass('selected');
+              var $oldThis = $this.closest('ul')
+                .find('li.selected');
+              $oldThis.removeClass('selected');
 
-            $this.addClass('selected');
+              $this.addClass('selected');
 
-            $customDropdown.removeClass('open')
-              .find('a.current')
-              .text($this.text());
+              $customDropdown.removeClass('open')
+                .find('a.current')
+                .text($this.text());
 
-            $this.closest('ul').find('li').each(function (index) {
-              if ($this[0] === this) {
-                selectedIndex = index;
-              }
-            });
-            $select[0].selectedIndex = selectedIndex;
+              $this.closest('ul').find('li').each(function (index) {
+                if ($this[0] === this) {
+                  selectedIndex = index;
+                }
+              });
+              $select[0].selectedIndex = selectedIndex;
 
-            //store the old value in data
-            $select.data('prevalue', $oldThis.html());
+              //store the old value in data
+              $select.data('prevalue', $oldThis.html());
             
-            // Kick off full DOM change event
-            if (typeof (document.createEvent) != 'undefined') {
-              var event = document.createEvent('HTMLEvents');
-              event.initEvent('change', true, true);
-              $select[0].dispatchEvent(event);
-            } else {
-              $select[0].fireEvent('onchange'); // for IE
+              // Kick off full DOM change event
+              if (typeof (document.createEvent) != 'undefined') {
+                var event = document.createEvent('HTMLEvents');
+                event.initEvent('change', true, true);
+                $select[0].dispatchEvent(event);
+              } else {
+                $select[0].fireEvent('onchange'); // for IE
+              }
             }
           }
       });

--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -50,7 +50,6 @@
 
     events: function () {
       var self = this;
-          selectScrolled = false;
 
       $(this.scope)
         .on('click.fndtn.forms', 'form.custom span.custom.checkbox', function (e) {
@@ -120,60 +119,45 @@
             return false;
           }
         })
-        .on('click.fndtn.forms touchend.fndtn.forms touchmove.fndtn.forms', 'form.custom div.custom.dropdown li', function (e) {
+        .on('click.fndtn.forms touchend.fndtn.forms', 'form.custom div.custom.dropdown li', function (e) {
           var $this = $(this),
               $customDropdown = $this.closest('div.custom.dropdown'),
               $select = getFirstPrevSibling($customDropdown, 'select'),
               selectedIndex = 0;
 
-          if (e.type == 'touchmove') {
-            selectScrolled = true;
-          }
+          e.preventDefault();
+          e.stopPropagation();
 
-          if (e.type == 'touchend') {
-            if (selectScrolled) {
-              selectScrolled = false;
-            }
-            else if (!selectScrolled) {
-              selectItem();
-            }
-          }
-          else if (e.type == 'click') {
-            selectItem();
-          }
-          
-          function selectItem() {
-            if (!$(this).hasClass('disabled')) {
-              $('div.dropdown').not($customDropdown).removeClass('open');
+          if (!$(this).hasClass('disabled')) {
+            $('div.dropdown').not($customDropdown).removeClass('open');
 
-              var $oldThis = $this.closest('ul')
-                .find('li.selected');
-              $oldThis.removeClass('selected');
+            var $oldThis = $this.closest('ul')
+              .find('li.selected');
+            $oldThis.removeClass('selected');
 
-              $this.addClass('selected');
+            $this.addClass('selected');
 
-              $customDropdown.removeClass('open')
-                .find('a.current')
-                .text($this.text());
+            $customDropdown.removeClass('open')
+              .find('a.current')
+              .text($this.text());
 
-              $this.closest('ul').find('li').each(function (index) {
-                if ($this[0] === this) {
-                  selectedIndex = index;
-                }
-              });
-              $select[0].selectedIndex = selectedIndex;
-
-              //store the old value in data
-              $select.data('prevalue', $oldThis.html());
-            
-              // Kick off full DOM change event
-              if (typeof (document.createEvent) != 'undefined') {
-                var event = document.createEvent('HTMLEvents');
-                event.initEvent('change', true, true);
-                $select[0].dispatchEvent(event);
-              } else {
-                $select[0].fireEvent('onchange'); // for IE
+            $this.closest('ul').find('li').each(function (index) {
+              if ($this[0] === this) {
+                selectedIndex = index;
               }
+            });
+            $select[0].selectedIndex = selectedIndex;
+
+            //store the old value in data
+            $select.data('prevalue', $oldThis.html());
+            
+            // Kick off full DOM change event
+            if (typeof (document.createEvent) != 'undefined') {
+              var event = document.createEvent('HTMLEvents');
+              event.initEvent('change', true, true);
+              $select[0].dispatchEvent(event);
+            } else {
+              $select[0].fireEvent('onchange'); // for IE
             }
           }
       });

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -195,6 +195,7 @@
         animate = new SlideAnimation(slides_container);        
       container.on('click', '.'+settings.next_class, self.next);
       container.on('click', '.'+settings.prev_class, self.prev);
+      container.on('click', '[data-orbit-slide]', self.link_bullet);
       container.on('click', self.toggle_timer);
       container.on('touchstart.fndtn.orbit', function(e) {
         if (!e.touches) {e = e.originalEvent;}
@@ -245,7 +246,6 @@
       });
       
       $(document).on('click', '[data-orbit-link]', self.link_custom);
-      $(document).on('click', '[data-orbit-slide]', self.link_bullet)
       $(window).on('resize', self.compute_dimensions);
       $(window).on('load', self.compute_dimensions);
       slides_container.trigger('orbit:ready');

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -165,7 +165,7 @@
               section.find('>.name').css({right: 100 * topbar.data('index') + '%'});
             }
 
-            topbar.css('height', self.outerHeight($this.siblings('ul'), true) + self.outerHeight(titlebar, true));
+            topbar.css('height', self.outerHeight($this.siblings('ul'), true) + self.height(titlebar));
           }
         });
 
@@ -213,7 +213,7 @@
         if (topbar.data('index') === 0) {
           topbar.css('height', '');
         } else {
-          topbar.css('height', self.outerHeight($previousLevelUl, true) + self.outerHeight(titlebar, true));
+          topbar.css('height', self.outerHeight($previousLevelUl, true) + self.height(titlebar));
         }
 
         setTimeout(function () {

--- a/lib/foundation/generators/templates/application.html.slim
+++ b/lib/foundation/generators/templates/application.html.slim
@@ -22,9 +22,9 @@ head
 
   title == content_for?(:title) ? yield(:title) : "Untitled"
 
-  = stylesheet_link_tag "application"
-  = javascript_include_tag "vendor/custom.modernizr"
-  = csrf_meta_tag
+  == stylesheet_link_tag "application"
+  == javascript_include_tag "vendor/custom.modernizr"
+  == csrf_meta_tag
 
 body
 

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -14,7 +14,7 @@ $base-font-size: 100% !default;
 // Since the typical default browser font-size is 16px, that makes the calculation for grid size.
 // If you want your base font-size to be a different size and not have it effect grid size too,
 // set the value of $em-base to $base-font-size ($em-base: $base-font-size;)
-$em-base: 16 !default;
+$em-base: 16px !default;
 
 // It strips the unit of measure and returns it
 @function strip-unit($num) {

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -374,7 +374,6 @@ $default-float: left;
 
 // $button-border-width: 1px;
 // $button-border-style: solid;
-// $button-border-color: darken($primary-color, $button-function-factor);
 
 // We use this to set the default radius used throughout the core.
 

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -30,7 +30,6 @@ $button-function-factor: 10% !default;
 // We use these to control button border styles.
 $button-border-width: 1px !default;
 $button-border-style: solid !default;
-$button-border-color: darken($primary-color, $button-function-factor) !default;
 
 // We use this to set the default radius used throughout the core.
 $button-radius: $global-radius !default;

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -97,7 +97,7 @@ $glowing-effect-color: $input-focus-border-color !default;
   font-size: $input-font-size;
   margin: 0 0 $form-spacing 0;
   padding: $form-spacing / 2;
-  height: emCalc(13) + ($form-spacing * 1.5);
+  height: ($input-font-size + ($form-spacing * 1.5) - emCalc(1));
   width: 100%;
   @include box-sizing(border-box);
   @if $input-include-glowing-effect {

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -284,11 +284,11 @@ $glowing-effect-color: $input-focus-border-color !default;
   .prefix.button.round { @include radius(0); @include side-radius(left, $button-round); }
   .postfix.button.round { @include radius(0); @include side-radius(right, $button-round); }
 
-  /* Separate prefix and postfix styles when on span so buttons keep their own */
-  span.prefix { @include prefix();
+  /* Separate prefix and postfix styles when on span or label so buttons keep their own */
+  span.prefix,label.prefix { @include prefix();
     &.radius { @include radius(0); @include side-radius(left, $global-radius); }
   }
-  span.postfix { @include postfix();
+  span.postfix,label.postfix { @include postfix();
     &.radius { @include radius(0); @include side-radius(right, $global-radius); }
   }
 


### PR DESCRIPTION
Several properties use the `$em-base` variable directly, so `px` should remain added. 

Looks like it was removed in commit: d7defd3bc0cfbc211a3e746fbf99987241220218
