### PR TITLE
Bug/off canvas menu short content

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -310,7 +310,10 @@ $cursor-text-value: text !default;
     }
 
     html,
-    body { font-size: $base-font-size; }
+    body {
+      font-size: $base-font-size;
+      height: 100%;
+    }
 
     // Default body styles
     body {

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -104,6 +104,7 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     overflow: hidden;
+    height: 100%;
 }
 
 // INNER WRAP
@@ -112,6 +113,7 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     @include clearfix;
+    height: 100%;
 
     -webkit-transition: -webkit-#{$menu-slide};
     -moz-transition: -moz-#{$menu-slide};

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -74,7 +74,6 @@ $menu-slide: "transform 500ms ease" !default;
 @mixin wrap-base {
   position: relative;
   width: 100%;
-  height: 100%;
 }
 
 // basic styles for off-canvas menu container
@@ -102,24 +101,26 @@ $menu-slide: "transform 500ms ease" !default;
 // OFF CANVAS WRAP
 // Wrap visible content and prevent scroll bars
 @mixin off-canvas-wrap {
-    @include kill-flicker;
-    @include wrap-base;
-    overflow: hidden;
+  @include kill-flicker;
+  @include wrap-base;
+  overflow: hidden;
+
+  &.move-right,
+  &.move-left { height: 100%; }
 }
 
 // INNER WRAP
 // Main content area that moves to reveal the off-canvas nav
 @mixin inner-wrap {
-    @include kill-flicker;
-    @include wrap-base;
-    @include clearfix;
+  @include kill-flicker;
+  @include wrap-base;
+  @include clearfix;
 
-    -webkit-transition: -webkit-#{$menu-slide};
-    -moz-transition: -moz-#{$menu-slide};
-    -ms-transition: -ms-#{$menu-slide};
-    -o-transition: -o-#{$menu-slide};
-    transition: #{$menu-slide};
-
+  -webkit-transition: -webkit-#{$menu-slide};
+  -moz-transition: -moz-#{$menu-slide};
+  -ms-transition: -ms-#{$menu-slide};
+  -o-transition: -o-#{$menu-slide};
+  transition: #{$menu-slide};
 }
 
 // TAB BAR

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -74,6 +74,7 @@ $menu-slide: "transform 500ms ease" !default;
 @mixin wrap-base {
   position: relative;
   width: 100%;
+  height: 100%;
 }
 
 // basic styles for off-canvas menu container
@@ -104,7 +105,6 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     overflow: hidden;
-    height: 100%;
 }
 
 // INNER WRAP
@@ -113,7 +113,6 @@ $menu-slide: "transform 500ms ease" !default;
     @include kill-flicker;
     @include wrap-base;
     @include clearfix;
-    height: 100%;
 
     -webkit-transition: -webkit-#{$menu-slide};
     -moz-transition: -moz-#{$menu-slide};


### PR DESCRIPTION
This fixes the scrolling that the previous commit broke, but still successfully keeps the off-canvas menu the full height of the browser window in the case that the page content is shorter than the browser window (which normally results in a short off canvas menu).

I also removed some double indented whitespace.
