### PR TITLE
Remove float declaration from collapsed columns

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -209,7 +209,7 @@ $total-columns: 12 !default;
 
       &.collapse {
          > .column,
-         > .columns { @include grid-column($collapse:true); }
+         > .columns { @include grid-column($collapse:true, $float:false); }
 
         .row {margin-left:0; margin-right:0;}
       }


### PR DESCRIPTION
The definition for a collapsed column includes a float declaration. This overrides any centering classes applied to the column such as small-centered. This declaration has been removed to avoid those issues.
