### PR TITLE
Added HTML5 dialog support

### DIFF
--- a/doc/includes/reveal/examples_reveal_basic_rendered.html
+++ b/doc/includes/reveal/examples_reveal_basic_rendered.html
@@ -1,10 +1,10 @@
 {{#markdown}}
 ```html
-<div id="myModal" class="reveal-modal" data-reveal>
+<dialog id="myModal" class="reveal-modal" data-reveal>
   <h2>Awesome. I have it.</h2>
   <p class="lead">Your couch.  It is mine.</p>
   <p>Im a cool paragraph that lives inside of an even cooler modal. Wins</p>
   <a class="close-reveal-modal">&#215;</a>
-</div>
+</dialog>
 ```
 {{/markdown}}

--- a/doc/includes/reveal/examples_reveal_basic_rendered.html
+++ b/doc/includes/reveal/examples_reveal_basic_rendered.html
@@ -1,6 +1,6 @@
 {{#markdown}}
 ```html
-<dialog id="myModal" class="reveal-modal" data-reveal>
+<dialog id="myModal" data-reveal>
   <h2>Awesome. I have it.</h2>
   <p class="lead">Your couch.  It is mine.</p>
   <p>Im a cool paragraph that lives inside of an even cooler modal. Wins</p>

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -137,16 +137,21 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     // Reveal Modals
     .reveal-modal-bg { @include reveal-bg; }
 
-    .#{$reveal-modal-class} {
+    dialog, .#{$reveal-modal-class} {
       @include reveal-modal-base;
       @include reveal-modal-style;
 
       .#{$close-reveal-modal-class} { @include reveal-close; }
     }
 
+    dialog[open] {
+	display:block;
+	visibility: visible;
+    }
+
     @media #{$medium-up} {
 
-      .#{$reveal-modal-class} {
+      dialog, .#{$reveal-modal-class} {
         @include reveal-modal-style(false, $reveal-modal-padding * 1.5, false, $box-shadow: false, $top-offset: $reveal-position-top);
 
         &.tiny  { @include reveal-modal-base(false, 30%); }
@@ -159,7 +164,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
 
     // Reveal Print Styles
     @media print {
-      .#{$reveal-modal-class} {background: #fff !important;}
+      dialog, .#{$reveal-modal-class} {background: #fff !important;}
     }
   }
 }


### PR DESCRIPTION
The `dialog` element for modals is a first class citizen in HTML5, with emerging browser support (http://blog.teamtreehouse.com/a-preview-of-the-new-dialog-element). 

I have changed the code such that `dialog` elements are styled like regular reveal modals, and when they have the `[open]` attribute (which browsers add when they have been opened through the native JS API) they are displayed.

However, I have also added it such that the dialog element can still be opened up using foundation's jQuery api (assuming they have `data-reveal` as an attr) . I have created mock files to demonstrate this.

If you have any problems I will be happy to fix. Thanks.
