### PR TITLE
Fixes small typo in SASS syntax for switch label text padding

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -147,7 +147,7 @@ $switch-label-outline: 1px dotted #888 !default;
   height: em-calc($height);
 
   label {
-    padding: em-calc(0, $switch-label-side-padding);
+    padding: em-calc(0 $switch-label-side-padding);
     line-height: $line-height;
     font-size: em-calc($font-size);
   }


### PR DESCRIPTION
removed a comma which causes the emcalc function to render the $switch-label-side-padding as "0" in the output CSS file

Example of current switch CSS with padding typo/error here:
http://foundation.zurb.com/docs/components/switch.html
