### PR TITLE
Fixes typo in URL from JavaScript.html to javascript.html

### DIFF
--- a/doc/pages/components/topbar.html
+++ b/doc/pages/components/topbar.html
@@ -338,7 +338,7 @@ We do include SCSS variable to help you control some of the styles for the top b
 ### Using the JavaScript
 
 <div class="panel">
-  Before you can use the top bar you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [JavaScript documentation](../JavaScript.html) on setting that up.
+  Before you can use the top bar you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [JavaScript documentation](../javascript.html) on setting that up.
 </div>
 
 Just add `foundation.topbar.js` AFTER the `foundation.js` file. Your markup should look something like this:


### PR DESCRIPTION
On docs/components/topbar.html the link in the "Using Javascript" section is incorrect, this fixes it from JavaScript.html to javascript.html

:smile: 
