### PR TITLE
Added media query breakpoints as variables

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -214,14 +214,18 @@ $include-html-classes: true !default;
 $include-print-styles: true !default;
 $include-html-global-classes: $include-html-classes !default;
 
+// Media Query Breakpoints
+$small-breakpoint: 640px;
+$medium-breakpoint: 1024px;
+$large-breakpoint: 1440px;
+$xlarge-breakpoint: 1920px;
 
 // Media Query Ranges
-$small-range: (0em, 40em) !default;
-$medium-range: (40.063em, 64em) !default;
-$large-range: (64.063em, 90em) !default;
-$xlarge-range: (90.063em, 120em) !default;
-$xxlarge-range: (120.063em) !default;
-
+$small-range: (0, $small-breakpoint / $rem-base * 1em) !default;
+$medium-range: (($small-breakpoint + 1) / $rem-base * 1em, $medium-breakpoint / $rem-base * 1em) !default;
+$large-range: (($medium-breakpoint + 1) / $rem-base * 1em, $large-breakpoint / $rem-base * 1em) !default;
+$xlarge-range: (($large-breakpoint + 1) / $rem-base * 1em, $xlarge-breakpoint / $rem-base * 1em) !default;
+$xxlarge-range: (($xlarge-breakpoint + 1) / $rem-base * 1em) !default;
 
 $screen: "only screen" !default;
 


### PR DESCRIPTION
Added media query breakpoints as variables and changed media query ranges to be calculated from the breakpoint variables in em units.

This will allow users to easily change breakpoints using pixels while still maintaining the same em-based breakpoints.
