### PR TITLE
Fix topbar behavior when scrolltop setting is false

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -121,6 +121,7 @@
           } else {
             topbar.addClass('fixed');
             topbar.parent().addClass('expanded');
+            $('body').addClass('f-topbar-fixed');
           }
         }
       }


### PR DESCRIPTION
When a topbar's `scrolltop` setting is set to false, the expected behavior is that the page content below the dropdown should not move at all when the dropdown is displayed. The actual behavior is that when the page content has scrolled past the top, and the dropdown is displayed, then the page content will move upwards by an amount equal to the topbar's height. This is because the the class `f-topbar-fixed` is not being applied to the body when the dropdown is displayed. This is fixed in the commit here.

The `f-topbar-fixed` class does not need to be manually removed when the dropdown is closed, since `self.update_sticky_positioning()` will take care it.
