### PR TITLE
Remove direct usages of $primary-color and $secondary-color

### DIFF
--- a/docs/components/alert-boxes.html.erb
+++ b/docs/components/alert-boxes.html.erb
@@ -154,11 +154,15 @@ $alert-padding-default-float: $alert-padding-top;
 $alert-padding-opposite-direction: $alert-padding-top + em-calc(10);
 $alert-padding-bottom: $alert-padding-top + em-calc(1);
 
+/* We use these to control base alert colors */
+$alert-primary-color: $primary-color !default;
+$alert-secondary-color: $secondary-color !default;
+
 /* We use these to control text style. */
 $alert-font-weight: bold;
 $alert-font-size: em-calc(14);
 $alert-font-color: #fff;
-$alert-font-color-alt: darken($secondary-color, 60%);
+$alert-font-color-alt: darken($alert-secondary-color, 60%);
 
 /* We use this for close hover effect. */
 $alert-function-factor: 10%;
@@ -166,7 +170,7 @@ $alert-function-factor: 10%;
 /* We use these to control border styles. */
 $alert-border-style: solid;
 $alert-border-width: 1px;
-$alert-border-color: darken($primary-color, $alert-function-factor);
+$alert-border-color: darken($alert-primary-color, $alert-function-factor);
 $alert-bottom-margin: em-calc(20);
 
 /* We use these to style the close buttons */

--- a/docs/components/buttons.html.erb
+++ b/docs/components/buttons.html.erb
@@ -102,7 +102,7 @@
 $padding: $button-med
 
 /* This controls button color. Set to one of our variables or a custom hex value */
-$bg: $primary-color
+$bg: $button-bg-color
 
 /* This controls button radius. Set to a variable, true/false, or custom px value */
 $radius: false
@@ -211,6 +211,9 @@ $button-round: $global-rounded;
 
 /* We use this to set default opacity for disabled buttons. */
 $button-disabled-opacity: 0.6;
+
+/* We use this to set the default button background color */
+$button-bg-color: $primary-color;
 ', :css %>
 
         <p><strong>Note:</strong> <code>em-calc();</code> is a function we wrote to convert <code>px</code> to <code>em</code>. It is included in <strong>_variables.scss</strong>.</p>

--- a/docs/components/labels.html.erb
+++ b/docs/components/labels.html.erb
@@ -71,7 +71,7 @@ $padding: $label-padding
 $text-size: $label-font-size
 
 /* Change the background color for your labels */
-$bg: $primary-color
+$bg: $label-bg-color
 
 /* Control how much radius is put on the labels */
 $radius: false
@@ -87,6 +87,8 @@ $include-html-label-classes: $include-html-classes;
 /* We use these to style the labels */
 $label-padding: em-calc(3 10 4);
 $label-radius: $global-radius;
+$label-bg-color: $primary-color;
+$label-secondary-bg-color: $secondary-color;
 
 /* We use these to style the label text */
 $label-font-sizing: em-calc(14);

--- a/docs/components/panels.html.erb
+++ b/docs/components/panels.html.erb
@@ -117,6 +117,8 @@ $panel-padding: em-calc(20);
 /* We use these to set default font colors */
 $panel-font-color: #333;
 $panel-font-color-alt: #fff;
+$callout-panel-link-color: #fff;
+$callout-bg-color: $primary-color;
 
 $panel-header-adjust: true;', :css %>
 

--- a/docs/components/split-buttons.html.erb
+++ b/docs/components/split-buttons.html.erb
@@ -125,7 +125,7 @@ $padding: $button-med
 $pip-color: $split-button-pip-color
 
 /* This controls the border color of the triangle span area. This can be a variable or color value. */
-$span-border: $primary-color
+$span-border: $split-button-span-color
 
 /* This controls whether or not base styles come through. Set to false to negate */
 /* Handy when you want to have many different styles */
@@ -141,6 +141,8 @@ $split-button-function-factor: 15%;
 $split-button-pip-color: #fff;
 $split-button-pip-color-alt: #333;
 $split-button-active-bg-tint: rgba(0,0,0,0.1);
