### PR TITLE
use $panel-border-color to set panel border color, instead of darken()

### DIFF
--- a/docs/components/panels.html.erb
+++ b/docs/components/panels.html.erb
@@ -77,10 +77,10 @@
           Panel content goes here...
         </div>
 
-        <p>You also have <strong>three options</strong> available to customize the panel within the mixin. These control the background color (which also effect border and font color) and the interior padding of the panel itself.</p>
+        <p>You also have <strong>four options</strong> available to customize the panel within the mixin. These control the background color (which also effect border and font color) and the interior padding of the panel itself.</p>
 
 <%= code_example '
-.your-class-name { @include panel($bg, $padding, $adjust); }
+.your-class-name { @include panel($bg, $border-color, $padding, $adjust); }
 
 /* This controls the background color, border color and type color based on brightness of the bg. */
 $bg: $secondary-color
@@ -106,7 +106,7 @@ $panel-bg: darken(#fff, 5%);
 $panel-border-style: solid;
 $panel-border-size: 1px;
 
-/* We use this % to control how much we darken things on hover */
+/* We use this % to control how much we darken border compared to background */
 $panel-function-factor: 10%;
 $panel-border-color: darken($panel-bg, $panel-function-factor);
 

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -882,7 +882,7 @@ $default-float: left;
 // $panel-border-style: solid;
 // $panel-border-size: 1px;
 
-// We use this % to control how much we darken things on hover
+// We use this % to control how much we darken border compared to background
 
 // $panel-function-factor: 10%;
 // $panel-border-color: darken($panel-bg, $panel-function-factor);

--- a/scss/foundation/components/_panels.scss
+++ b/scss/foundation/components/_panels.scss
@@ -8,7 +8,7 @@ $panel-bg: darken(#fff, 5%) !default;
 $panel-border-style: solid !default;
 $panel-border-size: 1px !default;
 
-// We use this % to control how much we darken things on hover
+// We use this % to control how much we darken border compared to background
 $panel-function-factor: 10% !default;
 $panel-border-color: darken($panel-bg, $panel-function-factor) !default;
 
@@ -27,14 +27,14 @@ $panel-header-adjust: true !default;
 //
 
 // We use this mixin to create panels.
-@mixin panel($bg:$panel-bg, $padding:$panel-padding, $adjust:$panel-header-adjust) {
+@mixin panel($bg:$panel-bg, $border-color:$panel-border-color, $padding:$panel-padding, $adjust:$panel-header-adjust) {
 
   @if $bg {
     $bg-lightness: lightness($bg);
 
     border-style: $panel-border-style;
     border-width: $panel-border-size;
-    border-color: darken($bg, $panel-function-factor);
+    border-color: $panel-border-color;
     margin-bottom: $panel-margin-bottom;
     padding: $padding;
 


### PR DESCRIPTION
$panel-border-color variale was not used anythere.
use $panel-border-color variable to set panel border color, instead of darken()
