### PR TITLE
FIX add mobile menu toggle to Top Bar default example

### DIFF
--- a/doc/includes/topbar/examples_topbar_default.html
+++ b/doc/includes/topbar/examples_topbar_default.html
@@ -3,6 +3,8 @@
     <li class="name">
       <h1><a href="#">My Site</a></h1>
     </li>
+    <!-- Mobile Menu Toggle -->
+    <li class="toggle-topbar menu-icon"><a href=""><span>Menu</span></a></li>
   </ul>
 
   <section class="top-bar-section">

--- a/doc/pages/components/topbar.html
+++ b/doc/pages/components/topbar.html
@@ -79,6 +79,8 @@ The top bar is a pretty complex piece of magical UI goodness. We rely on many pr
         <li class="name">
           <h1><a href="#">My Site</a></h1>
         </li>
+        <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
+        <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
       </ul>
 
       <section class="top-bar-section">


### PR DESCRIPTION
Example for default Top Bar was missing mobile menu toggle. The example was not working on mobile when copy/paste the example code. This adds the `<li class="toggle-topbar menu-icon"><a href=""><span>Menu</span></a></li>` element to the example.
