### PR TITLE
Added class for vertically centering block elements

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -141,6 +141,22 @@ $experimental: true !default;
   }
 }
 
+// We use this to vertically center block elements
+.vertical-center {  
+  &:before {
+    content: '';
+    display: inline-block;
+    height: 100%; 
+    vertical-align: middle;
+    margin-right: -0.25em; /* Adjusts for spacing */
+  }  
+  div {
+    display: inline-block;
+    vertical-align: middle;
+    width: auto;
+  }
+ }
+
 //
 // Foundation Variables
 //


### PR DESCRIPTION
Added a class (.vertical-center) for vertically centering block elements, based on a blog post by Chris Coyier (http://css-tricks.com/centering-in-the-unknown/).

Here is an example with some basic styling for demonstration: http://codepen.io/avclark/pen/yDKze. 
