### PR TITLE
Fix reveal is not closing on backdrop click if animations are off.

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -66,7 +66,7 @@
 
       $(this.scope)
         .off('.reveal');
-      
+
       $(document)
         .on('click.fndtn.reveal', this.close_targets(), function (e) {
 
@@ -278,6 +278,8 @@
       if (/fade/i.test(settings.animation)) {
         return el.fadeIn(settings.animation_speed / 2);
       }
+
+      this.locked = false;
 
       return el.show();
     },


### PR DESCRIPTION
When the animations are turned off, the `locked` internal is not changing back to `false`, therefore the reveal modal won't close at the second time on close targets click.

Until this is not merged, one can set the `animation_speed` to `0` to mock the functionality without animations.
