### PR TITLE
"end" class floats to the wrong side

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -145,7 +145,7 @@ $total-columns: 12 !default;
     }
 
     [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
-    [class*="column"] + [class*="column"].end { float: $default-float; }
+    [class*="column"] + [class*="column"].end { float: $opposite-direction; }
 
     .column.small-centered,
     .columns.small-centered { @include grid-column($center:true, $collapse:null, $float:false); }


### PR DESCRIPTION
Should float right when reading RTL, left when reading LTR.
