### PR TITLE
Extends don’t work with libsass

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -64,19 +64,19 @@ $menu-slide: "transform 500ms ease" !default;
 
 // EXTEND CLASSES
 // Remove transition flicker on phones
-%kill-flicker {
+@mixin kill-flicker {
   -webkit-transform: translateZ(0x);
   -webkit-backface-visibility: hidden;
 }
 
 // Basic properties for the content wraps
-%wrap-base {
+@mixin wrap-base {
   position: relative;
   width: 100%;
 }
 
 // basic styles for off-canvas menu container
-%off-canvas-menu {
+@mixin off-canvas-menu {
   width: $off-canvas-width;
   top:0;
   bottom:0;
@@ -100,16 +100,16 @@ $menu-slide: "transform 500ms ease" !default;
 // OFF CANVAS WRAP
 // Wrap visible content and prevent scroll bars
 @mixin off-canvas-wrap {
-    @extend %kill-flicker;
-    @extend %wrap-base;
+    @include kill-flicker;
+    @include wrap-base;
     overflow: hidden;
 }
 
 // INNER WRAP
 // Main content area that moves to reveal the off-canvas nav
 @mixin inner-wrap {
-    @extend %kill-flicker;
-    @extend %wrap-base;
+    @include kill-flicker;
+    @include wrap-base;
     @include clearfix;
 
     -webkit-transition: -webkit-#{$menu-slide};
@@ -123,7 +123,7 @@ $menu-slide: "transform 500ms ease" !default;
 // TAB BAR
 // This is the tab bar base
 @mixin tab-bar-base { 
-  @extend %kill-flicker;
+  @include kill-flicker;
 
   // base styles
   background: $tabbar-bg;
@@ -147,7 +147,7 @@ $menu-slide: "transform 500ms ease" !default;
 
 // SMALL SECTIONS
 // These are small sections on the left and right that contain the off-canvas toggle buttons;
-%tabbar-small-section {
+@mixin tabbar-small-section {
   width: $tabbar-height;
   height: $tabbar-height;
   position: absolute;
@@ -155,14 +155,14 @@ $menu-slide: "transform 500ms ease" !default;
 }
 
 @mixin left-small-section {
-  @extend %tabbar-small-section;
+  @include tabbar-small-section;
   border-right: $tabbar-left-section-border;
   box-shadow: 1px 0 0 lighten($tabbar-bg, 10%);
   left:0;
 }
 
 @mixin right-small-section {
-  @extend %tabbar-small-section;
+  @include tabbar-small-section;
   border-left: $tabbar-right-section-border;
   box-shadow: -1px 0 0 darken($tabbar-bg, 10%);
   right:0;
@@ -224,7 +224,7 @@ $menu-slide: "transform 500ms ease" !default;
 // BACK LINK
 // This is an overlay that, when clicked, will toggle off the off canvas menu
 @mixin back-link {
-    @extend %kill-flicker;
+    @include kill-flicker;
 
     transition: $off-canvas-overlay-transition;
     cursor: $off-canvas-overlay-cursor;
@@ -250,14 +250,14 @@ $menu-slide: "transform 500ms ease" !default;
 // OFF CANVAS MENUS
 // These are the containers that contain the off canvas content
 @mixin left-off-canvas-menu {
-  @extend %kill-flicker;
-  @extend %off-canvas-menu;
+  @include kill-flicker;
+  @include off-canvas-menu;
   @include translate3d(-100%,0,0);
-  * { @extend %kill-flicker; } 
+  * { @include kill-flicker; } 
 }
 @mixin right-off-canvas-menu {
-  @extend %kill-flicker;
-  @extend %off-canvas-menu;
+  @include kill-flicker;
+  @include off-canvas-menu;
   @include translate3d(100%,0,0);
   right:0;
 }

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -108,12 +108,12 @@ $microformat-abbr-font-decoration: none !default;
 //
 
 // These will throw a deprecation warning if used within a media query.
-%lead {
+@mixin lead {
   font-size: $paragraph-font-size + rem-calc(3.5);
   line-height: 1.6;
 }
 
-%subheader {
+@mixin subheader {
   line-height: $subheader-line-height;
   color: $subheader-font-color;
   font-weight: $subheader-font-weight;
@@ -169,7 +169,7 @@ $microformat-abbr-font-decoration: none !default;
       margin-bottom: $paragraph-margin-bottom;
       text-rendering: $paragraph-text-rendering;
 
-      &.lead { @extend %lead; }
+      &.lead { @include lead; }
 
       & aside {
         font-size: $paragraph-aside-font-size;
@@ -203,7 +203,7 @@ $microformat-abbr-font-decoration: none !default;
     h5 { font-size: $h5-font-size; }
     h6 { font-size: $h6-font-size; }
 
-    .subheader { @extend %subheader; }
+    .subheader { @include subheader; }
 
     hr {
       border: $hr-border-style $hr-border-color;


### PR DESCRIPTION
Foundation 5 seems like it’s supposed to work with libsass, which is great! Definitely the right choice. Unfortunately, right now, `@extend` and `%` silent classes aren’t suppored in libsass. (The duplicate issues are https://github.com/hcatlin/libsass/issues/80, https://github.com/hcatlin/libsass/issues/137, and https://github.com/hcatlin/libsass/issues/146.)

The feature is supposed to be coming, but right now compiling Foundation with libsass will just output `@extend` and `%` literally. Since it’s being used so sparingly anyway, I think all the silent classes should be switched to mixins for the time being.
