### PR TITLE
Update _settings.scss after removing Open Sans header font

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -1080,10 +1080,9 @@
 //
 
 // $include-html-type-classes: $include-html-classes;
-// $include-open-sans: true;
 
 // We use these to control header font styles
-// $header-font-family: join("Open Sans", $body-font-family);
+// $header-font-family: $body-font-family;
 // $header-font-weight: 300;
 // $header-font-style: normal;
 // $header-font-color: #222;


### PR DESCRIPTION
Open Sans was removed at https://github.com/zurb/foundation/commit/300821662ccaed514036a675d71846757be2bd8b, but the default settings still suggest related variables :ghost:.
