### PR TITLE
Allow block grids to align to column grid without extending beyond

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -9,6 +9,11 @@ $include-html-grid-classes: $include-html-classes !default;
 $block-grid-elements: 12 !default;
 $block-grid-default-spacing: rem-calc(20) !default;
 
+$align-block-grid-to-grid: true;
+@if $align-block-grid-to-grid {
+  $block-grid-default-spacing: $column-gutter;
+}
+
 // Enables media queries for block-grid classes. Set to false if writing semantic HTML.
 $block-grid-media-queries: true !default;
 
@@ -30,7 +35,11 @@ $block-grid-media-queries: true !default;
   @if $base-style {
     display: block;
     padding: 0;
-    margin: 0 (-$spacing/2);
+    @if $align-block-grid-to-grid {
+      margin: 0;
+    } @else {
+      margin: 0 (-$spacing/2);
+    }
     @include clearfix;
 
     &>li {
@@ -53,9 +62,26 @@ $block-grid-media-queries: true !default;
 
       &:nth-of-type(n) { clear: none; }
       &:nth-of-type(#{$per-row}n+1) { clear: both; }
+      @if $align-block-grid-to-grid {
+        @include block-grid-aligned($per-row, $spacing);
+      }
     }
   }
+}
 
+@mixin block-grid-aligned($per-row, $spacing) {
+  @for $i from 1 through $block-grid-elements {
+    @if $per-row >= $i {
+      $grid-column: '+' + $i;
+      @if $per-row == $i {
+        $grid-column: '';
+      }
+      &:nth-child(#{$per-row}n#{unquote($grid-column)}) {
+        padding-left: ($spacing - (($spacing / $per-row) * ($per-row - ($i - 1))));
+        padding-right: ($spacing - (($spacing / $per-row) * $i));
+      }
+    }
+  }
 }
 
 // Generate presentational markup for block grid.


### PR DESCRIPTION
Adds option to align block grids with the main grid, but not extend into the gutters. This allows for adding top and bottom borders to block grid list items without the borders extending seemingly outside of the content area.

Comparison image:
![aligned-block-grid](https://f.cloud.github.com/assets/2132519/2059752/3d79026a-8bd0-11e3-892a-9cae62d76f50.png)

If you add a top or bottom border (or a background color) to block grid list items in the current implementation, the borders (or background) will extend beyond the apparent edges of the content area, due to the padding and negative margins used to align block grid list items to the visual edges of the content area.

This new method changes all of the padding between block grid list items, so that they do not extend beyond the apparent edges of the content, but remain evenly spaced, butted up against one another, and aligned with the main column grid.

Merely removing the padding and negative margin on the outer edges of the block grid is not sufficient, as this would require the first and last elements in a block grid row to have a different width than the other elements. Since the widths are based on percentages, this is not a viable option. Therefore, each element in the block grid gets its own left and right padding, which is calculated automatically based on the number of elements in a row, and the index of the current element.

To be clear, this essentially nudges around the gutters between each element, so placing vertical borders between block grid list items would reveal some very peculiar spacing in the gutters. However, since vertical borders in grids are far less prevalent, and since a design is likely to use either vertical or horizontal borders, this provides an option for choosing which method fits an existing design language.
