### PR TITLE
Improve Android compatibility for the Switch component

### DIFF
--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -137,15 +137,12 @@ $switch-label-outline: 1px dotted #888 !default;
   // Hiding custom form spans since we auto-create them
   span.custom { display: none !important; }
 
-  // FIXME We should be able to remove this going forward.
-  // Bugfix for older Webkit, including mobile Webkit. Adapted from:
-  // http://css-tricks.com/webkit-sibling-bug/
-  // @media only screen and (-webkit-min-device-pixel-ratio:0) and (max-device-width:480px) {
-  //   @if $experimental { -webkit-animation: webkitSiblingBugfix infinite 1s; }
-  // }
-  // @media only screen and (-webkit-min-device-pixel-ratio:1.5) {
-  //   @if $experimental { -webkit-animation: none 0; }
-  // }
+  // Bugfix for older Webkit, including mobile Webkit.
+  // Adapted from: http://css-tricks.com/webkit-sibling-bug/
+  // Affects all Android versions up to 4.2.
+  @media only screen and (-webkit-max-device-pixel-ratio: 2) and (max-device-width: 1280px) {
+    @if $experimental { -webkit-animation: webkitSiblingBugfix infinite 1s; }
+  }
 
   form.custom & .hidden-field {
     margin-left: auto;
@@ -309,6 +306,6 @@ $switch-label-outline: 1px dotted #888 !default;
 
       }
 
-      @if $experimental { @-webkit-keyframes webkitSiblingBugfix { from { position: relative; } to { position: relative; } } }
+      @if $experimental { @-webkit-keyframes webkitSiblingBugfix { from { -webkit-transform: translate3d(0,0,0); } to { -webkit-transform: translate3d(0,0,0); } } }
   }
 }


### PR DESCRIPTION
Since the [old-Webkit Adjacent/General Sibling bug](http://css-tricks.com/webkit-sibling-bug/) seems to affect even newer Android devices, with Android versions up to 4.2, the conditional media query that targets them needs to be expanded.

This fixes support for devices like the Galaxy S2, S3, HTC Incredible S, that ship with Android 4.0, and probably many others.
This also changes the animated property to use a webkit-only `translate3d`, improving performance on when the media query is matched.

Since without the `$experimental` flag the fix is not rendered at all, the Switch component in the default Foundation build is not working at all on Android. Have you considered removing the `$experimental` flag, and just rendering the bugfix by default?
