### PR TITLE
Full screen modal/reveal on small screens

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -1035,6 +1035,8 @@ $default-float: left;
 // $reveal-modal-class: "reveal-modal";
 // $close-reveal-modal-class: "close-reveal-modal";
 
+// $reveal-full-on-small: false;
+
 //
 // Section Variables
 //

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -30,6 +30,8 @@ $reveal-border-color: #666 !default;
 $reveal-modal-class: "reveal-modal" !default;
 $close-reveal-modal-class: "close-reveal-modal" !default;
 
+$reveal-full-on-small: false !default;
+
 //
 // Reveal Mixins
 //
@@ -113,6 +115,15 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     @include reveal-modal-style;
 
     .#{$close-reveal-modal-class} { @include reveal-close; }
+
+    @if $reveal-full-on-small {
+      @include reveal-modal-style(false, emCalc(30), false, $box-shadow: false, $top-offset: 0);
+      &.tiny  { @include reveal-modal-base(false, 100%); }
+      &.small { @include reveal-modal-base(false, 100%); }
+      &.medium  { @include reveal-modal-base(false, 100%); }
+      &.large { @include reveal-modal-base(false, 100%); }
+      &.xlarge { @include reveal-modal-base(false, 100%); }
+    }
   }
 
   // Large Screen Styles


### PR DESCRIPTION
I think modals are awfully cramped on small screens when they contain a form.

Here I have provided a switch to expand all the class options (tiny, small, medium, large and xlarge) to 100% width on small screens.

It's set to false by default otherwise it would be considered a regression.
