### PR TITLE
Do not prevent default action on dropdowns trigger in hover mode  

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -26,9 +26,10 @@
         .off('.dropdown')
         .on('click.fndtn.dropdown', '[data-dropdown]', function (e) {
           var settings = $(this).data('dropdown-init') || self.settings;
-          e.preventDefault();
-
-          if (!settings.is_hover || Modernizr.touch) self.toggle($(this));
+          if (!settings.is_hover || Modernizr.touch) {
+            e.preventDefault();
+            self.toggle($(this));
+          }
         })
         .on('mouseenter.fndtn.dropdown', '[data-dropdown], [data-dropdown-content]', function (e) {
           var $this = $(this);


### PR DESCRIPTION
If you have a link which has a href attribute on it and a dropdown with a hover trigger, the link original action will be prevented by the dropdown. It seems as a bug to me not an intended feature.

With this pull request the default action will only be prevented if trigger is not a hover or on touch devices.