+$split-button-span-border-color: $primary-color !default;
+$split-button-secondary-span-border-color: $secondary-color !default;
 
 /* We use these to control tiny split buttons */
 $split-button-padding-tny: $button-tny * 9;

--- a/docs/components/top-bar.html.erb
+++ b/docs/components/top-bar.html.erb
@@ -402,7 +402,11 @@ $topbar-divider-border-top: solid 1px darken($topbar-bg, 10%);
 
 /* Sticky Class */
 $topbar-sticky-class: ".sticky";
-$topbar-arrows: true; //Set false to remove the triangle icon from the menu item', :css %>
+$topbar-arrows: true; //Set false to remove the triangle icon from the menu item
+
+// Control color of buttons in topbar
+$topbar-button-bg-color: $button-bg-color !default;
+$topbar-button-secondary-bg-color: $secondary-color !default;', :css %>
 
         <p><strong>Note:</strong> <code>em-calc();</code> is a function we wrote to convert <code>px</code> to <code>em</code>. It is included in <strong>_variables.scss</strong>.</p>
 

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -397,6 +397,10 @@ $default-float: left;
 
 // $button-disabled-opacity: 0.6;
 
+// We use this to set the default button background color
+// $button-bg-color: $primary-color;
+// $button-secondary-bg-color: $secondary-color;
+
 //
 // Button Groups
 //
@@ -452,6 +456,8 @@ $default-float: left;
 // $split-button-pip-color: #fff;
 // $split-button-pip-color-alt: #333;
 // $split-button-active-bg-tint: rgba(0,0,0,0.1);
+// $split-button-span-border-color: $primary-color;
+// $split-button-secondary-span-border-color: $secondary-color;
 
 // We use these to control tiny split buttons
 
@@ -488,6 +494,10 @@ $default-float: left;
 //
 // Alert Box Variables
 //
+
+// We use these to control base alert colors
+// $alert-primary-color: $primary-color;
+// $alert-secondary-color: $secondary-color;
 
 // We use this to control alert padding.
 
@@ -796,7 +806,8 @@ $default-float: left;
 
 // $label-padding: em-calc(3 10 4);
 // $label-radius: $global-radius;
-
+// $label-bg-color: $primary-color;
+// $label-secondary-bg-color: $secondary-color;
 // We use these to style the label text
 
 // $label-font-sizing: em-calc(14);
@@ -917,7 +928,8 @@ $default-float: left;
 // $panel-font-color-alt: #fff;
 
 // $panel-header-adjust: true;
-
+// $callout-panel-link-color: #fff;
+// $callout-bg-color: $primary-color;
 //
 // Pricing Table Variables
 //
@@ -1324,3 +1336,7 @@ $default-float: left;
 
 // $topbar-sticky-class: ".sticky";
 // $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
+
+// Control color of buttons in topbar
+// $topbar-button-bg-color: $button-bg-color;
+// $topbar-button-secondary-bg-color: $secondary-color;

--- a/scss/foundation/components/_alert-boxes.scss
+++ b/scss/foundation/components/_alert-boxes.scss
@@ -3,6 +3,10 @@
 //
 $include-html-alert-classes: $include-html-classes !default;
 
+// We use these to control base alert colors
+$alert-primary-color: $primary-color !default;
+$alert-secondary-color: $secondary-color !default;
+
 // We use this to control alert padding.
 $alert-padding-top: em-calc(11) !default;
 $alert-padding-default-float: $alert-padding-top !default;
@@ -13,7 +17,7 @@ $alert-padding-bottom: $alert-padding-top + em-calc(1) !default;
 $alert-font-weight: bold !default;
 $alert-font-size: em-calc(14) !default;
 $alert-font-color: #fff !default;
-$alert-font-color-alt: darken($secondary-color, 60%) !default;
+$alert-font-color-alt: darken($alert-secondary-color, 60%) !default;
 
 // We use this for close hover effect.
 $alert-function-factor: 10% !default;
@@ -21,7 +25,7 @@ $alert-function-factor: 10% !default;
 // We use these to control border styles.
 $alert-border-style: solid !default;
 $alert-border-width: 1px !default;
