### PR TITLE
Made the custom form checkboxes and radios update on the base element changing

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -33,14 +33,19 @@
     },
 
     assemble: function () {
-      $('form.custom input[type="radio"]', $(this.scope))
+
+      var forms = this;
+
+      $('form.custom input[type="radio"],[type="checkbox"]', $(this.scope))
         .not('[data-customforms="disabled"]')
         .not('.' + this.settings.disable_class)
-        .each(this.append_custom_markup);
-      $('form.custom input[type="checkbox"]', $(this.scope))
-        .not('[data-customforms="disabled"]')
-        .not('.' + this.settings.disable_class)
-        .each(this.append_custom_markup);
+        .each(function(idx, sel){
+          forms.set_custom_markup(sel);
+        })
+        .change(function(){
+          forms.set_custom_markup(this);
+        });
+
       $('form.custom select', $(this.scope))
         .not('[data-customforms="disabled"]')
         .not('.' + this.settings.disable_class)
@@ -240,7 +245,7 @@
       }.bind(this), 10);
     },
 
-    append_custom_markup: function (idx, sel) {
+    set_custom_markup: function (sel) {
       var $this = $(sel),
           type = $this.attr('type'),
           $span = $this.next('span.custom.' + type);


### PR DESCRIPTION
Allows you to use javascript that sets checkbox and input value, and have the custom forms update without a full reset of the custom form styling.

Fixes issue [#2840](https://github.com/zurb/foundation/issues/2840#issuecomment-21588888)
