### PR TITLE
Add 'active' class to the link that triggered accordion content

### DIFF
--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -19,18 +19,22 @@
       $(this.scope).off('.accordion').on('click.fndtn.accordion', '[data-accordion] > dd > a', function (e) {
         var accordion = $(this).parent(),
             target = $('#' + this.href.split('#')[1]),
+						target_link = target.prev(),
             siblings = $('> dd > .content', target.closest('[data-accordion]')),
             settings = accordion.parent().data('accordion-init'),
-            active = $('> dd > .content.' + settings.active_class, accordion.parent());
+            active = $('> dd > .content.' + settings.active_class, accordion.parent()),
+						active_link = active.prev();
 
         e.preventDefault();
 
         if (active[0] == target[0] && settings.toggleable) {
-          return target.toggleClass(settings.active_class);
+          return target.toggleClass(settings.active_class) && target_link.toggleClass(settings.active_class);
         }
 
         siblings.removeClass(settings.active_class);
-        target.addClass(settings.active_class);
+				active_link.removeClass(settings.active_class);
+        target.addClass(settings.active_class)
+				target_link.addClass(settings.active_class);
       });
     },
 


### PR DESCRIPTION
In previous incarnations the link that opened accordion content be be targeted based on whether or not it was active. I think this was because the HTML structure was different before place the link within the element that the "active" class was applied to whereas now it precedes it.

This fix adds an "active" class to the link that triggered the accordion content, making the assumption it is the nearest preceding sibling.
