### PR TITLE
Firefox input line-weight error

### DIFF
--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -51,7 +51,7 @@ $button-disabled-opacity: 0.6 !default;
     cursor: $cursor-pointer-value;
     font-family: $button-font-family;
     font-weight: $button-font-weight;
-    line-height: 1;
+    line-height: normal;
     margin: 0 0 $button-margin-bottom;
     position: relative;
     text-decoration: none;


### PR DESCRIPTION
#3004 and #2648 - In Firefox the property line-weight does not change the input tag
