### PR TITLE
Reinstate form error message styles for `.error small`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ test/css/styles.css
 node_modules
 docs/public/*
 *.scssc
-config.rb
 stylesheets/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ test/css/styles.css
 node_modules
 docs/public/*
 *.scssc
+config.rb
+stylesheets/

--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,25 @@
+# Require any additional compass plugins here.
+
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+css_dir = "stylesheets"
+sass_dir = "scss"
+images_dir = "images"
+javascripts_dir = "js"
+
+# You can select your preferred output style here (can be overridden via the command line):
+# output_style = :expanded or :nested or :compact or :compressed
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+# relative_assets = true
+
+# To disable debugging comments that display the original location of your selectors. Uncomment:
+# line_comments = false
+
+
+# If you prefer the indented syntax, you might want to regenerate this
+# project again passing --syntax sass, or you can uncomment this:
+# preferred_syntax = :sass
+# and then run:
+# sass-convert -R --from scss --to sass sass scss && rm -rf sass && mv scss sass

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -98,7 +98,7 @@ $default-float: left;
 // $include-html-media-classes: $include-html-classes;
 // $include-html-section-classes: $include-html-classes;
 // $include-html-orbit-classes: $include-html-classes;
-// $include-html-reveal-classes: $include-html-classes;
+$include-html-reveal-classes: false;
 // $include-html-joyride-classes: $include-html-classes;
 // $include-html-clearing-classes: $include-html-classes;
 // $include-html-alert-classes: $include-html-classes;
@@ -165,8 +165,8 @@ $default-float: left;
 // $header-font-style: normal;
 // $header-font-color: #222;
 // $header-line-height: 1.4;
-// $header-top-margin: .2em;
-// $header-bottom-margin: .5em;
+$header-top-margin: .625em;
+$header-bottom-margin: .313em;
 // $header-text-rendering: optimizeLegibility;
 
 // Control header font sizes
@@ -220,7 +220,7 @@ $default-float: left;
 // $hr-border-width: 1px;
 // $hr-border-style: solid;
 // $hr-border-color: #ddd;
-// $hr-margin: emCalc(20);
+$hr-margin: emCalc(15);
 
 // Style lists
 
@@ -1234,7 +1234,7 @@ $default-float: left;
 
 // Background color for the top bar
 
-// $topbar-bg: #111;
+$topbar-bg: #4d4235;
 
 // Height and margin
 
@@ -1252,7 +1252,7 @@ $default-float: left;
 
 // Style the top bar dropdown elements
 
-// $topbar-dropdown-bg: #222;
+$topbar-dropdown-bg: #9a7c59;
 // $topbar-dropdown-link-color: #fff;
 // $topbar-dropdown-link-bg: lighten($topbar-bg, 5%);
 // $topbar-dropdown-toggle-size: 5px;

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -376,6 +376,7 @@ $glowing-effect-color: $input-focus-border-color !default;
       @include form-label-error-color;
     }
 
+    small,
     small.error {
       @include form-error-message;
     }

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -356,7 +356,6 @@ $glowing-effect-color: $input-focus-border-color !default;
   [data-abide] {
     .error small.error, span.error, small.error {
       @include form-error-message;
-      margin-top: 0;
     }
     span.error, small.error { display: none; }
   }
@@ -368,7 +367,6 @@ $glowing-effect-color: $input-focus-border-color !default;
     textarea,
     select {
       @include form-error-color;
-      margin-bottom: 0;
     }
 
     label,

--- a/scss/funsha.scss
+++ b/scss/funsha.scss
@@ -1,0 +1,227 @@
+// Make sure the charset is set appropriately
+@charset "UTF-8";
+
+// This includes all of the foundation global elements that are needed to work with any of the other files.
+@import "foundation/variables";
+
+// We need just the mixins
+$include-html-alert-classes: false;
+@import "foundation/components/alert-boxes";
+
+// We need just the mixins
+$include-html-reveal-classes: false;
+@import "foundation/components/reveal";
+
+@import "compass/css3/transition";
+@import "compass/css3/box-shadow";
+
+//
+// Funsha Variables
+//
+$include-html-funsha-classes: true !default;
+
+//
+// Funsha Mixins
+//
+@mixin notice-box($bg, $radius) {
+    @include alert($bg, $radius);
+    top: 200px;
+    left: 50%;
+    position: fixed;
+    z-index: 100;
+    padding: 10px;
+    margin-left: -260px;
+    width: 520px;
+    @include box-shadow(0 0 10px rgba(0, 0, 0, 0.4));
+    opacity: 0;
+    visibility: hidden;
+
+    &.fade {
+        @include transition(opacity 0.3s ease, visibility 0.3s ease);
+    }
+
+    &.fade.in {
+        opacity: 1;
+        visibility: visible;
+    }
+
+    i {
+        font-size: 2em;
+        margin-right: 20px;
+        vertical-align: middle;
+    }
+
+    span {
+        vertical-align: middle;
+    }
+
+    .close { @include alert-close; }
+}
+
+@mixin mod-reveal-bg {
+    @include reveal-bg;
+    // display: block;
+
+    &.fade {
+        opacity: 0;
+    }
+
+    &, &.fade.in {
+        opacity: 0.8;
+        filter: alpha(opacity=80);
+    }
+}
+
+@if $include-html-funsha-classes != false {
+    /* Modified Foundation 4 Reveal classes
+     * Use Foundation 4 default as base and mix in some Bootstrap classe names,
+     * in order to make the Reveal classes compatible with AngularUI Bootstrap's
+     * `$modal` service.
+     */
+    .reveal-modal-bg {
+        @include mod-reveal-bg;
+    }
+
+    .reveal-modal {
+        @include reveal-modal-base;
+        // visibility: visible;
+        // display: block;
+
+        @include reveal-modal-style;
+
+        &.fade {
+            opacity: 0;
+            @include transition(opacity 0.3s linear);
+        }
+
+        &.fade.in {
+            opacity: 1;
+        }
+    }
+
+    span.hint, p.hint, ul.hint {
+        color: #6f6f6f;
+        font-size: 12px;
+    }
+
+    #page_header {
+        margin-bottom: 20px;
+        background-color: #F7F6F0;
+        border-radius: 0 0 10px 10px;
+    }
+
+    .btn_section {
+        text-align: right;
+    }
+
+    /* Supplementary to AngularJS */
+
+    [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
+        display: none !important;
+    }
+
+    // Taken from Bootstrap to supplement the `collapse` directive
+    .ng_ui_collapse {
+        position: relative;
+        height: 0;
+        overflow: hidden;
+        @include transition(height 0.35s ease);
+    }
+
+
+    /* Top navigation bar */
+
+    a#user_dropdown_toggle {
+        padding-right: $topbar-height / 3 !important;   // overrides Foundation's default for .has-dropdown > a
+
+        &:after {
+            content: none;  // clears Foundation's default triangle for dropdown
+        }
+
+        & > span {
+            margin-right: 10px;
+        }
+    }
+
+    input#quick_search {
+        width: 145px;
+        @include transition(width 0.1s ease);
+    }
+
+
+    /* Alert boxes (success action notice and top alert box) */
+
+    .notice-box-bg {
+        @include mod-reveal-bg;
+    }
+
+    .alert_notice {
+        @include notice-box($alert-color, $alert-radius);
+    }
+
+    .succ_notice {
+        @include notice-box($success-color, $alert-radius);
+    }
+
+    .dialog_alert_notice {
+        @include alert($alert-color);
+
+        i {
+            font-size: 1.2em;
+            margin-right: 5px;
+            vertical-align: middle;
+        }
+
+        span {
+            vertical-align: middle;
+        }
+    }
+
+
+    /* Input tooltip (ex. pwd strength) */
+
+    .input_tooltip {
+        position: absolute;
+        top: -15px;
+        left: 101%;
+        width: 320px;
+        padding: 10px;
+        background: #fefefe;
+        border-radius: 2px;
+        box-shadow: 0 0 5px #aaa;
+        border: 1px solid #ddd;
+        z-index: 40;
+
+        ul {
+            list-style-position: inside;
+        }
+
+        .left_arrow {
+            position:absolute;
+            top:25px;
+            left:-10px;
+            width: 10px;
+            height: 10px;
+        }
+
+        .pwd_fragile {
+            // TODO: [Patrick] define a colour for `fragile` strength
+        }
+
+        .pwd_weak {
+            color: #c60f13;
+        }
+
+        .pwd_fair {
+            // TODO: [Patrick] define a colour for `fair` strength
+        }
+
+        .pwd_good {
+            color: #CCCC33;
+        }
+
+        .pwd_strong {
+            color: #5da423;
+        }
+    }
+}

