### PR TITLE
Tooltip allow per tooltip settings and make tooltips behave according to event type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/public/*
 *.rbenv-version
 *.ruby-version
 /docs2/public/*
+.settings

--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -5,7 +5,7 @@
     name : 'tooltip',
 
     version : '5.0.0',
-    
+
     settings : {
       additional_inheritable_classes : [],
       tooltip_class : '.tooltip',
@@ -80,10 +80,10 @@
 
     getTip : function ($target) {
       var selector = this.selector($target),
+          settings = $.extend({}, this.settings, this.data_options($target)),
           tip = null;
 
       if (selector) {
-        var settings = $.extend({}, this.settings, this.data_options($('[data-tooltip="' + selector + '"]'))),
         tip = $('[data-selector="' + selector + '"]' + settings.tooltip_class);
       }
 


### PR DESCRIPTION
Tooltips currently behave based on if touch events are enabled in the browser, not whether or not the tooltip was triggered with a touch event.

This also allows all the tooltip settings to be set per tooltip, allowing for each tooltip to be rendered differently.

Fixes https://github.com/zurb/foundation/issues/4013
