### PR TITLE
Section: when changing the active tab in one section component of the pa...

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -320,7 +320,7 @@
     set_active_from_hash: function() {
       var self = Foundation.libs.section,
           hash = window.location.hash.substring(1),
-          sections = $(self.settings.section_selector);
+          sections = $(self.settings.section_selector).has('div[data-slug="' + hash + '"]');
 
       sections.each(function() {
         var section = $(this),


### PR DESCRIPTION
...ge, don't deactive the tab of other section components.

We have a page with two widgets that use Foundation's section component. When changing the tab on one such component, the tab of the other would get reset as well =(

I'm not sure this is the best way to fix the behaviour, maybe overwriting

```
set_active_from_hash = settings.deep_linking && hash.length > 0,
```

would be an alternative to achieve the same effect!??
