### PR TITLE
Open sans isn't loaded on https connection

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -281,7 +281,7 @@ $cursor-text-value: text !default;
 
 
 @include exports("global") {
-  @import url("http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
+  @import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
   
   // Used to provide media query values for javascript components.
   // Forward slash placed around everything to convince PhantomJS to read the value.


### PR DESCRIPTION
At the moment, the default foundation install will not use the Open Sans font on an https connection because it is requesting the font over an insecure channel.

Patched to change the `@import` declaration to be protocol agnostic:

``` css
@import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
```
