### PR TITLE
next_on_click doesn't work

### DIFF
--- a/doc/pages/components/orbit.html
+++ b/doc/pages/components/orbit.html
@@ -222,8 +222,7 @@ $(document).foundation({
     pause_on_hover: true,
     animation_speed: 500,
     navigation_arrows: true,
-    bullets: false,
-    next_on_click: true
+    bullets: false
   }
 });
 ```
@@ -244,8 +243,7 @@ $(document).foundation({
                   pause_on_hover:true;
                   animation_speed:500;
                   navigation_arrows:true;
-                  bullets:false;
-                  next_on_click:true;">
+                  bullets:false;">
 </ul>
 ```
 {{/markdown}}
@@ -261,8 +259,7 @@ $(document).foundation({
         pause_on_hover:true;
         animation_speed:500;
         navigation_arrows:true;
-        bullets:false;
-        next_on_click:true;">
+        bullets:false;">
         <li><img src="{{assets}}/img/examples/andromeda-orbit.jpg" alt="slide 1"></li>
         <li><img src="{{assets}}/img/examples/satelite-orbit.jpg" alt="slide 2"></li>
         <li><img src="{{assets}}/img/examples/launch-orbit.jpg" alt="slide 3"></li>


### PR DESCRIPTION
No matter if the setting is true or false, it will go to next on click. Also, since it expects data-orbit-link to equal an index, the example on http://foundation.zurb.com/docs/components/orbit.html does not work as expected under "deep linking". When you click on the slide, it'll transition to a blank slide.
