### PR TITLE
Allow usage of data-tab-content attibute instead of href in tabs

### DIFF
--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -25,7 +25,12 @@
             target = $('#' + this.href.split('#')[1]),
             siblings = tab.siblings(),
             settings = tabs.data('tab-init');
-
+        
+        // allow usage of data-tab-content attribute instead of href
+        if ($(this).data('tab-content')) {
+          target = $('#' + $(this).data('tab-content').split('#')[1]);
+        }
+        
         tab.addClass(settings.active_class).trigger('opened');
         siblings.removeClass(settings.active_class);
         target.siblings().removeClass(settings.active_class).end().addClass(settings.active_class);


### PR DESCRIPTION
This is very usefull when dealing with hash based routing in web apps, as tabs would set the hash and thus trigger another route.
