### PR TITLE
Added -webkit-tap-highlight-color to exit-off-canvas anchor

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -240,6 +240,7 @@ $menu-slide: "transform 500ms ease" !default;
     left:0;
     right:0;
     z-index: 1002;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
 
     @media #{$medium-up} {
       &:hover {


### PR DESCRIPTION
When the off canvas menu is open on a mobile Chrome browser, the `.exit-off-canvas` anchor has the webkit tap highlight color applied to it.  This fixes the issue by making the tap highlight color transparent.

Signed-off-by: Jake Wilson jake.e.wilson@gmail.com
