### PR TITLE
Fix javascript link in abide docs section

### DIFF
--- a/doc/pages/components/abide.html
+++ b/doc/pages/components/abide.html
@@ -86,8 +86,7 @@ You can bind to these events and fire your own callback:
 ## Using the JavaScript
 
 <div class="panel">
-  {{!-- TODO FIX JAVASCRIPT PATH --}}
-  Before you can use Abide you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [JavaScript documentation](../JavaScript.html) on setting that up.
+  Before you can use Abide you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [JavaScript documentation](../javascript.html) on setting that up.
 </div>
 
 Just add `foundation.abide.js` AFTER the `foundation.js` file. Your markup should look something like this:


### PR DESCRIPTION
The link to Javascript Documentation in Abide section points to http://foundation.zurb.com/docs/JavaScript.html and that returns a 404 error. Removing the CamelCase and making the link http://foundation.zurb.com/docs/javascript.html takes me to the correct webpage. So I went ahead and changed it
