### PR TITLE
Fixes Clearing error in Safari

### DIFF
--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -9,7 +9,7 @@
     settings : {
       templates : {
         viewing : '<a href="#" class="clearing-close">&times;</a>' +
-          '<div class="visible-img" style="display: none"><img src="//:0">' +
+          '<div class="visible-img" style="display: none"><img src="#">' +
           '<p class="clearing-caption"></p><a href="#" class="clearing-main-prev"><span></span></a>' +
           '<a href="#" class="clearing-main-next"><span></span></a></div>'
       },


### PR DESCRIPTION
The current code causes a `Failed to load resource: Could not connect to the server.` error in Safari. Suggest that this is reverted to the hash. 
