### PR TITLE
[documentation] fixed path to tooltip.js

### DIFF
--- a/doc/pages/components/tooltips.html
+++ b/doc/pages/components/tooltips.html
@@ -70,7 +70,7 @@ Tooltips can be easily customized using our provided Sass variables.
 
 ## Configure With JavaScript
 
-It's easy to configure tooltips using our JavaScript. You can use data-attributes or plain old JavaScript. Make sure `jquery.js`, `foundation.js`, and `foundation.tooltips.js` have been included on your page before continuing. For example, add the following before the closing `<body>` tag:
+It's easy to configure tooltips using our JavaScript. You can use data-attributes or plain old JavaScript. Make sure `jquery.js`, `foundation.js`, and `foundation.tooltip.js` have been included on your page before continuing. For example, add the following before the closing `<body>` tag:
 
 <h4>HTML</h4>
 
@@ -78,7 +78,7 @@ It's easy to configure tooltips using our JavaScript. You can use data-attribute
 ```html
 <script src="js/jquery.js"></script>
 <script src="js/foundation.js"></script>
-<script src="js/foundation.tooltips.js"></script>
+<script src="js/foundation.tooltip.js"></script>
 ```
 {{/markdown}}
 


### PR DESCRIPTION
it was changed from `tooltips.js` to `tooltip.js`
