### PR TITLE
Reveal z-index conflict with opened top-bar menu on iPhone

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -65,62 +65,70 @@
       }
     },
 
+    toggle: function() {
+      var self = this;
+      var topbar = $('.top-bar, [data-topbar]'),
+          section = topbar.find('section, .section'),
+          titlebar = topbar.children('ul').first();
+
+      var offst = self.outerHeight(topbar);
+      if (self.breakpoint()) {
+        if (!self.rtl) {
+          section.css({left: '0%'});
+          section.find('>.name').css({left: '100%'});
+        } else {
+          section.css({right: '0%'});
+          section.find('>.name').css({right: '100%'});
+        }
+
+        section.find('li.moved').removeClass('moved');
+        topbar.data('index', 0);
+
+        topbar
+          .toggleClass('expanded')
+          .css('height', '');
+      }
+
+      if (!topbar.hasClass('expanded')) {
+        if (topbar.hasClass('fixed')) {
+          topbar.parent().addClass('fixed');
+          topbar.removeClass('fixed');
+          $('body').css('padding-top',offst);
+        }
+      } else if (topbar.parent().hasClass('fixed')) {
+        topbar.parent().removeClass('fixed');
+        topbar.addClass('fixed');
+        $('body').css('padding-top','0');
+
+        if (self.settings.scrolltop) {
+          window.scrollTo(0,0);
+        }
+      }
+    },
+
     timer : null,
 
     events : function () {
       var self = this;
-      var offst = this.outerHeight($('.top-bar, [data-topbar]'));
       $(this.scope)
         .off('.fndtn.topbar')
         .on('click.fndtn.topbar', '.top-bar .toggle-topbar, [data-topbar] .toggle-topbar', function (e) {
-          var topbar = $(this).closest('.top-bar, [data-topbar]'),
-              section = topbar.find('section, .section'),
-              titlebar = topbar.children('ul').first();
-
           e.preventDefault();
-
-          if (self.breakpoint()) {
-            if (!self.rtl) {
-              section.css({left: '0%'});
-              section.find('>.name').css({left: '100%'});
-            } else {
-              section.css({right: '0%'});
-              section.find('>.name').css({right: '100%'});
-            }
-
-            section.find('li.moved').removeClass('moved');
-            topbar.data('index', 0);
-
-            topbar
-              .toggleClass('expanded')
-              .css('height', '');
-          }
-
-          if (!topbar.hasClass('expanded')) {
-            if (topbar.hasClass('fixed')) {
-              topbar.parent().addClass('fixed');
-              topbar.removeClass('fixed');
-              $('body').css('padding-top',offst);
-            }
-          } else if (topbar.parent().hasClass('fixed')) {
-            topbar.parent().removeClass('fixed');
-            topbar.addClass('fixed');
-            $('body').css('padding-top','0');
-
-            if (self.settings.scrolltop) {
-              window.scrollTo(0,0);
-            }
-          }
+          self.toggle();
         })
 
         .on('click.fndtn.topbar', '.top-bar li.has-dropdown', function (e) {
-          if (self.breakpoint()) return;
-
           var li = $(this),
               target = $(e.target),
               topbar = li.closest('[data-topbar], .top-bar'),
               is_hover = topbar.data('topbar');
 
+          if(target.data('revealId')) {
+            self.toggle();
+            return;
+          }
+
+          if (self.breakpoint()) return;
           if (self.settings.is_hover && !Modernizr.touch) return;
 
           e.stopImmediatePropagation();


### PR DESCRIPTION
When bringing up a reveal modal that overlays a dropped down top-bar menu, the touch area for the menu is above the z-index of the modal, making it difficult to close the modal.

A fix for this was to increase the z-index of both .reveal-modal-bg and .reveal-modal from 98 and 99 to 198 and 199 respectively.

It appears the issue is with the .fixed class which also shares the default z-index of 99. I haven't test this, but I am sure that moving the .fixed class to a z-index of 97 (below the modal) should solve the conflict also.
