### PR TITLE
Deprecation warnings in latest SASS

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -4,7 +4,7 @@ $rem-base: 16px !default;
 $modules: () !default;
 @mixin exports($name) {
   @if (index($modules, $name) == false) {
-    $modules: append($modules, $name);
+    $modules: append($modules, $name) !global;
     @content;
   }
 }

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -203,11 +203,11 @@ $text-direction: ltr !default;
 $default-float: left !default;
 $opposite-direction: right !default;
 @if $text-direction == ltr {
-  $default-float: left;
-  $opposite-direction: right;
+  $default-float: left !global;
+  $opposite-direction: right !global;
 } @else {
-  $default-float: right;
-  $opposite-direction: left;
+  $default-float: right !global;
+  $opposite-direction: left !global;
 }
 
 // We use these as default colors throughout


### PR DESCRIPTION
Latest SASS (v3.3.0.rc.2) shows the following deprecation warnings when compiling. I think my changes fix this.

```
DEPRECATION WARNING on line 187 of components/foundation/scss/foundation/components/_global.scss:
Assigning to global variable "$default-float" by default is deprecated.
In future versions of Sass, this will create a new local variable.
If you want to assign to the global variable, use "$default-float: left !global" instead.


DEPRECATION WARNING on line 188 of components/foundation/scss/foundation/components/_global.scss:
Assigning to global variable "$opposite-direction" by default is deprecated.
In future versions of Sass, this will create a new local variable.
If you want to assign to the global variable, use "$opposite-direction: right !global" instead.


DEPRECATION WARNING on line 9 of components/foundation/scss/foundation/components/../_functions.scss:
Assigning to global variable "$modules" by default is deprecated.
In future versions of Sass, this will create a new local variable.
If you want to assign to the global variable, use "$modules: append($modules, $name) !global" instead.
```
