### PR TITLE
Update _top-bar.css to support active class on li>a links

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -282,7 +282,7 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
       }
 
       // Apply the active link color when it has that class
-      &.active > a {
+      &.active > a, & > a.active {
         background: $topbar-link-bg-active;
         color: $topbar-link-color-active;
       }
@@ -521,7 +521,7 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
         }
 
         // Apply the active link color when it has that class
-        &:active > a {
+        &:active > a, & > a.active {
           background: $topbar-link-bg-active;
           color: $topbar-link-color-active;
         }


### PR DESCRIPTION
Ember.js automatically adds the 'active' class to links which reflect the current route, so it would be great to be able to support the .active UI look where the active class is on the "a" element inside a plain "li" element.
