### PR TITLE
Fix #4124 - pre/postfix labels don't work correctly with $input-border-radius set

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -400,11 +400,6 @@ $select-bg-color: #fafafa !default;
       }
       &.radius {
         @include radius($input-border-radius);
-      }
-      &.round {
-        @include radius($global-rounded);
-      }
-      &.radius, &.round {
         &.prefixed {
           @include side-radius($default-float, 0);
         }

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -83,13 +83,6 @@ $select-bg-color: #fafafa !default;
 
       .column,
       .columns { padding: 0; }
-      input {
-        -moz-border-radius-bottom#{$opposite-direction}: 0;
-        -moz-border-radius-top#{$opposite-direction}: 0;
-        -webkit-border-bottom-#{$opposite-direction}-radius: 0;
-        -webkit-border-top-#{$opposite-direction}-radius: 0;
-      }
-
     }
   }
   input.column,
@@ -401,11 +394,23 @@ $select-bg-color: #fafafa !default;
     input[type="url"],
     textarea {
       -webkit-appearance: none;
-      -webkit-border-radius: $input-border-radius;
-      border-radius: $input-border-radius;
       @include form-element;
       @if not $input-include-glowing-effect {
           @include single-transition(all, 0.15s, linear);
+      }
+      &.radius {
+        @include radius($input-border-radius);
+      }
+      &.round {
+        @include radius($global-rounded);
+      }
+      &.radius, &.round {
+        &.prefixed {
+          @include side-radius($default-float, 0);
+        }
+        &.postfixed {
+          @include side-radius($opposite-direction, 0);
+        }
       }
     }
     


### PR DESCRIPTION
Resolves issue #4124 by creating a new `.radius` modifier class and a `.prefixed` and `.postfixed` class to remove the rounded border when necessary.

I’m happy to update the docs with examples and/or amend this branch as appropriate if it’s of interest.
