### PR TITLE
Resolve issue #3909 (provided by user Clupiedae)

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -287,7 +287,7 @@ $cursor-text-value: text !default;
   }
 
   meta.foundation-mq-medium {
-    font-family: "/" + unquote($medium-only) + "/";
+    font-family: "/" + unquote($medium-up) + "/";
     width: lower-bound($medium-range);
   }
 


### PR DESCRIPTION
If i understand the purpose of the META tags with media queries, they should work the same as CSS classes, where smaller applies to larger unless overridden (`"small-12 large-6"` for example).

Clupiedae found this when Interchange wasn't applying a medium setting to large & up. The change resolved the issue for me.

Be kind, this is my first pull request, ever. ;)
