### PR TITLE
Fix escape key when no reveal is shown

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -106,7 +106,7 @@
       $('body').on('keyup.fndtn.reveal', function ( event ) {
         var open_modal = $('[data-reveal].open'),
             settings = open_modal.data('reveal-init');
-        if ( event.which === 27  && settings.close_on_esc) { // 27 is the keycode for the Escape key
+        if ( settings && event.which === 27  && settings.close_on_esc) { // 27 is the keycode for the Escape key
           open_modal.foundation('reveal', 'close');
         }
       });


### PR DESCRIPTION
If you try to press escape key when no reveal modal is shown; an error is thrown. Fixed.

Error reproduction : go on http://foundation.zurb.com/docs/components/reveal.html
Try to press escape without clicking on the button. Open the console.

js/foundation/foundation.reveal.js
Line 107/109 :
var open_modal = $('[data-reveal].open'), // [] if no reveal modal shown
     settings = open_modal.data('reveal-init'); // undefined if open_modal == []
if ( settings && event.which === 27  && settings.close_on_esc) { // settings.close_on_esc throw Error.
