### PR TITLE
Fix broken retina background-image for footer learn-links

### DIFF
--- a/doc/assets/scss/_footer.scss
+++ b/doc/assets/scss/_footer.scss
@@ -165,7 +165,7 @@
     &.expo { background-image: url("../img/icons/footer-expo-retina.png") left top no-repeat; }
   }
   .zurb-footer-bottom a.zurb-logo { background-image: url("../img/icons/footer-icons-retina.png"); background-size: 100px 1400px; }
-  .zurb-footer-top .property .learn-links, .zurb-footer-top .property .support-links, .zurb-footer-top .property .connect-links { background-image: url("icons/footer-top-icons-retina.png"); background-size: 100px 1400px; }
+  .zurb-footer-top .property .learn-links, .zurb-footer-top .property .support-links, .zurb-footer-top .property .connect-links { background-image: url("../img/icons/footer-top-icons-retina.png"); background-size: 100px 1400px; }
 }
 @media only screen and (max-width: 320px), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2 / 1), only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
   .zurb-footer-top .info-padding { background-image: url("../img/icons/footer-large-icon-retina.png"); background-size: 100px 400px; }


### PR DESCRIPTION
The battery icon is missing in the footer on retina:

![screen shot 2013-12-14 at 12 38 12 pm](https://f.cloud.github.com/assets/1831398/1749204/501908d0-6500-11e3-9669-6aa25ef87362.png)
![screen shot 2013-12-14 at 12 37 45 pm](https://f.cloud.github.com/assets/1831398/1749205/501913e8-6500-11e3-9b34-e672f0be8170.png)

Fixed the background-image to render from proper folder:
`doc/assets/scss/_footer.scss`

![screen shot 2013-12-14 at 12 38 43 pm](https://f.cloud.github.com/assets/1831398/1749206/5029e54c-6500-11e3-877c-51ba89e144ea.png)
![screen shot 2013-12-14 at 12 38 52 pm](https://f.cloud.github.com/assets/1831398/1749207/502ab30a-6500-11e3-9215-31966cf23157.png)
