### PR TITLE
Removing unnecessary form error margin overrides.

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -356,7 +356,6 @@ $glowing-effect-color: $input-focus-border-color !default;
   [data-abide] {
     .error small.error, span.error, small.error {
       @include form-error-message;
-      margin-top: 0;
     }
     span.error, small.error { display: none; }
   }
@@ -368,7 +367,6 @@ $glowing-effect-color: $input-focus-border-color !default;
     textarea,
     select {
       @include form-error-color;
-      margin-bottom: 0;
     }
 
     label,


### PR DESCRIPTION
A discussion has started at https://github.com/zurb/foundation/commit/58fd962bc5827202d31a2a66fe8422200146cef3#L6R366, specifically line 366 of _form.scss.

The margin-bottom breaks all inputs with a parent class of .error, which would of broken docs. In 8cfb5ffec491cf0baf6b0e4114c18a00c6b22a65 a margin-top override was introduced for the sibling small element.

Instead, removing both overrides will resolve docs, and any end users.
