### PR TITLE
Use native controls on mobile (#2090)

### DIFF
--- a/scss/foundation/components/_custom-forms.scss
+++ b/scss/foundation/components/_custom-forms.scss
@@ -275,4 +275,22 @@ $custom-dropdown-width-large: 434px !default;
     /* Custom input, disabled */
     .custom.disabled { background: $custom-form-bg-disabled; }
   }
+
+  @media only screen and (max-width: #{$small-screen}) {
+    form.custom .custom.dropdown {
+      display: none;
+    }
+
+    select {
+      visibility: visible !important;
+      margin-left: 0 !important;
+      position: static !important;
+
+      -webkit-appearance: menulist-button;
+      height: 30px;
+      padding: 4px 6px;
+      line-height: 30px;
+      display: inline-block;
+    }
+  }
 }


### PR DESCRIPTION
Here's a proof of concept for issue #2090. It hides the custom drop down and styles the native.
IMHO it would be better not to create the custom dropdown in the first place using some javascript like:

``` javascript
window.matchMedia('only screen and (max-width: 767px)').matches
```
