### PR TITLE
Fix modernizr path in docs

### DIFF
--- a/doc/pages/applications.html
+++ b/doc/pages/applications.html
@@ -55,7 +55,7 @@ $(document).foundation();
 Make sure that Modernizr is included in the `<head>` of your page:
 
 ```ruby
-javascript_include_tag "vendor/custom.modernizr"
+javascript_include_tag "vendor/modernizr"
 ```
 
 ### Set Viewport Width


### PR DESCRIPTION
The corret path is vendor/modernizr as can be seen in foundation-rails gem:
https://github.com/zurb/foundation-rails/blob/master/vendor/assets/javascripts/vendor/modernizr.js

The path vendor/custom.modernizr gives the following error:
ActionController::RoutingError (No route matches [GET] "/javascripts/vendor/custom.modernizr.js"):
