### PR TITLE
Actually honour the concept of `custom_back_text`

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -305,7 +305,7 @@
 
         // Copy link to subnav
         if (self.settings.custom_back_text == true) {
-          $titleLi.find('h5>a').html('&laquo; ' + self.settings.back_text);
+          $titleLi.find('h5>a').html(self.settings.back_text);
         } else {
           $titleLi.find('h5>a').html('&laquo; ' + $link.html());
         }


### PR DESCRIPTION
When I set `custom_back_text`, I expect the back button to only contain that text, not something prefixed with what someone else believes is a good piece of text.

These non alphanumeric symbols that are there for affordance, can be replaced with css3 and font-icons.
