### PR TITLE
remove dependence on CSS3 :not selector

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -179,7 +179,7 @@
     },
 
     update_nodes : function () {
-      var nodes = this.S('[' + this.data_attr + ']:not(img)'),
+      var nodes = this.S('[' + this.data_attr + ']').not('img'),
           count = nodes.length,
           loaded_count = 0,
           data_attr = this.data_attr;


### PR DESCRIPTION
This change is made necessary because not every browser that implements querySelectorAll implements all of CSS selectors.  This is very similar to https://github.com/zurb/foundation/pull/4033 just for a different selector.
