### PR TITLE
Replace 2x non-RFC2606 email addresses

### DIFF
--- a/doc/includes/typography/examples_typography_vcard.html
+++ b/doc/includes/typography/examples_typography_vcard.html
@@ -3,5 +3,5 @@
   <li class="street-address">123 Colonial Ave.</li>
   <li class="locality">Caprica City</li>
   <li><span class="state">Caprica</span>, <span class="zip">12345</span></li>
-  <li class="email"><a href="#">g.baltar@cmail.com</a></li>
+  <li class="email"><a href="#">g.baltar@example.com</a></li>
 </ul>

--- a/doc/includes/typography/examples_typography_vcard_rendered.html
+++ b/doc/includes/typography/examples_typography_vcard_rendered.html
@@ -5,7 +5,7 @@
   <li class="street-address">123 Colonial Ave.</li>
   <li class="locality">Caprica City</li>
   <li><span class="state">Caprica</span>, <span class="zip">12345</span></li>
-  <li class="email"><a href="#">g.baltar@cmail.com</a></li>
+  <li class="email"><a href="#">g.baltar@example.com</a></li>
 </ul>
 ```
 {{/markdown}}


### PR DESCRIPTION
Switched docs email domain to avoid a buttload of spam to non-RFC2606
address.

See also: https://github.com/zurb/foundation/pull/4418

Background: http://tools.ietf.org/search/rfc2606
