### PR TITLE
Correct way to check if cookie already exists on jquery.cookie 1.4

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -136,7 +136,7 @@
       }
 
       // generate the tips and insert into dom.
-      if (!this.settings.cookie_monster || this.settings.cookie_monster && $.cookie(this.settings.cookie_name) === null) {
+      if (!this.settings.cookie_monster || this.settings.cookie_monster && !$.cookie(this.settings.cookie_name)) {
         this.settings.$tip_content.each(function (index) {
           var $this = $(this);
           this.settings = $.extend({}, self.defaults, self.data_options($this))


### PR DESCRIPTION
Looks like it was the wrong way of comparing if the cookie already existed. I did not manage to have Joyride working until I dug into its code and found out the problem. Jquery.cookie doc (https://github.com/carhartl/jquery-cookie) says that $.cookie("name") returns "undefined" if the cookie does not exist. Since undefined is "falsey", it works when comparing as shown in the suggested modification.

Furthermore, the current documentation of Joyride on Zurb website is not up to date, the parameters are still camelcase, which is not the case anymore. I could update that, but I think that is not allowed.  

Ps.: Bare with me If something is wrong in the way of contributing, this is my first attempt of contributing here on Github.
