### PR TITLE
Added support for fieldset[disabled]

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -128,7 +128,7 @@ $select-bg-color: #fafafa !default;
   }
 
   // Disabled background input background color
-  &[disabled] { background-color: $input-disabled-bg; }
+  &[disabled], fieldset[disabled] & { background-color: $input-disabled-bg; }
 }
 
 // @MIXIN


### PR DESCRIPTION
Added support for fieldsets with the disabled attribute, which is valid as of HTML5:

``` html
<fieldset disabled>
  <legend>Personalia:</legend>
  Name: <input type="text"><br>
  Email: <input type="text"><br>
  Date of birth: <input type="text">
</fieldset>
```
