### PR TITLE
Fix data-reveal-id event binding

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -43,9 +43,9 @@
     events : function (scope) {
       var self = this;
 
-      $('[data-reveal-id]', this.scope)
+      $(this.scope)
         .off('.reveal')
-        .on('click.fndtn.reveal', function (e) {
+        .on('click.fndtn.reveal', '[data-reveal-id]', function (e) {
           e.preventDefault();
 
           if (!self.locked) {
@@ -63,9 +63,6 @@
             }
           }
         });
-
-      $(this.scope)
-        .off('.reveal');
 
       $(document)
         .on('click.fndtn.reveal', this.close_targets(), function (e) {


### PR DESCRIPTION
This patch fixes 2 issues. First, it removes a duplicate and probably
unintended removal of event handlers on elements with a `data-reveal-id`
attribute. Second, it fixes the event binding for elements with a
`data-reveal-id` attribute to also work with elements added after
foundation has been intialized (e.g. due to ajax calls).
