### PR TITLE
Fixed #4236 - Updated select control to more closely match other native controls in Chrome.

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -316,22 +316,17 @@ $select-bg-color: #fafafa !default;
 
     select {
       -webkit-appearance: none !important;
-      background:
-        $select-bg-color
-        url('data:image/svg+xml;base64, PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iM3B4IiB2aWV3Qm94PSIwIDAgNiAzIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA2IDMiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwb2x5Z29uIHBvaW50cz0iNS45OTIsMCAyLjk5MiwzIC0wLjAwOCwwICIvPjwvc3ZnPg==') no-repeat;
-      background-position-x: 97%;
-      background-position-y: center;
+      background-color: $select-bg-color;
+      background-image: url('data:image/svg+xml;base64, PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwcHgiIGhlaWdodD0iOHB4IiB2aWV3Qm94PSIwIDAgMzkgMzkiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPg0KPHBhdGggZD0iTTM4LjYwNiwwTDE5LjMwMywzOC41NzlMMCwwSDM4LjYwNnoiIGZpbGw9IiM0NDQiIC8+DQo8L3N2Zz4=');
+      background-repeat: no-repeat;
+      background-position: center right $form-spacing / 2;
       border: $input-border-width $input-border-style $input-border-color;
       padding: $form-spacing / 2;
       font-size: $input-font-size;
       @include radius(0);
       &.radius { @include radius($global-radius); }
       &:hover {
-        background:
-          scale-color($select-bg-color, $lightness: -3%)
-          url('data:image/svg+xml;base64, PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iM3B4IiB2aWV3Qm94PSIwIDAgNiAzIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA2IDMiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwb2x5Z29uIHBvaW50cz0iNS45OTIsMCAyLjk5MiwzIC0wLjAwOCwwICIvPjwvc3ZnPg==') no-repeat;
-        background-position-x: 97%;
-        background-position-y: center;
+        background-color: scale-color($select-bg-color, $lightness: -3%);
         border-color: $input-focus-border-color;
       }
     }
@@ -344,6 +339,7 @@ $select-bg-color: #fafafa !default;
       select { background: $select-bg-color; }
       select:hover { background: scale-color($select-bg-color, $lightness: -3%); }
     }
+    
     /* Attach elements to the beginning or end of an input */
     .prefix,
     .postfix { @include prefix-postfix-base; }

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -319,7 +319,7 @@ $select-bg-color: #fafafa !default;
       background-color: $select-bg-color;
       background-image: url('data:image/svg+xml;base64, PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwcHgiIGhlaWdodD0iOHB4IiB2aWV3Qm94PSIwIDAgMzkgMzkiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPg0KPHBhdGggZD0iTTM4LjYwNiwwTDE5LjMwMywzOC41NzlMMCwwSDM4LjYwNnoiIGZpbGw9IiM0NDQiIC8+DQo8L3N2Zz4=');
       background-repeat: no-repeat;
-      background-position: center right $form-spacing / 2;
+      background-position: center $opposite-direction $form-spacing / 2;
       border: $input-border-width $input-border-style $input-border-color;
       padding: $form-spacing / 2;
       font-size: $input-font-size;

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -317,7 +317,7 @@ $select-bg-color: #fafafa !default;
     select {
       -webkit-appearance: none !important;
       background-color: $select-bg-color;
-      background-image: url('data:image/svg+xml;base64, PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwcHgiIGhlaWdodD0iOHB4IiB2aWV3Qm94PSIwIDAgMzkgMzkiIHByZXNlcnZlQXNwZWN0UmF0aW89Im5vbmUiPg0KPHBhdGggZD0iTTM4LjYwNiwwTDE5LjMwMywzOC41NzlMMCwwSDM4LjYwNnoiIGZpbGw9IiM0NDQiIC8+DQo8L3N2Zz4=');
+      background-image: url('data:image/svg+xml;base64, PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjE5cHgiIGhlaWdodD0iMTRweCIgdmlld0JveD0iMCAwIDE5IDE0Ij4NCjxwYXRoIGZpbGw9IiMzRjNGM0YiIGQ9Ik0xNC4wMDUsMi44OTRsLTQuNSw4bC00LjUtOEgxNC4wMDV6Ii8+DQo8L3N2Zz4=');
       background-repeat: no-repeat;
       background-position: center $opposite-direction $form-spacing / 2;
       border: $input-border-width $input-border-style $input-border-color;


### PR DESCRIPTION
Updated the downwards arrow graphic to more closely match other native controls in Chrome on Windows and Mac. Other browsers conceal this graphic under their own native control, so it made sense to me to base the styling on Chrome. The graphic is now also positioned based on form field padding, as this is also more consistent with other controls in Chrome.

A native datetime-local form control:

![screen shot 2014-01-31 at 18 08 53](https://f.cloud.github.com/assets/922835/2053204/9abce29e-8aa3-11e3-9506-6f17ac0db5d7.png)

and a select control for comparison:

![screen shot 2014-01-31 at 18 14 43](https://f.cloud.github.com/assets/922835/2053203/9aa7567c-8aa3-11e3-9199-d8a59fb22f60.png)

As you can see, the spacing isn't entirely accurate as the native control has a containing box around the arrow. Let me know if you'd like this tweaked further. I'm also happy to update the docs if this change is accepted.

By happy coincidence, this patch also fixes #4236.
