### PR TITLE
Fix deep linking for sections

### DIFF
--- a/js/foundation/foundation.section.js
+++ b/js/foundation/foundation.section.js
@@ -349,7 +349,7 @@
       
       if (selectedSection != null) {
         sections.each(function() {
-          if (selectedSection == $(this)) {
+          if (selectedSection[0] === $(this)[0]) {
             var section = $(this),
                 settings = $.extend({}, self.settings, self.data_options(section)),
                 regions = section.children(self.settings.region_selector),


### PR DESCRIPTION
Deep linking in sections wasn't working for me. Changing L352 fixed it for me.
Tested with jQuery, not zepto.
