### PR TITLE
Fix $select-bg-color setting can’t overwrite

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -63,7 +63,7 @@ $glowing-effect-fade-time: 0.45s !default;
 $glowing-effect-color: $input-focus-border-color !default;
 
 // Select variables
-$select-bg-color: #fafafa;
+$select-bg-color: #fafafa !default;
 
 
 //


### PR DESCRIPTION
Add sass “!default” to fix $select-bg-color setting can’t overwrite.
