### PR TITLE
Joyride breaks if Modernizr isn't included on the page

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -3,6 +3,8 @@
 (function ($, window, document, undefined) {
   'use strict';
 
+  var Modernizr = Modernizr || false;
+
   Foundation.libs.joyride = {
     name : 'joyride',
 
@@ -339,7 +341,7 @@
         return Modernizr.mq('only screen and (max-width: 767px)') || $('.lt-ie9').length > 0;
       }
 
-      return (this.settings.$window.width() < 767);
+      return ($(window).width() < 767);
     },
 
     hide : function () {


### PR DESCRIPTION
JS Error: "Uncaught ReferenceError: Modernizr is not defined" within Joyride's #is_phone method when Modernizr isn't included on the page.

Basically applying [standalone Joyride's](https://github.com/zurb/joyride/blob/master/jquery.joyride-2.1.js#L54) Modernizr falsey assignment check and using the correct window inside #is_phone's fallback when Modernizr is falsey.
