### PR TITLE
Trim 2x h1. ref, switch email to RFC2606-compliant

### DIFF
--- a/doc/includes/kitchen/examples_kitchen_type.html
+++ b/doc/includes/kitchen/examples_kitchen_type.html
@@ -2,8 +2,8 @@
 <h2>h2. This is a large header.</h2>
 <h3>h3. This is a medium header.</h3>
 <h4>h4. This is a moderate header.</h4>
-<h5>h5. This is a small header. h1.</h5>
-<h6>h6. This is a tiny header. h1.</h6>
+<h5>h5. This is a small header.</h5>
+<h6>h6. This is a tiny header.</h6>
 
 <br>
 
@@ -55,5 +55,5 @@
   <li class="street-address">123 Colonial Ave.</li>
   <li class="locality">Caprica City</li>
   <li><span class="state">Caprica</span>, <span class="zip">12345</span></li>
-  <li class="email"><a href="#">g.baltar@cmail.com</a></li>
+  <li class="email"><a href="#">g.baltar@example.com</a></li>
 </ul>


### PR DESCRIPTION
Extraneous h1. in examples removed and switched the kitchen sink type
demo email domain to avoid a buttload of spam to non-RFC2606 address.

Background: http://tools.ietf.org/search/rfc2606
