### PR TITLE
Fix documentation insonsistencies

### DIFF
--- a/doc/includes/dropdown/examples_dropdown_variables.html
+++ b/doc/includes/dropdown/examples_dropdown_variables.html
@@ -2,26 +2,26 @@
 ```scss
 $include-html-button-classes: $include-html-classes;
 
-/* We use these to controls height and width styles. */
+// We use these to controls height and width styles.
 $f-dropdown-max-width: 200px;
 $f-dropdown-height: auto;
 $f-dropdown-max-height: none;
 $f-dropdown-margin-top: 2px;
 
-/* We use this to control the background color */
+// We use this to control the background color.
 $f-dropdown-bg: #fff;
 
-/* We use this to set the border styles for dropdowns. */
+// We use this to set the border styles for dropdowns.
 $f-dropdown-border-style: solid;
 $f-dropdown-border-width: 1px;
 $f-dropdown-border-color: darken(#fff, 20%);
 
-/* We use these to style the triangle pip. */
+// We use these to style the triangle pip.
 $f-dropdown-triangle-size: 6px;
 $f-dropdown-triangle-color: #fff;
 $f-dropdown-triangle-side-offset: 10px;
 
-/* We use these to control styles for the list elements. */
+// We use these to control styles for the list elements.
 $f-dropdown-list-style: none;
 $f-dropdown-font-color: #555;
 $f-dropdown-font-size: rem-calc(14);
@@ -30,7 +30,7 @@ $f-dropdown-line-height: rem-calc(18);
 $f-dropdown-list-hover-bg: #eeeeee;
 $dropdown-mobile-default-float: 0;
 
-/* We use this to control the styles for when the dropdown has custom content. */
+// We use this to control the styles for when the dropdowns have custom content.
 $f-dropdown-content-padding: rem-calc(20);
 ```
 {{/markdown}}

--- a/doc/includes/joyride/examples_joyride_variables.html
+++ b/doc/includes/joyride/examples_joyride_variables.html
@@ -2,7 +2,7 @@
 ```scss
 $include-html-joyride-classes: $include-html-classes;
 
-/* Controlling default Joyride styles */
+// Controlling default Joyride styles.
 $joyride-tip-bg: rgb(0,0,0);
 $joyride-tip-default-width: 300px;
 $joyride-tip-padding: rem-calc(18 20 24);
@@ -10,25 +10,25 @@ $joyride-tip-border: solid 1px #555;
 $joyride-tip-radius: 4px;
 $joyride-tip-position-offset: 22px;
 
-/* Here, we\'re setting the tip dont styles */
+// Here, we\'re setting the tip dont styles.
 $joyride-tip-font-color: #fff;
 $joyride-tip-font-size: rem-calc(14);
 $joyride-tip-header-weight: bold;
 
-/* This changes the nub size */
+// This changes the nub size.
 $joyride-tip-nub-size: 14px;
 
-/* This adjusts the styles for the timer when its enabled */
+// This adjusts the styles for the timer when its enabled.
 $joyride-tip-timer-width: 50px;
 $joyride-tip-timer-height: 3px;
 $joyride-tip-timer-color: #666;
 
-/* This changes up the styles for the close button */
+// This changes up the styles for the close button.
 $joyride-tip-close-color: #777;
 $joyride-tip-close-size: 30px;
 $joyride-tip-close-weight: normal;
 
-/* When Joyride is filling the screen, we use this style for the bg */
+// When Joyride is filling the screen, we use this style for the bg.
 $joyride-screenfill: rgba(0,0,0,0.5);
 ```
 {{/markdown}}

--- a/doc/includes/reveal/examples_reveal_variables.html
+++ b/doc/includes/reveal/examples_reveal_variables.html
@@ -2,25 +2,25 @@
 ```scss
 $include-html-reveal-classes: $include-html-classes;
 
-/* We use these to control the style of the reveal overlay. */
+// We use these to control the style of the reveal overlay.
 $reveal-overlay-bg: rgba(#000, .45);
 $reveal-overlay-bg-old: #000;
 
-/* We use these to control the style of the modal itself. */
+// We use these to control the style of the modal itself.
 $reveal-modal-bg: #fff;
 $reveal-position-top: 50px;
 $reveal-default-width: 80%;
 $reveal-modal-padding: rem-calc(20);
 $reveal-box-shadow: 0 0 10px rgba(#000,.4);
 
-/* We use these to style the reveal close button */
+// We use these to style the reveal close button.
 $reveal-close-font-size: rem-calc(22);
 $reveal-close-top: rem-calc(8);
 $reveal-close-side: rem-calc(11);
 $reveal-close-color: #aaa;
 $reveal-close-weight: bold;
 
-/* We use these to control the modal border */
+// We use these to control the modal border.
 $reveal-border-style: solid;
 $reveal-border-width: 1px;
 $reveal-border-color: #666;

--- a/doc/includes/split_button/examples_split_button_variables.html
+++ b/doc/includes/split_button/examples_split_button_variables.html
@@ -2,34 +2,34 @@
 ```scss
 $include-html-button-classes: $include-html-classes;
 
-/* We use these to control different shared styles for Split Buttons */
+// We use these to control different shared styles for Split Buttons.
 $split-button-function-factor: 15%;
 $split-button-pip-color: #fff;
 $split-button-pip-color-alt: #333;
 $split-button-active-bg-tint: rgba(0,0,0,0.1);
 
