### PR TITLE
Allows you to configure which element to append the reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -219,13 +219,14 @@
       if (css) {
         var settings = el.data('reveal-init');
         if (el.parent('body').length === 0) {
-          var placeholder = el.wrap('<div style="display: none;" />').parent();
+          var placeholder = el.wrap('<div style="display: none;" />').parent(),
+              rootElement = this.settings.rootElement || 'body';;
           el.on('closed.fndtn.reveal.wrapped', function() {
             el.detach().appendTo(placeholder);
             el.unwrap().unbind('closed.fndtn.reveal.wrapped');
           });
 
-          el.detach().appendTo('body');
+          el.detach().appendTo(rootElement);
         }
 
         if (/pop/i.test(settings.animation)) {


### PR DESCRIPTION
- Checks for the existence of rootElement in the settings object
- Uses rootElement if it is set, otherwise it appends the reveal
  to 'body'

**Depends on PR:** #3743
## Usage

To change the element, pass in an a settings object on initialization:

``` JS
$(document).foundation( 'reveal', { rootElement: '#alternate-element'})
```

Or on open:

``` JS
$('#myModal').foundation( 'reveal', 'open', { rootElement: '#alternate-element' });
```
## Purpose

In a QUnit test environment, I needed the reveal to stay within the confines of the testing sandbox, so that the app code under test retained access to the modal.

**This feature is transparent**, if no rootElement is specified, then reveal behaves exactly as expected. But, if you need to attach the reveal to another element, then you can.
