### PR TITLE
Fixes syntax errors for columns and visibility

### DIFF
--- a/scss/foundation/components/_button-groups.scss
+++ b/scss/foundation/components/_button-groups.scss
@@ -91,7 +91,7 @@ $button-group-border-width: 1px !default;
       &.round > * { @include button-group-style($radius:$button-round, $float:null); }
 
       @for $i from 2 through 8 {
-        &.even#{-$i} li { @include button-group-style($even:$i, $float:null); }
+        &.even-#{$i} li { @include button-group-style($even:$i, $float:null); }
       }
     }
 

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -164,10 +164,10 @@ $total-columns: 12 !default;
   }
 
   @for $i from 1 through $total-columns - 1 {
-    .#{$size}-push#{-$i} {
+    .#{$size}-push-#{$i} {
       @include grid-column($push:$i, $collapse:null, $float:false);
     }
-    .#{$size}-pull#{-$i} {
+    .#{$size}-pull-#{$i} {
       @include grid-column($pull:$i, $collapse:null, $float:false);
     }
   }
@@ -177,7 +177,7 @@ $total-columns: 12 !default;
 
 
   @for $i from 1 through $total-columns {
-    .#{$size}#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
+    .#{$size}-#{$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
   }
 
   [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
@@ -225,10 +225,10 @@ $total-columns: 12 !default;
       @include grid-html-classes($size:medium);
       // Old push and pull classes
       @for $i from 1 through $total-columns - 1 {
-        .push#{-$i} {
+        .push-#{$i} {
           @include grid-column($push:$i, $collapse:null, $float:false);
         }
-        .pull#{-$i} {
+        .pull-#{$i} {
           @include grid-column($pull:$i, $collapse:null, $float:false);
         }
       }
@@ -236,10 +236,10 @@ $total-columns: 12 !default;
     @media #{$large-up} {
       @include grid-html-classes($size:large);
       @for $i from 1 through $total-columns - 1 {
-        .push#{-$i} {
+        .push-#{$i} {
           @include grid-column($push:$i, $collapse:null, $float:false);
         }
-        .pull#{-$i} {
+        .pull-#{$i} {
           @include grid-column($pull:$i, $collapse:null, $float:false);
         }
       }

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -117,13 +117,13 @@ $include-html-visibility-classes: $include-html-classes !default;
   th {
     &.show-for-small,
     &.show-for-small-only,
-    &.show-for-medium-down
+    &.show-for-medium-down,
     &.show-for-large-down,
     &.hide-for-medium,
     &.hide-for-medium-up,
     &.hide-for-large,
     &.hide-for-large-up,
-    &.hide-for-xlarge
+    &.hide-for-xlarge,
     &.hide-for-xlarge-up,
     &.hide-for-xxlarge-up { display: table-cell !important; }
   }


### PR DESCRIPTION
I've added some commas missing from _visibility.scss that were causing certain visibility classes to be unavailable. Also fixed an issue with modifying loops in @mixin grid-html-classes(), where starting the loops at 0 would yield classes like ".small-push0" instead of ".small-push-0". This is due to the hyphen being inside #{-$i}, which evaluates negative 0 as 0. Moving the hyphen outside of the braces restores the hyphen. (And from a pedantic standpoint, the hyphen is used as a hyphen in the class name, not as an indication of negation.)
