### PR TITLE
Fix margin for custom $button-border-width

### DIFF
--- a/scss/foundation/components/_button-groups.scss
+++ b/scss/foundation/components/_button-groups.scss
@@ -29,7 +29,7 @@ $button-bar-margin-opposite: emCalc(10) !default;
 
   // We use this to control the flow, or remove those styles completely.
   @if $float {
-    margin: 0 0 0 -1px;
+    margin: 0 0 0 (-$button-border-width);
     float: $float;
     // Make sure the first child doesn't get the negative margin.
     &:first-child { margin-#{$default-float}: 0; }


### PR DESCRIPTION
The margin was fixed to "-1px", so if $button-border-width variable was set to custom border-width, it resulted in a disproportionately buttons-group.
