### PR TITLE
Update foundation.interchange.js to work with background-image

### DIFF
--- a/doc/pages/components/interchange.html
+++ b/doc/pages/components/interchange.html
@@ -60,6 +60,22 @@ You should always specify a `default` directive for Interchange.
 
 ***
 
+### Using Interchange with background-images
+
+When you add a data-interchange attribute containing image paths (.jpg, .jpeg, .png, .gif, .bmp, .tiff), instead of replacing the element content it will set a background-image css property with the corresponding path. 
+
+{{#markdown}}
+```html
+<div data-interchange="[/path/to/default.jpg, (default)], [/path/to/bigger-image.jpg, (large)]"></div>
+```
+{{/markdown}}
+
+This solution does not support browsers with JavaScript disabled. To add a fallback you can add a default background-image in your css but this can result in loading more than one image on some device.  This method is only switching the background-image on the element. You will need to set the others background properties in your css (background-repeat, background-position, background-size...). 
+
+
+***
+
+
 ### Using Retina Images
 
 You can easily include retina images by using a pixel-density media query for that image. You can even combine multiple parameters in the media query if need be. The retina media query would look something like this, but you can also use dpi or other pixel densities as well:

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -53,10 +53,18 @@
 
             return trigger(el[0].src);
           }
+          
           var last_path = el.data('interchange-last-path');
 
           if (last_path == path) return;
 
+          if (new RegExp("/^.(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)\??|#?./",'i').test(path)){
+
+              $(el).css('background-image', 'url('+path+')');
+
+              return trigger(path);
+          }
+          
           return $.get(path, function (response) {
             el.html(response);
             el.data('interchange-last-path', path);

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -44,7 +44,6 @@
           //   console.log($(this).html(), a, b, c);
           // });
 
-          console.log("REPLACE");
           if (/IMG/.test(el[0].nodeName)) {
             var orig_path = el[0].src;
 
@@ -61,10 +60,8 @@
 
           var regex = "/^.(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)\??|#?./";
 
-          console.log(new RegExp(regex,'i').test(path),path, last_path );
           if (new RegExp(regex,'i').test(path)){
 
-              console.log("Passed");
               $(el).css('background-image', 'url('+path+')');
 
               return trigger(path);
@@ -82,7 +79,7 @@
 
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');
-      console.log("INIT interchange");
+
       this.data_attr = 'data-' + this.settings.load_attr;
 
       $.extend(true, this.settings, method, options);
@@ -236,7 +233,6 @@
 
     convert_directive : function (directive) {
 
-      console.log("convert_directive",this.trim(directive));
       var trimmed = this.trim(directive);
 
       if (trimmed.length > 0) {

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -15,7 +15,7 @@
       load_attr : 'interchange',
 
       named_queries : {
-        'default' : 'only screen',
+        'default' : Foundation.media_queries.small,
         small : Foundation.media_queries.small,
         medium : Foundation.media_queries.medium,
         large : Foundation.media_queries.large,
@@ -23,11 +23,11 @@
         xxlarge: Foundation.media_queries.xxlarge,
         landscape : 'only screen and (orientation: landscape)',
         portrait : 'only screen and (orientation: portrait)',
-        retina : 'only screen and (-webkit-min-device-pixel-ratio: 2),' + 
-          'only screen and (min--moz-device-pixel-ratio: 2),' + 
-          'only screen and (-o-min-device-pixel-ratio: 2/1),' + 
-          'only screen and (min-device-pixel-ratio: 2),' + 
-          'only screen and (min-resolution: 192dpi),' + 
+        retina : 'only screen and (-webkit-min-device-pixel-ratio: 2),' +
+          'only screen and (min--moz-device-pixel-ratio: 2),' +
+          'only screen and (-o-min-device-pixel-ratio: 2/1),' +
+          'only screen and (min-device-pixel-ratio: 2),' +
+          'only screen and (min-resolution: 192dpi),' +
           'only screen and (min-resolution: 2dppx)'
       },
 
@@ -44,6 +44,7 @@
           //   console.log($(this).html(), a, b, c);
           // });
 
+          console.log("REPLACE");
           if (/IMG/.test(el[0].nodeName)) {
             var orig_path = el[0].src;
 
@@ -53,18 +54,22 @@
 
             return trigger(el[0].src);
           }
-          
           var last_path = el.data('interchange-last-path');
 
           if (last_path == path) return;
 
-          if (new RegExp("/^.(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)\??|#?./",'i').test(path)){
 
+          var regex = "/^.(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)\??|#?./";
+
+          console.log(new RegExp(regex,'i').test(path),path, last_path );
+          if (new RegExp(regex,'i').test(path)){
+
+              console.log("Passed");
               $(el).css('background-image', 'url('+path+')');
 
               return trigger(path);
           }
-          
+
           return $.get(path, function (response) {
             el.html(response);
             el.data('interchange-last-path', path);
@@ -77,10 +82,10 @@
 
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');
-
+      console.log("INIT interchange");
       this.data_attr = 'data-' + this.settings.load_attr;
-      $.extend(true, this.settings, method, options);
 
+      $.extend(true, this.settings, method, options);
       this.bindings(method, options);
       this.load('images');
       this.load('nodes');
@@ -230,6 +235,8 @@
     },
 
     convert_directive : function (directive) {
+
+      console.log("convert_directive",this.trim(directive));
       var trimmed = this.trim(directive);
 
       if (trimmed.length > 0) {
@@ -283,6 +290,7 @@
     },
 
     trim : function(str) {
+
       if (typeof str === 'string') {
         return $.trim(str);
       }

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -63,7 +63,7 @@
           if (new RegExp(regex,'i').test(path)){
 
               $(el).css('background-image', 'url('+path+')');
-
+              el.data('interchange-last-path', path);
               return trigger(path);
           }
 


### PR DESCRIPTION
When a tag(not an image tag) has a data-interchange attribute containing an image path it will set a background-image on element instead of trying to replace the innerHtml.
