### PR TITLE
Accordion split sections

### DIFF
--- a/doc/includes/accordion/examples_accordion_grid.html
+++ b/doc/includes/accordion/examples_accordion_grid.html
@@ -1,0 +1,42 @@
+<dl class="accordion" data-accordion>
+  <ul class="small-block-grid-1 medium-block-grid-2">
+    <li>
+      <dd>
+        <a href="#panel1">Accordion 1</a>
+        <div id="panel1" class="content">
+          Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+      </dd>
+      <dd>
+        <a href="#panel2">Accordion 2</a>
+        <div id="panel2" class="content">
+          Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+      </dd>
+      <dd>
+        <a href="#panel3">Accordion 3</a>
+        <div id="panel3" class="content">
+          Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+      </dd>
+      <dd>
+        <a href="#panel4">Accordion 4</a>
+        <div id="panel4" class="content">
+          Panel 4. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+      </dd>
+      <dd>
+        <a href="#panel5">Accordion 5</a>
+        <div id="panel5" class="content">
+          Panel 5. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+      </dd>
+      <dd>
+        <a href="#panel5">Accordion 6</a>
+        <div id="panel5" class="content">
+          Panel 5. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        </div>
+      </dd>
+    </li>
+  </ul>
+</dl>

--- a/doc/includes/accordion/examples_accordion_grid.html
+++ b/doc/includes/accordion/examples_accordion_grid.html
@@ -1,40 +1,42 @@
 <dl class="accordion" data-accordion>
-  <ul class="small-block-grid-1 medium-block-grid-2">
+  <ul class="small-block-grid-1 medium-block-grid-3">
     <li>
       <dd>
-        <a href="#panel1">Accordion 1</a>
-        <div id="panel1" class="content">
-          Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        <a href="#panel1c">Accordion 1</a>
+        <div id="panel1c" class="content">
+          Panel 1. Lorem ipsum dolor
         </div>
       </dd>
       <dd>
-        <a href="#panel2">Accordion 2</a>
-        <div id="panel2" class="content">
-          Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        <a href="#panel2c">Accordion 2</a>
+        <div id="panel2c" class="content">
+          Panel 2. Lorem ipsum dolor
         </div>
       </dd>
       <dd>
-        <a href="#panel3">Accordion 3</a>
-        <div id="panel3" class="content">
-          Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        <a href="#panel3c">Accordion 3</a>
+        <div id="panel3c" class="content">
+          Panel 3. Lorem ipsum dolor
+        </div>
+      </dd>
+    </li>
+    <li>
+      <dd>
+        <a href="#panel4c">Accordion 4</a>
+        <div id="panel4c" class="content">
+          Panel 4. Lorem ipsum dolor
         </div>
       </dd>
       <dd>
-        <a href="#panel4">Accordion 4</a>
-        <div id="panel4" class="content">
-          Panel 4. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        <a href="#panel5c">Accordion 5</a>
+        <div id="panel5c" class="content">
+          Panel 5. Lorem ipsum dolor
         </div>
       </dd>
       <dd>
-        <a href="#panel5">Accordion 5</a>
-        <div id="panel5" class="content">
-          Panel 5. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-        </div>
-      </dd>
-      <dd>
-        <a href="#panel5">Accordion 6</a>
-        <div id="panel5" class="content">
-          Panel 5. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        <a href="#panel6c">Accordion 6</a>
+        <div id="panel6c" class="content">
+          Panel 6. Lorem ipsum dolor
         </div>
       </dd>
     </li>

--- a/doc/pages/components/accordion.html
+++ b/doc/pages/components/accordion.html
@@ -36,7 +36,7 @@ You can create an accordion using minimal markup like so:
 
 <h3>Embedded Block Grid</h3>
 
-You can embed a block grid into the according for more than one column:
+You can embed a block grid into the accordion for responsive columns:
 
 <div class="row">
   <div class="large-6 columns">

--- a/doc/pages/components/accordion.html
+++ b/doc/pages/components/accordion.html
@@ -34,6 +34,27 @@ You can create an accordion using minimal markup like so:
 
 ***
 
+<h3>Embedded Block Grid</h3>
+
+You can embed a block grid into the according for more than one column:
+
+<div class="row">
+  <div class="large-6 columns">
+    <h4>HTML</h4>
+{{#markdown}}
+```html
+{{> examples_accordion_grid}}
+```
+{{/markdown}}
+  </div>
+  <div class="large-6 columns">
+    <h4>Rendered HTML</h4>
+    {{> examples_accordion_grid}}
+  </div>
+</div>
+
+***
+
 ## Customize With Sass
 
 Accordions can be easily customized with the Sass variables provided in the `_settings.scss` file.

--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -16,12 +16,14 @@
     },
 
     events : function () {
-      $(this.scope).off('.accordion').on('click.fndtn.accordion', '[data-accordion] > dd > a', function (e) {
-        var accordion = $(this).parent(),
+      $(this.scope)
+      .off('.accordion')
+      .on('click.fndtn.accordion', '[data-accordion] dd > a', function (e) {
+        var accordion = $(this).closest('[data-accordion]'),
             target = $('#' + this.href.split('#')[1]),
-            siblings = $('> dd > .content', target.closest('[data-accordion]')),
-            settings = accordion.parent().data('accordion-init'),
-            active = $('> dd > .content.' + settings.active_class, accordion.parent());
+            siblings = $(' dd > .content', accordion),
+            settings = accordion.data('accordion-init'),
+            active = $(' dd > .content.' + settings.active_class, accordion);
 
         e.preventDefault();
 


### PR DESCRIPTION
This branch contains a modification to accordion.js
It will allow accordion `dd` sections to be separated by other elements.  They are no longer required to be siblings. 

This allows a block grid to be embedded into the accordion so that the accordion has a different number of columns depending on screen size.  

Accordion documentation is also modified to show an example.
