### PR TITLE
Set <hr> margin difference to use rem-calc

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -291,7 +291,7 @@ $microformat-abbr-font-decoration: none !default;
       border: $hr-border-style $hr-border-color;
       border-width: $hr-border-width 0 0;
       clear: both;
-      margin: $hr-margin 0 ($hr-margin - em-calc(strip-unit($hr-border-width)));
+      margin: $hr-margin 0 ($hr-margin - rem-calc($hr-border-width));
       height: 0;
     }
 


### PR DESCRIPTION
As mentioned in #4549 foundation 5 replaces the need of em-calc and strip-unit functions in favor of rem-calc function.
