### PR TITLE
Joyride: honor configuration options by calling #events rather than #init so that non-default options aren't wiped

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -121,7 +121,7 @@
           integer_settings = ['timer', 'scrollSpeed', 'startOffset', 'tipAnimationFadeSpeed', 'cookieExpires'],
           int_settings_count = integer_settings.length;
 
-      if (!this.settings.init) this.init();
+      if (!this.settings.init) this.events();
 
       // non configureable settings
       this.settings.$content_el = $this;
@@ -605,7 +605,7 @@
         zIndex: el.css('z-index'),
         position: el.css('position')
       };
-      
+
       origClasses = el.attr('class') == null ? '' : el.attr('class');
 
       el.css('z-index',parseInt(expose.css('z-index'))+1);
@@ -684,7 +684,7 @@
           el.css('position', origCSS.position);
         }
       }
-      
+
       origClasses = el.data('orig-class');
       el.attr('class', origClasses);
       el.removeData('orig-classes');


### PR DESCRIPTION
Custom Joyride options that are properly specified, e.g.

``` javascript
$(document).foundation('joyride', 'start', {
    cookieMonster: true,
    cookieExpires: 600,
    cookieName: 'tour'
});
```

Weren't getting honored. This is because Joyride's #start method calls #init rather than #events--making an unnecessary call to #init that wipes out the custom options.
