### PR TITLE
Changed typo '.clear' to '.clearfix' in utility-classes.html

### DIFF
--- a/doc/pages/utility-classes.html
+++ b/doc/pages/utility-classes.html
@@ -8,7 +8,7 @@ layout: doc/layouts/default.html
 ***
 <h3>Float Classes</h3>
 
-You can change the float behavior of an element by adding `.left` or `.right` to an HTML element. To clear floats, add the class `.clear` to the parent element.
+You can change the float behavior of an element by adding `.left` or `.right` to an HTML element. To clear floats, add the class `.clearfix` to the parent element.
 
 <div class="row">
   <div class="large-6 columns">


### PR DESCRIPTION
Seems to be a typo here, not 100% up to date on Foundation 5, but a quick Chrome Dev Tools test showed that .clear did not clear the floats inside the element, but .clearfix did
