### PR TITLE
Fix off-canvas menu cut-off due to short page content

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -310,7 +310,10 @@ $cursor-text-value: text !default;
     }
 
     html,
-    body { font-size: $base-font-size; }
+    body {
+      font-size: $base-font-size;
+      height: 100%;
+    }
 
     // Default body styles
     body {

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -104,6 +104,7 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     overflow: hidden;
+    height: 100%;
 }
 
 // INNER WRAP
@@ -112,6 +113,7 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     @include clearfix;
+    height: 100%;
 
     -webkit-transition: -webkit-#{$menu-slide};
     -moz-transition: -moz-#{$menu-slide};

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -74,6 +74,7 @@ $menu-slide: "transform 500ms ease" !default;
 @mixin wrap-base {
   position: relative;
   width: 100%;
+  height: 100%;
 }
 
 // basic styles for off-canvas menu container
@@ -104,7 +105,6 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     overflow: hidden;
-    height: 100%;
 }
 
 // INNER WRAP
@@ -113,7 +113,6 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     @include clearfix;
-    height: 100%;
 
     -webkit-transition: -webkit-#{$menu-slide};
     -moz-transition: -moz-#{$menu-slide};


### PR DESCRIPTION
If the page content is small/short, the off-canvas menu typically is cut-off on the bottom because it only extends to the bottom of the content instead of the bottom of the browser window.  This fixes that.

Signed-off-by: Jake Wilson jake.e.wilson@gmail.com