--- a/scss/funsha.scss
+++ b/scss/funsha.scss
@@ -4,13 +4,15 @@
 // This includes all of the foundation global elements that are needed to work with any of the other files.
 @import "foundation/variables";
 
-// We need just the mixins
+// We need just the mixins and variables.
+$include-html-global-classes: false;
+@import "foundation/components/global";
 $include-html-alert-classes: false;
 @import "foundation/components/alert-boxes";
-
-// We need just the mixins
 $include-html-reveal-classes: false;
 @import "foundation/components/reveal";
+$include-html-top-bar-classes: false;
+@import "foundation/components/top-bar";
 
 @import "compass/css3/transition";
 @import "compass/css3/box-shadow";

--- a/scss/my_account.scss
+++ b/scss/my_account.scss
@@ -1,3 +1,6 @@
+// Make sure the charset is set appropriately
+@charset "UTF-8";
+
 #loc_book_tab .object_list button {
     font-size: 12px;
 }

--- a/scss/my_account.scss
+++ b/scss/my_account.scss
@@ -1,0 +1,70 @@
+#loc_book_tab .object_list button {
+    font-size: 12px;
+}
+
+.form_header h6 {
+    display: inline-block;
+}
+
+.edit_submit {
+    margin-left: 5px;
+}
+
+.primary_loc_icon {
+    margin-left: 10px;
+}
+
+.loc_map {
+    display: block;
+    width: 450px;
+    height: 300px;
+    background: #eee;
+    border: 1px solid #ccc;
+    margin: 0 auto;
+}
+
+// TODO: [Patrick] "user_img_container" exists in both general.css and
+// my_account.css. Each page-level css will be combined with general.css
+// to form one single CSS file for the corresponding page to link to, and
+// thus same name should not be used in both general.css and any of the
+// page-level css files to avoid confusion, or even, runtime errors.
+#personal_info_tab .profile_pic_container {
+    width: 240px;
+}
+
+#personal_info_tab form .field_error {
+    margin: 10px 0 0;
+}
+
+#crop_pic_form {
+    .container {
+        background: #eee;
+        border: 1px solid #ccc;
+
+        &.original_pic {
+            width: 360px;
+            height: 360px;
+
+            img {
+                // TODO: [Patrick] Make the img fill its containing element.
+                // The img should be centered if it doesn't fill up its containing element.
+            }
+        }
+
+        &.cropped_preview {
+            width: 200px;
+            height: 200px;
+            overflow: hidden;
+
+            img {
+                max-width: none;
+            }
+        }
+    }
+
+    .arrow {
+        margin-top: 100px;
+        font-size: 3em;
+        color: #ccc;
+    }
+}


### PR DESCRIPTION
According to the [official docs](http://foundation.zurb.com/docs/components/forms.html), when `.error` class is attached to a div/column that wraps around a `<small>`, the `<small>` should be styled in error message. It, indeed, had always been like that, but has stopped working since v4.3.0, in which abide was added. 

Below is a screenshot of the docs, which serves as a clear demo of the issue. Note the `<small>` associated with "Another error" is not properly styled. 
![screen shot 2013-09-04 at 12 42 55 pm](https://f.cloud.github.com/assets/538353/1085381/072bdca0-15ce-11e3-8827-57e3c5850a97.png)

The issue was introduced in commit [b5e9d05](https://github.com/zurb/foundation/commit/b5e9d05311544881e11af710bdd85113a9b7857b#scss/foundation/components/_forms.scss).

It has been reported in [issue 2906](https://github.com/zurb/foundation/issues/2906).

This fix is so simple that I am afraid that I don't see the complete picture and thus might have introduced other issues with this PR. Someone please take a look for me. Thx. 
