### PR TITLE
Error in IE with foundation clearing

### DIFF
--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -228,7 +228,7 @@
     },
 
     is_open : function (current) {
-      return current.parent().attr('style').length > 0;
+      return current.parent().prop('style').length > 0;
     },
 
     keydown : function (e) {


### PR DESCRIPTION
Fixed error that appeared in IE while trying to open clearing lightbox from the same image on 2-nd attempt

http://api.jquery.com/attr/
'As of jQuery 1.6, the .attr() method returns undefined for attributes that have not been set.'
