### PR TITLE
Indicate import needed for 'lower-bound' function

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -5,7 +5,7 @@
 // This is the default html and body font-size for the base rem value.
 // $rem-base: 16px;
 
-// Uncomment to use rem-calc() in your settings
+// Uncomment to use rem-calc() or lower-bound() in your settings
 @import "foundation/functions";
 
 // $experimental: true;


### PR DESCRIPTION
In order to redefine the default media query ranges in _settings.scss, you need to import "foundation/functions" so that the function 'lower-bound' is defined. The current comment implies you only need it for the function 'rem-calc'.
