### PR TITLE
Fixes #4186 which was caused by ...

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -28,8 +28,6 @@
           var settings = $(this).data('dropdown-init') || self.settings;
           e.preventDefault();
 
-          self.closeall.call(self);
-
           if (!settings.is_hover || Modernizr.touch) self.toggle($(this));
         })
         .on('mouseenter.fndtn.dropdown', '[data-dropdown], [data-dropdown-content]', function (e) {


### PR DESCRIPTION
commit da1a87af6d068b956b84353a9ee410fef89a9b1f. The issue is that I had it closing the dropdowns on click, which toggle() wasn't expecting. Only needed to handle closing all others for `is_hover`, not `click`.
