### PR TITLE
Fix IE9 Bug: toggleRadio, toggleCheckbox

### DIFF
--- a/javascripts/jquery.customforms.js
+++ b/javascripts/jquery.customforms.js
@@ -142,7 +142,8 @@ jQuery(document).ready(function ($) {
   function toggleCheckbox($element) {
     var $input = $element.prev(),
         input = $input[0];
-
+   if (input == undefined)
+          return false;
     if (false == $input.is(':disabled')) {
         input.checked = ((input.checked) ? false : true);
         $element.toggleClass('checked');
@@ -154,7 +155,8 @@ jQuery(document).ready(function ($) {
   function toggleRadio($element) {
     var $input = $element.prev(),
         input = $input[0];
-
+   if (input == undefined)
+          return false;
     if (false == $input.is(':disabled')) {
       $('input:radio[name="' + $input.attr('name') + '"]').each(function () {
         $(this).next().removeClass('checked');


### PR DESCRIPTION
On IE 9  : 
click on checkbox or radio button label throw exception
input is undefined, and therefore throw exception. 
For this particular case I added an extra check 
to avoid javascript error
