### PR TITLE
Fixes collapse bug that causes the collapse of columns on non-collapsed child rows.

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -4,7 +4,7 @@
     .row { width: auto; max-width: none; min-width: 0; margin: 0 (-($columnGutter/2)); }
 
     &.collapse {
-      .column, .columns { padding: 0; }
+      > .column, > .columns { padding: 0; }
     }
     .row { width: auto; max-width: none; min-width: 0; margin: 0 (-($columnGutter/2));
       &.collapse { margin: 0; }


### PR DESCRIPTION
Prior to this commit collapsing a row would cause ALL child columns, at
any depth, to be collapsed. However, it would not cause all child rows
to be collapsed. This would result in rows/columns that were not a
direct child of the collapsed row to break outside of their parent
column. This occurred due to the rows having negative margin, while
lacking the typical padding on the columns to offset it.

Applying the collapse only to the child columns directly under the
collapsed row fixes this issue. This fix is accomplished simply by
adding a child selector to the SCSS.
