### PR TITLE
Fix broken link to JavaScript Setup doc

### DIFF
--- a/doc/pages/components/interchange.html
+++ b/doc/pages/components/interchange.html
@@ -107,7 +107,7 @@ If you add new content after the page has been loaded, you will need to trigger 
 ### Using the JavaScript
 
 
-Before you can use Interchange you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [JavaScript documentation](../JavaScript.html) on setting that up.
+Before you can use Interchange you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [JavaScript documentation](../javascript.html) on setting that up.
 
 
 Just add `foundation.interchange.js` AFTER the `foundation.js` file. Your markup should look something like this:


### PR DESCRIPTION
Replaced link 'JavaScript.html' with 'javascript.html'.
