### PR TITLE
Remove unnecessary top css property

### DIFF
--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -32,7 +32,6 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
       dd {
         position: relative;
         margin-bottom: 0 !important;
-        top: 1px;
         float: $default-float;
         > a {
           display: block;


### PR DESCRIPTION
The css property top: 1px; has no positive impact (for example if you want a background color for the whole tabs bar you will see this 1px breaking the visual consistency) on the tabs, so just remove.
