### PR TITLE
Remove setting size for embed and object

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -344,12 +344,8 @@ $cursor-text-value: text !default;
   a:hover { cursor: $cursor-pointer-value; }
 
     // Grid Defaults to get images and embeds to work properly
-    img,
-    object,
-    embed { max-width: 100%; height: auto; }
+    img { max-width: 100%; height: auto; }
 
-    object,
-    embed { height: 100%; }
     img { -ms-interpolation-mode: bicubic; }
 
     #map_canvas,


### PR DESCRIPTION
Setting height: auto; for embed and object causes errors with rich media ads if the ad partner is setting the height at the attribute level. See comment [https://github.com/zurb/foundation/pull/763#issuecomment-31139717](https://github.com/zurb/foundation/pull/763#issuecomment-31139717)
