### PR TITLE
Remove margin from ul.no-bullet

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -270,7 +270,10 @@ $microformat-abbr-font-decoration: none !default;
     &.square { list-style-type: square; }
     &.circle { list-style-type: circle; }
     &.disc { list-style-type: disc; }
-    &.no-bullet { list-style: none; }
+    &.no-bullet {
+      list-style: none;
+      margin-#{$default-float}: 0;
+    }
   }
 
   /* Ordered Lists */


### PR DESCRIPTION
I think it's common for people to set `$list-side-margin` to `1.25em` (or so) so the bullets from their lists do not go outside of their grid.

However, I think it doesn't work very well on `ul.no-bullet` where it looks a bit awkward. The items have a margin, but no bullet.

This PR removes the side margin on `ul.no-bullet`:

![ul no-bullet](https://f.cloud.github.com/assets/188390/977454/51699886-06a4-11e3-9149-314c4e7fbbd1.png)
