### PR TITLE
Removed requirement to hand in force refresh when triggering change event on backing select..

### DIFF
--- a/js/foundation/foundation.forms.js
+++ b/js/foundation/foundation.forms.js
@@ -67,9 +67,9 @@
           e.stopPropagation();
           self.toggle_radio($(this));
         })
-        .on('change.fndtn.forms', 'form.custom select', function (e, force_refresh) {
+        .on('change.fndtn.forms', 'form.custom select', function (e) {
           if ($(this).is('[data-customforms="disabled"]')) return;
-          self.refresh_custom_select($(this), force_refresh);
+          self.refresh_custom_select($(this), true);
         })
         .on('click.fndtn.forms', 'form.custom label', function (e) {
           if ($(e.target).is('label')) {


### PR DESCRIPTION
This fixes the remaining issue on #2840 where the select would not reflect the changes done to the underlying select element.
