### PR TITLE
Update topbar to work without jQuery Sizzle Engine (direct querySelectorAll)

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -28,7 +28,7 @@
         var topbar = $(this),
             settings = topbar.data('topbar-init'),
             section = $('section', this),
-            titlebar = $('> ul', this).first();
+            titlebar = topbar.children().filter('ul').first();
 
         topbar.data('index', 0);
 
@@ -293,7 +293,7 @@
       var self = this,
           settings = topbar.data('topbar-init'),
           section = $('section', topbar),
-          titlebar = $('> ul', topbar).first();
+          titlebar = $(this).children().filter('ul').first();
 
       // Pull element out of the DOM for manipulation
       section.detach();


### PR DESCRIPTION
The `> ul` selector is not valid for `querySelectorAll`. If I'm using a minimal jQuery build, `foundation.topbar` fails. This change uses `children` and `filter` to accomplish the same effect. As this is only running at init, I doubt there would be any performance implications.
