### PR TITLE
remove margin-bottom in .contain-to-grid.top-bar

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -385,7 +385,6 @@ $topbar-sticky-class: ".sticky" !default;
     .contain-to-grid .top-bar {
       max-width: $row-width;
       margin: 0 auto;
-      margin-bottom: $topbar-margin-bottom;
     }
 
     .top-bar-section {


### PR DESCRIPTION
A large black background occurs under top-bar, while wraped top-bar it in a div class="fixed contain-to-grid".
