### PR TITLE
Button radius default true

### DIFF
--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -130,7 +130,7 @@ $button-disabled-opacity: 0.7 !default;
 // $bg - Primary color set in settings file. Default: $primary-color.
 // $radius - If true, set to button radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
 // $disabled - We can set $disabled:true to create a disabled transparent button. Default: false
-@mixin button-style($bg:$primary-color, $radius:false, $disabled:false) {
+@mixin button-style($bg:$primary-color, $radius:true, $disabled:false) {
 
   // We control which background styles are used,
   // these can be removed by setting $bg:false

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -128,7 +128,7 @@ $button-disabled-opacity: 0.7 !default;
 // We use this mixin to add button color styles
 //
 // $bg - Primary color set in settings file. Default: $primary-color.
-// $radius - If true, set to button radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
+// $radius - If true, set to button radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: true
 // $disabled - We can set $disabled:true to create a disabled transparent button. Default: false
 @mixin button-style($bg:$primary-color, $radius:true, $disabled:false) {
 


### PR DESCRIPTION
Note: apologies for the dual commits, failed quickie with github's online editor.

The docs show button radius as being true by default, and the comments in _settings indicate that $global-radius and $button-radius are used throughout the core by default. I think the docs have it best - if there's a global radius set, it should be applied to buttons by default.
