### PR TITLE
Quotes around thumbs' background image url

### DIFF
--- a/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
+++ b/vendor/assets/javascripts/foundation/jquery.foundation.orbit.js
@@ -473,7 +473,7 @@
         if (thumbName) {
           $li
             .addClass('has-thumb')
-            .css({background: "url(" + this.options.bulletThumbLocation + thumbName + ") no-repeat"});;
+            .css({background: "url('" + this.options.bulletThumbLocation + thumbName + "') no-repeat"});;
         }
       }
       this.$bullets.append($li);


### PR DESCRIPTION
Thumbs are not generated(visually) when their filenames contain brackets
