### PR TITLE
dropdown callbacks can't be overridden after the first instanciation of the dropdown plugin

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -54,8 +54,12 @@
               settings = $.extend({}, self.settings, self.data_options(target));
           if (settings.is_hover) self.close.call(self, $(this));
         })
-        .on('opened.fndtn.dropdown', '[data-dropdown-content]', this.settings.opened)
-        .on('closed.fndtn.dropdown', '[data-dropdown-content]', this.settings.closed);
+        .on('opened.fndtn.dropdown', '[data-dropdown-content]', function () {
+            self.settings.opened.call(this);
+        })
+        .on('closed.fndtn.dropdown', '[data-dropdown-content]', function () {
+            self.settings.closed.call(this);
+        });
 
       $(document).on('click.fndtn.dropdown', function (e) {
         var parent = $(e.target).closest('[data-dropdown-content]');


### PR DESCRIPTION
## Problem

Currently you can set the opened and closed callbacks only on the first init of the dropdown because of the following code:

``` javascript
.on('opened.fndtn.dropdown', '[data-dropdown-content]', this.settings.opened)
/* If you change the settings.opened function,
the "on" will still use the first version you gave him...*/
```

Using the following code forces "on" to use the new function set in the settings:

``` javascript
.on('opened.fndtn.dropdown', '[data-dropdown-content]', function () {
    self.settings.opened.call(this); // Dynamically call self.settings.opened
})
```

The callback functions will be updated each time you initialize the dropdown function as follow:

```
$(document).foundation('dropdown', {opened: myOpenedCallback, closed: myClosedCallback});
```
## Test

You can test it yourself:

HTML:

``` html
<a id="myTestButton" href="#">Click me</a>
```

Javascript:

``` javascript
callback = {click: function () {console.log(1); return false;}}
$(document).on('click', '#myTestButton', callback.click);
$('#myTestButton').trigger('click'); // display: 1

callback.click = function () {console.log(2); return false;}
$('#myTestButton').trigger('click'); // display 1 instead of 2...
```
