### PR TITLE
Use the settings object from the current function scope so that the multi_expand property can be overridden in data-options.

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -122,7 +122,7 @@
       e.stopPropagation(); //do not catch same click again on parent
 
       if (!region.hasClass(self.settings.active_class)) {
-        if (!self.is_accordion(section) || (self.is_accordion(section) && !self.settings.multi_expand)) {
+        if (!self.is_accordion(section) || (self.is_accordion(section) && !settings.multi_expand)) {
           prev_active_region.removeClass(self.settings.active_class);
           prev_active_region.trigger('closed.fndtn.section');
         }


### PR DESCRIPTION
self.settings.multi_expand is always false otherwise
