### PR TITLE
Ensure the next slide is in the correct position before animating.

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -330,6 +330,7 @@
     var easing = (typeof jQuery === 'undefined') ? 'ease-in-out' : undefined;
 
     this.next = function(current, next, callback) {
+      next.css(margin, '100%');
       next.animate(animMargin, duration, easing, function() {
         current.css(margin, '100%');
         callback();


### PR DESCRIPTION
Without this line the next slide can sometimes be in the wrong location causing the current slide to exit to the left and the next slide to enter from the left.
