### PR TITLE
Top Bar in mobile mode on iOS doesn't clear previous selection highlight on Back

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -297,7 +297,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
       }
 
       // Apply the hover link color when it has that class
-      &:hover > a {
+      &.hover > a {
         background: $topbar-link-bg-hover;
         color: $topbar-link-color-hover;
       }


### PR DESCRIPTION
When navigating the top bar in mobile mode on iOS (I'm on iOS 7), the selection highlight that shows before navigation occurs doesn't clear itself when you click the Back button.  This doesn't occur on the desktop browser in mobile mode, so it appears to be specific to the mobile OS.
