### PR TITLE
Check if sticky nav has the fixed class before adding or removing it. 

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -280,13 +280,17 @@
       		});
           $window.scroll(function() {
             if ($window.scrollTop() > (distance)) {
-              $(klass).addClass("fixed");
-              $('body').css('padding-top',offst);
+              if (!$(klass).hasClass("fixed")) {
+                $(klass).addClass("fixed");
+                $('body').css('padding-top',offst);
+              }
             } else if ($window.scrollTop() <= distance) {
-              $(klass).removeClass("fixed");
-              $('body').css('padding-top','0');
+              if ($(klass).hasClass("fixed")) {
+                $(klass).removeClass("fixed");
+                $('body').css('padding-top','0');
+              }
             }
-        });
+          });
       }
     },
 


### PR DESCRIPTION
Not checking for the class existence before calling addClass causes severe framerate drops as it is fired continuously during page scroll.
