### PR TITLE
Don't wipe style attribute in foundation.dropdown.js#css

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -159,8 +159,10 @@
           var left = position.left - (this.outerWidth(dropdown) - this.outerWidth(target));
         }
 
-        dropdown.attr('style', '').css({
+        dropdown.css({
           position : 'absolute',
+          width: '',
+          'max-width': '',
           top: position.top + this.outerHeight(target),
           left: left
         });


### PR DESCRIPTION
In dropdown.js, css function:

``` javascript
dropdown.attr('style', '').css({
  position : 'absolute',
  top: position.top + this.outerHeight(target),
  left: left
});
```

By wiping the style attribute, it can needlessly break other plugins bound to the same element.

As a use case, I'm using foundation dropdown with Packery for a "meganav".
