### PR TITLE
Added the live_validate option that was present on the docs, but not on the code. 

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -7,6 +7,7 @@
     version : '5.0.3',
 
     settings : {
+      live_validate : true,
       focus_on_invalid : true,
       error_labels: true, // labels with a for="inputId" will recieve an `error` class
       timeout : 1000,
@@ -67,11 +68,13 @@
             self.validate([this], e);
           })
           .on('keydown.fndtn.abide', function (e) {
-            var settings = $(this).closest('form').data('abide-init');
-            clearTimeout(self.timer);
-            self.timer = setTimeout(function () {
-              self.validate([this], e);
-            }.bind(this), settings.timeout);
+            if (live_validate === true) {
+              var settings = $(this).closest('form').data('abide-init');
+              clearTimeout(self.timer);
+              self.timer = setTimeout(function () {
+                self.validate([this], e);
+              }.bind(this), settings.timeout);
+            }
           });
     },
 

--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -68,8 +68,8 @@
             self.validate([this], e);
           })
           .on('keydown.fndtn.abide', function (e) {
-            if (live_validate === true) {
-              var settings = $(this).closest('form').data('abide-init');
+            var settings = $(this).closest('form').data('abide-init');
+            if (settings.live_validate === true) {
               clearTimeout(self.timer);
               self.timer = setTimeout(function () {
                 self.validate([this], e);


### PR DESCRIPTION
The docs present the "live_validate" option, but the code does not have it. That is a nice option to have on. To do so I simply added the live_validate flag that is going to be checked on the keydown event. Therefore, it is possible to choose not to validate the fields every "timeout" on the keydown, aka, polling and let it only when "blur.fndtn" and "change.fndtn" events.
