### PR TITLE
offcanvas wraps set to 100% height

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -73,6 +73,7 @@ $menu-slide: "transform 500ms ease" !default;
 @mixin wrap-base {
   position: relative;
   width: 100%;
+  height: 100%;
 }
 
 // basic styles for off-canvas menu container


### PR DESCRIPTION
Fixes the clipped Offcanvas issue that occurs when content height is low (or there's no content loaded yet). Seen others struggling with this [here in the Foundation forum](http://foundation.zurb.com/forum/posts/273-full-height-off-canvas) and [on stackexchange](http://stackoverflow.com/questions/20158607/foundation-5-off-canvas-full-height-of-device/20290707).
This fixes the issue for me, but html and body heights still need to be set to 100% for it to work. I might have missed something, but this seems like the correct solution to me.
