### PR TITLE
Section reflow fix and nesting fix. 

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -49,7 +49,7 @@
 
           if (section.children(self.settings.content_selector).length > 0) {
             self.toggle_active.call(this, e, self);
-            self.reflow();
+            self.reflow($(this).parents(self.settings.section_selector));
           }
         });
 
@@ -156,10 +156,11 @@
       settings.callback();
     },
 
-    resize : function () {
-      var self = Foundation.libs.section,
-          sections = $(self.settings.section_selector);
-
+      resize: function (sections) {
+        var self = Foundation.libs.section;
+      if (typeof sections === 'undefined') {
+        sections = $(self.settings.section_selector);
+      }
       sections.each(function() {
         var $this = $(this),
             active_section = $this

--- a/scss/foundation/components/_section.scss
+++ b/scss/foundation/components/_section.scss
@@ -99,7 +99,7 @@ $content-selector: ".content" !default;
     &:hover { background-color: $title-bg-hover; }
   }
 
-  #{$content-selector} {
+  > #{$content-selector} {
     display: none;
     padding: $content-padding;
     background-color: $content-bg;
@@ -149,7 +149,7 @@ $content-selector: ".content" !default;
     }
     &:last-child #{$title-selector} { border-#{$opposite-direction}: $section-border-style $section-border-size $section-border-color; }
 
-    #{$content-selector} {
+    > #{$content-selector} {
       border: $section-border-style $section-border-size $section-border-color;
       position: absolute;
       z-index: 10;
@@ -180,7 +180,7 @@ $content-selector: ".content" !default;
     }
     &:first-child #{$title-selector} { border-top: 0; }
 
-    #{$content-selector} {
+    > #{$content-selector} {
       // Display all content blocks to account for the scrollbar
       // in the outerWidth measurements. JavaScript will toggle the active tabs.
       display: block;
@@ -215,7 +215,7 @@ $content-selector: ".content" !default;
         width: 100%;
       }
     }
-    #{$content-selector} { display: none; }
+    > #{$content-selector} { display: none; }
     &:first-child #{$title-selector} { border-bottom: none; }
 
     &.active {
@@ -248,7 +248,7 @@ $content-selector: ".content" !default;
       a { width: 100%; }
     }
 
-    #{$content-selector} { display: none; }
+    > #{$content-selector} { display: none; }
 
     &.active {
       & > #{$content-selector} {


### PR DESCRIPTION
There are two fixes in this branch:

The first fix regards section re-flow, which originally was re-flowing every section on the page every time there was a section click.  We noticed a very large performance issue when we had 8 accordions in our page (with a lot of other stuff). It was taking upwards of 8 seconds to re-flow the sections when a click on a accordion at the bottom of the DOM was clicked. .   After this change the last accordion is just as fast as the first accordion.

The second fix regards nesting tabs and accordions. There was an issue where styles were being applied to the wrong element.   `>` was added to resolve this. 
