### PR TITLE
Fix for topbar + dropdown on iPad

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -140,7 +140,8 @@
         })
 
         .on('click.fndtn.topbar', '.top-bar .has-dropdown>a, [data-topbar] .has-dropdown>a', function (e) {
-          if (self.breakpoint()) {
+          if (self.breakpoint() && $(window).width() != self.settings.breakPoint) {
+
             e.preventDefault();
 
             var $this = $(this),


### PR DESCRIPTION
We were having a hard time getting the topbar links working on iPad with a breakpoint at 768px. It was tripping the javascript to toggle the dropdown and calling preventDefault on the anchor link for our top level nav.

This fix excludes the breakpoint width from tripping the drop down menu code. 
