### PR TITLE
Only add back to topbar once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public/*
 *.rbenv-version
 *.ruby-version
 /docs2/public/*
+.settings

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -302,6 +302,10 @@
         var $link = $(this),
             $dropdown = $link.siblings('.dropdown'),
             url = $link.attr('href');
+        
+        if($dropdown.children('.back').length > 0) {
+          return true;
+        }
 
         if (settings.mobile_show_parent_link && url && url.length > 1) {
           var $titleLi = $('<li class="title back js-generated"><h5><a href="javascript:void(0)"></a></h5></li><li><a class="parent-link js-generated" href="' + url + '">' + $link.text() +'</a></li>');


### PR DESCRIPTION
If `$(document).foundation()` is called more than once, topbar current adds the "back" button every time it is called. This makes it so that there can only be one element with `.back` per section.
