### PR TITLE
Correct header size default

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -114,7 +114,7 @@
 
 // We use these to control header font styles
 // $header-font-family: $body-font-family;
-// $header-font-weight: 300;
+// $header-font-weight: normal;
 // $header-font-style: normal;
 // $header-font-color: #222;
 // $header-line-height: 1.4;

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -130,7 +130,7 @@ $button-disabled-opacity: 0.7 !default;
 // $bg - Primary color set in settings file. Default: $primary-color.
 // $radius - If true, set to button radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
 // $disabled - We can set $disabled:true to create a disabled transparent button. Default: false
-@mixin button-style($bg:$primary-color, $radius:false, $disabled:false) {
+@mixin button-style($bg:$primary-color, $radius:true, $disabled:false) {
 
   // We control which background styles are used,
   // these can be removed by setting $bg:false

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -130,7 +130,7 @@ $button-disabled-opacity: 0.7 !default;
 // $bg - Primary color set in settings file. Default: $primary-color.
 // $radius - If true, set to button radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
 // $disabled - We can set $disabled:true to create a disabled transparent button. Default: false
-@mixin button-style($bg:$primary-color, $radius:true, $disabled:false) {
+@mixin button-style($bg:$primary-color, $radius:false, $disabled:false) {
 
   // We control which background styles are used,
   // these can be removed by setting $bg:false


### PR DESCRIPTION
In `_settings.scss`, `$header-font-weight` shows a default value of `300`. The actual value in `_type.scss` is `normal`. This commit updates the value in `_settings.scss` to match.
