### PR TITLE
fix for topbar menu icon not visible

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -274,7 +274,7 @@ $menu-slide: "transform 500ms ease" !default;
 
     // MENU BUTTON
     // This is a little bonus. You don't need it for off canvas to work. Mixins to be written in the future.
-    .menu-icon {
+    .tab-bar .menu-icon {
       text-indent: $tabbar-menu-icon-text-indent;
       width: $tabbar-height;
       height: $tabbar-height;


### PR DESCRIPTION
Added tab-bar class to offcanvas menu-icon
Resolves conflict with topbar menu-icon
Fixes #4399
