### PR TITLE
Fix Travis link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Foundation](http://foundation.zurb.com)
 
-[![Build Status](https://travis-ci.org/zurb/foundation.png)](https://travis-ci.org/[zurb]/[foundation])
+[![Build Status](https://travis-ci.org/zurb/foundation.png)](https://travis-ci.org/zurb/foundation)
 
 
 Foundation is the most advanced responsive front-end framework in the world. You can quickly prototype and build sites or apps that work on any kind of device with Foundation, which includes layout constructs (like a fully responsive grid), elements and best practices.


### PR DESCRIPTION
Current URL points to `https://travis-ci.org/%5Bzurb%5D/%5Bfoundation%5D` which is invalid
