### PR TITLE
Added a 'validate' event to Foundation.libs.abide

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -95,6 +95,7 @@
           form = this.S(els[0]).closest('form'),
           submit_event = /submit/.test(e.type);
 
+      form.trigger('validated');
       // Has to count up to make sure the focus gets applied to the top error
       for (var i=0; i < validation_count; i++) {
         if (!validations[i] && (submit_event || is_ajax)) {


### PR DESCRIPTION
Added a `validated` event to Foundation.libs.abide to allow implementors to respond when validation happens. For example I need to move the `error` classes around when validation fails on an input that uses typeahead.js.
