### PR TITLE
Fix for two errors in _sub-nav.scss

### DIFF
--- a/scss/foundation/components/_sub-nav.scss
+++ b/scss/foundation/components/_sub-nav.scss
@@ -47,11 +47,12 @@ $sub-nav-item-divider-margin: rem-calc(12) !default;
 // $font-color - Font color. Default: $sub-nav-font-color.
 // $font-size - Font size. Default: $sub-nav-font-size.
 // $active-bg - Background of active nav item. Default: $sub-nav-active-bg.
+// $active-bg-hover - Background of active nav item, when hovered. Default: $sub-nav-active-bg-hover.
 @mixin sub-nav(
   $font-color: $sub-nav-font-color,
   $font-size: $sub-nav-font-size,
   $active-bg: $sub-nav-active-bg,
-  $active-bg-hover: scale-color(#008CBA, $lightness: -5%)) {
+  $active-bg-hover: $sub-nav-active-bg-hover) {
   display: block;
   width: auto;
   overflow: hidden;
@@ -80,7 +81,7 @@ $sub-nav-item-divider-margin: rem-calc(12) !default;
       text-decoration: $sub-nav-text-decoration;
       color: $sub-nav-font-color;
       &:hover {
-        color: $active-bg-hover;
+        color: $sub-nav-font-color-hover;
       }
     }
 


### PR DESCRIPTION
1. sub-nav-active-bg-color was hard-coded. Now it is set to proper value
   from _settings.scss
2. the hover color for the sub-nav-font was erroneously set to a
   background color. Now it is set to the proper value from _settings.scss.
