### PR TITLE
dropdown arrow animation fix for small screen

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -365,6 +365,9 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           & > .dropdown {
             display: block;
           }
+          & > a:after {
+            display: none;  
+          }
         }
       }
 


### PR DESCRIPTION
display set to none for drop-down arrows when moved
It fixes arrows moving abnormally in small screen
A fix for #4342 
