### PR TITLE
topbar search input cutoff

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -398,12 +398,15 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
       input,
       .button {
-        line-height: 2em;
         font-size: em-calc(14);
         height: 2em;
         padding: 0 10px;
         position: relative;
         top: 8px;
+      }
+
+      .button {
+        line-height: 2em;
       }
 
       &.expanded { background: $topbar-bg; }


### PR DESCRIPTION
From the examples' Doc foudn here (looking at the sample with search input, shown in code):
http://foundation.zurb.com/docs/components/top-bar.html

The input field appears cuttoff;

It appears the height property of the input should be  2.45em (default value):
From _topbar.scss:

> .topbar {
>    ...
>    **Line 84 in _topbar.scss**
>    input { height: $topbar-input-height; }
>    ...
> }

Rule is thus `.topbar input`

But is overriden by _topbar.scss _line 334_:

> ...
> input, .button {
>        line-height: 2em;
>        font-size: emCalc(14px);
>        height: 2em;
>        padding: 0 10px;
>        position: relative;
>        top: 8px;
>      }

2em is the height applied;

Observed this behavior in Chrome and IE10

I am just starting using Foundation so I am not sure what would be a proper fix that won't break anything

Thanks
