### PR TITLE
Fix duplicated ids in label.inline.right example

### DIFF
--- a/doc/includes/form/examples_form_inline.html
+++ b/doc/includes/form/examples_form_inline.html
@@ -3,10 +3,10 @@
     <div class="small-8">
       <div class="row">
         <div class="small-3 columns">
-          <label for="right-label" class="right inline">Label</label>
+          <label for="right-label-inline" class="right inline">Label</label>
         </div>
         <div class="small-9 columns">
-          <input type="text" id="right-label" placeholder="Inline Text Input">
+          <input type="text" id="right-label-inline" placeholder="Inline Text Input">
         </div>
       </div>
     </div>


### PR DESCRIPTION
The id `right-label` is duplicate, and colides with https://github.com/zurb/foundation/blob/master/doc/includes/form/examples_form_inline_labels.html. To replicate the issue just click in the `label.right.inline` in http://foundation.zurb.com/docs/components/forms.html
