### PR TITLE
Adding the "data-reveal" to the link example.

### DIFF
--- a/doc/includes/reveal/examples_reveal_data.html
+++ b/doc/includes/reveal/examples_reveal_data.html
@@ -1,5 +1,5 @@
 {{#markdown}}
 ```html
-<a href="#" data-reveal-id="myModal">Click Me For A Modal</a>
+<a href="#" data-reveal data-reveal-id="myModal">Click Me For A Modal</a>
 ```
 {{/markdown}}


### PR DESCRIPTION
This won't work without `data-reveal`, no? I couldn't get it working until I added this.
