### PR TITLE
missing "http:" in the @import rule

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -280,7 +280,7 @@ $cursor-text-value: text !default;
 
 @include exports("global") {
   @if $include-open-sans {
-    @import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
+    @import url("http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
   }
   // Used to provide media query values for javascript components.
   // Forward slash placed around everything to convince PhantomJS to read the value.


### PR DESCRIPTION
short story:
if the URL begins with "//" then browser doesn't fetch the data from googleapis.com, but tries to get the file from file:// location

long story:
I have installed foundation using "bower install foundation", created index.html and found this issue, because page was loading for about 10 seconds. I am proposing this fix into zurb/foundation but have now no chance to build it and test it afterwards - it should work, but it would be great if somebody could make sure that this is valid fix
