### PR TITLE
Fix block-grid to allow only large-block-grid-*

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -47,7 +47,10 @@ $block-grid-media-queries: true !default;
 @if $include-html-grid-classes {
   /* Foundation Block Grids for below small breakpoint */
   @media only screen {
-    [class*="block-grid-"] { @include block-grid; }
+    [class*="block-grid-"] {
+      @include block-grid;
+      clear: both;
+    }
 
     @for $i from 1 through $block-grid-elements {
       .small-block-grid-#{($i)} {


### PR DESCRIPTION
the wildcard [class_=block-grid-] selector gets an additional clear:both
style so that having only a large-block-grid-_ class on a container
will have the same effect as large-block-grid-\* small-block-grid-1

this fixes issue #3333
