### PR TITLE
Fix null settings for out of form inputs

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -73,7 +73,7 @@
             self.validate([this], e);
           })
           .on('keydown.fndtn.abide', function (e) {
-            var settings = $(this).closest('form').data('abide-init');
+            var settings = $(this).closest('form').data('abide-init') || {};
             if (settings.live_validate === true) {
               clearTimeout(self.timer);
               self.timer = setTimeout(function () {


### PR DESCRIPTION
If the actual location of input is outside the form (like popular plugins such as select2 do) then settings will be null in throw an error. This fixes that error.

A better solution would be to still find the original form another way to access any settings.
