### PR TITLE
add href to anchor tag

### DIFF
--- a/doc/includes/off_canvas/examples_offcanvas_minimal_markup.html
+++ b/doc/includes/off_canvas/examples_offcanvas_minimal_markup.html
@@ -3,7 +3,7 @@
 <div class="off-canvas-wrap">
   <div class="inner-wrap">
     
-    <a class="left-off-canvas-toggle" >Menu</a> 
+    <a class="left-off-canvas-toggle" href="#" >Menu</a> 
 
     <!-- Off Canvas Menu -->
     <aside class="left-off-canvas-menu">


### PR DESCRIPTION
The a.left-off-canvas-toggle does not toggle on ipad devices if there is no href="#".
