### PR TITLE
Add button.medium

### DIFF
--- a/doc/includes/buttons/examples_buttons_advanced_rendered.html
+++ b/doc/includes/buttons/examples_buttons_advanced_rendered.html
@@ -1,5 +1,5 @@
 <!-- Size Classes -->
-<a href="#" class="button [tiny small large]">Default Button</a>
+<a href="#" class="button [tiny small medium large]">Default Button</a>
 <!-- Color Classes -->
 <a href="#" class="button [secondary success alert]">Color Button</a>
 <!-- Radius Classes -->

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -209,6 +209,7 @@ $button-disabled-opacity: 0.7 !default;
       &.alert     { @include button-style($bg:$alert-color); }
 
       &.large  { @include button-size($padding:$button-lrg); }
+      &.medium { @include button-size($padding:$button-med); }
       &.small  { @include button-size($padding:$button-sml); }
       &.tiny   { @include button-size($padding:$button-tny); }
       &.expand { @include button-size($padding:null,$full-width:true); }


### PR DESCRIPTION
For some reason there are classes for tiny, small, and large buttons, but not medium. This is despite there being sass variables for it, and even though in the docs for dropdown buttons, there is mention of it.
