### PR TITLE
Make data-orbit-link fully compatible with non-a elements

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -40,7 +40,7 @@
     };
 
     self.update_active_link = function(index) {
-      var link = $('a[data-orbit-link="'+self.slides().eq(index).attr('data-orbit-slide')+'"]');
+      var link = $('[data-orbit-link="'+self.slides().eq(index).attr('data-orbit-slide')+'"]');
       link.siblings().removeClass(settings.bullets_active_class);
       link.addClass(settings.bullets_active_class);
     };


### PR DESCRIPTION
Since data-orbit-link does work on non-a elements when it comes to controlling the slideshow, the same should be true for updating the active link status for those elements (alternatively both should fail on non-a elements). Either way, it should be consistent. This proposal does the former, since I find it to be useful and can't see a reason why not.
