### PR TITLE
Fixing issue #3982.

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -220,7 +220,7 @@
           return this.libs[lib].init.apply(this.libs[lib], [this.scope, args[lib]]);
         }
 
-        return this.libs[lib].init.apply(this.libs[lib], args);
+        return this.libs[lib].init.apply(this.libs[lib], [args]);
       }
 
       return function () {};

--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -220,7 +220,8 @@
           return this.libs[lib].init.apply(this.libs[lib], [this.scope, args[lib]]);
         }
 
-        return this.libs[lib].init.apply(this.libs[lib], [args]);
+        args = args instanceof Array ? args : Array(args);    // PATCH: added this line
+        return this.libs[lib].init.apply(this.libs[lib], args);
       }
 
       return function () {};


### PR DESCRIPTION
Refers to https://github.com/zurb/foundation/issues/3982.

"Not a valid argument for 'Function.prototype.apply' JS error in foundation.js (F5) on older Safari"

This error was being thrown in JS on an older iPhone 4 with Safari 5.0.5 and user prembo has indicated that this is also happening on a desktop client with Safari 5.0.5.

I've been able to confirm on a desktop with FF and Chrome this fix doesn't not result in any new errors. Also tested on an iPhone 5 with iOS5 and Android 4.1.
