### PR TITLE
Added variable for $side-nav-font-weight-active

### DIFF
--- a/scss/foundation/components/_side-nav.scss
+++ b/scss/foundation/components/_side-nav.scss
@@ -19,8 +19,9 @@ $side-nav-link-color: $primary-color !default;
 $side-nav-link-color-active: scale-color(#000, $lightness: 30%) !default;
 $side-nav-font-size: rem-calc(14) !default;
 $side-nav-font-weight: normal !default;
+$side-nav-font-weight-active: $side-nav-font-weight !default;
 $side-nav-font-family: $body-font-family !default;
-$side-nav-active-font-family: $side-nav-font-family !default;
+$side-nav-font-family-active: $side-nav-font-family !default;
 
 
 
@@ -62,8 +63,8 @@ $side-nav-divider-color: scale-color(#fff, $lightness: 10%) !default;
 
     &.active > a:first-child {
       color: $side-nav-link-color-active;
-      font-weight: $side-nav-font-weight;
-      font-family: $side-nav-active-font-family;
+      font-weight: $side-nav-font-weight-active;
+      font-family: $side-nav-font-family-active;
     }
 
     &.divider {


### PR DESCRIPTION
Sometimes in websites, it's not font colour I vary when a link is active, but font weight. That's why I think it's essential to have a variable for that. Otherwise you end up having to compete with an extremely long selector.
