### PR TITLE
Fix fallback to 2d transforms or standard positioning of offcanvas on legacy browsers, Opera 12 and IE9

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -183,6 +183,21 @@ $base-line-height: 150% !default;
   }
 }
 
+// @mixins
+//
+// We use this to translate elements in 2D
+// $horizontal: Default: 0
+// $vertical: Default: 0
+@mixin translate2d($horizontal:0, $vertical:0) {
+  @if $experimental {
+    -webkit-transform: translate($horizontal,$vertical);
+    -moz-transform: translate($horizontal,$vertical);
+    -ms-transform: translate($horizontal,$vertical);
+    -o-transform: translate($horizontal,$vertical);
+  }
+  transform: translate($horizontal,$vertical)
+}
+
 // We use these to control various global styles
 $body-bg: #fff !default;
 $body-font-color: #222 !default;

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -369,6 +369,11 @@ $cursor-text-value: text !default;
     .text-center  { text-align: center !important; }
     .text-justify { text-align: justify !important; }
     .hide         { display: none; }
+    // Bidi counterparts to .left, .right, .text-left, .text-right
+    .start { float: $default-float !important; }
+    .end   { float: $opposite-direction !important; }
+    .text-start { text-align: $default-float !important; }
+    .text-end   { text-align: $opposite-direction !important; }
 
     // Font smoothing
     // Antialiased font smoothing works best for light text on a dark background.

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -349,33 +349,24 @@ $menu-slide: "transform 500ms ease" !default;
     a.exit-off-canvas { @include back-link; }
   }
 
-  // IE9 HAX
-  // Womp womp! IE9 doesn't do CSS transforms. Let's fix this.
-  .lt-ie10 {
+  // Opera 12.16 and IE9 - don't have 3d transforms
+  .csstransforms.no-csstransforms3d {
+    .left-off-canvas-menu { @include translate2d(-100%, 0); }
+    .right-off-canvas-menu { @include translate2d(100%, 0); }
 
-    // move off canvas menus off the viewport
+    .move-left > .inner-wrap { @include translate2d(-($off-canvas-width),0); }
+    .move-right > .inner-wrap { @include translate2d($off-canvas-width,0); }
+  }
+
+  // Older browsers
+  .no-csstransforms {
     .left-off-canvas-menu { left: -($off-canvas-width); }
     .right-off-canvas-menu { right: -($off-canvas-width); }
 
-    // Snap them in place
     .move-left > .inner-wrap { right: $off-canvas-width; }
     .move-right > .inner-wrap { left: $off-canvas-width; }
   }
+
 }
 
-// Opera 12.16 - don't have 3d transforms
-.csstransforms.no-csstransforms3d {
-  @mixin translate($tx,$ty) {
-    -webkit-transform: translate($tx,$ty);
-    -moz-transform: translate($tx,$ty);
-    // -ms-transform: translate($tx,$ty);
-    -o-transform: translate($tx,$ty);
-    transform: translate($tx,$ty)
-  }
 
-  .left-off-canvas-menu { @include translate(-100%, 0); }
-  .right-off-canvas-menu { @include translate(100%, 0); }
-
-  .move-left > .inner-wrap { @include translate(-($off-canvas-width),0); }
-  .move-right > .inner-wrap { @include translate($off-canvas-width,0) }
-}


### PR DESCRIPTION
IE9 actually supports 2d transforms with -ms prefix, so it will actually use the same code as Opera 12.16

Also a general transform2d mixin along the lines of transform3d makes sense to me.

This code also removes the necessity of using conditional comments in the markup to add .lt-ie10 class to <html> tag.
