### PR TITLE
Added Media Query breakpoint variables

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -213,12 +213,18 @@ $include-print-styles: true !default;
 $include-html-global-classes: $include-html-classes !default;
 
 
+// We use this to define our Media Query breakpoints.
+$small-breakpoint: 640px;
+$medium-breakpoint: 1024px;
+$large-breakpoint: 1440px;
+$xlarge-breakpoint: 1920px;
+
 // Media Query Ranges
-$small-range: (0em, 40em) !default;
-$medium-range: (40.063em, 64em) !default;
-$large-range: (64.063em, 90em) !default;
-$xlarge-range: (90.063em, 120em) !default;
-$xxlarge-range: (120.063em) !default;
+$small-range: (0, rem-calc($small-breakpoint)) !default;
+$medium-range: (rem-calc($small-breakpoint+1), rem-calc($medium-breakpoint)) !default;
+$large-range: (rem-calc($medium-breakpoint+1), rem-calc($large-breakpoint)) !default;
+$xlarge-range: (rem-calc($large-breakpoint+1), rem-calc($xlarge-breakpoint)) !default;
+$xxlarge-range: (rem-calc($xlarge-breakpoint+1)) !default;
 
 
 $screen: "only screen" !default;


### PR DESCRIPTION
Added the Media Query breakpoint values as variables in pixels instead of the existing method of defining the Media Query ranges in em's.  This new method will:
- Automatically calculate the Media Query ranges using rem-calc.
- Make it much easier for a developer to alter the breakpoints using pixel values instead of fiddling with em ranges.
- Gives the developer media query variables that can be used elsewhere, in custom mixin's, etc.

Other notes:
- This approach replaces the Media Query ranges with calculated rem ranges instead of em values.  But since em's are the same as rem's at the root of the html structure, it doesn't matter.
- rem-calc results in higher accuracy values (40.0625rem vs the existing 40.063em).
- For the small range I changed 0em to just 0 (save those precious bytes!).

Overall, this change results in the same (more accurate actually) compiled code while giving more freedom and flexibility to the developer.

Signed-off-by: Jake Wilson jake.e.wilson@gmail.com
