### PR TITLE
Remove kill-flicker class from off-canvas mixins

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -114,7 +114,6 @@ $menu-slide: "transform 500ms ease" !default;
 // OFF CANVAS WRAP
 // Wrap visible content and prevent scroll bars
 @mixin off-canvas-wrap {
-  @include kill-flicker;
   @include wrap-base;
   overflow-x: hidden;
   &.move-right,
@@ -124,7 +123,6 @@ $menu-slide: "transform 500ms ease" !default;
 // INNER WRAP
 // Main content area that moves to reveal the off-canvas nav
 @mixin inner-wrap {
-  @include kill-flicker;
   @include wrap-base;
   @include clearfix;
   -webkit-transition: -webkit-#{$menu-slide};


### PR DESCRIPTION
Proposed fix for https://github.com/zurb/foundation/issues/4491

Also documented here: http://foundation.zurb.com/forum/posts/1308-foundation-website-crashes-while-zooming

Currently, if you go to any foundation 5 powered site using the off-canvas menu, including foundation.zurb.com, on iOS Safari and zoom in, then zoom out, you'll notice that zooming stutters. On iPads/iPhones that are not the newest versions, it will actually crash Safari. 

I did quite a bit of digging and found that it was the application of -webkit-backface-visibility: hidden; to the .off-canvas-wrap and .inner-wrap classes that cause this crash. Since I did not experience the flicker that this css is supposed to prevent, I propose removing it from those two classes to improve zooming experience and prevent browser crashes.
