### PR TITLE
Community update

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Drupal
 
 Alfred
 
-* [Foundation Alfred](https://github.com/joshmedeski/foundation-alfred) by Josh Medeski (@joshmedeski)
+* [Foundation Alfred](https://github.com/joshmedeski/foundation-alfred) by [Josh Medeski](http://joshmedeski.com)
 
 Jekyll
 


### PR DESCRIPTION
removed Josh’s twitter handle, added a link instead. This plugin now works for Foundation 5 if you are interested in knowing :)
