### PR TITLE
fix(section): deep_linking option

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -350,7 +350,7 @@
       
       if (selectedSection != null) {
         sections.each(function() {
-          if (selectedSection == $(this)) {
+          if (selectedSection[0] == this) {
             var section = $(this),
                 settings = $.extend({}, self.settings, self.data_options(section)),
                 regions = section.children(self.settings.region_selector),


### PR DESCRIPTION
Deep linking was broken after recent changes for multi expand (8401f9dc1a / #2673).

Logic here is quite odd. I don't think it's expanding all sections that match, if that was the intention. It looks like it's doing two searches through `sections` for no reason. The second pass expands the only match that was found in the first pass?
