### PR TITLE
update rails docs so they're in parity with the javascript docs

### DIFF
--- a/docs/rails.html.erb
+++ b/docs/rails.html.erb
@@ -58,6 +58,10 @@ end
 $(document).foundation();
 ', :js %>
 
+      <h5 class="subheader">Ensure your application.js is included at the bottom of your layout</h5>
+      
+      <p>It is recommended that you initialize Foundation at the end of the page <code>&lt;body&gt;</code>.</p>
+
       <h5 class="subheader">Add Modernizr</h5>
       <p>Make sure that <a href="http://modernizr.com/" rel="nofollow">Modernizr</a> is included in the <code>&lt;head&gt;</code> of your page:</p>
 


### PR DESCRIPTION
I encountered the error that other folks identified in #2057 

I did some investigation and it looks like the current javascript documentation recommends that the initialization of foundation occur at the bottom of the `<body>`. I've updated the Rails docs so others can avoid this error.
