### PR TITLE
$topbar-dropdown-label-bg can't be overridden.

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -449,7 +449,8 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
             &:after {
               border: none;
               content: "\00bb";
-              margin-top: -16px;
+              top: 1em;
+              margin-top: -7px;
               #{$opposite-direction}: 5px;
             }
           }

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -41,7 +41,7 @@ $topbar-dropdown-label-color: #555 !default;
 $topbar-dropdown-label-text-transform: uppercase !default;
 $topbar-dropdown-label-font-weight: bold !default;
 $topbar-dropdown-label-font-size: em-calc(10) !default;
-$topbar-dropdown-label-bg: lighten($topbar-bg-color, 5%);
+$topbar-dropdown-label-bg: lighten($topbar-bg-color, 5%) !default;
 
 // Top menu icon styles
 $topbar-menu-link-transform: uppercase !default;


### PR DESCRIPTION
`$topbar-dropdown-label-bg` needs `!default` in its declaration in file `_topbar.scss`.
https://github.com/zurb/foundation/blob/master/scss/foundation/components/_top-bar.scss#L44

``` scss
$topbar-dropdown-label-bg: lighten($topbar-bg-color, 5%);
```

Right now I can not override its value.
