### PR TITLE
make $include-html-classes: false work properly

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -260,44 +260,45 @@ $cursor-text-value: text !default;
 
 
 @include exports("global") {
-  meta.foundation-version {
-    font-family: "/5.1.0/";
-  }
-  // Used to provide media query values for javascript components.
-  // Forward slash placed around everything to convince PhantomJS to read the value.
-  meta.foundation-mq-small {
-    font-family: "/" + unquote($small-only) + "/";
-    width: lower-bound($small-range);
-  }
-
-  meta.foundation-mq-medium {
-    font-family: "/" + unquote($medium-up) + "/";
-    width: lower-bound($medium-range);
-  }
-
-  meta.foundation-mq-large {
-    font-family: "/" + unquote($large-up) + "/";
-    width: lower-bound($large-range);
-  }
-
-  meta.foundation-mq-xlarge {
-    font-family: "/" + unquote($xlarge-up) + "/";
-    width: lower-bound($xlarge-range);
-  }
-
-  meta.foundation-mq-xxlarge {
-    font-family: "/" + unquote($xxlarge-up) + "/";
-    width: lower-bound($xxlarge-range);
-  }
-
-  meta.foundation-data-attribute-namespace {
-    font-family: #{$namespace};
-  }
-
-  // Must be 100% for off canvas to work
-  html, body { height: 100%; }
 
   @if $include-html-global-classes {
+
+    meta.foundation-version {
+      font-family: "/5.1.0/";
+    }
+    // Used to provide media query values for javascript components.
+    // Forward slash placed around everything to convince PhantomJS to read the value.
+    meta.foundation-mq-small {
+      font-family: "/" + unquote($small-only) + "/";
+      width: lower-bound($small-range);
+    }
+
+    meta.foundation-mq-medium {
+      font-family: "/" + unquote($medium-up) + "/";
+      width: lower-bound($medium-range);
+    }
+
+    meta.foundation-mq-large {
+      font-family: "/" + unquote($large-up) + "/";
+      width: lower-bound($large-range);
+    }
+
+    meta.foundation-mq-xlarge {
+      font-family: "/" + unquote($xlarge-up) + "/";
+      width: lower-bound($xlarge-range);
+    }
+
+    meta.foundation-mq-xxlarge {
+      font-family: "/" + unquote($xxlarge-up) + "/";
+      width: lower-bound($xxlarge-range);
+    }
+
+    meta.foundation-data-attribute-namespace {
+      font-family: #{$namespace};
+    }
+
+    // Must be 100% for off canvas to work
+    html, body { height: 100%; }
 
     // Set box-sizing globally to handle padding and border widths
     *,

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -78,15 +78,16 @@ $topbar-sticky-class: ".sticky" !default;
 $topbar-arrows: true !default; //Set false to remove the triangle icon from the menu item
 
 @include exports("top-bar") {
-  // Used to provide media query values for javascript components.
-  // This class is generated despite the value of $include-html-top-bar-classes
-  // to ensure width calculations work correctly.
-  meta.foundation-mq-topbar {
-    font-family: "/" + unquote($topbar-media-query) + "/";
-    width: $topbar-breakpoint;
-  }
 
   @if $include-html-top-bar-classes {
+
+    // Used to provide media query values for javascript components.
+    // This class is generated despite the value of $include-html-top-bar-classes
+    // to ensure width calculations work correctly.
+    meta.foundation-mq-topbar {
+      font-family: "/" + unquote($topbar-media-query) + "/";
+      width: $topbar-breakpoint;
+    }
 
     /* Wrapped around .top-bar to contain to grid width */
     .contain-to-grid {

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -110,81 +110,6 @@ $microformat-abbr-font-decoration: none !default;
 // Responsive Text alignment
 //
 
-// Global Text Styles
-.text-left    { text-align: left !important; }
-.text-right   { text-align: right !important; }
-.text-center  { text-align: center !important; }
-.text-justify { text-align: justify !important; }
-
-@media #{$small-only} {
-    .small-only-text-left    { text-align: left !important; }
-    .small-only-text-right   { text-align: right !important; }
-    .small-only-text-center  { text-align: center !important; }
-    .small-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$small-up} {
-    .small-text-left    { text-align: left !important; }
-    .small-text-right   { text-align: right !important; }
-    .small-text-center  { text-align: center !important; }
-    .small-text-justify { text-align: justify !important; }
-}
-
-@media #{$medium-only} {
-    .medium-only-text-left    { text-align: left !important; }
-    .medium-only-text-right   { text-align: right !important; }
-    .medium-only-text-center  { text-align: center !important; }
-    .medium-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$medium-up} {
-    .medium-text-left    { text-align: left !important; }
-    .medium-text-right   { text-align: right !important; }
-    .medium-text-center  { text-align: center !important; }
-    .medium-text-justify { text-align: justify !important; }
-}
-
-@media #{$large-only} {
-    .large-only-text-left    { text-align: left !important; }
-    .large-only-text-right   { text-align: right !important; }
-    .large-only-text-center  { text-align: center !important; }
-    .large-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$large-up} {
-    .large-text-left    { text-align: left !important; }
-    .large-text-right   { text-align: right !important; }
-    .large-text-center  { text-align: center !important; }
-    .large-text-justify { text-align: justify !important; }
-}
-
-@media #{$xlarge-only} {
-    .xlarge-only-text-left    { text-align: left !important; }
-    .xlarge-only-text-right   { text-align: right !important; }
-    .xlarge-only-text-center  { text-align: center !important; }
-    .xlarge-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$xlarge-up} {
-    .xlarge-text-left    { text-align: left !important; }
-    .xlarge-text-right   { text-align: right !important; }
-    .xlarge-text-center  { text-align: center !important; }
-    .xlarge-text-justify { text-align: justify !important; }
-}
-
-@media #{$xxlarge-only} {
-    .xxlarge-only-text-left    { text-align: left !important; }
-    .xxlarge-only-text-right   { text-align: right !important; }
-    .xxlarge-only-text-center  { text-align: center !important; }
-    .xxlarge-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$xxlarge-up} {
-    .xxlarge-text-left    { text-align: left !important; }
-    .xxlarge-text-right   { text-align: right !important; }
-    .xxlarge-text-center  { text-align: center !important; }
-    .xxlarge-text-justify { text-align: justify !important; }
-}
 
 //
 // Typography Placeholders
