### PR TITLE
fixed page overflow in small when using block grids on the page

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -29,7 +29,7 @@ $block-grid-media-queries: true !default;
   @if $base-style {
     display: block;
     padding: 0;
-    margin: 0 (-$spacing/2);
+    margin: 0 0 0 (-$spacing/2);
     @include clearfix;
 
     &>li {


### PR DESCRIPTION
without this fix, any page using block-grids created an overflow in the right side of the screen.
