### PR TITLE
Fixed the deep linking data-orbit-link "active" class issue.

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -36,7 +36,7 @@
 
     self.update_active_link = function(index) {
       var link = $('a[data-orbit-link="'+slides_container.children().eq(index).attr('data-orbit-slide')+'"]');
-      link.parents('ul').find('[data-orbit-link]').removeClass(settings.bullets_active_class);
+      link.siblings().removeClass(settings.bullets_active_class);
       link.addClass(settings.bullets_active_class);
     };
 


### PR DESCRIPTION
The below data-orbit-link classes would add active, but not delete the previous; With the current markup, the old was asking for a ul, which does not exist in the on-site example This method just removes all other active links for data-orbit-link so `active` class css markup can be added for custom effects on active links.

```

<a data-orbit-link="headline-1" class="small button">
  Goto Slide 1
</a>
<a data-orbit-link="headline-2" class="small button">
  Goto Slide 2
</a>
<a data-orbit-link="headline-3" class="small button">
  Goto Slide 3
</a>

```
