### PR TITLE
Reveal requires markup to be a direct child of the body element for proper positioning

### DIFF
--- a/docs/components/reveal.html.erb
+++ b/docs/components/reveal.html.erb
@@ -21,7 +21,7 @@
       <div class="large-12 columns">
 
         <h3>Build With HTML Classes</h3>
-        <p>Reveal modals are easy to build, just make sure they live right above your closing <code>body</code> tag or they won't work properly. Follow the markup below to get started:</p>
+        <p>Reveal modals are easy to build.  They should live right above your closing <code>body</code> tag, but if they are nested within the document, Reveal will temporarily relocate them while open to ensure proper positioning. Follow the markup below to get started:</p>
 
 <%= code_example '
 <div id="myModal" class="reveal-modal">

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -212,6 +212,16 @@
     show : function (el, css) {
       // is modal
       if (css) {
+        if (el.parent('body').length === 0) {
+          var placeholder = el.wrap('<div style="display: none;" />').parent();
+          el.on('closed.fndtn.reveal.wrapped', function() {
+            el.detach().appendTo(placeholder);
+            el.unwrap().unbind('closed.fndtn.reveal.wrapped');
+          });
+
+          el.detach().appendTo('body');
+        }
+
         if (/pop/i.test(this.settings.animation)) {
           css.top = $(window).scrollTop() - el.data('offset') + 'px';
           var end_css = {


### PR DESCRIPTION
If modal content is contained within other elements, the layout and positioning of the modal has the potential to be affected by the containing content.  In order to avoid this, modals must be created as direct children of the body element.

However, if someone doesn't catch this issue, they could spin their wheels for a while trying to figure out what was going on.  Additionally, certain server-side techniques for code sharing (such as partials and master pages in ASP.NET MVC) make getting these placed within the body tag more difficult.

We can make this much simpler for the user by automatically detaching modal content that isn't a direct child of body and appending it to body during opening of the modal and then put it back in place when it's closed.
