### PR TITLE
Close meta class tags

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -14,7 +14,7 @@
 
     while (i--) {
       if($('head').has('.' + class_array[i]).length === 0) {
-        $('head').append('<meta class="' + class_array[i] + '">');
+        $('head').append('<meta class="' + class_array[i] + '" />');
       }
     }
   };


### PR DESCRIPTION
In order to use foundation.js on polyglot or XHTML documents, the `<meta class="...">` tags need to be self-closing.
