### PR TITLE
Fix orbit's events method

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -436,6 +436,7 @@
     },
 
     events : function (instance) {
+      var self = this;
       var orbit_instance = new Orbit($(instance), $(instance).data('orbit-init'));
       $(instance).data(self.name + '-instance', orbit_instance);
     },


### PR DESCRIPTION
events method is using `self.name` but never defines `self`.
This causes the data-attribute to be called '-instance' (Instance)
instead of 'orbit-instance'.
