### PR TITLE
fix for unordered nested-lists font-size

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -269,7 +269,6 @@ $microformat-abbr-font-decoration: none !default;
         ol {
           margin-#{$default-float}: $list-nested-margin;
           margin-bottom: 0;
-          font-size: 1rem; /* Override nested font-size change */
         }
       }
       &.square,


### PR DESCRIPTION
```
font-size: 1rem 
```

styling removed for nested unordered lists.
This creates errors with nested lists. The fix would be to set it to 1em. Since foundation has moved to rem, i find that removing the styling would be the appropriate way.
