### PR TITLE
Fixed $input-prefix-border-color ignored

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -183,17 +183,20 @@ $select-bg-color: #fafafa !default;
 // $bg - Default:$input-prefix-bg || scale-color(#fff, $lightness: -5%) !default;
 // $is-button - Toggle position settings if prefix is a button. Default:false
 //
-@mixin prefix($bg:$input-prefix-bg,$is-button:false) {
+@mixin prefix($bg:$input-prefix-bg, $border:$input-prefix-border-color, $is-button:false) {
 
   @if $bg {
     $bg-lightness: lightness($bg);
     background: $bg;
-    border-color: scale-color($bg, $lightness: -11%);
     border-#{$opposite-direction}: none;
 
     // Control the font color based on background brightness
     @if $bg-lightness > 70% or $bg == yellow { color: $input-prefix-font-color; }
     @else { color: $input-prefix-font-color-alt; }
+  }
+
+  @if $border {
+    border-color: $border;
   }
 
   @if $is-button {
@@ -213,17 +216,20 @@ $select-bg-color: #fafafa !default;
 // We use this mixin to create postfix label styles
 // $bg - Default:$input-prefix-bg || scale-color(#fff, $lightness: -5%) !default;
 // $is-button - Toggle position settings if prefix is a button. Default: false
-@mixin postfix($bg:$input-prefix-bg, $is-button:false) {
+@mixin postfix($bg:$input-prefix-bg, $border:$input-prefix-border-color, $is-button:false) {
 
   @if $bg {
     $bg-lightness: lightness($bg);
     background: $bg;
-    border-color: scale-color($bg, $lightness: -16%);
     border-#{$default-float}: none;
 
     // Control the font color based on background brightness
     @if $bg-lightness > 70%  or $bg == yellow { color: $input-prefix-font-color; }
     @else { color: $input-prefix-font-color-alt; }
+  }
+
+  @if $border {
+    border-color: $border;
   }
 
   @if $is-button {
@@ -349,8 +355,8 @@ $select-bg-color: #fafafa !default;
     .postfix { @include prefix-postfix-base; }
 
     /* Adjust padding, alignment and radius if pre/post element is a button */
-    .postfix.button { @include button-size(false,false,false); @include postfix(false,true); }
-    .prefix.button { @include button-size(false,false,false); @include prefix(false,true); }
+    .postfix.button { @include button-size(false,false,false); @include postfix(false, false, true); }
+    .prefix.button { @include button-size(false,false,false); @include prefix(false, false, true); }
 
     .prefix.button.radius { @include radius(0); @include side-radius(left, $button-radius); }
     .postfix.button.radius { @include radius(0); @include side-radius(right, $button-radius); }


### PR DESCRIPTION
Added $input-prefix-border-color to the pre/postfix mixins. This value was not previously used anywhere, despite being defined in _forms.scss and _settings.scss.

Let me know if you’d like me to change anything.
