### PR TITLE
Empty fields are not marked with 'error' when a user is tabbing through the form

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -11,6 +11,7 @@
     settings : {
       live_validate : true,
       focus_on_invalid : true,
+      ignore_empty: false,
       timeout : 1000,
       patterns : {
         alpha: /[a-zA-Z]+/,
@@ -88,6 +89,9 @@
     },
 
     validate : function (els, e) {
+      if (!$(this).val() && this.settings.ignore_empty) {
+        return false;
+      }
       var validations = this.parse_patterns(els),
           validation_count = validations.length,
           form = $(els[0]).closest('form');

--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -89,7 +89,7 @@
     },
 
     validate : function (els, e) {
-      if (!$(this).val() && this.settings.ignore_empty) {
+      if (!$(e.target).val() && this.settings.ignore_empty) {
         return false;
       }
       var validations = this.parse_patterns(els),


### PR DESCRIPTION
If 'ignore_empty' is set to 'true' and a user is hitting TAB to navigate through Abide forms then no validation is triggered. The validation
only occurs if the user has entered something into the input field.

By default the 'ignore_empty' is set to 'false' and validation still
occurs normally. One must set 'ignore_empty' to 'true' during
Foundation initialisation to activate this behaviour.

But, perhaps 'ignore_empty' should be set to 'true' by default? I think
that in most cases you'd want the user to tab through the form and fill
it out in any order they wish. It seems a bit strange to have errors
popping up when I haven't yet filled out the form. And if I submit an
incomplete form, I'll get those errors anyway. Just a thought :)
