### PR TITLE
Fix issue #3656 - Added fallback to 2D CSS transforms (offcanvas)

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -358,3 +358,21 @@ ul.off-canvas-list { @include off-canvas-list; }
   .move-right > .inner-wrap { left: $off-canvas-width; }
 
 }
+
+// Opera 12.16 - don't have 3d transforms
+.csstransforms.no-csstransforms3d {
+  @mixin translate($tx,$ty) {
+    -webkit-transform: translate($tx,$ty);
+    -moz-transform: translate($tx,$ty);
+    -ms-transform: translate($tx,$ty);
+    -o-transform: translate($tx,$ty);
+    transform: translate($tx,$ty)
+  }
+
+  .left-off-canvas-menu { @include translate(-100%, 0); }
+  .right-off-canvas-menu { @include translate(100%, 0); }
+
+  .move-left > .inner-wrap { @include translate(-($off-canvas-width),0); }
+  .move-right > .inner-wrap { @include translate($off-canvas-width,0) }
+
+}


### PR DESCRIPTION
Opera 12.16 browser (Presto engine) doesn't support 3d CSS transforms.

This fix provide 2d fallback for 3d transforms for _offcanvas.scss component, and fix issue #3656 

Strange, but the translate3d mixin:

``` scss
@mixin translate3d($tx,$ty,$tz) {
  // ...
  transform: translate3d($tx,$ty,$tz)
}
```

really used only for the 2d transforms

``` scss
@mixin left-off-canvas-menu {
  // ...
  @include translate3d(-100%,0,0); // $tz always zero
  // ...
}
```

How about change translate3d, to translate?

``` scss
@mixin translate($tx,$ty) {
  // ...
  transform: translate3d($tx,$ty)
}

@mixin left-off-canvas-menu {
  // ...
  @include translate(-100%,0);
  // ...
}
```
