### PR TITLE
Include `type` component when `@import`ing all the foundation SCSS components

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -33,6 +33,7 @@
   "foundation/components/tables",
   "foundation/components/tabs",
   "foundation/components/thumbs",
+  "foundation/components/type",
   "foundation/components/tooltips",
   "foundation/components/offcanvas",
   "foundation/components/visibility";


### PR DESCRIPTION
This is very usefull if you pick and choose the components based on this list.  Since `type` is not part of this list it would only be pulled in as a dependency of `offcanvas`
