### PR TITLE
Fix "close" event for Reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -80,13 +80,14 @@
         .on('click.fndtn.reveal touchend', this.close_targets(), function (e) {
           e.preventDefault();
           if (!self.locked) {
-            var settings = $.extend({}, self.settings, self.data_options($('.reveal-modal.open')));
-            if ($(e.target)[0] === $('.' + settings.bgClass)[0] && !settings.closeOnBackgroundClick) {
+            var settings = $.extend({}, self.settings, self.data_options($('.reveal-modal.open'))),
+              bgClicked = $(e.target)[0] === $('.' + settings.bgClass)[0];
+            if (bgClicked && !settings.closeOnBackgroundClick) {
               return;
             }
 
             self.locked = true;
-            self.close.call(self, $(this).closest('.reveal-modal'));
+            self.close.call(self, bgClicked ? $('.reveal-modal.open') : $(this).closest('.reveal-modal'));
           }
         })
         .on('open.fndtn.reveal', '.reveal-modal', this.settings.open)


### PR DESCRIPTION
Currently the "close" event is not being fired when the user clicks the
modal backdrop with closeOnBackgroundClick true, since the close event
is being triggered on the closest .reveal-modal parent of the target.
This naturally doesn't exist when the target is the backdrop.
