### PR TITLE
Separate form error classes from other classes

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -106,6 +106,7 @@ $default-float: left;
 // $include-html-visibility-classes: $include-html-classes;
 // $include-html-button-classes: $include-html-classes;
 // $include-html-form-classes: $include-html-classes;
+// $include-html-form-error-classes: $include-html-classes;
 // $include-html-custom-form-classes: $include-html-classes;
 // $include-html-media-classes: $include-html-classes;
 // $include-html-section-classes: $include-html-classes;

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -2,6 +2,7 @@
 // Form Variables
 //
 $include-html-form-classes: $include-html-classes !default;
+$include-html-form-error-classes: $include-html-form-classes !default;
 
 // We use this to set the base for lots of form spacing and positioning styles
 $form-spacing: em-calc(16) !default;
@@ -359,7 +360,9 @@ $glowing-effect-color: $input-focus-border-color !default;
   fieldset {
     @include fieldset;
   }
+}
 
+@if $include-html-form-error-classes != false {
   /* Error Handling */
 
   [data-abide] {
@@ -405,5 +408,4 @@ $glowing-effect-color: $input-focus-border-color !default;
   }
 
   label.error { @include form-label-error-color; }
-
 }


### PR DESCRIPTION
Some projects want the ability to use abide and display errors with the default
error styling, but not include foundation's defaults for input and select styling

This commit adds a variable $include-html-form-error-classes that will include
the error classes separately, thus letting us use abide independently.
