### PR TITLE
Switches inside of <td>'s don't work at all with Firefox, don't work well in Chrome

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -144,7 +144,7 @@ $switch-label-outline: 1px dotted #888 !default;
 // We use this mixin to create the size styles for switches.
 @mixin switch-size($height:$switch-height-med, $font-size:$switch-font-size-med, $line-height:2.3em) {
 
-  height: $height;
+  height: em-calc($height);
 
   label {
     padding: em-calc(0, $switch-label-side-padding);


### PR DESCRIPTION
In Chrome it's slightly offsetted. 
In Firefox (latest version) it fills up the whole screen, covering everything else. 

Chrome:

![switchintablechrome](https://f.cloud.github.com/assets/4498834/594635/4dade74a-caa1-11e2-985d-96a770dd71cf.png)

Firefox:

![switchintable](https://f.cloud.github.com/assets/4498834/594629/8e5eed12-caa0-11e2-927c-839d6dead0b5.png)
