### PR TITLE
Do not reset direction

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -145,7 +145,6 @@ $microformat-abbr-font-decoration: none !default;
   td {
     margin:0;
     padding:0;
-    direction: $text-direction;
   }
 
   /* Default Link Styles */


### PR DESCRIPTION
Please merge this. It fixed issue #3539. It doesn't hurt anything and it will only improve bi-directionality support. It allows the embedding of elements with `dir="rtl"` attribute value to render in their proper declared direction. Without this merge a workaround is needed:

```
[dir="ltr"] * { direction: ltr; }
[dir="rtl"] * { direction: rtl; }
[dir="ltr"] { direction: ltr; }
[dir="rtl"] { direction: rtl; }
```
