### PR TITLE
Orbit: Allow a configurable selector for slides

### DIFF
--- a/doc/pages/components/orbit.html
+++ b/doc/pages/components/orbit.html
@@ -185,6 +185,7 @@ $(document).foundation({
       timer_paused_class: 'paused', // Class name given to the paused button
       timer_progress_class: 'orbit-progress', // Class name given to the progress bar
       slides_container_class: 'orbit-slides-container', // Class name given to the slides container
+      slide_selector: 'li', // Default is "*" which selects all chilren under the container
       bullets_container_class: 'orbit-bullets',
       bullets_active_class: 'active', // Class name given to the active bullet
       slide_number_class: 'orbit-slide-number', // Class name given to the slide number

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -21,12 +21,17 @@
         locked = false,
         adjust_height_after = false;
 
-    slides_container.children().first().addClass(settings.active_slide_class);
+
+    self.slides = function() {
+      return slides_container.children(settings.slide_selector);
+    };
+
+    self.slides().first().addClass(settings.active_slide_class);
 
     self.update_slide_number = function(index) {
       if (settings.slide_number) {
         number_container.find('span:first').text(parseInt(index)+1);
-        number_container.find('span:last').text(slides_container.children().length);
+        number_container.find('span:last').text(self.slides().length);
       }
       if (settings.bullets) {
         bullets_container.children().removeClass(settings.bullets_active_class);
@@ -35,7 +40,7 @@
     };
 
     self.update_active_link = function(index) {
-      var link = $('a[data-orbit-link="'+slides_container.children().eq(index).attr('data-orbit-slide')+'"]');
+      var link = $('a[data-orbit-link="'+self.slides().eq(index).attr('data-orbit-slide')+'"]');
       link.siblings().removeClass(settings.bullets_active_class);
       link.addClass(settings.bullets_active_class);
     };
@@ -68,7 +73,7 @@
         bullets_container = $('<ol>').addClass(settings.bullets_container_class);
         container.append(bullets_container);
         bullets_container.wrap('<div class="orbit-bullets-container"></div>');
-        slides_container.children().each(function(idx, el) {
+        self.slides().each(function(idx, el) {
           var bullet = $('<li>').attr('data-orbit-slide', idx);
           bullets_container.append(bullet);
         });
@@ -86,7 +91,7 @@
       // if (locked) {return false;}
       if (next_idx === idx) {return false;}
       if (typeof timer === 'object') {timer.restart();}
-      var slides = slides_container.children();
+      var slides = self.slides();
 
       var dir = 'next';
       locked = true;
@@ -168,10 +173,10 @@
     }
     
     self.compute_dimensions = function() {
-      var current = $(slides_container.children().get(idx));
+      var current = $(self.slides().get(idx));
       var h = current.height();
       if (!settings.variable_height) {
-        slides_container.children().each(function(){
+        self.slides().each(function(){
           if ($(this).height() > h) { h = $(this).height(); }
         });
       }
@@ -395,6 +400,7 @@
       timer_paused_class: 'paused',
       timer_progress_class: 'orbit-progress',
       slides_container_class: 'orbit-slides-container',
+      slide_selector: '*',
       bullets_container_class: 'orbit-bullets',
       bullets_active_class: 'active',
       slide_number_class: 'orbit-slide-number',


### PR DESCRIPTION
### Context

When working with [Ember.js](http://emberjs.com/), the library generates [metamorphs](http://emberjs.com/guides/understanding-ember/keeping-templates-up-to-date/) to support the features it provides. These tend to go everywhere, and js libraries that aren't careful about what they select often pick up these `script` tags by mistake.
### Problem

Here is a screenshot from a project I'm working on. This Orbit slideshow is supposed to have 3 items, generated dynamically, however it is generating 9 slides due to metamorphs inserted in the dom by Ember.
![screen shot 2014-01-07 at 1 52 55 am](https://f.cloud.github.com/assets/50039/1857868/87b9b044-7781-11e3-9aa7-e05b03fc07f9.png)
### Solution

``` javascript
$(document).foundation({
  orbit: {slide_selector: 'li'}
});
```

My first instinct was to simply hardcode a selector for the slides, `li` seemed appropriate. But with only slightly more effort I added a configurable selector so that developers could make it whatever they deem appropriate. By default, the selector is "*", making Orbit retain the same behavior as today (backwards compatibility).
