### PR TITLE
Update _top-bar.scss

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -246,7 +246,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
         .toggle-topbar {
           a { color: $topbar-menu-link-color-toggled;
-            span {
+            &:after {
               // Shh, don't tell, but box-shadows create the menu icon :)
               @if $experimental {
                 -webkit-box-shadow: 1px 10px 1px 1px $topbar-menu-icon-color-toggled,


### PR DESCRIPTION
If I'm not mistaken, this is the proper way to correct an issue where the menu "icon" made via box shadow doesn't show its "active" colour
