### PR TITLE
Removed dropdown dependancy on button configuration

### DIFF
--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -3,7 +3,7 @@
 //
 // @variables
 //
-$include-html-button-classes: $include-html-classes !default;
+$include-html-dropdown-classes: $include-html-classes !default;
 
 // We use these to controls height and width styles.
 $f-dropdown-max-width: 200px !default;
@@ -129,7 +129,7 @@ $f-dropdown-content-padding: rem-calc(20) !default;
 }
 
 @include exports("dropdown") {
-  @if $include-html-button-classes {
+  @if $include-html-dropdown-classes {
 
     @media #{$small-only} {
       .f-dropdown {


### PR DESCRIPTION
The dropdown export was checking if `$include-html-button-classes == true`. This created a situation where disabling button classes disabled the dropdown classes as well.

I created another variable called $include-html-dropdown-classes which can be used to enable or disable the dropdown classes.
