### PR TITLE
The foundation.js removeQuotes method's regex characters no longer cause...

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -167,7 +167,7 @@
 
   function removeQuotes (string) {
     if (typeof string === 'string' || string instanceof String) {
-      string = string.replace(/^[\\/'"]+|(;\s?})+|[\\/'"]+$/g, '');
+      string = string.replace(/^['\\/"]+|(;\s?})+|['\\/"]+$/g, '');
     }
 
     return string;


### PR DESCRIPTION
... exception (Unexpected End of String) to be thrown when parsed by php minifier.

Fixes issue #4337
