### PR TITLE
Prevent tap highlight on Mobile Safari

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -278,7 +278,10 @@ $cursor-text-value: text !default;
   }
 
   html,
-  body { font-size: $base-font-size; }
+  body {
+    font-size: $base-font-size;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  }
 
   // Default body styles
   body {


### PR DESCRIPTION
When I touch a input tag on webkit based mobile browsers (Safari and Chrome), it appears a gray box overlay on input tag. It's not very good. I checked Bootstrap 3 and it disabled this behavior. So I google for the solution and add  this pull request.

You can also see this:
http://stackoverflow.com/questions/3463527/when-you-touch-an-html-element-in-safari-on-the-ipad-it-turns-gray-what-is-the
