### PR TITLE
Access correct data attribute for reveal settings

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -186,7 +186,7 @@
               self.S(modal).foundation('section', 'reflow');
 
               if (open_modal.length > 0) {
-                var open_modal_settings = open_modal.data(self.attr_name(true));
+                var open_modal_settings = open_modal.data(self.attr_name(true) + '-init');
                 self.hide(open_modal, open_modal_settings.css.close);
               }
               self.show(modal, settings.css.open);


### PR DESCRIPTION
This fixes a small error that prohibits the use of multi-window ajax modals.
