### PR TITLE
Fix to show default section with deep_linking

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -349,7 +349,7 @@
           }
         });
 
-        if (!selected && !settings.deep_linking && (settings.one_up || !self.is_horizontal_nav(section) &&
+        if (!selected && (settings.one_up || !self.is_horizontal_nav(section) &&
          !self.is_vertical_nav(section) && !self.is_accordion(section)))
           regions.filter(":visible").first().addClass(self.settings.active_class);
       });


### PR DESCRIPTION
When using deep_linking a default section would not automatically show
when the url did not have a valid hashtag in it. This changes the
behavior to automatically show the first section even if there is not a
valid hashtag visible.

This is related to Issue #2857. 
