### PR TITLE
Removed repeated IDs in Kitchen Sink demo

### DIFF
--- a/doc/includes/kitchen/examples_kitchen_accordion.html
+++ b/doc/includes/kitchen/examples_kitchen_accordion.html
@@ -3,22 +3,22 @@
     <a href="#panel1">Accordion 1</a>
     <div id="panel1" class="content active">
       <dl class="tabs" data-tab>
-        <dd class="active"><a href="#panel2-1">Tab 1</a></dd>
-        <dd><a href="#panel2-2">Tab 2</a></dd>
-        <dd><a href="#panel2-3">Tab 3</a></dd>
-        <dd><a href="#panel2-4">Tab 4</a></dd>
+        <dd class="active"><a href="#panel1-1">Tab 1</a></dd>
+        <dd><a href="#panel1-2">Tab 2</a></dd>
+        <dd><a href="#panel1-3">Tab 3</a></dd>
+        <dd><a href="#panel1-4">Tab 4</a></dd>
       </dl>
       <div class="tabs-content">
-        <div class="content active" id="panel2-1">
+        <div class="content active" id="panel1-1">
           <p>First panel content goes here...</p>
         </div>
-        <div class="content" id="panel2-2">
+        <div class="content" id="panel1-2">
           <p>Second panel content goes here...</p>
         </div>
-        <div class="content" id="panel2-3">
+        <div class="content" id="panel1-3">
           <p>Third panel content goes here...</p>
         </div>
-        <div class="content" id="panel2-4">
+        <div class="content" id="panel1-4">
           <p>Fourth panel content goes here...</p>
         </div>
       </div>


### PR DESCRIPTION
Tabs in Accordion demo’s first panel was sharing IDs with the tabs demo. Although old code may act as an example of the importance of not reusing ID tags ;)
