### PR TITLE
Removing caret from multi-select.

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -325,6 +325,11 @@ $select-bg-color: #fafafa !default;
       padding: $form-spacing / 2;
       font-size: $input-font-size;
       @include radius(0);
+      
+      &[multiple] {
+        background: $select-bg-color;
+      }
+      
       &.radius { @include radius($global-radius); }
       &:hover {
         background:


### PR DESCRIPTION
Selects with the attribute "multiple", were getting a caret added.
