### PR TITLE
removed auto advance click event when data-orbit-slide is defined

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -229,7 +229,7 @@
         animate = new SlideAnimation(settings, slides_container);
       container.on('click', '.'+settings.next_class, self.next);
       container.on('click', '.'+settings.prev_class, self.prev);
-      container.on('click', '[data-orbit-slide]', self.link_bullet);
+      //container.on('click', '[data-orbit-slide]', self.link_bullet);
       container.on('click', self.toggle_timer);
       if (settings.swipe) {
         container.on('touchstart.fndtn.orbit', function(e) {


### PR DESCRIPTION
Inconsistent Behavior: Orbit would advance to the next slide when the content inside the orbit was clicked. This would only happen when data-orbit-slide was set.

There has been some discussion about having a "next_on_click: false" feature, but it is my opinion that the orbit should not have any auto slide advance functionality other than the timer. There appears to be more folks trying to inhibit the auto advance on click functionality, than people who are asking for that function.

If developers would like to enable auto-advance, they can embed a data-orbit-link inside the slide.

Removing this line of code appears to disable the automatic next on click feature. Please consider merging this.

thanks,
Don V.
