### PR TITLE
Show magellan placeholder only when appropriate

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -71,7 +71,7 @@
               if (fixed_position) {
                 $expedition.addClass('fixed');
                 $expedition.css({position:"fixed", top:0});
-                if($expedition.css('display') =='block') {
+                if($expedition.css('display') == 'block' && $expedition.css('position') == 'fixed') {
                  self.magellan_placeholder.show();
                 }
               } else {

--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -71,7 +71,9 @@
               if (fixed_position) {
                 $expedition.addClass('fixed');
                 $expedition.css({position:"fixed", top:0});
-                self.magellan_placeholder.show();
+                if($expedition.css('display') =='block') {
+                 self.magellan_placeholder.show();
+                }
               } else {
                 $expedition.removeClass('fixed');
                 $expedition.css({position:"", top:""});


### PR DESCRIPTION
In cases like one I just encountered where I wanted magellan to be hidden  in mobile view, the placeholder still fired thus displacing the page layout a bit. This fix shows the placeholder only when the magellan expedition div is not display:none
