### PR TITLE
fixes a problem where an emptied cache from update_images won't be repop...

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -267,7 +267,7 @@
       var uuid = this.uuid(),
           current_uuid = el.data('uuid');
 
-      if (current_uuid) return this.cache[current_uuid];
+      if (this.cache[current_uuid]) return this.cache[current_uuid];
 
       el.attr('data-uuid', uuid);
 


### PR DESCRIPTION
when calling update_images, the cache is deleted, but not the element uuids.

The store then just checks if the element has a uuid and returns the (now empty) cache value, rather than putting the required data back into the store. If you call a foundation('interchange', 'reflow') after adding images, updating effectively deletes everything that's gone before and none of the interchange images work. 

This version checks to see if the cache value actually exists before returning.
