### PR TITLE
Alert hide instead of remove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public/*
 *.rbenv-version
 *.ruby-version
 /docs2/public/*
+.settings

--- a/js/foundation/foundation.alert.js
+++ b/js/foundation/foundation.alert.js
@@ -23,7 +23,7 @@
 
         e.preventDefault();
         alertBox[settings.animation](settings.speed, function () {
-          $(this).trigger('closed').remove();
+          $(this).trigger('closed').hide();
           settings.callback();
         });
       });


### PR DESCRIPTION
This allows the alert to be reused.

For instance, I have the following HTML already on the page prior to any events taking place.

``` html
<div class="alert-box success hide" data-alert>
  <strong>The email has been sent</strong>
</div>
```

This gets shown whenever the user clicks the export button on a page. If they want to export it multiple times, but happen to have closed the alert between each export, they won't get the alert because currently closing the alert performs a `remove()`.
