### PR TITLE
Update anchor tag with required "data-reveal"

### DIFF
--- a/doc/includes/reveal/examples_reveal_data.html
+++ b/doc/includes/reveal/examples_reveal_data.html
@@ -1,5 +1,5 @@
 {{#markdown}}
 ```html
-<a href="#" data-reveal-id="myModal">Click Me For A Modal</a>
+<a href="#" data-reveal-id="myModal" data-reveal>Click Me For A Modal</a>
 ```
 {{/markdown}}


### PR DESCRIPTION
As described here:
http://foundation.zurb.com/forum/posts/258-reveal-problem-with-foundation-5
"data-reveal" is required to have reveal plugin working properly. This example works nice as is but if you have your buttons (anchors) loaded with jQuery (DOM update after document ready) it will not work.
Let's save devs time with this tip in the documentation.
Thanks!
