### PR TITLE
Fixes #4036 Fixed reveal closing randomly all .flex-videos from document

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -349,7 +349,7 @@
     },
 
     close_video : function (e) {
-      var video = $(this).find('.flex-video'),
+      var video = $(e.target).find('.flex-video'),
           iframe = video.find('iframe');
 
       if (iframe.length > 0) {
@@ -360,7 +360,7 @@
     },
 
     open_video : function (e) {
-      var video = $(this).find('.flex-video'),
+      var video = $(e.target).find('.flex-video'),
           iframe = video.find('iframe');
 
       if (iframe.length > 0) {


### PR DESCRIPTION
In the context of the function, `this` refers to `window.document`, so when you do `$(document).find('.flex-video')` and then set the iframe src to about:blank, all videos on the website are dying.

The huge problem is that this method is also called by alert-boxes, dropdowns and so on.
