### PR TITLE
Fix Orbit navigation background color setting.

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -244,6 +244,7 @@ $preloader-class: "preloader" !default;
         height: 60px;
         line-height: 50px;
         color: white;
+        background-color: $orbit-nav-bg;
         text-indent: -9999px !important;
         z-index: 10;
 


### PR DESCRIPTION
The `$orbit-nav-bg` setting doesn't do anything because the relevant `background-color` CSS declaration was missing. This puts it back in.
