### PR TITLE
Add height value for select elements to match text input height.

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -402,6 +402,11 @@ $select-bg-color: #fafafa;
           @include single-transition(all, 0.15s, linear);
       }
     }
+    
+    /* Add height value for select elements to match text input height */
+    select {
+      height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+    }
 
     /* Adjust margin for form elements below */
     input[type="file"],


### PR DESCRIPTION
When changing the default $form-spacing, heights for select elements were not matching the input[type=text]'s, which looks inconsistent.
