### PR TITLE
Fix Issue #2767: Positioning and closing issues with Reveal modal when "animation:'none'" option is set

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -260,6 +260,7 @@
           }.bind(this), this.settings.animationSpeed / 2);
         }
 
+        this.locked = false;
         return el.css(css).show().css({opacity: 1}).addClass('open').trigger('opened');
       }
 
@@ -303,6 +304,7 @@
           }.bind(this), this.settings.animationSpeed / 2);
         }
 
+        this.locked = false;
         return el.hide().css(css).removeClass('open').trigger('closed');
       }
 

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -241,6 +241,7 @@
         }
 
         if (/fade/i.test(this.settings.animation)) {
+          css.top = $(window).scrollTop() + el.data('css-top') + 'px';
           var end_css = {opacity: 1};
 
           return this.delay(function () {

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -210,6 +210,10 @@
     },
 
     show : function (el, css) {
+
+      // Get the top of the viewport so we know where to show the modal
+      var viewport_top = $(window).scrollTop() + el.data('css-top') + 'px';
+
       // is modal
       if (css) {
         if (el.parent('body').length === 0) {
@@ -225,7 +229,7 @@
         if (/pop/i.test(this.settings.animation)) {
           css.top = $(window).scrollTop() - el.data('offset') + 'px';
           var end_css = {
-            top: $(window).scrollTop() + el.data('css-top') + 'px',
+            top: viewport_top,
             opacity: 1
           };
 
@@ -240,8 +244,9 @@
           }.bind(this), this.settings.animationSpeed / 2);
         }
 
+        css.top = viewport_top;
+
         if (/fade/i.test(this.settings.animation)) {
-          css.top = $(window).scrollTop() + el.data('css-top') + 'px';
           var end_css = {opacity: 1};
 
           return this.delay(function () {


### PR DESCRIPTION
In response to Issue #2767 

Fixes issue where modals with no animation or an animation of 'fade' appeared at the top of the document regardless of how far the user has scrolled down the page. The modal should instead appear at the top of the viewport.

Fixes issue where modals with no animation don't respond to attempts to close via the 'close-reveal-modal' button, the esc key, or clicking outside of the modal. Props to @RobertinoValue
