### PR TITLE
Added deep_linking and scroll_to_content configuration parameters

### DIFF
--- a/doc/includes/tabs/examples_tabs_deep_linking.html
+++ b/doc/includes/tabs/examples_tabs_deep_linking.html
@@ -1,0 +1,13 @@
+<dl class="tabs" data-tab data-options="deep_linking: true">
+  <dd class="active"><a href="#tabs-deeplink-1">Tab 1</a></dd>
+  <dd><a href="#tabs-deeplink-2">Tab 2</a></dd>
+</dl>
+<div class="tabs-content">
+  <div class="content active" id="tabs-deeplink-1">
+    <p>First panel content goes here...</p>
+  </div>
+  <div class="content" id="tabs-deeplink-2">
+    <p>Second panel content goes here...</p>
+    <p id="tabs-deeplink-content-2">Test content</p>
+  </div>
+</div>

--- a/doc/pages/components/tabs.html
+++ b/doc/pages/components/tabs.html
@@ -61,6 +61,16 @@ You can create a group of vertical tabs using minimal markup.
 
 ***
 
+### Deep linking to tabs or tab contents
+
+The tabs Foundation component can parse the location hash value and open the corresponding tab content pane. If the location hash maps to an element ID within a tab content pane, then the appropriate tab will become active and the browser window will scroll to the specified element. If you do not want to scroll to the specified element then set `data-options="scroll_to_content: false"`.
+
+In the following example, deep linking is enabled. If the location hash is `#tabs-deeplink-2` then the second tab will become active. If the location hash is `#tabs-deeplink-content-2` then the second tab will become active, and the browser will scroll to the paragraph tag with ID, tabs-deeplink-content-2.
+
+<!-- {{> examples_tabs_deep_linking}} -->
+
+***
+
 ### Callbacks
 
 There are two ways to bind to callbacks in your tabs.

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -9,38 +9,136 @@
 
     settings : {
       active_class: 'active',
-      callback : function () {}
+      callback : function () {},
+      deep_linking: false,
+      scroll_to_content: true
     },
 
+    default_tab_hashes: [],
+
     init : function (scope, method, options) {
+      var self = this,
+          S = this.S;
+
       this.bindings(method, options);
+      this.handle_location_hash_change();
+
+      // Store the default active tabs which will be referenced when the
+      // location hash is absent, as in the case of navigating the tabs and
+      // returning to the first viewing via the browser Back button.
+      S('[' + this.attr_name() + '] > dd.active > a', this.scope).each(function () {
+        self.default_tab_hashes.push(this.hash);
+      });
     },
 
     events : function () {
       var self = this,
           S = this.S;
 
+      // Click event: tab title
       S(this.scope).off('.tab').on('click.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
         e.preventDefault();
         e.stopPropagation();
-
-        var tab = S(this).parent(),
-            tabs = tab.closest('[' + self.attr_name() + ']'),
-            target = S('#' + this.href.split('#')[1]),
-            siblings = tab.siblings(),
-            settings = tabs.data(self.attr_name(true) + '-init');
-        
-        // allow usage of data-tab-content attribute instead of href
-        if (S(this).data(self.data_attr('tab-content'))) {
-          target = S('#' + S(this).data(self.data_attr('tab-content')).split('#')[1]);
-        }
-        
-        tab.addClass(settings.active_class).triggerHandler('opened');
-        siblings.removeClass(settings.active_class);
-        target.siblings().removeClass(settings.active_class).end().addClass(settings.active_class);
-        settings.callback(tab);
-        tabs.triggerHandler('toggled', [tab]);
+        self.toggle_active_tab(S(this).parent());
       });
