### PR TITLE
Vertically aligns left/right tooltips with their target

### DIFF
--- a/js/foundation/foundation.tooltips.js
+++ b/js/foundation/foundation.tooltips.js
@@ -154,10 +154,10 @@
           objPos(tip, (target.offset().top - this.outerHeight(tip)), 'auto', 'auto', left, width)
             .removeClass('tip-override');
         } else if (classes && classes.indexOf('tip-left') > -1) {
-          objPos(tip, (target.offset().top + (this.outerHeight(target) / 2) - nubHeight*2.5), 'auto', 'auto', (target.offset().left - this.outerWidth(tip) - nubHeight), width)
+          objPos(tip, (target.offset().top + (this.outerHeight(target) / 2) - (this.outerHeight(tip) / 2)), 'auto', 'auto', (target.offset().left - this.outerWidth(tip) - nubHeight), width)
             .removeClass('tip-override');
         } else if (classes && classes.indexOf('tip-right') > -1) {
-          objPos(tip, (target.offset().top + (this.outerHeight(target) / 2) - nubHeight*2.5), 'auto', 'auto', (target.offset().left + this.outerWidth(target) + nubHeight), width)
+          objPos(tip, (target.offset().top + (this.outerHeight(target) / 2) - (this.outerHeight(tip) / 2)), 'auto', 'auto', (target.offset().left + this.outerWidth(target) + nubHeight), width)
             .removeClass('tip-override');
         }
       }


### PR DESCRIPTION
The previous calculation for the top offset of left/right tooltips was based on the nub height rather than the height of the tooltip itself.  This worked in some cases to approximately align the target and tip vertically, but was wrong for most cases.

The new calculation takes in to account the offset of the target from the top of the page, the height of the target, and the height of the tip.  The result is that the tip is aligned vertically with its target.

Before (the target is the first edit icon):

![screen shot 2013-11-21 at 11 38 43 am](https://f.cloud.github.com/assets/4657/1593502/6eb12d0e-52cc-11e3-89af-2131baf00cad.png)

After:

![screen shot 2013-11-21 at 11 37 02 am](https://f.cloud.github.com/assets/4657/1593505/76750fc4-52cc-11e3-8822-1a3fe548fc7a.png)

Visual representation of the new calculation:

![foundation-left-right-tooltips](https://f.cloud.github.com/assets/4657/1593511/9a0b5cf4-52cc-11e3-93c1-d7a335404597.png)
