### PR TITLE
Correcting order of fieldset mixin border properties

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -248,7 +248,7 @@ $select-bg-color: #fafafa !default;
 
 // We use this mixin to style fieldsets
 @mixin fieldset {
-  border: $fieldset-border-style $fieldset-border-width $fieldset-border-color;
+  border: $fieldset-border-width $fieldset-border-style $fieldset-border-color;
   padding: $fieldset-padding;
   margin: $fieldset-margin;
 


### PR DESCRIPTION
The fieldset mixin's border shorthand properties in are the wrong order. Browsers handle it fine, but grunt's cssmin task can't handle the style property being in the first spot and it minifies it incorrectly. 
