### PR TITLE
$base-font-size guidelines in _settings.scss don't work

### DIFF
--- a/scss/foundation/_variables.scss
+++ b/scss/foundation/_variables.scss
@@ -12,8 +12,8 @@ $base-font-size: 100% !default;
 // This is the default html and body font-size for the base em value.
 
 // Since the typical default browser font-size is 16px, that makes the calculation for grid size.
-// If you want your base font-size to be a different size and not have it effect grid size too,
-// set the value of $em-base to $base-font-size ($em-base: $base-font-size;)
+// If you want your base font-size to be different and not have it effect the grid breakpoints,
+// set $em-base to $base-font-size and make sure $base-font-size is a px value.
 $em-base: 16px !default;
 
 // It strips the unit of measure and returns it

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -293,8 +293,7 @@ $cursor-text-value: text !default;
     @include box-sizing(border-box);
   }
 
-  html,
-  body { font-size: $base-font-size; }
+  html { font-size: $base-font-size; }
 
   // Default body styles
   body {
@@ -302,6 +301,8 @@ $cursor-text-value: text !default;
     color: $body-font-color;
     padding: 0;
     margin: 0;
+    font-size: $em-base; // In case the browser doesn't support rem units
+    font-size: 1rem;
     font-family: $body-font-family;
     font-weight: $body-font-weight;
     font-style: $body-font-style;


### PR DESCRIPTION
So I'm trying to reduce the standard font size from 16px to 14px. So I've adjusted the $base-font-size to 95% which then makes the grid smaller.

The instructions in _settings.scss say to "set the value of $em-base to $base-font-size ($em-base: $base-font-size;)". If I do that, I get a compile error saying:

"Syntax error: 9.25301em*px/% isn't a valid CSS value."

It doesn't seem to be particularly straight forward to adjust the font size and maintain the original grid dimensions.
