### PR TITLE
Update _offcanvas.scss

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -81,7 +81,6 @@ $menu-slide: "transform 500ms ease" !default;
   width: $off-canvas-width;
   top:0;
   bottom:0;
-  height: 100%;
   position: absolute;
   overflow-y: auto;
   background: $off-canvas-bg;


### PR DESCRIPTION
"height:100%;" is superfluous since the class has "position: absolute;", "top:0;" and "bottom:0;"
This can also create issues when viewing the off canvas menu on a device with a screen size width <= 640.

See:
![screenshot 2013-12-30 02 07 27](https://f.cloud.github.com/assets/6283320/1820523/008a4be8-70f0-11e3-8729-e7d6e1256bcd.png)

![screenshot 2013-12-30 02 07 46](https://f.cloud.github.com/assets/6283320/1820524/048c581c-70f0-11e3-8621-5c7b08e1ac64.png)
