### PR TITLE
Made  display: block important. Fixes issue with using jquery show on error messages

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -238,7 +238,7 @@ $glowing-effect-color: $input-focus-border-color !default;
 
 // We use this mixin to create error message styles
 @mixin form-error-message($bg:$alert-color) {
-  display: block;
+  display: block !important;
   padding: $input-error-message-padding;
   margin-top: $input-error-message-top;
   margin-bottom: $form-spacing;


### PR DESCRIPTION
This fixes an issue where you use jquery's show method on a error messag following an input. jQuery adds uses the style attribute to set the display to inline, which causes the message to not stick to the input.
