### PR TITLE
Fixed the position issue of top tooltips

### DIFF
--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -141,7 +141,7 @@
         objPos(tip, (target.offset().top + target.outerHeight() + 10), 'auto', 'auto', left);
         tip.removeClass('tip-override');
         if (classes && classes.indexOf('tip-top') > -1) {
-          objPos(tip, (target.offset().top - tip.outerHeight()), 'auto', 'auto', left)
+          objPos(tip, (target.offset().top - tip.outerHeight() - 10), 'auto', 'auto', left)
             .removeClass('tip-override');
         } else if (classes && classes.indexOf('tip-left') > -1) {
           objPos(tip, (target.offset().top + (target.outerHeight() / 2) - (tip.outerHeight() / 2)), 'auto', 'auto', (target.offset().left - tip.outerWidth() - nubHeight))


### PR DESCRIPTION
I've added a small change that fixes the position of top tooltips. Without this fix the triangle is positioned directly above the parent, see the image below.

![tooltipexample](https://f.cloud.github.com/assets/6249209/1909723/ae3b1ed6-7d05-11e3-87a1-19f6b1bfdca2.jpg)

When hovering the green block the triangle gets on top of it. You'll lose focus on the green block and the tooltip will disappear, which results in a 'flickering' effect.
With my fix the tooltip works as expected.

You can also see this behaviour on http://foundation.zurb.com/docs/components/tooltips.html. When you hover the 5 heighest pixels of the first 't' in 'tip-top', the tooltip will flicker.
