### PR TITLE
Fix documentation for the 'Grid', 'Source Ordering' section

### DIFF
--- a/docs/components/grid.html.erb
+++ b/docs/components/grid.html.erb
@@ -206,45 +206,45 @@
 
 <%= code_example '
 <div class="row">
-  <div class="small-2 push-10 columns">2</div>
-  <div class="small-10 pull-2 columns">10, last</div>
+  <div class="large-10 push-2 columns">10</div>
+  <div class="large-2 pull-10 columns">2, last</div>
 </div>
 <div class="row">
-  <div class="small-3 push-9 columns">3</div>
-  <div class="small-9 pull-3 columns">9, last</div>
+  <div class="large-9 push-3 columns">9</div>
+  <div class="large-3 pull-9 columns">3, last</div>
 </div>
 <div class="row">
-  <div class="small-4 push-8 columns">4</div>
-  <div class="small-8 pull-4 columns">8, last</div>
+  <div class="large-8 push-4 columns">8</div>
+  <div class="large-4 puljl-8 columns">4, last</div>
 </div>
 <div class="row">
-  <div class="small-5 push-7 columns">5</div>
-  <div class="small-7 pull-5 columns">5, last</div>
+  <div class="large-7 push-5 columns">5</div>
+  <div class="large-5 pull-7 columns">5, last</div>
 </div>
 <div class="row">
-  <div class="small-6 push-6 columns">6</div>
-  <div class="small-6 pull-6 columns">6, last</div>
+  <div class="large-6 push-6 columns">6</div>
+  <div class="large-6 pull-6 columns">6, last</div>
 </div>', :html %>
 
         <div class="row display">
-          <div class="small-2 push-10 columns">2</div>
-          <div class="small-10 pull-2 columns">10, last</div>
+          <div class="large-10 push-2 columns">10</div>
+          <div class="large-2 pull-10 columns">2, last</div>
         </div>
         <div class="row display">
-          <div class="small-3 push-9 columns">3</div>
-          <div class="small-9 pull-3 columns">9, last</div>
+          <div class="large-9 push-3 columns">9</div>
+          <div class="large-3 pull-9 columns">3, last</div>
         </div>
         <div class="row display">
-          <div class="small-4 push-8 columns">4</div>
-          <div class="small-8 pull-4 columns">8, last</div>
+          <div class="large-8 push-4 columns">8</div>
+          <div class="large-4 pull-8 columns">4, last</div>
         </div>
         <div class="row display">
-          <div class="small-5 push-7 columns">5</div>
-          <div class="small-7 pull-5 columns">5, last</div>
+          <div class="large-7 push-5 columns">5</div>
+          <div class="large-5 pull-7 columns">5, last</div>
         </div>
         <div class="row display">
-          <div class="small-6 push-6 columns">6</div>
-          <div class="small-6 pull-6 columns">6, last</div>
+          <div class="large-6 push-6 columns">6</div>
+          <div class="large-6 pull-6 columns">6, last</div>
         </div>
 
         <hr>


### PR DESCRIPTION
The source for the 'Source Ordering' section isnt correct. Firstly the sub-nav is on the _right_; and it doesnt go below on small displays.
