### PR TITLE
Adjust success callback timing for reveal-ajax

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -156,12 +156,13 @@
 
           $.extend(ajax_settings, {
             success: function (data, textStatus, jqXHR) {
-              if ( $.isFunction(old_success) ) {
-                old_success(data, textStatus, jqXHR);
-              }
 
               modal.html(data);
               $(modal).foundation('section', 'reflow');
+
+              if ( $.isFunction(old_success) ) {
+                old_success(data, textStatus, jqXHR);
+              }
 
               self.hide(open_modal, self.settings.css.close);
               self.show(modal, self.settings.css.open);


### PR DESCRIPTION
Call the user defined success callback after the data is set in the modal. This way one can manipulate the modal structure before it is displayed.
