### PR TITLE
Make old WebKit workaround a bit more specific and turn it off for high-density devices

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -126,7 +126,13 @@ $switch-label-outline: 1px dotted #888 !default;
 
   // Bugfix for older Webkit, including mobile Webkit. Adapted from:
   // http://css-tricks.com/webkit-sibling-bug/
-  @if $experimental { -webkit-animation: webkitSiblingBugfix infinite 1s; }
+  @media only screen and (-webkit-min-device-pixel-ratio:0) and (max-device-width:480px) {
+    @if $experimental { -webkit-animation: webkitSiblingBugfix infinite 1s; }
+  }
+
+  @media only screen and (-webkit-min-device-pixel-ratio:1.5) {
+    @if $experimental { -webkit-animation: none 0; }
+  }
 
   form.custom & .hidden-field {
     margin-left: auto;
@@ -256,6 +262,5 @@ $switch-label-outline: 1px dotted #888 !default;
     }
 
     @if $experimental { @-webkit-keyframes webkitSiblingBugfix { from { position: relative; } to { position: relative; } } }
-
   }
 }


### PR DESCRIPTION
This change for issue #2725 makes the Webkit bugfix a bit more specific and turns it off for higher dpi devices that would be running a newer version of Webkit.
