### PR TITLE
Added closing tags to the JS for creating the navigation arrows to fix bug when viewing in IE8

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -46,8 +46,8 @@
       slides_container.addClass(settings.slides_container_class);
       
       if (settings.navigation_arrows) {
-        container.append($('<a href="#">').addClass(settings.prev_class).append('<span>'));
-        container.append($('<a href="#">').addClass(settings.next_class).append('<span>'));
+        container.append($('<a href="#"><span></span></a>').addClass(settings.prev_class));
+        container.append($('<a href="#"><span></span></a>').addClass(settings.next_class));
       }
 
       if (settings.timer) {


### PR DESCRIPTION
Added the closing tags to the the append due to the JS not creating the elements at all IE8.

NB This may be a problem with the timer JS also.
