### PR TITLE
Grid 5 @media tag adjustment

### DIFF
--- a/scss/foundation/components/_grid-5.scss
+++ b/scss/foundation/components/_grid-5.scss
@@ -13,8 +13,8 @@
 // Grid Variables
 //
 $include-html-grid-classes: true !default;
-$row-width: em-calc(1000) !default;
-$column-gutter: em-calc(30) !default;
+$row-width: emCalc(1000) !default;
+$column-gutter: emCalc(30) !default;
 $total-columns: 12 !default;
 
 //
@@ -157,7 +157,7 @@ $total-columns: 12 !default;
     .columns.small-centered { @include grid-column($center:true, $collapse:null, $float:false); }
   }
 
-  @media only screen and (min-width: $small-screen) {
+  @media #{$small} {
 
     @for $i from 1 through $total-columns {
       .medium#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
@@ -184,7 +184,7 @@ $total-columns: 12 !default;
 
   }
 
-  @media only screen and (min-width: $medium-screen) {
+  @media #{$medium} {
 
     @for $i from 1 through $total-columns {
       .large#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }

--- a/scss/foundation/components/_grid-5.scss
+++ b/scss/foundation/components/_grid-5.scss
@@ -13,8 +13,8 @@
 // Grid Variables
 //
 $include-html-grid-classes: true !default;
-$row-width: emCalc(1000) !default;
-$column-gutter: emCalc(30) !default;
+$row-width: em-calc(1000) !default;
+$column-gutter: em-calc(30) !default;
 $total-columns: 12 !default;
 
 //
@@ -157,7 +157,7 @@ $total-columns: 12 !default;
     .columns.small-centered { @include grid-column($center:true, $collapse:null, $float:false); }
   }
 
-  @media #{$small} {
+  @media only screen and (min-width: $small-screen) {
 
     @for $i from 1 through $total-columns {
       .medium#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
@@ -184,7 +184,7 @@ $total-columns: 12 !default;
 
   }
 
-  @media #{$medium} {
+  @media only screen and (min-width: $medium-screen) {
 
     @for $i from 1 through $total-columns {
       .large#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }


### PR DESCRIPTION
Unlike _grid.scss, for some reason, the @media tags in _grid-5.scss are using a different syntax. I changed it to resemble the syntax in _grid.scss so they match up and use the proper grid variables.
