### PR TITLE
Abide isequal validation

### DIFF
--- a/docs/components/abide.html.erb
+++ b/docs/components/abide.html.erb
@@ -19,6 +19,11 @@
                 <input type="password" id="password" placeholder="LittleW0men." name="password" required>
                 <small class="error" data-error-message>Passwords must be at least 8 characters with 1 capital letter, 1 number, and one special character.</small>
               </div>
+              <div class="large-12 columns">
+                <label for="confirmPassword">Confirm Password <small>required</small></label>
+                <input type="password" id="confirmPassword" placeholder="LittleW0men." name="confirmPassword" required data-equal="password">
+                <small class="error" data-error-message>Passwords must match.</small>
+              </div>
             </div>
 
             <div class="row">
@@ -252,7 +257,7 @@ $(document)
     }
   });
 ", :js %>
-        
+
         <p>You can then use these custom patterns like you would the predfined patterns in your markup:</p>
 
 <%= code_example '
@@ -279,7 +284,7 @@ $(document)
   <small class="error">A valid email address is required.</small>
 </div>
 ', :html %>
-        
+
         <p>In the above example we have wrapped our input in a <code>div</code>. This div will receive an <code>error</code> class when the input is invalid. This class will show our error message and style the label and input accordingly.</p>
 
         <p>Invalid inputs inherit a <code>data-invalid</code> attribute.</p>

--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -154,14 +154,11 @@
         var el = el_patterns[i][0],
             required = el_patterns[i][2],
             value = el.value,
-            is_equal = el.getAttribute('data-equalto'),
             is_radio = el.type === "radio",
             valid_length = (required) ? (el.value.length > 0) : true;
 
         if (is_radio && required) {
           validations.push(this.valid_radio(el, required));
-        } else if (is_equal && required) {
-          validations.push(this.valid_equal(el, required));
         } else {
           if (el_patterns[i][1].test(value) && valid_length ||
             !required && el.value.length < 1) {
@@ -196,20 +193,6 @@
       }
 
       return valid;
-    },
-
-    valid_equal: function(el, required) {
-        var from  = document.getElementById( el.getAttribute('data-equalto') ).value,
-            to    = el.value,
-            valid = (from === to);
-
-        if (valid) {
-          $(el).removeAttr('data-invalid').parent().removeClass('error');
-        } else {
-          $(el).attr('data-invalid', '').parent().addClass('error');
-        }
-
-        return valid
     }
   };
 }(Foundation.zj, this, this.document));

--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -154,11 +154,14 @@
         var el = el_patterns[i][0],
             required = el_patterns[i][2],
             value = el.value,
+            is_equal = el.getAttribute('data-equalto'),
             is_radio = el.type === "radio",
             valid_length = (required) ? (el.value.length > 0) : true;
 
         if (is_radio && required) {
           validations.push(this.valid_radio(el, required));
+        } else if (is_equal && required) {
+          validations.push(this.valid_equal(el, required));
         } else {
           if (el_patterns[i][1].test(value) && valid_length ||
             !required && el.value.length < 1) {
@@ -193,6 +196,20 @@
       }
 
       return valid;
+    },
+
+    valid_equal: function(el, required) {
+        var from  = document.getElementById( el.getAttribute('data-equalto') ).value,
+            to    = el.value,
+            valid = (from === to);
+
+        if (valid) {
+          $(el).removeAttr('data-invalid').parent().removeClass('error');
+        } else {
+          $(el).attr('data-invalid', '').parent().addClass('error');
+        }
+
+        return valid
     }
   };
 }(Foundation.zj, this, this.document));


### PR DESCRIPTION
I had to add an "is equal" validation for a reset password page. In the markup you just set the data-equalto atribute to the id of the value that you want to match:

```
<input type="password" placeholder="confirm new password" required data-equalto="firstPassword">
```

Any recommendation is welcome, thanks!

ps. Sorry for the extra commits, I was working on master first.
