### PR TITLE
Add $topbar-link-hover-bg, instead of just being black.

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -143,6 +143,9 @@
               .removeClass('hover')
               .find('li')
               .removeClass('hover');
+
+            li.parents('li.hover')
+              .removeClass('hover');
           } else {
             li.addClass('hover');
           }
@@ -185,7 +188,7 @@
       }.bind(this));
 
       $('body').on('click.fndtn.topbar', function (e) {
-        var parent = $(e.target).closest('[data-topbar], .top-bar');
+        var parent = $(e.target).closest('li').closest('li.hover');
 
         if (parent.length > 0) {
           return;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -33,7 +33,7 @@ $topbar-link-color-active: #fff !default;
 $topbar-link-weight: bold !default;
 $topbar-link-font-size: em-calc(13) !default;
 $topbar-link-hover-lightness: -30% !default; // Darken by 30%
-$topbar-link-bg-hover: darken($topbar-bg-color, 3%) !default;
+$topbar-link-bg-hover: adjust-color($topbar-dropdown-bg, $lightness: $topbar-link-hover-lightness) !default;
 $topbar-link-bg-active: darken($topbar-bg-color, 3%) !default;
 
 
@@ -413,11 +413,17 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
       }
 
       li {
+        &.hover { 
+          > a:not(.button) {
+            background: $topbar-link-bg-hover;
+            color: $topbar-link-color-hover;
+          }
+        }
         a:not(.button) {
           padding: 0 $topbar-height / 3;
           line-height: $topbar-height;
           background: $topbar-bg;
-          &.hover, &:hover { background: adjust-color($topbar-dropdown-bg, $lightness: $topbar-link-hover-lightness); }
+          &:hover { background: $topbar-link-bg-hover; }
         }
       }
 


### PR DESCRIPTION
I have to override the standard black color with the following rule:

.top-bar-section li a:not(.button):hover {
  background-color: $topbar-menu-link-color-toggled;
}

It would be great if that was a variable set instead, so I didn't have to have that mess in my stylesheet.

I'd love to submit a PR on that if it's something you'd be interested in.
