### PR TITLE
Fixes #3897 - Removed incorrectly placed speech marks around #cccccc

### DIFF
--- a/doc/pages/components/alert_boxes.html
+++ b/doc/pages/components/alert_boxes.html
@@ -170,7 +170,7 @@ You can further customize your alert boxes using the provided options in the `al
 .custom-alert-box {
   @include alert(
     // Adjust the background of the alert
-    $bg: '#cccccc',
+    $bg: #cccccc,
     // Give a border to the alert box
     $radius: true
   );


### PR DESCRIPTION
Resolves typo as described in Issue #3897.
