### PR TITLE
Fix orbit bullets not lining up horizontally.

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -79,7 +79,7 @@ $preloader-class: "preloader" !default;
       .orbit-container { background-color: transparent;
 
         // Show images when .orbit-container is loaded
-        li { display: block;
+        ul li { display: block;
 
           .orbit-caption { display: block; }
         }


### PR DESCRIPTION
Observed: orbit bullets are lined up vertically, with `display: block` style set instead of `display: inline-block`. This is because the styles of the `li` element of `.orbit-container` overwrites `li` element of `.orbit-bullets`.
Fix: Add additional specificity to `.orbit-container li` as `.orbit-container ul li` so that it applies only to the images of the Orbit, not to the bullets.
