### PR TITLE
Top bar, fixed and contain-to-grid

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -83,6 +83,24 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
     position: fixed;
     top: 0;
     z-index: 99;
+  
+    &.expanded:not(.top-bar) {
+        overflow-y: auto; 
+        height: auto;
+        width: 100%;
+        max-height: 100%;
+
+      .title-area {
+        position: fixed;
+        width: 100%;
+        z-index: 99;
+      }
+      // Ensure you can scroll the menu on small screens 
+      .top-bar-section {
+        z-index: 98;
+        margin-top: $topbar-height;
+      }
+    }
   }
 
   .top-bar {
@@ -313,7 +331,7 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
 
       &.moved { position: static;
         & > .dropdown {
-          visibility: visible;
+          display: block;
         }
       }
     }
@@ -323,7 +341,7 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
       position: absolute;
       #{$default-float}: 100%;
       top: 0;
-      visibility: hidden;
+      display: none;
       z-index: 99;
 
       li {
@@ -441,12 +459,12 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
         }
 
         &.moved { position: relative;
-          & > .dropdown { visibility: hidden; }
+          & > .dropdown { display: none; }
         }
 
         &.hover, &.not-click:hover {
           & > .dropdown {
-            visibility: visible;
+            display: block;
           }
         }
 
@@ -540,7 +558,7 @@ $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
 	  .has-dropdown {
         &:hover {
           & > .dropdown {
-            visibility: visible;
+            display: block;
           }
         }
 	  }


### PR DESCRIPTION
Hi guys.

I'm using a top-bar, fixed and contained to grid. I also set my topbar to not to scroll to top on click. My markup:

```
<div class="contain-to-grid fixed">
    <nav class="top-bar" data-options="scrolltop:false">
        <!-- commented for brevity -->
    </nav>
</div>
```

This is happening on phones or browsers resized like a small screen. 
I don't really know if this is an expected behaviour, my markup is wrong or it's a bug.

If I disable the scrolltop (`scrolltop:false`), when I click to toggle the topbar disappears (actually, if I scroll up a little bit it's there).

If I enable the scrolltop (`scrolltop:true`), it works perfectly, but I'm forcing the user to scroll top every time he opens the menu. This is also the case if I don't set any _data-options_ as `scrolltop:true` is the default.

I've uploaded a demo: http://fedeisas.com.ar/test/. Resize your browser like at <~768, scroll content and click to toggle the menu.

I've tried a sticky approach but it flickers a lot when scrolling.

Is there any way to have a fixed contained to grid topbar that remains fixed all the time?

Thanks!
