### PR TITLE
[bug] default settings fallback for dynamically added alert-boxes

### DIFF
--- a/js/foundation/foundation.alert.js
+++ b/js/foundation/foundation.alert.js
@@ -19,7 +19,7 @@
     events : function () {
       $(this.scope).off('.alert').on('click.fndtn.alert', '[data-alert] a.close', function (e) {
           var alertBox = $(this).closest("[data-alert]"),
-              settings = alertBox.data('alert-init');
+              settings = alertBox.data('alert-init') || Foundation.libs.alert.settings;
 
         e.preventDefault();
         alertBox[settings.animation](settings.speed, function () {


### PR DESCRIPTION
when adding alert boxes dynamically, the settings option on the alert-box is empty and throws an error when trying to close the alert-box:

> Uncaught TypeError: Cannot read property 'animation' of undefined 

this change allows to fall back to default settings, which otherwise are not accessible
