### PR TITLE
Docs fix for Alert Box examples. Fixes #3664

### DIFF
--- a/doc/pages/components/alert_boxes.html
+++ b/doc/pages/components/alert_boxes.html
@@ -43,17 +43,17 @@ You can add more classes to your alert box to change its appearance.
 
 {{#markdown}}
 ```html
-<div class="alert-box success radius">
+<div data-alert class="alert-box success radius">
   This is a success alert with a radius.
   <a href="#" class="close">&times;</a>
 </div>
 
-<div class="alert-box warning round">
+<div data-alert class="alert-box warning round">
   This is a warning alert that is rounded.
   <a href="#" class="close">&times;</a>
 </div>
 
-<div class="alert-box info radius">
+<div data-alert class="alert-box info radius">
   This is an info alert with a radius.
   <a href="#" class="close">&times;</a>
 </div>


### PR DESCRIPTION
The advanced examples for Alert Boxes were missing the data-alert
attribute in the example code
