### PR TITLE
avoid treating zero as a falsey value

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -120,7 +120,7 @@
     },
 
     set_threshold : function () {
-      if (!this.settings.threshold) {
+      if (typeof this.settings.threshold !== 'number') {
         this.settings.threshold = (this.fixed_magellan.length > 0) ? 
           this.outerHeight(this.fixed_magellan, true) : 0;
       }


### PR DESCRIPTION
This allows you to use : 

```
$(document).foundation('magellan', { threshold: 0 })
```

and not have it be overridden with some unrelated number.
