### PR TITLE
Fix <script> displaying in inline-lists

### DIFF
--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -39,6 +39,7 @@ $inline-list-children-display: block !default;
     margin-#{$default-float}: em-calc(22);
     display: $inline-list-display;
     &>* { display: $inline-list-children-display; }
+    &>script { display: none; }
   }
 }
 


### PR DESCRIPTION
I know it's not a very good code style, but sometimes `script` tag is used not only before closing `body` tag. For example when inserting social widgets code (it really better to keep it in the place you want the widget to be displayed).
This patch fixes displaying javascript code in inline lists.
