### PR TITLE
Update data-orbit-link with data-orbit-slide

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -34,6 +34,12 @@
       }
     };
 
+    self.update_active_link = function(index) {
+      var link = $('a[data-orbit-link="'+slides_container.children().eq(index).attr('data-orbit-slide')+'"]')
+      link.parents('ul').find('[data-orbit-link]').removeClass('active');
+      link.addClass('active');
+    }
+
     self.build_markup = function() {
       slides_container.wrap('<div class="'+settings.container_class+'"></div>');
       container = slides_container.parent();
@@ -72,6 +78,7 @@
       }
 
       self.update_slide_number(0);
+      self.update_active_link(0);
     };
 
     self._goto = function(next_idx, start_timer) {
@@ -95,6 +102,7 @@
 
       slides_container.trigger('orbit:before-slide-change');
       settings.before_slide_change();
+      self.update_active_link(next_idx);
       
       var callback = function() {
         var unlock = function() {

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -36,8 +36,8 @@
 
     self.update_active_link = function(index) {
       var link = $('a[data-orbit-link="'+slides_container.children().eq(index).attr('data-orbit-slide')+'"]')
-      link.parents('ul').find('[data-orbit-link]').removeClass('active');
-      link.addClass('active');
+      link.parents('ul').find('[data-orbit-link]').removeClass(settings.bullets_active_class);
+      link.addClass(settings.bullets_active_class);
     }
 
     self.build_markup = function() {


### PR DESCRIPTION
When a orbit slide changes, any data-orbit-link elements that are
linked to the newly active data-orbit-slide will be updated
accordingly. This is done by adding a class of 'active' to the link
that corresponds to the active slide.

This allows for thumbnail like behaviour for Orbit slideshows.
