### PR TITLE
Fix ability to set active_class for magellan plugin

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -11,9 +11,10 @@
       threshold: 0
     },
 
-    init : function (scope, method, options) {
+    init : function (scope, options) {
       this.fixed_magellan = $("[data-magellan-expedition]");
       this.set_threshold();
+      this.set_active_class(options);
       this.last_destination = $('[data-magellan-destination]').last();
       this.events();
     },
@@ -105,6 +106,12 @@
       if (typeof this.settings.threshold !== 'number') {
         this.settings.threshold = (this.fixed_magellan.length > 0) ?
           this.fixed_magellan.outerHeight(true) : 0;
+      }
+    },
+
+    set_active_class : function (options) {
+      if (options && options.active_class && typeof options.active_class === 'string') {
+        this.settings.active_class = options.active_class;
       }
     },
 

--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -11,10 +11,10 @@
       threshold: 0
     },
 
-    init : function (scope, options) {
+    init : function (scope, method, options) {
       this.fixed_magellan = $("[data-magellan-expedition]");
       this.set_threshold();
-      this.set_active_class(options);
+      this.set_active_class(method);
       this.last_destination = $('[data-magellan-destination]').last();
       this.events();
     },


### PR DESCRIPTION
Custom class was not being set per #3869 

Broken at [commit](https://github.com/devinmcinnis/foundation/commit/48c7f05e169ac7fd714e8c143ebc20504f76c1cb#diff-c7a3357463136dd9249e989454730526L19)

Based on the [Foundation JS Configuration docs](http://foundation.zurb.com/docs/javascript.html#configuration), this will now work.

```
$(document).foundation({
  magellan : {
    active_class: 'custom'
  }
});
```
