### PR TITLE
fix incorrect refs from interchange to equalizer

### DIFF
--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -159,10 +159,10 @@ $(document).on('after-height-change', function(){
 
 ### Using the Javascript
 
-Before you can use Interchange you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [Javascript documentation](../javascript.html) on setting that up.
+Before you can use Equalizer you'll want to verify that jQuery and `foundation.js` are available on your page. You can refer to the [Javascript documentation](../javascript.html) on setting that up.
 
 
-Just add `foundation.interchange.js` AFTER the `foundation.js` file. Your markup should look something like this:
+Just add `foundation.equalizer.js` AFTER the `foundation.js` file. Your markup should look something like this:
 
 {{> examples_equalizer_javascript}}
 


### PR DESCRIPTION
Fix some incorrect references to Interchange that were left in the Equalizer docs. 
