### PR TITLE
Add block-grid mixin setting to specify child element

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -60,7 +60,7 @@ $block-grid-media-queries: true !default;
   @media #{$small} {
     /* Remove small grid clearing */
     @for $i from 1 through $block-grid-elements {
-      .small-block-grid-#{($i)} > #{$child-element}:nth-of-type(#{$i}n+1) { clear: none; }
+      .small-block-grid-#{($i)} > li:nth-of-type(#{$i}n+1) { clear: none; }
     }
     @for $i from 1 through $block-grid-elements {
       .large-block-grid-#{($i)} {

--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -16,7 +16,7 @@ $block-grid-media-queries: true !default;
 
 // We use this mixin to create different block-grids. You can apply per-row and spacing options.
 // Setting $base-style to false will ommit default styles.
-@mixin block-grid($per-row:false, $spacing:$block-grid-default-spacing, $base-style:true) {
+@mixin block-grid($per-row:false, $spacing:$block-grid-default-spacing, $base-style:true, $child-element:"li") {
 
   @if $base-style {
     display: block;
@@ -24,7 +24,7 @@ $block-grid-media-queries: true !default;
     margin: 0 (-$spacing/2);
     @include clearfix;
 
-    &>li {
+    &>#{$child-element} {
       display: inline;
       height: auto;
       float: $default-float;
@@ -33,7 +33,7 @@ $block-grid-media-queries: true !default;
   }
 
   @if $per-row {
-    &>li {
+    &>#{$child-element} {
       width: 100%/$per-row;
       padding: 0 ($spacing/2) $spacing;
 
@@ -60,7 +60,7 @@ $block-grid-media-queries: true !default;
   @media #{$small} {
     /* Remove small grid clearing */
     @for $i from 1 through $block-grid-elements {
-      .small-block-grid-#{($i)} > li:nth-of-type(#{$i}n+1) { clear: none; }
+      .small-block-grid-#{($i)} > #{$child-element}:nth-of-type(#{$i}n+1) { clear: none; }
     }
     @for $i from 1 through $block-grid-elements {
       .large-block-grid-#{($i)} {


### PR DESCRIPTION
Allows mixin to be used for non li elements eg:

```
div.block {
  @include block-grid(4, $child-element:"div");
}
```
