### PR TITLE
Fix: as the variable name was renamed, it missed a change in the line the variable is used.

### DIFF
--- a/js/foundation/foundation.tooltips.js
+++ b/js/foundation/foundation.tooltips.js
@@ -111,7 +111,7 @@
 
       $tip.addClass(classes).appendTo(this.settings.appendTo);
       if (Modernizr.touch) {
-        $tip.append('<span class="tap-to-close">'+this.settings.tapToClose_text+'</span>');
+        $tip.append('<span class="tap-to-close">'+this.settings.touchCloseText+'</span>');
       }
       $target.removeAttr('title').attr('title','');
       this.show($target);


### PR DESCRIPTION
Fix: as the display string variable name was renamed in the previous commit, it missed a change in the line the variable is used.
