### PR TITLE
Remove global .start, .end, .text-start, and .text-end classes

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -369,11 +369,6 @@ $cursor-text-value: text !default;
     .text-center  { text-align: center !important; }
     .text-justify { text-align: justify !important; }
     .hide         { display: none; }
-    // Bidi counterparts to .left, .right, .text-left, .text-right
-    .start { float: $default-float !important; }
-    .end   { float: $opposite-direction !important; }
-    .text-start { text-align: $default-float !important; }
-    .text-end   { text-align: $opposite-direction !important; }
 
     // Font smoothing
     // Antialiased font smoothing works best for light text on a dark background.


### PR DESCRIPTION
Commit a13a0db7b4379f0cacbb3cf30f63fc1ee20d03e5 added four new global classes intended to be used for bidirectionally. This broke the `.end` class in _grid.scss.

These new classes haven't been documented anywhere and were added in an unrelated pull request, https://github.com/zurb/foundation/pull/4035. From what I can tell, the intention is that you can use `.start` instead of `.left` to float an element to either the left or the right depending on the document's text direction. Likewise for the other added classes. I guess this has some semantic value, but I think it dangerously pollutes the global namespace, especially since these use `!important`.

We can simply continue using `.left` `.right` `.text-left` and `.text-right` depending on what side we want something. I don't see the use-case for abstracting this to `.start` `.end` `.text-start` and `.text-end`.

This closes #4175.
