### PR TITLE
Fix issue #3128: Enable prev/next AJAX functionality in reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -133,9 +133,10 @@
         var modal = $(this.scope);
       }
 
-      if (!modal.hasClass('open')) {
-        var open_modal = $('.reveal-modal.open');
+      var already_open = modal.hasClass('open');
+      var open_modal = $('.reveal-modal.open');
 
+      if (!already_open) {
         if (typeof modal.data('css-top') === 'undefined') {
           modal.data('css-top', parseInt(modal.css('top'), 10))
             .data('offset', this.cache_offset(modal));
@@ -146,30 +147,37 @@
         if (open_modal.length < 1) {
           this.toggle_bg();
         }
+      }
+      else {
+        this.locked = false;
+      }
 
-        if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
+      if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
+        if (!already_open) {
           this.hide(open_modal, this.settings.css.close);
           this.show(modal, this.settings.css.open);
-        } else {
-          var self = this,
-              old_success = typeof ajax_settings.success !== 'undefined' ? ajax_settings.success : null;
+        }
+      } else {
+        var self = this,
+            old_success = typeof ajax_settings.success !== 'undefined' ? ajax_settings.success : null;
 
-          $.extend(ajax_settings, {
-            success: function (data, textStatus, jqXHR) {
-              if ( $.isFunction(old_success) ) {
-                old_success(data, textStatus, jqXHR);
-              }
+        $.extend(ajax_settings, {
+          success: function (data, textStatus, jqXHR) {
+            if ( $.isFunction(old_success) ) {
+              old_success(data, textStatus, jqXHR);
+            }
 
-              modal.html(data);
-              $(modal).foundation('section', 'reflow');
+            modal.html(data);
+            $(modal).foundation('section', 'reflow');
 
+            if (!already_open) {
               self.hide(open_modal, self.settings.css.close);
               self.show(modal, self.settings.css.open);
             }
-          });
+          }
+        });
 
-          $.ajax(ajax_settings);
-        }
+        $.ajax(ajax_settings);
       }
     },
 


### PR DESCRIPTION
- An AJAX reveal modal trying to open itself with a different URL does not work with the current code:
  the code checks if the modal is already open, and does nothing if the modal is open because it assumes
  that the content of a modal is static. This is not the case for AJAX modals, where the same container
  could be used to display dynamic content.
  
  This fix deals differently with the check of whether the reveal modal is open or not: in case of an
  AJAX modal, it will simply load the new content inside the same modal without animating it again.
