### PR TITLE
Reveal - opening and creating within JS

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -65,7 +65,9 @@
         });
 
       $(this.scope)
-        .off('.reveal')
+        .off('.reveal');
+      
+      $(document)
         .on('click.fndtn.reveal', this.close_targets(), function (e) {
 
           e.preventDefault();
@@ -106,7 +108,7 @@
       $('body').on('keyup.fndtn.reveal', function ( event ) {
         var open_modal = $('[data-reveal].open'),
             settings = open_modal.data('reveal-init');
-        if ( event.which === 27  && settings.close_on_esc) { // 27 is the keycode for the Escape key
+        if ( settings && event.which === 27  && settings.close_on_esc) { // 27 is the keycode for the Escape key
           open_modal.foundation('reveal', 'close');
         }
       });


### PR DESCRIPTION
Should fix eg. https://github.com/zurb/foundation/issues/3758

Closing by clicking on bg, X button or pressing ESC key now works properly when reveal is created and opened by javascript.

Example:

```
var $div = $("<div class='reveal-modal' data-reveal><p>asd</p><a class='close-reveal-modal'>&#215;</a></div>");
$div.foundation('reveal');
$div.foundation('reveal', 'open');
```
