### PR TITLE
Added Active Classing to the parent dd for ease-of-styling the a tag for...

### DIFF
--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -19,6 +19,7 @@
       $(this.scope).off('.accordion').on('click.fndtn.accordion', '[data-accordion] > dd > a', function (e) {
         var accordion = $(this).parent(),
             target = $('#' + this.href.split('#')[1]),
+            parent = target.closest('dd'),
             siblings = $('> dd > .content', target.closest('[data-accordion]')),
             settings = accordion.parent().data('accordion-init'),
             active = $('> dd > .content.' + settings.active_class, accordion.parent());
@@ -26,10 +27,12 @@
         e.preventDefault();
 
         if (active[0] == target[0] && settings.toggleable) {
+          parent.toggleClass(settings.active_class);
           return target.toggleClass(settings.active_class);
         }
 
         siblings.removeClass(settings.active_class);
+        parent.addClass(settings.active_class);
         target.addClass(settings.active_class);
       });
     },


### PR DESCRIPTION
I've added 3 lines of javascript that also add the "active_class" to the accordion cell container (the dd tag) so that you can add styles to the accordion cell a tag, for things like an arrow that points down when idle, and points right or up when active.

Taken from issue #4082, and is really only a workaround for the time being.  To make this a clean active placement, we would need to just switch the "target" but that would provide NO backwards compatibility to the accordions, because callbacks and styles will fail on users, so that may be something necessary for a Foundation 6, possibly?
