### PR TITLE
Topbar - With increased height, the dropdown symbol in a dropdown menu, is pushed down almost one line.

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -449,7 +449,8 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
             &:after {
               border: none;
               content: "\00bb";
-              margin-top: -16px;
+              top: 1em;
+              margin-top: -7px;
               #{$opposite-direction}: 5px;
             }
           }


### PR DESCRIPTION
Removed!
