### PR TITLE
Fix alert close box.

### DIFF
--- a/js/foundation/foundation.alerts.js
+++ b/js/foundation/foundation.alerts.js
@@ -9,12 +9,14 @@
     version : '4.3.2',
 
     settings : {
+      animation: 'fadeOut',
       speed: 300, // fade out speed
       callback: function (){}
     },
 
     init : function (scope, method, options) {
       this.scope = scope || this.scope;
+      Foundation.inherit(this, 'data_options');
 
       if (typeof method === 'object') {
         $.extend(true, this.settings, method);


### PR DESCRIPTION
Current alert close boxes fail to actually close. Instead they throw an `Uncaught TypeError: Object[object Object] has no method data_options` error. This PR restores what already worked on 4.3.1.
