### PR TITLE
Multiline Tooltips w/ DATA-WIDTH vertical alignment fix : TIP-LEFT/TIP-RIGHT

### DIFF
--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -115,6 +115,8 @@
       nub = tip.children('.nub');
       nubHeight = nub.outerHeight();
       nubWidth = nub.outerHeight();
+      
+      tip.css({'width' : (width) ? width : 'auto'});
 
       objPos = function (obj, top, right, bottom, left, width) {
         return obj.css({
@@ -122,11 +124,10 @@
           'bottom' : (bottom) ? bottom : 'auto',
           'left' : (left) ? left : 'auto',
           'right' : (right) ? right : 'auto',
-          'width' : (width) ? width : 'auto'
         }).end();
       };
 
-      objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', target.offset().left, width);
+      objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', target.offset().left);
 
       if (this.small()) {
         objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', 12.5, $(this.scope).width());
@@ -137,16 +138,16 @@
         if (Foundation.rtl) {
           left = target.offset().left + target.offset().width - tip.outerWidth();
         }
-        objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', left, width);
+        objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', left);
         tip.removeClass('tip-override');
         if (classes && classes.indexOf('tip-top') > -1) {
-          objPos(tip, (target.offset().top - tip.outerHeight()), 'auto', 'auto', left, width)
+          objPos(tip, (target.offset().top - tip.outerHeight()), 'auto', 'auto', left)
             .removeClass('tip-override');
         } else if (classes && classes.indexOf('tip-left') > -1) {
-          objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight*2.5), 'auto', 'auto', (target.offset().left - tip.outerWidth() - nubHeight), width)
+          objPos(tip, (target.offset().top + (target.outerHeight() / 2) - (tip.outerHeight() / 2)), 'auto', 'auto', (target.offset().left - tip.outerWidth() - nubHeight))
             .removeClass('tip-override');
         } else if (classes && classes.indexOf('tip-right') > -1) {
-          objPos(tip, (target.offset().top + (target.outerHeight() / 2) - nubHeight*2.5), 'auto', 'auto', (target.offset().left + target.outerWidth() + nubHeight), width)
+          objPos(tip, (target.offset().top + (target.outerHeight() / 2) - (tip.outerHeight() / 2)), 'auto', 'auto', (target.offset().left + target.outerWidth() + nubHeight))
             .removeClass('tip-override');
         }
       }


### PR DESCRIPTION
When using DATA-WIDTH or any multiline tooltip, the tooltip is top aligned with the nub vertically centered and pointing at the wrong item.

Width of Tooltip needs to be set first to calculate vertical middle point and tooltip height. Moved width setting it outside of the objPos function. Updated tip-left and -right to move tooltip up by half the objects height, pointing nub at target.

![comparison](https://f.cloud.github.com/assets/3998604/1603510/7ca4ac76-53ab-11e3-967e-c5657bddcf6d.jpg)
