### PR TITLE
Move hyphen outside of column number loops

### DIFF
--- a/scss/foundation/components/_button-groups.scss
+++ b/scss/foundation/components/_button-groups.scss
@@ -91,7 +91,7 @@ $button-group-border-width: 1px !default;
       &.round > * { @include button-group-style($radius:$button-round, $float:null); }
 
       @for $i from 2 through 8 {
-        &.even#{-$i} li { @include button-group-style($even:$i, $float:null); }
+        &.even-#{$i} li { @include button-group-style($even:$i, $float:null); }
       }
     }
 

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -163,11 +163,11 @@ $total-columns: 12 !default;
     float: $opposite-direction;
   }
 
-  @for $i from 1 through $total-columns - 1 {
-    .#{$size}-push#{-$i} {
+  @for $i from 0 through $total-columns - 1 {
+    .#{$size}-push-#{$i} {
       @include grid-column($push:$i, $collapse:null, $float:false);
     }
-    .#{$size}-pull#{-$i} {
+    .#{$size}-pull-#{$i} {
       @include grid-column($pull:$i, $collapse:null, $float:false);
     }
   }
@@ -177,14 +177,14 @@ $total-columns: 12 !default;
 
 
   @for $i from 1 through $total-columns {
-    .#{$size}#{-$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
+    .#{$size}-#{$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
   }
 
   [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
   [class*="column"] + [class*="column"].end { float: $default-float; }
 
 
-  @for $i from 0 through $total-columns - 2 {
+  @for $i from 0 through $total-columns - 1 {
     .#{$size}-offset-#{$i} { @include grid-column($offset:$i, $collapse:null,$float:false); }
   }
   .column.#{$size}-reset-order,
@@ -224,22 +224,22 @@ $total-columns: 12 !default;
     @media #{$medium-up} {
       @include grid-html-classes($size:medium);
       // Old push and pull classes
-      @for $i from 1 through $total-columns - 1 {
-        .push#{-$i} {
+      @for $i from 0 through $total-columns - 1 {
+        .push-#{$i} {
           @include grid-column($push:$i, $collapse:null, $float:false);
         }
-        .pull#{-$i} {
+        .pull-#{$i} {
           @include grid-column($pull:$i, $collapse:null, $float:false);
         }
       }
     }
     @media #{$large-up} {
       @include grid-html-classes($size:large);
-      @for $i from 1 through $total-columns - 1 {
-        .push#{-$i} {
+      @for $i from 0 through $total-columns - 1 {
+        .push-#{$i} {
           @include grid-column($push:$i, $collapse:null, $float:false);
         }
-        .pull#{-$i} {
+        .pull-#{$i} {
           @include grid-column($pull:$i, $collapse:null, $float:false);
         }
       }


### PR DESCRIPTION
Fixed an issue with modifying loops in mixin grid-html-classes(), where starting the loops at zero would yield classes like ".small-push0" instead of ".small-push-0". This is due to the hyphen being inside #{-$i}, which evaluates -0 (negative zero) as 0. Moving the hyphen outside of the braces restores the hyphen. (And from a pedantic standpoint, the hyphen is used as a hyphen in the class name, not as an indication of negation.) This syntax is already in use for offset classes.

Also increases loop range to include 0 through 11 in push/pull/offset classes, which are necessary for overriding.
