### PR TITLE
Document .end class for grids

### DIFF
--- a/doc/includes/grid/examples_grid_end.html
+++ b/doc/includes/grid/examples_grid_end.html
@@ -1,0 +1,14 @@
+{{#markdown}}
+```html
+<div class="row">
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns">3</div>
+</div>
+<div class="row">
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns end">3 end</div>
+</div>
+```
+{{/markdown}}

--- a/doc/includes/grid/examples_grid_end_rendered.html
+++ b/doc/includes/grid/examples_grid_end_rendered.html
@@ -1,0 +1,10 @@
+<div class="row display">
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns">3</div>
+</div>
+<div class="row display">
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns">3</div>
+  <div class="large-3 columns end">3 end</div>
+</div>

--- a/doc/pages/components/grid.html
+++ b/doc/pages/components/grid.html
@@ -80,7 +80,7 @@ Move blocks up to 11 columns to the right by using classes like `.large-offset-1
 
 ### Incomplete Rows
 
-In order to work around browsers' different rounding behaviors, Foundation will float the last column in a row to the right so the edge aligns. If your row doesn't have a count that adds up to 12 columns, you can tag the last column with class of `end` in order to override that behavior.
+In order to work around browsers' different rounding behaviors, Foundation will float the last column in a row to the right so the edge aligns. If your row doesn't have a count that adds up to 12 columns, you can tag the last column with a class of `end` in order to override that behavior.
 
 <h4>HTML</h4>
 

--- a/doc/pages/components/grid.html
+++ b/doc/pages/components/grid.html
@@ -78,6 +78,20 @@ Move blocks up to 11 columns to the right by using classes like `.large-offset-1
 
 ***
 
+### Incomplete Rows
+
+In order to work around browsers' different rounding behaviors, Foundation will float the last column in a row to the right so the edge aligns. If your row doesn't have a count that adds up to 12 columns, you can tag the last column with class of `end` in order to override that behavior.
+
+<h4>HTML</h4>
+
+{{> examples_grid_end}}
+
+<h4>Rendered HTML</h4>
+
+{{> examples_grid_end_rendered}}
+
+***
+
 ### Centered Columns
 
 Center your columns by adding a class of `small-centered` to your `column`. Large will inherit small centering by default, but you can also center solely on large by applying a `large-centered` class. To uncenter on large screens use `large-uncentered`.


### PR DESCRIPTION
Documentation for the `end` class in grids has been missing since Foundation 4, even though the class still exists and is very useful.

I added documentation and an example for the class, which are mostly copied from [Foundation 3's documentation](http://foundation.zurb.com/docs/v/3.2.5/grid.php).

![screen shot 2014-01-21 at 12 06 07 pm](https://f.cloud.github.com/assets/1009531/1967833/ccb87b72-82d9-11e3-9a7b-61b912b6d853.png)

See #3660 and #4175 for evidence that documentation is needed.
