### PR TITLE
Reinstate form error message styles for `.error small`

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -376,6 +376,7 @@ $glowing-effect-color: $input-focus-border-color !default;
       @include form-label-error-color;
     }
 
+    small,
     small.error {
       @include form-error-message;
     }


### PR DESCRIPTION
According to the official docs, when .error class is attached to a div/column that wraps around a <small>, the <small> should be styled in error message. It, indeed, had always been like that, but has stopped working since v4.3.0, in which abide was added.

Below is a screenshot of the docs, which serves as a clear demo of the issue. Note the <small> associated with "Another error" is not properly styled. 
![screen shot 2013-09-04 at 12 42 55 pm](https://f.cloud.github.com/assets/538353/1104898/d669ee14-190f-11e3-93ed-a079303fb240.png)

The issue was introduced in commit [b5e9d05](https://github.com/zurb/foundation/commit/b5e9d05311544881e11af710bdd85113a9b7857b#scss/foundation/components/_forms.scss).

It has been reported in [issue 2906](https://github.com/zurb/foundation/issues/2906).

This fix is so simple that I am afraid that I don't see the complete picture and thus might have introduced other issues with this PR. Someone please take a look for me. Thx. 
