### PR TITLE
Corrected the hover style for buttons in the top-bar

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -246,25 +246,25 @@ $topbar-sticky-class: ".sticky" !default;
         &.button {
           background: $primary-color;
           font-size: $topbar-link-font-size;
-          &.hover {
+          &:hover {
             background: darken($primary-color, 10%);
           }
         }
         &.button.secondary {
           background: $secondary-color;
-          &.hover {
+          &:hover {
             background: darken($secondary-color, 10%);
           }
         }
         &.button.success {
           background: $success-color;
-          &.hover {
+          &:hover {
             background: darken($success-color, 10%);
           }
         }
         &.button.alert {
           background: $alert-color;
-          &.hover {
+          &:hover {
             background: darken($alert-color, 10%);
           }
         }


### PR DESCRIPTION
I don't quite follow the JavaScript behaviour yet, but It seems that [this change](https://github.com/zurb/foundation/commit/68c529a24104ab6b1f13a301207039310d43b748) altered the way that the "hover" class is applied to the elements, and the SCSS rules seem to imply that the button should be given a **.hover** class.

This PR changes the SCSS to use the **:hover** rule and not require the JS at all. But I'm not sure if this is the intended behaviour.
