### PR TITLE
Adding the "data-reveal" to the link example.

### DIFF
--- a/doc/pages/components/reveal.html
+++ b/doc/pages/components/reveal.html
@@ -50,7 +50,7 @@ The class options:
 
 <h5>Firing a Reveal Modal</h5>
 
-<p>To launch a modal, just add a `data-reveal-id` to the object which you want to fire the modal when clicked. The `data-reveal-id` needs to match the `id` of your reveal.</p>
+<p>To launch a modal, add `data-reveal` and the `data-reveal-id` of the object which you want to fire the modal when clicked. The `data-reveal-id` needs to match the `id` of your reveal.</p>
 
 <h4>HTML</h4>
 


### PR DESCRIPTION
The link needs both data-reveal and data-reveal-id.