@@ -205,6 +130,82 @@ $microformat-abbr-font-decoration: none !default;
 }
 @include exports("type") {
   @if $include-html-type-classes {
+
+    // Global Text Styles
+    .text-left    { text-align: left !important; }
+    .text-right   { text-align: right !important; }
+    .text-center  { text-align: center !important; }
+    .text-justify { text-align: justify !important; }
+
+    @media #{$small-only} {
+        .small-only-text-left    { text-align: left !important; }
+        .small-only-text-right   { text-align: right !important; }
+        .small-only-text-center  { text-align: center !important; }
+        .small-only-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$small-up} {
+        .small-text-left    { text-align: left !important; }
+        .small-text-right   { text-align: right !important; }
+        .small-text-center  { text-align: center !important; }
+        .small-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$medium-only} {
+        .medium-only-text-left    { text-align: left !important; }
+        .medium-only-text-right   { text-align: right !important; }
+        .medium-only-text-center  { text-align: center !important; }
+        .medium-only-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$medium-up} {
+        .medium-text-left    { text-align: left !important; }
+        .medium-text-right   { text-align: right !important; }
+        .medium-text-center  { text-align: center !important; }
+        .medium-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$large-only} {
+        .large-only-text-left    { text-align: left !important; }
+        .large-only-text-right   { text-align: right !important; }
+        .large-only-text-center  { text-align: center !important; }
+        .large-only-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$large-up} {
+        .large-text-left    { text-align: left !important; }
+        .large-text-right   { text-align: right !important; }
+        .large-text-center  { text-align: center !important; }
+        .large-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$xlarge-only} {
+        .xlarge-only-text-left    { text-align: left !important; }
+        .xlarge-only-text-right   { text-align: right !important; }
+        .xlarge-only-text-center  { text-align: center !important; }
+        .xlarge-only-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$xlarge-up} {
+        .xlarge-text-left    { text-align: left !important; }
+        .xlarge-text-right   { text-align: right !important; }
+        .xlarge-text-center  { text-align: center !important; }
+        .xlarge-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$xxlarge-only} {
+        .xxlarge-only-text-left    { text-align: left !important; }
+        .xxlarge-only-text-right   { text-align: right !important; }
+        .xxlarge-only-text-center  { text-align: center !important; }
+        .xxlarge-only-text-justify { text-align: justify !important; }
+    }
+
+    @media #{$xxlarge-up} {
+        .xxlarge-text-left    { text-align: left !important; }
+        .xxlarge-text-right   { text-align: right !important; }
+        .xxlarge-text-center  { text-align: center !important; }
+        .xxlarge-text-justify { text-align: justify !important; }
+    }
 
     /* Typography resets */
     div,


### PR DESCRIPTION
These changes make it so the `$include-html-classes: false` variable setting actually remove all html classes in produced css, this fixes the issue I brought up in #4555 
