### PR TITLE
Fix typo in topbar examples.

### DIFF
--- a/doc/includes/topbar/examples_topbar_default.html
+++ b/doc/includes/topbar/examples_topbar_default.html
@@ -1,10 +1,10 @@
-<nav class="top-bar" data-top-bar>
+<nav class="top-bar" data-topbar>
   <ul class="title-area">
     <li class="name">
       <h1><a href="#">My Site</a></h1>
     </li>
   </ul>
-    
+
   <section class="top-bar-section">
     <!-- Right Nav Section -->
     <ul class="right">


### PR DESCRIPTION
Example listed data-top-bar instead of data-topbar.
