### PR TITLE
fixing undefined settings when doing reflow on dropdowns

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -25,7 +25,7 @@
       $(this.scope)
         .off('.dropdown')
         .on('click.fndtn.dropdown', '[data-dropdown]', function (e) {
-          var settings = $(this).data('dropdown-init');
+          var settings = $(this).data('dropdown-init') || self.settings;
           e.preventDefault();
 
           if (!settings.is_hover || Modernizr.touch) self.toggle($(this));
@@ -42,18 +42,18 @@
                 target = $("[data-dropdown='" + dropdown.attr('id') + "']");
           }
 
-          var settings = target.data('dropdown-init');
+          var settings = target.data('dropdown-init') || self.settings;
           if (settings.is_hover) self.open.apply(self, [dropdown, target]);
         })
         .on('mouseleave.fndtn.dropdown', '[data-dropdown], [data-dropdown-content]', function (e) {
           var $this = $(this);
           self.timeout = setTimeout(function () {
             if ($this.data('dropdown')) {
-              var settings = $this.data('dropdown-init');
+              var settings = $this.data('dropdown-init') || self.settings;
               if (settings.is_hover) self.close.call(self, $('#' + $this.data('dropdown')));
             } else {
               var target = $('[data-dropdown="' + $(this).attr('id') + '"]'),
-                  settings = target.data('dropdown-init');
+                  settings = target.data('dropdown-init') || self.settings;
               if (settings.is_hover) self.close.call(self, $this);
             }
           }.bind(this), 150);


### PR DESCRIPTION
this was causing 'settings' to be undefined when doing $(document).foundation('dropdown','reflow'), and it would fail the reflow of newly created dropdown widgets
