### PR TITLE
Add 'next_on_click' setting for Orbit (#4387)

### DIFF
--- a/doc/pages/components/orbit.html
+++ b/doc/pages/components/orbit.html
@@ -172,6 +172,7 @@ $(document).foundation({
       timer_speed: 10000, // Sets the amount of time in milliseconds before transitioning a slide
       pause_on_hover: true, // Pauses on the current slide while hovering
       resume_on_mouseout: false, // If pause on hover is set to true, this setting resumes playback after mousing out of slide
+      next_on_click: true, // Advance to next slide on click
       animation_speed: 500, // Sets the amount of time in milliseconds the transition between slides will last
       stack_on_small: false,
       navigation_arrows: true,

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -229,7 +229,8 @@
         animate = new SlideAnimation(settings, slides_container);
       container.on('click', '.'+settings.next_class, self.next);
       container.on('click', '.'+settings.prev_class, self.prev);
-      container.on('click', '[data-orbit-slide]', self.link_bullet);
+      if (settings.next_on_click)
+        container.on('click', '[data-orbit-slide]', self.link_bullet);
       container.on('click', self.toggle_timer);
       if (settings.swipe) {
         container.on('touchstart.fndtn.orbit', function(e) {
@@ -403,6 +404,7 @@
       timer_speed: 10000,
       pause_on_hover: true,
       resume_on_mouseout: false,
+      next_on_click: true,
       animation_speed: 500,
       stack_on_small: false,
       navigation_arrows: true,


### PR DESCRIPTION
Allows for conditionally disabling the auto-advance on click behavior with the "next_on_click" behavior.

See #4387, #4467
