### PR TITLE
define a specific animation for an alert-box

### DIFF
--- a/js/foundation/foundation.alerts.js
+++ b/js/foundation/foundation.alerts.js
@@ -33,10 +33,13 @@
       var self = this;
 
       $(this.scope).on('click.fndtn.alerts', '[data-alert] a.close', function (e) {
+          var alertBox = $(this).closest("[data-alert]"),
+              settings = $.extend({}, self.settings, self.data_options(alertBox));
+
         e.preventDefault();
-        $(this).closest("[data-alert]").fadeOut(self.speed, function () {
+        alertBox[settings.animation](settings.speed, function () {
           $(this).remove();
-          self.settings.callback();
+          settings.callback();
         });
       });
 


### PR DESCRIPTION
Use another animation than the default _fadeOut_. It can be defined during the initialization:

```
$(document).foundation('alerts', {animation: "slideUp"});
```

or at the element level:

```
<div data-alert class="alert-box" data-options="animation:slideUp">
  This is a notification.
  <a href="#" class="close">&times;</a>
</div>
```

I'm using data-options, I'm not sure what is the convention: data-options or data-animation in this case ?
