### PR TITLE
remove block-grid bullets in IE

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -36,6 +36,7 @@ $block-grid-media-queries: true !default;
     &>li {
       width: 100%/$per-row;
       padding: 0 ($spacing/2) $spacing;
+      list-style: none;
 
       &:nth-of-type(n) { clear: none; }
       &:nth-of-type(#{$per-row}n+1) { clear: both; }


### PR DESCRIPTION
I know Zurb dropped support for IE8, but maybe you'll accept this small change that improves IE8 users' life a little bit and should not have side effects.

Basically, in IE9+ and other modern browsers `display: inline` on a `<li>` will not include the bullet point (because they are not `display: list-item` anymore, so it makes sense).

But IE8 does display the bullets, because it's IE8.

This PR just sets `list-style: none;` for the `li`'s in `.block-grid`'s
