### PR TITLE
Update normalize.css to the latest 2.1.3 version

### DIFF
--- a/scss/normalize.scss
+++ b/scss/normalize.scss
@@ -1,4 +1,4 @@
-/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/*! normalize.css v2.1.3 | MIT License | git.io/normalize */
 
 /* ==========================================================================
    HTML5 display definitions
@@ -51,10 +51,6 @@ audio:not([controls]) {
 [hidden],
 template {
     display: none;
-}
-
-script {
-  display: none !important;
 }
 
 /* ==========================================================================
@@ -343,8 +339,8 @@ html input[disabled] {
 }
 
 /**
- * 1. Address box sizing set to `content-box` in IE 8/9.
- * 2. Remove excess padding in IE 8/9.
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
  */
 
 input[type="checkbox"],


### PR DESCRIPTION
As seen on http://necolas.github.io/normalize.css/ the version 2.1.3 is the latest for now, so it's time to update.
