### PR TITLE
Fix Split Button example markup.

### DIFF
--- a/docs/components/split-buttons.html.erb
+++ b/docs/components/split-buttons.html.erb
@@ -187,7 +187,7 @@ $split-button-pip-default-float-lrg: emCalc(-9);
         <p>To create a dropdown, you'll need to attach a data-attribute to whatever element you want the dropdown attached to (in this case a button). From there, you'll create a list that holds the links or content and add another data-attribute that associates with the element it belongs to. Here's an example of that markup:</p>
 
 <%= code_example '
-<a href="#" data-dropdown="drop1" class="button dropdown">Dropdown Button <span data-dropdown="drop1"></span></a><br>
+<a href="#" class="button split">Dropdown Button <span data-dropdown="drop1"></span></a>
 <ul id="drop1" class="f-dropdown" data-dropdown-content>
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>


### PR DESCRIPTION
The code example for split buttons on http://foundation.zurb.com/docs/components/split-buttons.html is broken. Thanks!
