### PR TITLE
Fixes SCSS 3.3.0.rc.2 deprecation error. 

### DIFF
--- a/scss/foundation/components/_functions.scss
+++ b/scss/foundation/components/_functions.scss
@@ -1,7 +1,7 @@
 // This is the default html and body font-size for the base rem value.
 $rem-base: 16px !default;
 
-$modules: () !default;
+$modules: () !default !global;
 @mixin exports($name) {
   @if (index($modules, $name) == false) {
     $modules: append($modules, $name);


### PR DESCRIPTION
When using the Breakpoint (v2.2.0) gem w/ Foundation 5, it causes many deprecation errors.
There may already be a push notification about ltr/rtl globals. 
This fixed it, but I Don't know the repercussions of using global like this.
