### PR TITLE
Added radius to a non-anchor current pagination item

### DIFF
--- a/scss/foundation/components/_pagination.scss
+++ b/scss/foundation/components/_pagination.scss
@@ -77,6 +77,7 @@ $pagination-link-current-active-bg: $primary-color !default;
     color: $pagination-link-current-font-color;
     font-weight: $pagination-link-current-font-weight;
     cursor: $pagination-link-current-cursor;
+    @include radius;
 
     &:hover,
     &:focus { background: $pagination-link-current-active-bg; }
@@ -106,7 +107,7 @@ $pagination-link-current-active-bg: $primary-color !default;
         display: block;
         padding: $pagination-link-pad;
         color: $pagination-link-font-color;
-        @include radius($global-radius)
+        @include radius;
       }
 
       &:hover a,


### PR DESCRIPTION
A non-anchor current pagination item won't get a radius if you are using the mixin's to create your own (semantic) pagination.
