### PR TITLE
fix the issue: Foundation Configuration doesn't  work

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -328,6 +328,12 @@
         this.patch(this.libs[lib]);
 
         if (args && args.hasOwnProperty(lib)) {
+            if (typeof this.libs[lib].settings !== 'undefined') {
+                $.extend(true, this.libs[lib].settings, args[lib]);
+            }
+            else if (typeof this.libs[lib].defaults !== 'undefined') {
+                $.extend(true, this.libs[lib].defaults, args[lib]);
+            }
           return this.libs[lib].init.apply(this.libs[lib], [this.scope, args[lib]]);
         }
 


### PR DESCRIPTION
I created an issue https://github.com/zurb/foundation/issues/4509, When I work on that issue I thought It  was just an issue of "abide", but when I see some others issues(thanks to @tmugford) I think It may be an issue of the framework.
I read the source code for hours, here is my understanding of the Plugin Setting mechanism,if I misunderstand something, please correct me:
there are three ways to change a plugin's setting:
1.Data Options

```
data-options="timeout:2000"
```

2.Foundation Initializer 

```
$(document).foundation({
            abide: {
            patterns: {
                my_password: /.{8,}/
            }
}});
```

3.Default Settings of plugin

and their priorities are the same as their orders in list above, it means you can use "Data Options" to overwrite the settings which set by "Foundation Initializer ",and use "Foundation Initializer " to overwrite the "Default Setting". Sorry for my poor english:(
but this mechanism seems not work properly. In my understanding, the framework wants to merge all of the three settings into one ultimate setting object and stores in jQuery.data, I saw some codes at line 107 in foundation.js

```
//I also don't know why don't use deep copy here
S(this).data(self.attr_name(true) + '-init', $.extend({}, self.settings, (options || method), self.data_options(S(this))));
```

after that,the object in $.data should include the ultimate settings of the plugin. from now on the codes in plugin should not access settings from "DataOptions" or "Foundation Initializer" or "Default Settings " anymore, they should use the ultimate setting object in $.data( such as "abide-init" ).
but what I saw is it does not works like that in some plugins,"abide" for example:

In line 75: it uses the settings in $.data('abide-init') , that is what we expect

```
 .on('keydown.fndtn.abide', function (e) {
            var settings = $(this).closest('form').data('abide-init');
            if (settings.live_validate === true) {
              clearTimeout(self.timer);
              self.timer = setTimeout(function () {
                self.validate([this], e);
              }.bind(this), settings.timeout);
            }
          });
```

but in line 130,it use the "Plugin Default Setting" 

```
pattern : function (el) {
      var type = el.getAttribute('type'),
          required = typeof el.getAttribute('required') === 'string';

      var pattern = el.getAttribute('pattern') || '';

      if (this.settings.patterns.hasOwnProperty(pattern) && pattern.length > 0) {
        return [el, this.settings.patterns[pattern], required];
      } else if (pattern.length > 0) {
        return [el, new RegExp(pattern), required];
      }

      if (this.settings.patterns.hasOwnProperty(type)) {
        return [el, this.settings.patterns[type], required];
      }

      pattern = /.*/;

      return [el, pattern, required];
    },
```

that is the reason why Custom Named Pattern in "Foundation Initializer " dosen't work in issue https://github.com/zurb/foundation/issues/4509 .and some issues like that happened in some other plugins.the root cause is complex and relates to many files ,I have no idea how to fix it rightly. so I just modify some codes to fix a part of it, it will make settings from "Foundation Initializer " working property

```
init_lib : function (lib, args) {
      if (this.libs.hasOwnProperty(lib)) {
        this.patch(this.libs[lib]);

        if (args && args.hasOwnProperty(lib)) {
            //YaoHuiJi: add this to merge "Foundation Initializer Settings " into "Default Setting"
            if (typeof this.libs[lib].settings !== 'undefined') {
                $.extend(true, this.libs[lib].settings, args[lib]);
            }
            else if (typeof this.libs[lib].defaults !== 'undefined') {
           //YaoHuiJi: add this line to support "joyride", because "joyride" has a diffrent name of "Default Setting"
                $.extend(true, this.libs[lib].defaults, args[lib]);
            }
          return this.libs[lib].init.apply(this.libs[lib], [this.scope, args[lib]]);
        }

        args = args instanceof Array ? args : Array(args);    // PATCH: added this line
        return this.libs[lib].init.apply(this.libs[lib], args);
      }

      return function () {};
    },
```
