### PR TITLE
"Error States" small CSS Addition (foundation.css)

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -475,7 +475,8 @@ $select-bg-color: #fafafa !default;
     }
 
     input.error,
-    textarea.error {
+    textarea.error,
+    select.error {
       margin-bottom: 0;
     }
     label.error { @include form-label-error-color; }


### PR DESCRIPTION
The following lines of CSS remove the "margin-bottom" from "input" and "textarea" elements that have the ".error" class applied to them:

input.error, textarea.error {
  margin-bottom:0;
}

I'm suggesting an additional rule for the "select" element:

input.error, textarea.error, select.error {
  margin-bottom:0;
}

With this addition, the "small class="error"" can be used and properly formatted on mandatory <select> drop-downs such as "Country" on Registration forms.

![select_country](https://f.cloud.github.com/assets/3220165/1819480/58412e7c-7098-11e3-9430-650e75458783.png)
