### PR TITLE
Fix issue #4150: Reveal: escape key press event capturing does not work consistently

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -105,6 +105,13 @@
           .on('closed.fndtn.reveal', '[data-reveal]', this.close_video);
       }
 
+      return true;
+    },
+
+    // PATCH #3: turning on key up capture only when a reveal window is open
+    key_up_on : function (scope) {
+      var self = this;
+
       // PATCH #1: fixing multiple keyup event trigger from single key press
       $('body').off('keyup.fndtn.reveal').on('keyup.fndtn.reveal', function ( event ) {
         var open_modal = $('[data-reveal].open'),
@@ -116,6 +123,12 @@
         }
       });
 
+      return true;
+    },
+
+    // PATCH #3: turning on key up capture only when a reveal window is open
+    key_up_off : function (scope) {
+      $('body').off('keyup.fndtn.reveal');
       return true;
     },
 
@@ -143,6 +156,7 @@
             .data('offset', this.cache_offset(modal));
         }
 
+        this.key_up_on(modal);    // PATCH #3: turning on key up capture only when a reveal window is open
         modal.trigger('open');
 
         if (open_modal.length < 1) {
@@ -194,6 +208,7 @@
 
       if (open_modals.length > 0) {
         this.locked = true;
+        this.key_up_off(modal);   // PATCH #3: turning on key up capture only when a reveal window is open
         modal.trigger('close');
         this.toggle_bg(modal);
         this.hide(open_modals, settings.css.close, settings);

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -109,8 +109,10 @@
       $('body').off('keyup.fndtn.reveal').on('keyup.fndtn.reveal', function ( event ) {
         var open_modal = $('[data-reveal].open'),
             settings = open_modal.data('reveal-init');
-        if ( settings && event.which === 27  && settings.close_on_esc) { // 27 is the keycode for the Escape key
-          open_modal.foundation('reveal', 'close');
+        // PATCH #2: making sure that the close event can be called only while unlocked,
+        //           so that multiple keyup.fndtn.reveal events don't prevent clean closing of the reveal window.
+        if ( settings && event.which === 27  && settings.close_on_esc && !self.locked) { // 27 is the keycode for the Escape key
+          self.close.call(self, open_modal);
         }
       });
 

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -66,7 +66,7 @@
 
       $(this.scope)
         .off('.reveal');
-      
+
       $(document)
         .on('click.fndtn.reveal', this.close_targets(), function (e) {
 
@@ -105,7 +105,8 @@
           .on('closed.fndtn.reveal', '[data-reveal]', this.close_video);
       }
 
-      $('body').on('keyup.fndtn.reveal', function ( event ) {
+      // PATCH #1: fixing multiple keyup event trigger from single key press
+      $('body').off('keyup.fndtn.reveal').on('keyup.fndtn.reveal', function ( event ) {
         var open_modal = $('[data-reveal].open'),
             settings = open_modal.data('reveal-init');
         if ( settings && event.which === 27  && settings.close_on_esc) { // 27 is the keycode for the Escape key


### PR DESCRIPTION
hi zurbists,

thanks again for your great framework.

i noticed this functionality problem while trying to implement some stuff.

i broke this into three separate commits so you can pick and choose what you want to use.
1. your `$('body').on('keyup.fndtn.reveal')` was firing between 4 to 7 times for each key press, once a reveal window was displayed.
2. because of the multiple triggered events when the escape key was pressed, the reveal window did not close properly and remained in a locked state, so it would not open again.
3. you had the keyup event mapped from the time the reveal library was initialized, and it was always on. i would recommend that you actually have the keyup event captured only when you need it, ie. when there is a reveal modal open.

in its current implementation, once you opened a reveal modal, typing on the page would trigger this block of code 4 to 7 times each time you typed a single letter:

```
        var open_modal = $('[data-reveal].open'),
            settings = open_modal.data('reveal-init');
```

i've tested this with both an in-page reveal dialog and an ajax-based reveal dialog, as well as with one modal having a link to a second modal, and both work.

good luck,

brian
