### PR TITLE
Only allow one dropdown at a time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public/*
 *.rbenv-version
 *.ruby-version
 /docs2/public/*
+.settings

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -36,10 +36,6 @@
           var $this = $(this);
           clearTimeout(self.timeout);
 
-          if($(e.target).data('dropdown')) {
-            self.closeall.call(self);
-          }
-
           if ($this.data('dropdown')) {
             var dropdown = $('#' + $this.data('dropdown')),
                 target = $this;
@@ -49,6 +45,11 @@
           }
 
           var settings = target.data('dropdown-init') || self.settings;
+          
+          if($(e.target).data('dropdown') && settings.is_hover) {
+            self.closeall.call(self);
+          }
+          
           if (settings.is_hover) self.open.apply(self, [dropdown, target]);
         })
         .on('mouseleave.fndtn.dropdown', '[data-dropdown], [data-dropdown-content]', function (e) {

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -36,7 +36,9 @@
           var $this = $(this);
           clearTimeout(self.timeout);
 
-          self.closeall.call(self);
+          if($(e.target).data('dropdown')) {
+            self.closeall.call(self);
+          }
 
           if ($this.data('dropdown')) {
             var dropdown = $('#' + $this.data('dropdown')),

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -28,11 +28,15 @@
           var settings = $(this).data('dropdown-init') || self.settings;
           e.preventDefault();
 
+          self.closeall.call(self);
+
           if (!settings.is_hover || Modernizr.touch) self.toggle($(this));
         })
         .on('mouseenter.fndtn.dropdown', '[data-dropdown], [data-dropdown-content]', function (e) {
           var $this = $(this);
           clearTimeout(self.timeout);
+
+          self.closeall.call(self);
 
           if ($this.data('dropdown')) {
             var dropdown = $('#' + $this.data('dropdown')),
@@ -96,6 +100,13 @@
             .removeClass(self.settings.active_class);
           $(this).trigger('closed');
         }
+      });
+    },
+
+    closeall: function() {
+      var self = this;
+      $.each($('[data-dropdown-content]'), function() {
+        self.close.call(self, $(this))
       });
     },
 


### PR DESCRIPTION
Automatically close all others when opening a new one, so we prevent overlapping dropdowns.