-/* We use these to control tiny split buttons */
+// We use these to control tiny split buttons.
 $split-button-padding-tny: $button-tny * 9;
 $split-button-span-width-tny: $button-tny * 6.5;
 $split-button-pip-size-tny: $button-tny;
 $split-button-pip-top-tny: $button-tny * 2;
 $split-button-pip-default-float-tny: rem-calc(-5);
 
-/* We use these to control small split buttons */
+// We use these to control small split buttons.
 $split-button-padding-sml: $button-sml * 7;
 $split-button-span-width-sml: $button-sml * 5;
 $split-button-pip-size-sml: $button-sml;
 $split-button-pip-top-sml: $button-sml * 1.5;
 $split-button-pip-default-float-sml: rem-calc(-9);
 
-/* We use these to control medium split buttons */
+// We use these to control medium split buttons.
 $split-button-padding-med: $button-med * 6.4;
 $split-button-span-width-med: $button-med * 4;
 $split-button-pip-size-med: $button-med - rem-calc(3);
 $split-button-pip-top-med: $button-med * 1.5;
 $split-button-pip-default-float-med: rem-calc(-9);
 
-/* We use these to control large split buttons */
+// We use these to control large split buttons.
 $split-button-padding-lrg: $button-lrg * 6;
 $split-button-span-width-lrg: $button-lrg * 3.75;
 $split-button-pip-size-lrg: $button-lrg - rem-calc(6);

--- a/doc/includes/topbar/examples_topbar_variables.html
+++ b/doc/includes/topbar/examples_topbar_variables.html
@@ -2,21 +2,21 @@
 ```scss
 $include-html-top-bar-classes: $include-html-classes;
 
-/* Background color for the top bar */
+// Background color for the top bar
 $topbar-bg: #111;
 
-/* Height and margin */
+// Height and margin
 $topbar-height: 45px;
 $topbar-margin-bottom: rem-calc(30);
 
-/* Control Input height for top bar */
+// Control Input height for top bar
 $topbar-input-height: 2.45em;
 
-/* Controlling the styles for the title in the top bar */
+// Controlling the styles for the title in the top bar
 $topbar-title-weight: bold;
 $topbar-title-font-size: rem-calc(17);
 
-/* Style the top bar dropdown elements */
+// Style the top bar dropdown elements
 $topbar-dropdown-bg: #222;
 $topbar-dropdown-link-color: #fff;
 $topbar-dropdown-link-bg: lighten($topbar-bg, 5%);
@@ -24,13 +24,13 @@ $topbar-dropdown-toggle-size: 5px;
 $topbar-dropdown-toggle-color: #fff;
 $topbar-dropdown-toggle-alpha: 0.5;
 
-/* Set the link colors and styles for top-level nav */
+// Set the link colors and styles for top-level nav
 $topbar-link-color: #fff;
 $topbar-link-color-hover: #fff;
 $topbar-link-color-active: #fff;
 $topbar-link-weight: bold;
 $topbar-link-font-size: rem-calc(13);
-$topbar-link-hover-lightness: -30%; /* Darken by 30% */
+$topbar-link-hover-lightness: -30%; // Darken by 30%
 $topbar-link-bg-hover: darken($topbar-bg, 3%);
 $topbar-link-bg-active: darken($topbar-bg, 3%);
 
@@ -39,7 +39,7 @@ $topbar-dropdown-label-text-transform: uppercase;
 $topbar-dropdown-label-font-weight: bold;
 $topbar-dropdown-label-font-size: rem-calc(10);
 
-/* Top menu icon styles */
+// Top menu icon styles
 $topbar-menu-link-transform: uppercase;
 $topbar-menu-link-font-size: rem-calc(13);
 $topbar-menu-link-weight: bold;
@@ -48,16 +48,16 @@ $topbar-menu-icon-color: #fff;
 $topbar-menu-link-color-toggled: #888;
 $topbar-menu-icon-color-toggled: #888;
 
-/* Transitions and breakpoint styles */
+// Transitions and breakpoint styles
 $topbar-transition-speed: 300ms;
-$topbar-breakpoint: rem-calc(940); /* Change to 9999px for always mobile layout */
+$topbar-breakpoint: rem-calc(940); // Change to 9999px for always mobile layout
 $topbar-media-query: "only screen and (min-width: #{$topbar-breakpoint})";
 
-/* Divider Styles */
+// Divider Styles
 $topbar-divider-border-bottom: solid 1px lighten($topbar-bg, 10%);
 $topbar-divider-border-top: solid 1px darken($topbar-bg, 10%);
 
-/* Sticky Class */
+// Sticky Class
 $topbar-sticky-class: ".sticky";
 $topbar-arrows: true; //Set false to remove the triangle icon from the menu item
 ```

--- a/doc/pages/components/dropdown.html
+++ b/doc/pages/components/dropdown.html
@@ -3,7 +3,7 @@ title: Dropdown menus
 layout: doc/layouts/default.html
 ---
 
-# Dropdown
+# Dropdowns
 
 <h3 class="subheader">We removed the various dropdowns within different UI elements for Foundation 5. Instead, we created a universal dropdown plugin that will attach dropdowns or popovers to whatever element you need.</h3>
 


### PR DESCRIPTION
Some of the sass variables in the documentation used html comments instead of sass comments. The dropdown page should be titled "dropdowns" to be consistent with the navigation.
