### PR TITLE
Added option to personalize the tooltip text "tap to close"

### DIFF
--- a/js/foundation/foundation.tooltips.js
+++ b/js/foundation/foundation.tooltips.js
@@ -12,6 +12,7 @@
       selector : '.has-tip',
       additionalInheritableClasses : [],
       tooltipClass : '.tooltip',
+      tapToClose_text: 'tap to close',
       appendTo: 'body',
       'disable-for-touch': false,
       tipTemplate : function (selector, content) {
@@ -110,7 +111,7 @@
 
       $tip.addClass(classes).appendTo(this.settings.appendTo);
       if (Modernizr.touch) {
-        $tip.append('<span class="tap-to-close">tap to close </span>');
+        $tip.append('<span class="tap-to-close">'+this.settings.tapToClose_text+'</span>');
       }
       $target.removeAttr('title').attr('title','');
       this.show($target);


### PR DESCRIPTION
Added option to personalize the tooltip text "tap to close".
I need this option so I can translate it to my language.
I named the variable based on the topbar option "back_text", so I called it "tapToClose_text"
