### PR TITLE
Fix for top-bar active class in large view (issue #4232)

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -471,6 +471,15 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               &:hover { background: $topbar-link-bg-hover; }
             }
           }
+          &.active:not(.has-form) {
+            a:not(.button) {
+              padding: 0 $topbar-height / 3;
+              line-height: $topbar-height;
+              color: $topbar-link-color-active;
+              background: $topbar-link-bg-active;
+              &:hover { background: $topbar-link-bg-active-hover; }
+            }
+          }
         }
 
         .has-dropdown {


### PR DESCRIPTION
A fix for top-bar active class in large view (issue #4232) that extends the existing scss, taking into account the .has-form and .button excludes.
