### PR TITLE
Support child elements inside data-dropdown anchors

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -60,7 +60,7 @@
       $('body').on('click.fndtn.dropdown', function (e) {
         var parent = $(e.target).closest('[data-dropdown-content]');
 
-        if ($(e.target).data('dropdown')) {
+        if ($(e.target).data('dropdown') || $(e.target).parent().data('dropdown')) {
           return;
         }
         if (parent.length > 0 && ($(e.target).is('[data-dropdown-content]') || $.contains(parent.first()[0], e.target))) {


### PR DESCRIPTION
If data-dropdown anchor contains a child element (like an image for an
icon), this code will allow the appropriate dropdown functionality to
execute even when those child element are clicked.

Currently, if you place a child element like an image inside of the icon clicking directly on that child element will not cause the dropdown functionality to trigger.
