### PR TITLE
Orbit height not set on accordion

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -412,21 +412,38 @@
     init: function (scope, method, options) {
       var self = this;
 
-      if (typeof method === 'object') {
-        $.extend(true, self.settings, method);
-      }
+      this.bindings(method, options);
+    },
 
-      if ($(scope).is('[data-orbit]')) {
-        var $el = $(scope);
-        var opts = self.data_options($el);
-        new Orbit($el, $.extend({},self.settings, opts));
-      }
+    events : function () {
+      var self = this;
 
-      $('[data-orbit]', scope).each(function(idx, el) {
-        var $el = $(el);
-        var opts = self.data_options($el);
-        new Orbit($el, $.extend({},self.settings, opts));
-      });
+      if ($(self.scope).is('[data-orbit]')) {
+        var $el = $(self.scope);
+        $el.data(self.name + '-instance', new Orbit($el, $el.data('orbit-init')));
+      } else {
+        $('[data-orbit]', self.scope).each(function(idx, el) {
+          var $el = $(el);
+          $el.data(self.name + '-instance', new Orbit($el, $el.data('orbit-init')));
+        });
+      }
+    },
+
+    reflow : function () {
+      var self = this;
+
+      if ($(self.scope).is('[data-orbit]')) {
+        var $el = $(self.scope);
+        var instance = $el.data(self.name + '-instance');
+        instance.compute_dimensions();
+      } else {
+        $('[data-orbit]', self.scope).each(function(idx, el) {
+          var $el = $(el);
+          var opts = self.data_options($el);
+          var instance = $el.data(self.name + '-instance');
+          instance.compute_dimensions();
+        });
+      }
     }
   };
 


### PR DESCRIPTION
Orbit slider container height is not being calculated, when Orbit slider is not visible (when inside closed accordion).

Orbit's container height normally is being calculated from the largest image/element in it. But, if the container is not being displayed, it can not calculate the height, because jQuery can't calculate image height, if parent element is not displayed `display: none`... It is how it its.

In the code ( https://github.com/zurb/foundation/blob/master/js/foundation/foundation.orbit.js#L266 ) there I see those lines:

``` javascript
$(window).on('resize', self.compute_dimensions);
$(window).on('load', self.compute_dimensions);
```

If somehow you could trigger `compute_dimensions` after opening an accordion's tab... For example, you could trigger `accordionOpened` event or something and bind Orbit to listen the event... At least give me a direct access to `compute_dimensions` !

Currently I fixed this problem by calling

``` javascript
$(window).resize();
```

on accordion's tab click.
