### PR TITLE
Updating version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zurb-foundation",
-  "version": "4.0.0-wip",
+  "version": "5.0.0",
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-watch": "~0.1.0",


### PR DESCRIPTION
This will allow Foundation 5.0.0 to be published to npm.

Let me know if there's a different version I should be using.
