### PR TITLE
Remove unnecessary + rem-calc(1) on bottom padding

### DIFF
--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -37,10 +37,7 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
           display: block;
           background: $tabs-navigation-bg-color;
           color: $tabs-navigation-font-color;
-          padding-top: $tabs-navigation-padding;
-          padding-#{$opposite-direction}: $tabs-navigation-padding * 2;
-          padding-bottom: $tabs-navigation-padding + rem-calc(1);
-          padding-#{$default-float}: $tabs-navigation-padding * 2;
+          padding: $tabs-navigation-padding $tabs-navigation-padding * 2;
           font-family: $tabs-navigation-font-family;
           font-size: $tabs-navigation-font-size;
           &:hover { background: $tabs-navigation-hover-bg-color; }


### PR DESCRIPTION
After merge of https://github.com/zurb/foundation/pull/4484 we also don't need any padding bottom on the links in tabs anymore. Just removed + rem-calc(1) and cleaned up the paddings into 1 property
