### PR TITLE
Section js breakpoint different from css breakpoint

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -167,6 +167,13 @@ if (typeof jQuery === "undefined" &&
     return this;
   };
 
+  function removeQuotes(string) {
+      if (typeof string === 'string' || string instanceof String) {
+          string = string.replace(/^['"]+|(;\s?})+|['"]$/g, '');
+      }
+      return string;
+  }
+
   window.Foundation = {
     name : 'Foundation',
 
@@ -175,9 +182,9 @@ if (typeof jQuery === "undefined" &&
     cache : {},
 
     media_queries : {
-      small : $('.foundation-mq-small').css('font-family').replace(/\'/g, ''),
-      medium : $('.foundation-mq-medium').css('font-family').replace(/\'/g, ''),
-      large : $('.foundation-mq-large').css('font-family').replace(/\'/g, '')
+      small : removeQuotes($('.foundation-mq-small').css('font-family')),
+      medium : removeQuotes($('.foundation-mq-medium').css('font-family')),
+      large : removeQuotes($('.foundation-mq-large').css('font-family'))
     },
 
     stylesheet : $('<style></style>').appendTo('head')[0].sheet,

--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -11,7 +11,6 @@
 
     settings: {
       deep_linking: false,
-      small_breakpoint: 768,
       one_up: true,
       multi_expand: false,
       section_selector: '[data-section]',
@@ -407,7 +406,8 @@
       if ($('html').hasClass('ie8compat')) {
         return true;
       }
-      return $(this.scope).width() < settings.small_breakpoint;
+
+      return !matchMedia(Foundation.media_queries['small']).matches;
     },
 
     off: function() {


### PR DESCRIPTION
When using sections as horizontal nav the section container loses it's height at screen widths below 768px, causing elements below to collapse up into it. It doesn't switch to an accordion until 750px. This can be seen on the sections doc page http://foundation.zurb.com/docs/components/section.html
Look at the 3 examples right at the start, change your browser width to between 768 and 750px and you will see the effect.

I tried on my own site changing the media query for $small-screen to 750px. The result was that the section container still lost it's height at 768px, but didn't change to an accordion until 732px, so same 18px difference.

Edit: This issue appears in Firefox 22. It doesn't appear in Chrome 28, or IE 10.
