### PR TITLE
New variable $topbar-button-top to center buttons

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -41,6 +41,7 @@ $topbar-link-bg-active-hover: scale-color($primary-color, $lightness: -14%) !def
 $topbar-link-font-family: $body-font-family !default;
 
 $topbar-button-font-size: 0.75rem;
+$topbar-button-top: 7px !default;
 
 $topbar-dropdown-label-color: #777 !default;
 $topbar-dropdown-label-text-transform: uppercase !default;
@@ -429,7 +430,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
         .button {
           font-size: rem-calc(14);
           position: relative;
-          top: 7px;
+          top: $topbar-button-top;
         }
 
         &.expanded { background: $topbar-bg; }


### PR DESCRIPTION
It's impossible (or I didn't get it right) to center horizontally a button inside a topbar with a custom defined height. 

Added a new variable $topbar-button-top to fix this issue
