### PR TITLE
large medium & small @media queries

### DIFF
--- a/scss/foundation/components/_grid-5.scss
+++ b/scss/foundation/components/_grid-5.scss
@@ -140,7 +140,13 @@ $total-columns: 12 !default;
   .column,
   .columns { @include grid-column($columns:$total-columns, $include-position-relative: true); }
 
-  @media only screen {
+    @media only screen {
+
+    [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
+    [class*="column"] + [class*="column"].end { float: $default-float; }
+
+  }
+  @media only screen and (min-width: $small-screen) {
 
     @for $i from 1 through $total-columns {
       .small#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
@@ -150,14 +156,24 @@ $total-columns: 12 !default;
       .small-offset-#{$i} { @include grid-column($offset:$i, $collapse:null,$float:false); }
     }
 
-    [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
-    [class*="column"] + [class*="column"].end { float: $default-float; }
-
+    @for $i from 1 through $total-columns - 1 {
+      .small-push#{-$i} { @include grid-column($push:$i, $collapse:null, $float:false); }
+      .small-pull#{-$i} { @include grid-column($pull:$i, $collapse:null, $float:false); }
+    }
+    
     .column.small-centered,
     .columns.small-centered { @include grid-column($center:true, $collapse:null, $float:false); }
+
+    .column.small-uncentered,
+    .columns.small-uncentered {
+      margin-#{$default-float}: 0;
+      margin-#{$opposite-direction}: 0;
+      float: $default-float !important;
+    }
+
   }
 
-  @media only screen and (min-width: $small-screen) {
+  @media only screen and (min-width: $medium-screen) {
 
     @for $i from 1 through $total-columns {
       .medium#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
@@ -184,7 +200,7 @@ $total-columns: 12 !default;
 
   }
 
-  @media only screen and (min-width: $medium-screen) {
+  @media only screen and (min-width: $large-screen) {
 
     @for $i from 1 through $total-columns {
       .large#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }


### PR DESCRIPTION
I tried to use the combination fo large-7 medium-6 small-8 in an 8 columns grid, but the small is not using the same as Media Queries setted from _variables.scss, that´s why I made this mini change and now the grids work perfectly.
