### PR TITLE
Moved table-head-font-weight variable to proper selector.

### DIFF
--- a/scss/foundation/components/_tables.scss
+++ b/scss/foundation/components/_tables.scss
@@ -40,14 +40,14 @@ $table-margin-bottom: em-calc(20) !default;
 
   thead,
   tfoot {
-    background: $table-head-bg;
-    font-weight: $table-head-font-weight;
+    background: $table-head-bg;    
 
     tr {
       th,
       td {
         padding: $table-head-padding;
         font-size: $table-head-font-size;
+        font-weight: $table-head-font-weight;
         color: $table-head-font-color;
         text-align: $default-float;
       }


### PR DESCRIPTION
Font-weight is declared in a wrong selector thus making changes to $table-head-font-weight variable doesn't work. The variable is now moved to a proper selector.
