### PR TITLE
flag to disable open sans missing from the generated _settings.scss

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -40,6 +40,8 @@
 // $body-font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
 // $body-font-weight: normal;
 // $body-font-style: normal;
+// $include-open-sans: true; // loads open sans from a google server
+
 
 // We use this to control font-smoothing
 // $font-smoothing: antialiased;


### PR DESCRIPTION
I did not plan on using the font, so i looked for the place to disable it. I then found it in _global - but my first stop was the settings file (where i am now putting the config flag). I placed it squarely with other "font-related" settings.
