### PR TITLE
Fix bug where joyride fails to scroll up for next tip

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -390,7 +390,7 @@
       window_half = $(window).height() / 2;
       tipOffset = Math.ceil(this.settings.$target.offset().top - window_half + this.settings.$next_tip.outerHeight());
 
-      if (tipOffset > 0) {
+      if (tipOffset != 0) {
         $('html, body').animate({
           scrollTop: tipOffset
         }, this.settings.scroll_speed, 'swing');


### PR DESCRIPTION
If the next tip is higher on the page than current tip a negative tipOffset results in joyride not scrolling to show position of the next tip. This commit fixes that behaviour by scrolling unless tipOffset is 0 which I assume is intended behaviour