+
+      // Location hash change event
+      S(window).on('hashchange.fndtn.tab', function (e) {
+        e.preventDefault();
+        self.handle_location_hash_change();
+      });
+    },
+
+    handle_location_hash_change : function () {
+      var self = this,
+          S = this.S;
+
+      S('[' + this.attr_name() + ']', this.scope).each(function () {
+        var settings = S(this).data(self.attr_name(true) + '-init');
+        if (settings.deep_linking) {
+          // Match the location hash to a label
+          var hash = self.scope.location.hash;
+          if (hash != '') {
+            // Check whether the location hash references a tab content div or
+            // another element on the page (inside or outside the tab content div)
+            var hash_element = S(hash);
+            if (hash_element.hasClass('content') && hash_element.parent().hasClass('tab-content')) {
+              // Tab content div
+              self.toggle_active_tab($('[' + self.attr_name() + '] > dd > a[href=' + hash + ']').parent());
+            } else {
+              // Not the tab content div. If inside the tab content, find the
+              // containing tab and toggle it as active.
+              var hash_tab_container_id = hash_element.closest('.content').attr('id');
+              if (hash_tab_container_id != undefined) {
+                self.toggle_active_tab($('[' + self.attr_name() + '] > dd > a[href=#' + hash_tab_container_id + ']').parent(), hash);
+              }
+            }
+          } else {
+            // Reference the default tab hashes which were initialized in the init function
+            for (var ind in self.default_tab_hashes) {
+              self.toggle_active_tab($('[' + self.attr_name() + '] > dd > a[href=' + self.default_tab_hashes[ind] + ']').parent());
+            }
+          }
+        }
+       });
+     },
+
+    toggle_active_tab: function (tab, location_hash) {
+      var S = this.S,
+          tabs = tab.closest('[' + this.attr_name() + ']'),
+          anchor = tab.children('a').first(),
+          target_hash = '#' + anchor.attr('href').split('#')[1],
+          target = S(target_hash),
+          siblings = tab.siblings(),
+          settings = tabs.data(this.attr_name(true) + '-init');
+
+      // allow usage of data-tab-content attribute instead of href
+      if (S(this).data(this.data_attr('tab-content'))) {
+        target_hash = '#' + S(this).data(this.data_attr('tab-content')).split('#')[1];
+        target = S(target_hash);
+      }
+
+      if (settings.deep_linking) {
+        // Get the scroll Y position prior to moving to the hash ID
+        var cur_ypos = $('body,html').scrollTop();
+
+        // Update the location hash to preserve browser history
+        // Note that the hash does not need to correspond to the
+        // tab content ID anchor; it can be an ID inside or outside of the tab
+        // content div.
+        if (location_hash != undefined) {
+          window.location.hash = location_hash;
+        } else {
+          window.location.hash = target_hash;
+        }
+
+        if (settings.scroll_to_content) {
+          // If the user is requesting the content of a tab, then scroll to the
+          // top of the title area; otherwise, scroll to the element within
+          // the content area as defined by the hash value.
+          if (location_hash == undefined || location_hash == target_hash) {
+            tab.parent()[0].scrollIntoView();
+          } else {
+            S(target_hash)[0].scrollIntoView();
+          }
+        } else {
+          // Adjust the scrollbar to the Y position prior to setting the hash
+          // Only do this for the tab content anchor, otherwise there will be
+          // conflicts with in-tab anchor links nested in the tab-content div
+          if (location_hash == undefined || location_hash == target_hash) {
+            $('body,html').scrollTop(cur_ypos);
+          }
+        }
+      }
+
+      // WARNING: The activation and deactivation of the tab content must
+      // occur after the deep linking in order to properly refresh the browser
+      // window (notably in Chrome).
+      tab.addClass(settings.active_class).triggerHandler('opened');
+      siblings.removeClass(settings.active_class);
+      target.siblings().removeClass(settings.active_class).end().addClass(settings.active_class);
+      settings.callback(tab);
+      tabs.triggerHandler('toggled', [tab]);
     },
 
     data_attr: function (str) {


### PR DESCRIPTION
This pull request provides the following functionality:
1. Parse a tab title location hash and open the appropriate tab
2. Parse an element ID hash, open the appropriate tab, and scroll to the element within the tab
