### PR TITLE
Call resize() only if the media-query has changed

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -78,13 +78,25 @@
       this.load('nodes');
     },
 
+    getMediaHash : function() {
+        var mediaHash='';
+        for (var queryName in this.settings.named_queries ) {
+            mediaHash += matchMedia(this.settings.named_queries[queryName]).matches.toString();
+        }
+        return mediaHash;
+    },
+
     events : function () {
-      var self = this;
+      var self = this, prevMediaHash;
 
       $(window)
         .off('.interchange')
         .on('resize.fndtn.interchange', self.throttle(function () {
-          self.resize();
+            var currMediaHash = self.getMediaHash();
+            if (currMediaHash !== prevMediaHash) {
+                self.resize();
+            }
+            prevMediaHash = currMediaHash;
         }, 50));
 
       return this;


### PR DESCRIPTION
Currently the interchangeable content is reloaded every 50ms during window resize, if one has facebook, twitter or GMaps widgets as interchangeable content, things get nasty :) With this change content is reloaded only when the media-query changes.
