### PR TITLE
Remove unwanted effect in sub-nav from magellan

### DIFF
--- a/scss/foundation/components/_magellan.scss
+++ b/scss/foundation/components/_magellan.scss
@@ -20,9 +20,6 @@ $magellan-padding: 10px !default;
       .sub-nav {
         margin-bottom: 0;
         dd { margin-bottom: 0; }
-        .active {
-          line-height: 1.8em;
-        }
       }
     }
 


### PR DESCRIPTION
A text element in the sub-nav jumped in combination with magellan when
becoming active. This can best be seen by chosing the same background
color for active and non-active elements.
