### PR TITLE
Dropdowns don't close on iPad once opened

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -57,7 +57,7 @@
         .on('opened.fndtn.dropdown', '[data-dropdown-content]', this.settings.opened)
         .on('closed.fndtn.dropdown', '[data-dropdown-content]', this.settings.closed);
 
-      $(document).on('click.fndtn.dropdown', function (e) {
+      $(document).on('click.fndtn.dropdown touchstart.fndtn.dropdown', function (e) {
         var parent = $(e.target).closest('[data-dropdown-content]');
 
         if ($(e.target).data('dropdown') || $(e.target).parent().data('dropdown')) {


### PR DESCRIPTION
I'm looking at  http://foundation.zurb.com/docs/components/dropdown-buttons.html and http://foundation.zurb.com/docs/components/dropdown.html

When you tap on a dropdown in iPad, it doesn't close if clicked anywhere outside the dropdown. You have to tap the same link or button.

I've tried this on an iPad 1 and an iPad 4. Desktop browser works fine as expected.

This is the pretty much the same as issue #1386 , which has been closed.
