### PR TITLE
Removed full width 100% style from switch mixin - fixes conflict with grid and switch css

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -47,7 +47,6 @@ $switch-label-outline: 1px dotted #888 !default;
 
   // Default position and structure for switch container.
   position: relative;
-  width: 100%;
   padding: 0;
   display: block;
   overflow: hidden;


### PR DESCRIPTION
- this fixes the issue where grid col widths and the .switch class do not work together (switch width is currently overriding normally specified grid widths)
- switch will go to full width either way in testing here
- see current foundation 4 demo for an example of grid/switch css conflict
