### PR TITLE
Use settings variables for setting the breakpoints.

### DIFF
--- a/scss/foundation/components/_grid-5.scss
+++ b/scss/foundation/components/_grid-5.scss
@@ -157,7 +157,7 @@ $total-columns: 12 !default;
     .columns.small-centered { @include grid-column($center:true, $collapse:null, $float:false); }
   }
 
-  @media only screen and (min-width: 640px) {
+  @media only screen and (min-width: $small-screen) {
 
     @for $i from 1 through $total-columns {
       .medium#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
@@ -184,7 +184,7 @@ $total-columns: 12 !default;
 
   }
 
-  @media only screen and (min-width: 1024px) {
+  @media only screen and (min-width: $medium-screen) {
 
     @for $i from 1 through $total-columns {
       .large#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }


### PR DESCRIPTION
The old medium grid was using hard-coded break points, rather than those set in the settings file.  This change means that using a combination of small-, medium-, large-, hide-on-small, hide-on-medium and hide-on-large will work as expected.
