### PR TITLE
added info about asset pipline config

### DIFF
--- a/doc/pages/applications.html
+++ b/doc/pages/applications.html
@@ -49,6 +49,13 @@ Append the following lines to your `app/assets/javascripts/application.js` file:
 //= require foundation
 $(document).foundation();
 ```
+### Configure Asset pipeline
+
+Add Modernizr to precompiled assets for production in `config/enviroments/production.rb`.
+
+```ruby
+config.assets.precompile += %w( vendor/modernizr.js )
+```
 
 ### Add Modernizr
 


### PR DESCRIPTION
Ammnded the documentation. In order to have modernizer available on production you have to add it to the precompile config to avoid issue #3672. Solution by @btsai
