### PR TITLE
NARGA WordPress Starter theme, upgraded to Foundation 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Many thanks to all the people working on Foundation either to improve the base c
 
 WordPress (Versions marked 3/20/13)
 
+* [NARGA](http://www.narga.net/narga-core/) is WordPress Starter Theme made by Nguyễn Đình Quân using Foundation version 5
 * [WP-Forge](http://themeawesome.com/responsive-wordpress-theme/) by Thomas E. Vasquez using Foundation 4.3.1
-* [NARGA](http://www.narga.net/narga-core/) by Nguyễn Đình Quân using Foundation version 4
 * [Reactor](https://github.com/awtheme/reactor) by Anthony Wilhelm using Foundation version 4
 * [Reverie](http://themefortress.com/reverie/) by Zhen using Foundation version 4
 * [Corner Stone](https://github.com/thewirelessguy/cornerstone) by [Stephen Mullen](https://twitter.com/wirelessguyuk) using Foundation version v4.09


### PR DESCRIPTION
NARGA WordPress Starter theme, upgraded to Foundation 5, approved on WordPress.org
