### PR TITLE
fix issue where errors occur if data('index') is NaN

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -113,6 +113,10 @@
             var $this = $(this),
                 $selectedLi = $this.closest('li');
 
+            if (isNaN(topbar.data('index'))) {
+              topbar.data('index', 0);
+            }
+
             topbar.data('index', topbar.data('index') + 1);
             $selectedLi.addClass('moved');
             if (!self.rtl) {


### PR DESCRIPTION
Ran into this issue while implementing a top nav in a single page application that loads the nav bar dynamically. I couldn't isolate exactly why data('index') ended up as NaN but i suspect that it had to do with the coming and going of the nav DOM (via backbone render function)

because this only occurred when the menu was toggling open after having been previously closed resetting data('index') to zero made sense.
