### PR TITLE
Update reveal.html.erb

### DIFF
--- a/docs/components/reveal.html.erb
+++ b/docs/components/reveal.html.erb
@@ -84,7 +84,7 @@ $('#myModal').foundation('reveal', 'close');
 
 <%= code_example "
 // just an url
-$('#myModal').foundation('reveal', 'open', 'http://some-url');
+$('#myModal').foundation('reveal', 'open', {url: 'http://some-url'});
 
 // url with extra parameters
 $('#myModal').foundation('reveal', 'open', {


### PR DESCRIPTION
Just passing an url when opening modals via Javascript does not seem to work. Instead use {url: "http://some-url"}.
