### PR TITLE
Added 'opened' and 'closed' events when sections are opened/closed

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -123,14 +123,14 @@
 
       if (!region.hasClass(self.settings.active_class)) {
         prev_active_region.removeClass(self.settings.active_class);
-        prev_active_region.trigger('closed');
+        prev_active_region.trigger('closed.fndtn.section');
         region.addClass(self.settings.active_class);
         //force resize for better performance (do not wait timer)
         self.resize(region.find(self.settings.section_selector).not("[" + self.settings.resized_data_attr + "]"), true);
-        region.trigger('opened');
+        region.trigger('opened.fndtn.section');
       } else if (region.hasClass(self.settings.active_class) && self.is_accordion(section) || !settings.one_up && (self.small(section) || self.is_vertical_nav(section) || self.is_horizontal_nav(section) || self.is_accordion(section))) {
         region.removeClass(self.settings.active_class);
-        region.trigger('closed');
+        region.trigger('closed.fndtn.section');
       }
       settings.callback(section);
     },

--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -123,11 +123,14 @@
 
       if (!region.hasClass(self.settings.active_class)) {
         prev_active_region.removeClass(self.settings.active_class);
+        prev_active_region.trigger('closed');
         region.addClass(self.settings.active_class);
         //force resize for better performance (do not wait timer)
         self.resize(region.find(self.settings.section_selector).not("[" + self.settings.resized_data_attr + "]"), true);
+        region.trigger('opened');
       } else if (region.hasClass(self.settings.active_class) && self.is_accordion(section) || !settings.one_up && (self.small(section) || self.is_vertical_nav(section) || self.is_horizontal_nav(section) || self.is_accordion(section))) {
         region.removeClass(self.settings.active_class);
+        region.trigger('closed');
       }
       settings.callback(section);
     },


### PR DESCRIPTION
Opened/Closed events are extremely useful, and I believe used in the reveal plugin.  It would be nice to have them in the section plugin.  Actually, I thought Foundation already had opened/closed events for several of the section types (accordion in particular), but maybe that was Foundation 3.

This works in my project using my private fork, so I thought I would share it for others that could use a reveal like section system.  There may be a better way to add these events, and somebody more involved with the development of Foundation might do a better job.  So I will not take any offense if this is rejected.

Also, please let me know if there is a testing framework.  I could not find one, but would be happy to write tests for this too.
