### PR TITLE
Using bgClass instead of hardcoding to .reveal-modal-bg

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -131,7 +131,7 @@
         modal.trigger('open');
 
         if (open_modal.length < 1) {
-          this.toggle_bg(modal);
+          this.toggle_bg();
         }
 
         if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
@@ -168,7 +168,7 @@
       if (open_modals.length > 0) {
         this.locked = true;
         modal.trigger('close');
-        this.toggle_bg(modal);
+        this.toggle_bg();
         this.hide(open_modals, this.settings.css.close);
       }
     },
@@ -183,8 +183,8 @@
       return base;
     },
 
-    toggle_bg : function (modal) {
-      if ($('.reveal-modal-bg').length === 0) {
+    toggle_bg : function () {
+      if ($('.' + this.settings.bgClass).length === 0) {
         this.settings.bg = $('<div />', {'class': this.settings.bgClass})
           .appendTo('body');
       }


### PR DESCRIPTION
This caused problems for me because I'm using my own background class, with my own div on the page. When `toggle_bg` is called, it looks for `.reveal-modal-bg` and of course doesn't find it because that's not the class in use. I don't see any reason to hardcode it to look for `.reveal-modal-bg` instead of using `bgClass`.
