### PR TITLE
topbar: Fix lines appearing when no menu-icon

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -212,8 +212,12 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
       .title-area { background: $topbar-bg; }
 
       .toggle-topbar {
-        a { color: $topbar-menu-link-color-toggled;
-          span {
+        a {
+          color: $topbar-menu-link-color-toggled;
+        }
+
+        &.menu-icon {
+          a span {
             // Shh, don't tell, but box-shadows create the menu icon :)
             @if $experimental {
               -webkit-box-shadow: 0 10px 0 1px $topbar-menu-icon-color-toggled,


### PR DESCRIPTION
When .menu-icon is not specified and the menu is expanded, the shadow
used to generate the toggled menu-icon is still being applied.

Resolution:
- Check whether .menu-icon is applied

Fixes #2711
