### PR TITLE
Style tags other than li (eg; dt and dd) as inline-list elements

### DIFF
--- a/docs/components/inline-lists.html.erb
+++ b/docs/components/inline-lists.html.erb
@@ -82,9 +82,6 @@ $inline-list-overflow: hidden;
 /* We use this to control the list items */
 $inline-list-display: block;
 
-/* We use this to control what tags are considered a list item */
-$list-item-tags: 'li';
-
 /* We use this to control any elements within list items */
 $inline-list-children-display: block;', :css %>
 

--- a/docs/components/inline-lists.html.erb
+++ b/docs/components/inline-lists.html.erb
@@ -82,7 +82,10 @@ $inline-list-overflow: hidden;
 /* We use this to control the list items */
 $inline-list-display: block;
 
-/* We use this to control any elments within list items */
+/* We use this to control what tags are considered a list item */
+$list-item-tags: 'li';
+
+/* We use this to control any elements within list items */
 $inline-list-children-display: block;', :css %>
 
         <p><strong>Note:</strong> <code>em-calc();</code> is a function we wrote to convert <code>px</code> to <code>em</code>. It is included in <strong>_variables.scss</strong>.</p>

--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -17,7 +17,10 @@ $inline-list-overflow: hidden !default;
 // We use this to control the list items
 $inline-list-display: block !default;
 
-// We use this to control any elments within list items
+// We use this to control what tags are considered a list item
+$list-item-tags: 'li';
+
+// We use this to control any elements within list items
 $inline-list-children-display: block !default;
 
 //
@@ -33,7 +36,7 @@ $inline-list-children-display: block !default;
   list-style: none;
   overflow: $inline-list-overflow;
 
-  & > li {
+  & > #{$list-item-tags} {
     list-style: none;
     float: $default-float;
     margin-#{$default-float}: em-calc(22);

--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -17,9 +17,6 @@ $inline-list-overflow: hidden !default;
 // We use this to control the list items
 $inline-list-display: block !default;
 
-// We use this to control what tags are considered a list item
-$list-item-tags: 'li';
-
 // We use this to control any elements within list items
 $inline-list-children-display: block !default;
 
@@ -36,7 +33,7 @@ $inline-list-children-display: block !default;
   list-style: none;
   overflow: $inline-list-overflow;
 
-  & > #{$list-item-tags} {
+  & > * {
     list-style: none;
     float: $default-float;
     margin-#{$default-float}: em-calc(22);


### PR DESCRIPTION
Added a variable ($list-item-tags) allowing any tag to be used as a list-item while leaving the default behavior the same. Nice if using descriptive lists or doing something odd.

Also fixed a typo.
