### PR TITLE
Abide only vaildate some fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public/*
 *.rbenv-version
 *.ruby-version
 /docs2/public/*
+.settings


### PR DESCRIPTION
Only validate some fields via Abide. Either we set data-abide="all" or data-abide="all ajax", or we set data-field-abide on each of the <input>, <textarea> and <select> fields. This way you can have a field that is validated via Abide, but isn't required, a field that is validated via Abide and is required, or a field that isn't validated by Abide.

This fixes https://github.com/zurb/foundation/issues/3989
