### PR TITLE
Remove hardcoded margin value for inline list items

### DIFF
--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -36,7 +36,7 @@ $inline-list-children-display: block !default;
   & > li {
     list-style: none;
     float: $default-float;
-    margin-#{$default-float}: em-calc(22);
+    margin-#{$default-float}: abs($inline-list-default-float-margin);
     display: $inline-list-display;
     &>* { display: $inline-list-children-display; }
   }


### PR DESCRIPTION
The 'li' elements in the inline list had a margin hard-coded to the em equivalent of 22px. This removes that hardcoded value and replaces it with the absolute (positive) value held in the $inline-list-default-float-margin variable. Now the margins for the ul and li will always cancel each other out.
