### PR TITLE
dropdown callbacks can't be overridden after the first instanciation of the dropdown plugin

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -54,8 +54,12 @@
               settings = $.extend({}, self.settings, self.data_options(target));
           if (settings.is_hover) self.close.call(self, $(this));
         })
-        .on('opened.fndtn.dropdown', '[data-dropdown-content]', this.settings.opened)
-        .on('closed.fndtn.dropdown', '[data-dropdown-content]', this.settings.closed);
+        .on('opened.fndtn.dropdown', '[data-dropdown-content]', function () {
+            self.settings.opened.call(this);
+        })
+        .on('closed.fndtn.dropdown', '[data-dropdown-content]', function () {
+            self.settings.closed.call(this);
+        });
 
       $(document).on('click.fndtn.dropdown', function (e) {
         var parent = $(e.target).closest('[data-dropdown-content]');


### PR DESCRIPTION
See previous pull request for version 4.0.0 https://github.com/zurb/foundation/pull/3253#issuecomment-30770343
