### PR TITLE
Replace the <hr> margin difference with its width

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -291,7 +291,7 @@ $microformat-abbr-font-decoration: none !default;
       border: $hr-border-style $hr-border-color;
       border-width: $hr-border-width 0 0;
       clear: both;
-      margin: $hr-margin 0 ($hr-margin - rem-calc(1));
+      margin: $hr-margin 0 ($hr-margin - em-calc(strip-unit($hr-border-width)));
       height: 0;
     }
 


### PR DESCRIPTION
By default the bottom margin of the hr tag is 1px smaller than the top margin. This results through the default $hr-border-width: 1px; setting. If you change $hr-border-width to another value the margin-bottom still remains the same. This fix resolves this issue, so the bottom margin respond to the $hr-border-width value.
