### PR TITLE
Optimise tight loop on foundation.js

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -11,10 +11,11 @@
 
   var header_helpers = function (class_array) {
     var i = class_array.length;
+    var head = $('head');
 
     while (i--) {
-      if($('head').has('.' + class_array[i]).length === 0) {
-        $('head').append('<meta class="' + class_array[i] + '">');
+      if(head.has('.' + class_array[i]).length === 0) {
+        head.append('<meta class="' + class_array[i] + '">');
       }
     }
   };


### PR DESCRIPTION
We should avoid jQuery selector repeats. Here I have cached the $('head') calls occurring on lines 17 and 18. This improves performance in the loop.
