### PR TITLE
interchange TypeError: el[0] is undefined

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -32,7 +32,7 @@
 
       directives : {
         replace: function (el, path) {
-          if (/IMG/.test(el[0].nodeName)) {
+          if (el[0] && /IMG/.test(el[0].nodeName)) {
             var orig_path = el[0].src;
 
             if (new RegExp(path, 'i').test(orig_path)) return;
@@ -64,6 +64,8 @@
 
     events : function () {
       var self = this;
+
+      this.off();
 
       $(window).on('resize.fndtn.interchange', self.throttle(function () {
         self.resize.call(self);
@@ -236,6 +238,10 @@
       }
 
       return output;
+    },
+
+    off: function() {
+      $(window).off('.fndtn.interchange');
     },
 
     reflow : function () {

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -14,7 +14,7 @@ function when(size, testFunc) {
       testFunc.apply(this);
     } else {
       // Uncomment to verify skipping correct tests for media queries...
-      //console.log('[' + document.width.toString() + 'px]: Skipping ' + jasmine.getEnv().currentSpec.getFullName());
+      //console.log('[' + $(window).width().toString() + 'px]: Skipping ' + jasmine.getEnv().currentSpec.getFullName());
     }
   }
 }

--- a/spec/interchange/defaultAndSmall.html
+++ b/spec/interchange/defaultAndSmall.html
@@ -1,0 +1,1 @@
+<img id="mainImage" data-interchange="[http://placehold.it/350x150, (default)], [http://placehold.it/900x400, (small)]" src="http://placehold.it/350x150">

--- a/spec/interchange/interchange.js
+++ b/spec/interchange/interchange.js
@@ -1,0 +1,61 @@
+describe('interchange:', function() {
+  beforeEach(function() {
+    this.addMatchers({
+      // Interchange-specific matchers go here...
+    });
+  });
+
+  describe('an image with built-in sizes specified', function() {
+    beforeEach(function() {
+      document.body.innerHTML = __html__['spec/interchange/defaultAndSmall.html'];
+
+      $.ajax({ dataType: 'script', cache: false, async: false, url: '/base/js/foundation/foundation.js'});
+
+      var origFunc = $.fn.foundation;
+      spyOn($.fn, 'foundation').andCallFake(function() {
+        var result = origFunc.apply(this);
+        jasmine.Clock.tick(1000); // Let things settle...
+        return result;
+      });
+
+      $.ajax({ dataType: 'script', cache: false, async: false, url: '/base/js/foundation/foundation.interchange.js'});
+    });
+
+    describe('when below the small breakpoint', function () {
+      it('should be the default image', when('tiny', function() {
+        $(document).foundation();
+
+        var image = $('#mainImage');
+        expect(image[0].src).toBe('http://placehold.it/350x150');
+      }));
+    });
+
+    describe('when above the small breakpoint', function() {
+      it('should be the small image', when('small', function() {
+        $(document).foundation();
+
+        var settings = Foundation.libs.interchange.settings;
+
+        var image = $('#mainImage');
+        expect(image[0].src).toBe('http://placehold.it/900x400');
+      }));
+    });
+
+    describe('when the image is removed dynamically', function() {
+      it('should not cause errors during resize', function() {
+
+        var resizeFunc = Foundation.libs.interchange.resize;
+        spyOn(Foundation.libs.interchange, 'resize').andCallFake(function() {
+          expect($.proxy(resizeFunc, this)).not.toThrow();
+        });
+
+        $(document).foundation();
+
+        $('#mainImage').detach();
+
+        $(window).trigger('resize');
+        jasmine.Clock.tick(1000);
+      });
+    });
+  });
+});


### PR DESCRIPTION
I'm using interchange along with angular. When a part of the page is re-rendered and there are no images on it then an error is displayed:
TypeError: el[0] is undefined

I fixed it by adding a el[0] check in the following place: (foundation.interchange.js v.4.3.2 line 33-35)

```
  directives : {
    replace: function (el, path) {
      if (el[0] && /IMG/.test(el[0].nodeName)) {
```

not sure if this is the best way to solve the problem, I guess you guys will know ;)
