### PR TITLE
Fixed colors for hover/active in top bar links

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -113,6 +113,16 @@
           }
         })
 
+        .on('mouseenter mouseleave', '.top-bar li, .top-bar li.has-dropdown', function (e) {
+          if (!self.settings.is_hover) return;
+
+          if (/enter|over/i.test(e.type)) {
+            $(this).addClass('hover').siblings().removeClass('hover');
+          } else {
+            $(this).removeClass('hover');
+          }
+        }) 
+
         .on('click.fndtn.topbar', '.top-bar li.has-dropdown', function (e) {
           if (self.breakpoint()) return;
 


### PR DESCRIPTION
The style was applied to `.top-bar-section ul li.hover > a` instead of `.top-bar-section ul li:hover > a` (similarly with .active and :active). This should fix #2823 and the problem mentioned in the most recent comments of #2483.
