### PR TITLE
Update off-canvas menu icon to be visible on Android 2.3 devices

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -304,9 +304,9 @@ $menu-slide: "transform 500ms ease" !default;
       // margin-top: $tabbar-height / 4;
 
       @if $experimental {
-        -webkit-box-shadow: 0 10px 0 1px $tabbar-menu-icon-color,
-                            0 16px 0 1px $tabbar-menu-icon-color,
-                            0 22px 0 1px $tabbar-menu-icon-color;
+        -webkit-box-shadow: 1px 10px 1px 1px $tabbar-menu-icon-color,
+                            1px 16px 1px 1px $tabbar-menu-icon-color,
+                            1px 22px 1px 1px $tabbar-menu-icon-color;
       }
         box-shadow:        0 10px 0 1px $tabbar-menu-icon-color,
                             0 16px 0 1px $tabbar-menu-icon-color,
@@ -315,9 +315,9 @@ $menu-slide: "transform 500ms ease" !default;
     
     &:hover span {
       @if $experimental {
-        -webkit-box-shadow: 0 10px 0 1px $tabbar-menu-icon-hover,
-                            0 16px 0 1px $tabbar-menu-icon-hover,
-                            0 22px 0 1px $tabbar-menu-icon-hover;
+        -webkit-box-shadow: 1px 10px 1px 1px $tabbar-menu-icon-hover,
+                            1px 16px 1px 1px $tabbar-menu-icon-hover,
+                            1px 22px 1px 1px $tabbar-menu-icon-hover;
       }
         box-shadow:        0 10px 0 1px $tabbar-menu-icon-hover,
                             0 16px 0 1px $tabbar-menu-icon-hover,


### PR DESCRIPTION
As detailed on CanIUse:

> Android 2.3 default browser doesn't seem to appreciate 0px values. e.g. -webkit-box-shadow: 5px 1px 0px #f04e29; doesn't work, but -webkit-box-shadow: 5px 1px 1px #f04e29 does!
> http://caniuse.com/#search=box-shadow

This is the case on Android 2.3 browsers (i.e. a tested Samsung Galaxy S2). Modifying the 0 value to 1px only for the -webkit prefixed box-shadow solves the issue without causing visual degradation, ensuring the icon appears on all  modern devices.
