### PR TITLE
Fixed spelling error

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -576,7 +576,7 @@
 // $off-canvas-overlay-background: rgba(#FFF, 0.2);
 // $off-canvas-overlay-background-hover: rgba(#FFF, 0.05);
 
-// Transition Variabls
+// Transition Variables
 // $menu-slide: "transform 500ms ease";
 
 // Orbit


### PR DESCRIPTION
Fixed a spelling error in scss/foundation/_settings.scss "Transition Variables"
