### PR TITLE
[abide] pattern attribute should have priority over type pattern

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -126,19 +126,19 @@
     },
 
     pattern : function (el) {
-      var type = el.getAttribute('type'),
+      var pattern = el.getAttribute('pattern') || '',
           required = typeof el.getAttribute('required') === 'string';
-
-      if (this.settings.patterns.hasOwnProperty(type)) {
-        return [el, this.settings.patterns[type], required];
-      }
-
-      var pattern = el.getAttribute('pattern') || '';
 
       if (this.settings.patterns.hasOwnProperty(pattern) && pattern.length > 0) {
         return [el, this.settings.patterns[pattern], required];
       } else if (pattern.length > 0) {
         return [el, new RegExp(pattern), required];
+      }
+      
+      var type = el.getAttribute('type');
+
+      if (this.settings.patterns.hasOwnProperty(type)) {
+        return [el, this.settings.patterns[type], required];
       }
 
       pattern = /.*/;


### PR DESCRIPTION
Pattern directly specified by pattern attribute (pattern="integer") should have priority over pattern specified by type (ex. type="password").

Attached pull request changes the priority and pattern attribute has higher priority then type pattern.

Example usage:

On a sign-up page we require password to conform the password pattern (1 capital letter, 1 number etc.):

```
<form action="signup" data-abide>
  <div class="input-wrapper">
    <input type="password" required>
    <small class="error">Passwords must be at least 8 characters with 
    1 capital letter, 1 number, and one special character.</small>
  </div>
</form>
```

On a login page we should accept any password, and override password pattern (because password requirements could change):

```
<form action="login" data-abide>
  <div class="input-wrapper">
    <input type="password" pattern=".*" required>
    <small class="error">Please enter your password</small>
  </div>
</form>
```
