### PR TITLE
Respect $reveal-modal-padding variable on all screen sizes.

### DIFF
--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -147,7 +147,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     @media #{$medium-up} {
 
       .#{$reveal-modal-class} {
-        @include reveal-modal-style(false, rem-calc(30), false, $box-shadow: false, $top-offset: rem-calc(100));
+        @include reveal-modal-style(false, $reveal-modal-padding * 1.5, false, $box-shadow: false, $top-offset: rem-calc(100));
 
         &.tiny  { @include reveal-modal-base(false, 30%); }
         &.small { @include reveal-modal-base(false, 40%); }


### PR DESCRIPTION
The reveal modal was only using the $reveal-modal-padding variable for small screens. On larger screens it was being overridden with rem-calc(30).

Since $reveal-modal-padding defaulted to rem-calc(20), I replaced rem-calc(30) with "$reveal-modal-padding \* 1.5". This results in the exact same dimensions by default.