-$alert-border-color: darken($primary-color, $alert-function-factor) !default;
+$alert-border-color: darken($alert-primary-color, $alert-function-factor) !default;
 $alert-bottom-margin: em-calc(20) !default;
 
 // We use these to style the close buttons
@@ -101,7 +105,7 @@ $alert-radius: $global-radius !default;
 
     &.success { @include alert-style($success-color); }
     &.alert { @include alert-style($alert-color); }
-    &.secondary { @include alert-style($secondary-color); }
+    &.secondary { @include alert-style($alert-secondary-color); }
   }
 
 }

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -38,6 +38,9 @@ $button-round: $global-rounded !default;
 // We use this to set default opacity for disabled buttons.
 $button-disabled-opacity: 0.6 !default;
 
+// We use this to set the default button background color
+$button-bg-color: $primary-color !default;
+$button-secondary-bg-color: $secondary-color !default;
 
 //
 // Button Mixins
@@ -108,7 +111,7 @@ $button-disabled-opacity: 0.6 !default;
 }
 
 // We use this mixin to add button color styles
-@mixin button-style($bg:$primary-color, $radius:false, $disabled:false) {
+@mixin button-style($bg:$button-bg-color, $radius:false, $disabled:false) {
 
   // We control which background styles are used,
   // these can be removed by setting $bg:false
@@ -153,7 +156,7 @@ $button-disabled-opacity: 0.6 !default;
 }
 
 // We use this to quickly create buttons with a single mixin. As @jaredhardy puts it, "the kitchen sink mixin"
-@mixin button($padding:$button-med, $bg:$primary-color, $radius:false, $full-width:false, $disabled:false, $is-input:false, $is-prefix:false) {
+@mixin button($padding:$button-med, $bg:$button-bg-color, $radius:false, $full-width:false, $disabled:false, $is-input:false, $is-prefix:false) {
   @include button-base;
   @include button-size($padding, $full-width, $is-input);
   @include button-style($bg, $radius, $disabled);
@@ -173,7 +176,7 @@ $button-disabled-opacity: 0.6 !default;
     @include button-size;
     @include button-style;
 
-    &.secondary { @include button-style($bg:$secondary-color); }
+    &.secondary { @include button-style($bg:$button-secondary-bg-color); }
     &.success   { @include button-style($bg:$success-color); }
     &.alert     { @include button-style($bg:$alert-color); }
 
@@ -185,8 +188,8 @@ $button-disabled-opacity: 0.6 !default;
     &.left-align  { text-align: left; text-indent: em-calc(12); }
     &.right-align { text-align: right; padding-right: em-calc(12); }
 
-    &.disabled, &[disabled] { @include button-style($bg:$primary-color, $disabled:true);
-      &.secondary { @include button-style($bg:$secondary-color, $disabled:true); }
+    &.disabled, &[disabled] { @include button-style($bg:$button-bg-color, $disabled:true);
+      &.secondary { @include button-style($bg:$button-secondary-bg-color, $disabled:true); }
       &.success { @include button-style($bg:$success-color, $disabled:true); }
       &.alert { @include button-style($bg:$alert-color, $disabled:true); }
     }

--- a/scss/foundation/components/_labels.scss
+++ b/scss/foundation/components/_labels.scss
@@ -6,6 +6,8 @@ $include-html-label-classes: $include-html-classes !default;
 // We use these to style the labels
 $label-padding: em-calc(3 10 4) !default;
 $label-radius: $global-radius !default;
+$label-bg-color: $primary-color !default;
+$label-secondary-bg-color: $secondary-color !default;
 
 // We use these to style the label text
 $label-font-sizing: em-calc(14) !default;
@@ -35,7 +37,7 @@ $label-font-color-alt: #fff !default;
 }
 
 // We use this mixin to add label styles.
-@mixin label-style($bg:$primary-color, $radius:false) {
+@mixin label-style($bg:$label-bg-color, $radius:false) {
 
   // We control which background color comes through
   @if $bg {
@@ -79,7 +81,7 @@ $label-font-color-alt: #fff !default;
 
     &.alert     { @include label-style($alert-color); }
     &.success   { @include label-style($success-color); }
-    &.secondary { @include label-style($secondary-color); }
+    &.secondary { @include label-style($label-secondary-bg-color); }
   }
 
 }

--- a/scss/foundation/components/_panels.scss
+++ b/scss/foundation/components/_panels.scss
@@ -22,6 +22,9 @@ $panel-font-color-alt: #fff !default;
 
 $panel-header-adjust: true !default;
 $callout-panel-link-color: #fff !default;
+$callout-bg-color: $primary-color !default;
+
+
 //
 // Panel Mixins
 //
@@ -66,7 +69,7 @@ $callout-panel-link-color: #fff !default;
   .panel { @include panel;
 
     &.callout {
-      @include panel($primary-color);
+      @include panel($callout-bg-color);
       @include inset-shadow($active:false);
       a {
         color: $callout-panel-link-color;

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -8,6 +8,8 @@ $split-button-function-factor: 15% !default;
 $split-button-pip-color: #fff !default;
 $split-button-pip-color-alt: #333 !default;
 $split-button-active-bg-tint: rgba(0,0,0,0.1) !default;
+$split-button-span-border-color: $primary-color !default;
+$split-button-secondary-span-border-color: $secondary-color !default;
 
 // We use these to control tiny split buttons
 $split-button-padding-tny: $button-tny * 9 !default;
@@ -37,13 +39,12 @@ $split-button-pip-size-lrg: $button-lrg - em-calc(6) !default;
 $split-button-pip-top-lrg: $button-lrg + em-calc(5) !default;
 $split-button-pip-default-float-lrg: em-calc(-9) !default;
 
-
 //
 // Split Button Mixin
 //
 
 // We use this mixin to create split buttons that build upon the button mixins
-@mixin split-button($padding:medium, $pip-color:$split-button-pip-color, $span-border:$primary-color, $base-style:true) {
+@mixin split-button($padding:medium, $pip-color:$split-button-pip-color, $span-border:$split-button-span-border-color, $base-style:true) {
 
   // With this, we can control whether or not the base styles come through.
   @if $base-style {
@@ -149,7 +150,7 @@ $split-button-pip-default-float-lrg: em-calc(-9) !default;
   /* Split Buttons */
   .split.button { @include split-button;
 
-    &.secondary { @include split-button(false, $split-button-pip-color, $secondary-color, false); }
+    &.secondary { @include split-button(false, $split-button-pip-color, $split-button-secondary-span-border-color, false); }
     &.alert { @include split-button(false, false, $alert-color, false); }
     &.success { @include split-button(false, false, $success-color, false); }
 

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -66,6 +66,10 @@ $topbar-divider-border-top: solid 1px darken($topbar-bg-color, 10%) !default;
 $topbar-sticky-class: ".sticky" !default;
 $topbar-arrows: true !default; //Set false to remove the triangle icon from the menu item
 
+// Control color of buttons in topbar
+$topbar-button-bg-color: $button-bg-color !default;
+$topbar-button-secondary-bg-color: $secondary-color !default;
+
 @if $include-html-top-bar-classes != false {
 
   /* Wrapped around .top-bar to contain to grid width */
@@ -267,18 +271,18 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
         background: $topbar-dropdown-bg;
 
         &.button {
-          background: $primary-color;
+          background: $topbar-button-bg-color;
           font-size: $topbar-link-font-size;
            padding-right: $topbar-height / 3;
            padding-left: $topbar-height / 3;
           &:hover {
-            background: darken($primary-color, 10%);
+            background: darken($topbar-button-bg-color, 10%);
           }
         }
         &.button.secondary {
-          background: $secondary-color;
+          background: $topbar-button-secondary-bg-color;
           &:hover {
-            background: darken($secondary-color, 10%);
+            background: darken($topbar-button-secondary-bg-color, 10%);
           }
         }
         &.button.success {


### PR DESCRIPTION
 Instead, prefer overridable defaults in each component, but still use $primary-color and $secondary-color as defaults.
