### PR TITLE
Fix Reveal Javascript API to match docs

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -381,7 +381,7 @@
             should_bind_events = !S(this).data(this.name + '-init');
 
         if (typeof method === 'string') {
-          return this[method].call(this);
+          return this[method].call(this, options);
         }
 
         if (S(this.scope).is('[data-' + this.name +']')) {

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -144,6 +144,12 @@
           this.toggle_bg(modal);
         }
 
+        if (typeof ajax_settings === 'string') {
+          ajax_settings = {
+            url: ajax_settings
+          };
+        }
+
         if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
           if (open_modal.length > 0) {
             var open_modal_settings = open_modal.data('reveal-init');


### PR DESCRIPTION
The initialization of Reveal Modals with AJAX content is currently broken. Some other people reported this bug in #3799 and #3444.

The first example from the documentation (just a simple url) also does not work. I added a small if condition to convert ajax_settings string to an object with url property.
