### PR TITLE
Update FastClick to v0.6.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "jquery" : ">= 2.0.0",
     "modernizr": ">= 2.6.2",
-    "fastclick": "~0.6.10",
+    "fastclick": "~0.6.11",
     "jquery.cookie": "~1.4.0",
     "jquery-placeholder": "~2.0.7"
   },


### PR DESCRIPTION
Hi there, one of the FastClick developers here just kindly suggesting that you might like to try out the latest version.

This is the commit history between v0.6.10 and v0.6.11 (sorry it's a little messy):
https://github.com/ftlabs/fastclick/compare/v0.6.10...v0.6.11

And includes the following bug fixes / enhancements:
https://github.com/ftlabs/fastclick/issues/160.
https://github.com/ftlabs/fastclick/issues/156
https://github.com/ftlabs/fastclick/issues/162
https://github.com/ftlabs/fastclick/issues/163
https://github.com/ftlabs/fastclick/issues/168
https://github.com/ftlabs/fastclick/issues/169
https://github.com/ftlabs/fastclick/issues/171
