### PR TITLE
Top Bar breakpoint may not account for scrollbar resulting in incorrect behavior

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -406,6 +406,13 @@ if (typeof jQuery === "undefined" &&
         return true;
       },
 
+      register_media : function(media, media_class) {
+        if(Foundation.media_queries[media] === undefined) {
+          $('head').append('<meta class="' + media_class + '">');
+          Foundation.media_queries[media] = removeQuotes($('.' + media_class).css('font-family'));
+        }
+      },
+
       addCustomRule : function(rule, media) {
         if(media === undefined) {
           Foundation.stylesheet.insertRule(rule, Foundation.stylesheet.cssRules.length);

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -239,7 +239,7 @@
         }
       }.bind(this));
 
-      $('body').on('click.fndtn.topbar touchstart', function (e) {
+      $('body').on('click.fndtn.topbar touchstart.fndtn.topbar', function (e) {
         var parent = $(e.target).closest('li').closest('li.hover');
 
         if (parent.length > 0) {

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -160,10 +160,6 @@
 
           e.stopImmediatePropagation();
 
-          if (target[0].nodeName === 'A' && target.parent().hasClass('has-dropdown')) {
-            //e.preventDefault();
-          }
-
           if (li.hasClass('hover')) {
             li
               .removeClass('hover')
@@ -174,6 +170,9 @@
               .removeClass('hover');
           } else {
             li.addClass('hover');
+            if (target[0].nodeName === 'A' && target.parent().hasClass('has-dropdown')) {
+              e.preventDefault();
+            }
           }
         })
 
@@ -240,7 +239,7 @@
         }
       }.bind(this));
 
-      $('body').on('click.fndtn.topbar', function (e) {
+      $('body').on('click.fndtn.topbar touchstart', function (e) {
         var parent = $(e.target).closest('li').closest('li.hover');
 
         if (parent.length > 0) {

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -20,8 +20,10 @@
     },
 
     init : function (section, method, options) {
-      Foundation.inherit(this, 'data_options addCustomRule');
+      Foundation.inherit(this, 'data_options register_media addCustomRule');
       var self = this;
+
+      self.register_media('topbar', 'foundation-mq-topbar');
 
       if (typeof method === 'object') {
         $.extend(true, this.settings, method);
@@ -46,10 +48,6 @@
           } else {
             self.settings.$topbar.data('height', self.outerHeight(self.settings.$topbar));
           }
-
-          var breakpoint = $("<div class='top-bar-js-breakpoint'/>").insertAfter(self.settings.$topbar);
-          self.settings.breakPoint = breakpoint.width();
-          breakpoint.remove();
 
           self.assemble();
 
@@ -163,7 +161,7 @@
           e.stopImmediatePropagation();
 
           if (target[0].nodeName === 'A' && target.parent().hasClass('has-dropdown')) {
-            e.preventDefault();
+            //e.preventDefault();
           }
 
           if (li.hasClass('hover')) {
@@ -180,7 +178,7 @@
         })
 
         .on('click.fndtn.topbar', '.top-bar .has-dropdown>a, [data-topbar] .has-dropdown>a', function (e) {
-          if (self.breakpoint() && $(window).width() != self.settings.breakPoint) {
+          if (self.breakpoint()) {
 
             e.preventDefault();
 
@@ -285,7 +283,7 @@
     },
 
     breakpoint : function () {
-      return $(document).width() <= this.settings.breakPoint || $('html').hasClass('lt-ie9');
+      return !matchMedia(Foundation.media_queries['topbar']).matches || $('html').hasClass('lt-ie9');
     },
 
     assemble : function () {

--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -1312,7 +1312,7 @@ $default-float: left;
 // Transitions and breakpoint styles
 
 // $topbar-transition-speed: 300ms;
-// $topbar-breakpoint: 940 !default; // Change to 9999px for always mobile layout
+// $topbar-breakpoint: 940px !default; // Change to 9999px for always mobile layout
 // $topbar-media-query: "only screen and (min-width: #{$topbar-breakpoint})";
 
 // Divider Styles

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -66,6 +66,14 @@ $topbar-divider-border-top: solid 1px darken($topbar-bg-color, 10%) !default;
 $topbar-sticky-class: ".sticky" !default;
 $topbar-arrows: true !default; //Set false to remove the triangle icon from the menu item
 
+// Used to provide media query values for javascript components.
+// This class is generated despite the value of $include-html-top-bar-classes
+// to ensure width calculations work correctly.
+meta.foundation-mq-topbar {
+  font-family: $topbar-media-query;
+  width: $topbar-breakpoint;
+}
+
 @if $include-html-top-bar-classes != false {
 
   /* Wrapped around .top-bar to contain to grid width */
@@ -376,11 +384,6 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
     }
   }
 
-  // Element that controls breakpoint, no need to change this ever
-  .top-bar-js-breakpoint {
-    width: $topbar-breakpoint !important;
-    visibility: hidden;
-  }
   .js-generated { display: block; }
 
 


### PR DESCRIPTION
This issue is similar to the one I fixed in #2755.  Basically, the width calculations for breakpoints in javascript have to be checked against the actual media query rather than the document width due to browser differences in how media queries calculate the size (including or excluding scrollbars).

You can see the problem behavior if you reduce your Chrome browser size a pixel or two below the top bar breakpoint (which won't appear to switch into mobile mode), but if you click a dropdown, you'll end up with a large black bar appearing as if it was mobile.

I need some of the changes to land in #2755, and then I'll submit the pull request that fixes this.
