### PR TITLE
Make dropdown respect data-options for dynamically added dropdowns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public/*
 *.rbenv-version
 *.ruby-version
 /docs2/public/*
+.settings

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -25,7 +25,7 @@
       $(this.scope)
         .off('.dropdown')
         .on('click.fndtn.dropdown', '[data-dropdown]', function (e) {
-          var settings = $(this).data('dropdown-init') || self.settings;
+          var settings = $.extend({}, self.settings, self.data_options($(this)));
           e.preventDefault();
 
           if (!settings.is_hover || Modernizr.touch) self.toggle($(this));
@@ -42,18 +42,18 @@
                 target = $("[data-dropdown='" + dropdown.attr('id') + "']");
           }
 
-          var settings = target.data('dropdown-init') || self.settings;
+          var settings = $.extend({}, self.settings, self.data_options(target));
           if (settings.is_hover) self.open.apply(self, [dropdown, target]);
         })
         .on('mouseleave.fndtn.dropdown', '[data-dropdown], [data-dropdown-content]', function (e) {
           var $this = $(this);
           self.timeout = setTimeout(function () {
             if ($this.data('dropdown')) {
-              var settings = $this.data('dropdown-init') || self.settings;
+              var settings = $.extend({}, self.settings, self.data_options($this));
               if (settings.is_hover) self.close.call(self, $('#' + $this.data('dropdown')));
             } else {
               var target = $('[data-dropdown="' + $(this).attr('id') + '"]'),
-                  settings = target.data('dropdown-init') || self.settings;
+                  settings = $.extend({}, self.settings, self.data_options(target));
               if (settings.is_hover) self.close.call(self, $this);
             }
           }.bind(this), 150);


### PR DESCRIPTION
Without this, the dropdowns work, but only use the settings that Foundation was initialized with. This makes dropdowns respect data-options for elements after `$(document).foundation();` is called.
