### PR TITLE
Add missing commas to visibility classes

### DIFF
--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -117,13 +117,13 @@ $include-html-visibility-classes: $include-html-classes !default;
   th {
     &.show-for-small,
     &.show-for-small-only,
-    &.show-for-medium-down
+    &.show-for-medium-down,
     &.show-for-large-down,
     &.hide-for-medium,
     &.hide-for-medium-up,
     &.hide-for-large,
     &.hide-for-large-up,
-    &.hide-for-xlarge
+    &.hide-for-xlarge,
     &.hide-for-xlarge-up,
     &.hide-for-xxlarge-up { display: table-cell !important; }
   }


### PR DESCRIPTION
I've added some commas missing from _visibility.scss that were causing certain visibility classes to be unavailable.
