### PR TITLE
Don't fail installing rAF polyfill if jQuery.fx isn't present

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -114,7 +114,8 @@
     lastTime = 0,
     vendors = ['webkit', 'moz'],
     requestAnimationFrame = window.requestAnimationFrame,
-    cancelAnimationFrame = window.cancelAnimationFrame;
+    cancelAnimationFrame = window.cancelAnimationFrame,
+    jqueryFxAvailable = 'undefined' !== typeof jQuery.fx;
 
   for(; lastTime < vendors.length && !requestAnimationFrame; lastTime++) {
     requestAnimationFrame = window[ vendors[lastTime] + "RequestAnimationFrame" ];
@@ -126,7 +127,10 @@
   function raf() {
     if ( animating ) {
       requestAnimationFrame( raf );
-      jQuery.fx.tick();
+      
+      if ( jqueryFxAvailable ) {
+        jQuery.fx.tick();
+      }
     }
   }
 
@@ -134,16 +138,19 @@
     // use rAF
     window.requestAnimationFrame = requestAnimationFrame;
     window.cancelAnimationFrame = cancelAnimationFrame;
-    jQuery.fx.timer = function( timer ) {
-      if ( timer() && jQuery.timers.push( timer ) && !animating ) {
-        animating = true;
-        raf();
-      }
-    };
+    
+    if ( jqueryFxAvailable ) {
+      jQuery.fx.timer = function( timer ) {
+        if ( timer() && jQuery.timers.push( timer ) && !animating ) {
+          animating = true;
+          raf();
+        }
+      };
 
-    jQuery.fx.stop = function() {
-      animating = false;
-    };
+      jQuery.fx.stop = function() {
+        animating = false;
+      };
+    }
   } else {
     // polyfill
     window.requestAnimationFrame = function( callback, element ) {


### PR DESCRIPTION
When using a minimal jQuery build, `jQuery.fx` might not be available. This patch checks to make sure the namespace exists before trying to overwrite the functionality.
