### PR TITLE
Orbit fix / Run images_loaded callback if images.length == 0

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -539,7 +539,9 @@
       image_loaded : function (images, callback) {
         var self = this,
             unloaded = images.length;
-
+        if(unloaded == 0){
+            callback(images);
+        }
         images.each(function(){
           single_image_loaded(self.S(this),function(){
             unloaded -= 1; 

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -222,7 +222,7 @@
       self.build_markup();
       if (settings.timer) {
         timer = self.create_timer();
-        Foundation.utils.image_loaded(this.slides().children('img'), timer.start);
+        Foundation.utils.image_loaded(this.slides().find('img'), timer.start);
       }
       animate = new FadeAnimation(settings, slides_container);
       if (settings.animation === 'slide')
@@ -283,8 +283,8 @@
 
       $(document).on('click', '[data-orbit-link]', self.link_custom);
       $(window).on('resize', self.compute_dimensions);
-      Foundation.utils.image_loaded(this.slides().children('img'), self.compute_dimensions);
-      Foundation.utils.image_loaded(this.slides().children('img'), function() {
+      Foundation.utils.image_loaded(this.slides().find('img'), self.compute_dimensions);
+      Foundation.utils.image_loaded(this.slides().find('img'), function() {
         container.prev('.preloader').css('display', 'none');
         self.update_slide_number(0);
         self.update_active_link(0);


### PR DESCRIPTION
This caused the orbit slider to not load/init. If orbit is used as content slider and not as images slider than the callback image_loaded in L287 (foundation.orbit.js) is never fired.

So the callback needs also to be fired if the image array is empty.

Related issues:
http://foundation.zurb.com/forum/posts/2144-orbit-not-visible-on-load-when-interchange-used-for-images
