### PR TITLE
configuration of sub-nav radius is not scoped.

### DIFF
--- a/scss/foundation/components/_sub-nav.scss
+++ b/scss/foundation/components/_sub-nav.scss
@@ -88,7 +88,7 @@ $sub-nav-item-divider-margin: rem-calc(12) !default;
     }
 
     &.active a {
-      @include radius($global-radius);
+      @include radius($sub-nav-border-radius);
       font-weight: $sub-nav-active-font-weight;
       background: $active-bg;
       padding: $sub-nav-active-padding;


### PR DESCRIPTION
Configuration of sub-nav radius is not scoped since it is using $global-radius. Fix is to consume $sub-nav-border-radius instead of $global-radius. Fixing bug #4397
