### PR TITLE
Update readme to remove older yeoman generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Ruby on Rails Sass Gems
 Yeoman Generator
 
 * [Yeoman 1.0-Foundation 4](https://github.com/lkbgift/foundation4-yeoman) by [Leonard Bogdonoff](http://twitter.com/lkbcc)
-* [Yeoman-Foundation](https://npmjs.org/package/yeoman-foundation) by Vincent Mac
+* [Generator-Browserify](https://npmjs.org/package/generator-browserify) by [Vincent Mac](http://twitter.com/vincentmac)
 * [Generator-Foundation-Ext](https://github.com/jamesakers/generator-foundation-ext) by James Akers
 
 MIT Open Source License


### PR DESCRIPTION
Update readme to remove older yeoman generator (`yeoman-foundation`), that I am not actively developing anymore,
and replace with new generator that is compatible with the new yeoman architecture (`generator-browserify`).

Alternatively, I can just add this new generator to the readme if you'd like.
