### PR TITLE
Target the parent dropdown div rather than the anchors within

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -101,7 +101,7 @@
         .on('mousedown.fndtn.forms', 'form.custom div.custom.dropdown', function () {
           return false;
         })
-        .on('click.fndtn.forms', 'form.custom div.custom.dropdown a.current, form.custom div.custom.dropdown a.selector', function (e) {
+        .on('click.fndtn.forms', 'form.custom div.custom.dropdown', function (e) {
           var $this = $(this),
               $dropdown = $this.closest('div.custom.dropdown'),
               $select = getFirstPrevSibling($dropdown, 'select');


### PR DESCRIPTION
Targeting the dropdown anchors rather than the dropdown div itself causes issues when there is no placeholder content. In that case, you cannot click on the select box, only the selector arrow element.

Moving the click handler to the div itself solves this problem and seems to cause no ill effect.
