### PR TITLE
Support for mixed directionality (only in Grid, so far)

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -86,6 +86,7 @@ $total-columns: 12 !default;
 
     // If last column, float naturally instead of with with text direction
     @if $last-column {
+      float: left;
       [dir="ltr"] & { float: left; }
       [dir="rtl"] & { float: right; }
       &[dir="ltr"] { float: left; }
@@ -95,6 +96,7 @@ $total-columns: 12 !default;
 
   // If offset, calculate appropriate margins
   @if $offset {
+    margin-left: gridCalc($offset, $total-columns);
     [dir=ltr] & { margin-left: gridCalc($offset, $total-columns); }
     [dir=rtl] & { margin-right: gridCalc($offset, $total-columns); }
     &[dir=ltr] { margin-left: gridCalc($offset, $total-columns); }
@@ -103,6 +105,7 @@ $total-columns: 12 !default;
 
   // Source Ordering, adds left/right depending on directionality.
   @if $push {
+    left: gridCalc($push, $total-columns); right: auto;
     [dir=ltr] & { left: gridCalc($push, $total-columns); right: auto; }
     [dir=rtl] & { right: gridCalc($push, $total-columns); left: auto; }
     &[dir=ltr] { left: gridCalc($push, $total-columns); right: auto; }
@@ -118,6 +121,7 @@ $total-columns: 12 !default;
 
   @if $float {
     @if $float == true {
+      float: left;
       [dir="ltr"] & { float: left; }
       [dir="rtl"] & { float: right; }
       &[dir="ltr"] { float: left; }
@@ -163,6 +167,7 @@ $total-columns: 12 !default;
     }
 
       [class*="column"] + [class*="column"]:last-child {
+        float: right;
         [dir=ltr] & { float: right; }
         [dir=rtl] & { float: left; }
         &[dir=ltr] { float: right; }
@@ -170,6 +175,7 @@ $total-columns: 12 !default;
       }
 
       [class*="column"] + [class*="column"].end {
+        float: left;
         [dir=ltr] & { float: left; }
         [dir=rtl] & { float: right; }
         &[dir=ltr] { float: left; }
@@ -203,6 +209,7 @@ $total-columns: 12 !default;
     .columns.large-uncentered {
       margin-left: 0;
       margin-right: 0;
+      float: left !important;
       [dir=ltr] & { float: left !important; }
       [dir=rtl] & { float: right !important; }
       &[dir=ltr] { float: left !important; }
@@ -211,6 +218,7 @@ $total-columns: 12 !default;
 
     .column.large-uncentered.opposite,
     .columns.large-uncentered.opposite {
+      float: right !important;
       [dir=ltr] & { float: right !important; }
       [dir=rtl] & { float: left !important; }
       &[dir=ltr] { float: right !important; }

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -25,8 +25,8 @@ $total-columns: 12 !default;
   // use @include grid-row(nest); to include a nested row
   @if $behavior == nest {
     width: auto;
-    margin-#{$default-float}: -($column-gutter/2);
-    margin-#{$opposite-direction}: -($column-gutter/2);
+    margin-left: -($column-gutter/2);
+    margin-right: -($column-gutter/2);
     margin-top: 0;
     margin-bottom: 0;
     max-width: none;
@@ -49,8 +49,8 @@ $total-columns: 12 !default;
   // use @include grid-row; to use a container row
   @else {
     width: 100%;
-    margin-#{$default-float}: auto;
-    margin-#{$opposite-direction}: auto;
+    margin-left: auto;
+    margin-right: auto;
     margin-top: 0;
     margin-bottom: 0;
     max-width: $row-width;
@@ -84,27 +84,45 @@ $total-columns: 12 !default;
   @if $columns {
     width: gridCalc($columns, $total-columns);
 
-    // If last column, float naturally instead of to the right
-    @if $last-column { float: $opposite-direction; }
+    // If last column, float naturally instead of with with text direction
+    @if $last-column {
+      [dir="ltr"] & { float: left; }
+      [dir="rtl"] & { float: right; }
+      &[dir="ltr"] { float: left; }
+      &[dir="rtl"] { float: right; }
+    }
   }
 
   // If offset, calculate appropriate margins
-  @if $offset { margin-#{$default-float}: gridCalc($offset, $total-columns); }
+  @if $offset {
+    [dir=ltr] & { margin-left: gridCalc($offset, $total-columns); }
+    [dir=rtl] & { margin-right: gridCalc($offset, $total-columns); }
+    &[dir=ltr] { margin-left: gridCalc($offset, $total-columns); }
+    &[dir=rtl] { margin-right: gridCalc($offset, $total-columns); }
+  }
 
-  // Source Ordering, adds left/right depending on which you use.
-  @if $push { #{$default-float}: gridCalc($push, $total-columns); #{$opposite-direction}: auto; }
-  @if $pull { #{$opposite-direction}: gridCalc($pull, $total-columns); #{$default-float}: auto; }
+  // Source Ordering, adds left/right depending on directionality.
+  @if $push {
+    [dir=ltr] & { left: gridCalc($push, $total-columns); right: auto; }
+    [dir=rtl] & { right: gridCalc($push, $total-columns); left: auto; }
+    &[dir=ltr] { left: gridCalc($push, $total-columns); right: auto; }
+    &[dir=rtl] { right: gridCalc($push, $total-columns); left: auto; }
+  }
 
   // If centered, get rid of float and add appropriate margins
   @if $center {
-    margin-#{$default-float}: auto;
-    margin-#{$opposite-direction}: auto;
+    margin-left: auto;
+    margin-right: auto;
     float: none !important;
   }
 
   @if $float {
-    @if $float == left or $float == true { float: $default-float; }
-    @else if $float == right { float: $opposite-direction; }
+    @if $float == true {
+      [dir="ltr"] & { float: left; }
+      [dir="rtl"] & { float: right; }
+      &[dir="ltr"] { float: left; }
+      &[dir="rtl"] { float: right; }
+    }
     @else { float: none; }
   }
 
@@ -144,8 +162,19 @@ $total-columns: 12 !default;
       .small-offset-#{$i} { @include grid-column($offset:$i, $collapse:null,$float:false); }
     }
 
-    [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
-    [class*="column"] + [class*="column"].end { float: $default-float; }
+      [class*="column"] + [class*="column"]:last-child {
+        [dir=ltr] & { float: right; }
+        [dir=rtl] & { float: left; }
+        &[dir=ltr] { float: right; }
+        &[dir=rtl] { float: left; }
+      }
+
+      [class*="column"] + [class*="column"].end {
+        [dir=ltr] & { float: left; }
+        [dir=rtl] & { float: right; }
+        &[dir=ltr] { float: left; }
+        &[dir=rtl] { float: right; }
+      }
 
     .column.small-centered,
     .columns.small-centered { @include grid-column($center:true, $collapse:null, $float:false); }
@@ -172,14 +201,20 @@ $total-columns: 12 !default;
 
     .column.large-uncentered,
     .columns.large-uncentered {
-      margin-#{$default-float}: 0;
-      margin-#{$opposite-direction}: 0;
-      float: $default-float !important;
+      margin-left: 0;
+      margin-right: 0;
+      [dir=ltr] & { float: left !important; }
+      [dir=rtl] & { float: right !important; }
+      &[dir=ltr] { float: left !important; }
+      &[dir=rtl] { float: right !important; }
     }
 
     .column.large-uncentered.opposite,
     .columns.large-uncentered.opposite {
-      float: $opposite-direction !important;
+      [dir=ltr] & { float: right !important; }
+      [dir=rtl] & { float: left !important; }
+      &[dir=ltr] { float: right !important; }
+      &[dir=rtl] { float: left !important; }
     }
 
 

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -84,7 +84,7 @@ $total-columns: 12 !default;
   @if $columns {
     width: gridCalc($columns, $total-columns);
 
-    // If last column, float naturally instead of with with text direction
+    // If last column, float naturally instead of with text direction
     @if $last-column {
       float: left;
       [dir="ltr"] & { float: left; }

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -145,7 +145,6 @@ $microformat-abbr-font-decoration: none !default;
   td {
     margin:0;
     padding:0;
-    direction: $text-direction;
   }
 
   /* Default Link Styles */


### PR DESCRIPTION
Hi,
I'm trying to add support for bidi and this is what I'm coming up with so far.
The rather repetitive code is due to the inability in CSS to declare something like `float: forward;`/`float: backward;`.
If there was such a value for `float` then the code would be much simpler.

Since there isn't such a value for `float`, the floating direction must be set according to the directionality of the element (and not globally, as it is currently, using `$text-direction`).

If only I could select on the direction _property_ of elements! then I wouldn't have to write quadruple code. Instead, I'm selecting on the `dir` _attribute_. Thus the double code - because it considers inheritance.

Does this seem reasonable?

It does work.

It allows mixed directionality HTML with both RTL and LTR grids, automagically, according to the elements' `dir` attribute.

so far, this only includes the removal of the resetting of direction and the support for mixed directionality in Grid. If this method is approved then I'll do the rest of the components.
