### PR TITLE
fix abide sample

### DIFF
--- a/docs/components/abide.html.erb
+++ b/docs/components/abide.html.erb
@@ -115,12 +115,12 @@
 <form data-abide>
   <div class="name-field">
     <label>Your name <small>required</small></label>
-    <input type="number" required pattern="[a-zA-Z]+">
+    <input type="text" required pattern="[a-zA-Z]+">
     <small class="error">Name is required and must be a string.</small>
   </div>
   <div class="email-field">
     <label>Email <small>required</small></label>
-    <input type="password" required>
+    <input type="email" required>
     <small class="error">An email address is required.</small>
   </div>
   <button type="submit">Submit</button>


### PR DESCRIPTION
I've found that sample in Abide document page (http://foundation.zurb.com/docs/components/abide.html) doesn't run correctly because it uses incorrect input's type.
