### PR TITLE
A way to refresh selection in custom select without refreshing the whole component

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -64,7 +64,7 @@
         })
         .on('change.fndtn.forms', 'form.custom select', function (e, force_refresh) {
           if ($(this).is('[data-customforms="disabled"]')) return;
-          self.refresh_custom_select($(this), force_refresh);
+          self.refresh_custom_selection($(this));
         })
         .on('click.fndtn.forms', 'form.custom label', function (e) {
           if ($(e.target).is('label')) {
@@ -405,6 +405,11 @@
         // cache list length
         this.cache[$customSelect.data('id')] = $listItems.length;
       }
+    },
+    
+    refresh_custom_selection: function ($select) {
+      var selectedValue = $('option:selected', $select).text();
+      $('a.current', $select.next()).text(selectedValue);
     },
 
     toggle_checkbox: function ($element) {


### PR DESCRIPTION
When changing the selection in a list, we don't to refresh the whole component (it can be time consumer when the list contains a lot of options)
