### PR TITLE
Fix for issue #4445

### DIFF
--- a/scss/foundation/components/_accordion.scss
+++ b/scss/foundation/components/_accordion.scss
@@ -25,7 +25,7 @@ $accordion-content-active-bg-color: #fff !default;
       dd {
         display: block;
         margin-bottom: 0 !important;
-        &.active a { background: $accordion-navigation-active-bg-color; }
+        &.active > a { background: $accordion-navigation-active-bg-color; }
         > a {
           background: $accordion-navigation-bg-color;
           color: $accordion-navigation-font-color;


### PR DESCRIPTION
I want to fix #4445. By default foundation is styling the all links inside of an accordion item as `$accordion-navigation-active-bg-color`, not just the header.
