### PR TITLE
Antialiasing for Firefox (v25 and later) on Mac

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -364,8 +364,8 @@ $cursor-text-value: text !default;
     // Font smoothing
     // Antialiased font smoothing works best for light text on a dark background.
     // Apply to single elements instead of globally to body.
-    // Note this only applies to webkit-based desktop browsers on the Mac.
-    .antialiased { -webkit-font-smoothing: antialiased; }
+    // Note this only applies to webkit-based desktop browsers and Firefox 25 (and later) on the Mac.
+    .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
     // Get rid of gap under images by making them display: inline-block; by default
     img {


### PR DESCRIPTION
As of version 25 of Firefox, antialiasing is now available on Mac using the "-moz-osx-font-smoothing: grayscale;" property. This should be added to the .antialiased class.
