### PR TITLE
Type align mixin and align classes duplicated fix

### DIFF
--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -109,7 +109,48 @@ $microformat-abbr-font-decoration: none !default;
 //
 // Responsive Text alignment
 //
+// Text alignment class names
+$align-class-names:
+  small-only,
+  small,
+  medium-only,
+  medium,
+  large-only,
+  large,
+  xlarge-only,
+  xlarge,
+  xxlarge-only,
+  xxlarge;
 
+// Text alignment breakpoints
+$align-class-breakpoints:
+  $small-only,
+  $small-up,
+  $medium-only,
+  $medium-up,
+  $large-only,
+  $large-up,
+  $xlarge-only,
+  $xlarge-up,
+  $xxlarge-only,
+  $xxlarge-up;
+
+// Generates text align and justify classes
+@mixin align-classes{
+  .text-left    { text-align: left !important; }
+  .text-right   { text-align: right !important; }
+  .text-center  { text-align: center !important; }
+  .text-justify { text-align: justify !important; }
+
+  @for $i from 1 through length($align-class-names) {
+    @media #{(nth($align-class-breakpoints, $i))} {
+      .#{(nth($align-class-names, $i))}-text-left { text-align: left !important; }
+      .#{(nth($align-class-names, $i))}-text-right   { text-align: right !important; }
+      .#{(nth($align-class-names, $i))}-text-center  { text-align: center !important; }
+      .#{(nth($align-class-names, $i))}-text-justify { text-align: justify !important; }
+    }
+  }
+}
 // Global Text Styles
 .text-left    { text-align: left !important; }
 .text-right   { text-align: right !important; }

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -106,9 +106,6 @@ $microformat-abbr-padding: rem-calc(0 1) !default;
 $microformat-abbr-font-weight: bold !default;
 $microformat-abbr-font-decoration: none !default;
 
-//
-// Responsive Text alignment
-//
 // Text alignment class names
 $align-class-names:
   small-only,
@@ -151,81 +148,8 @@ $align-class-breakpoints:
     }
   }
 }
+
 // Global Text Styles
-.text-left    { text-align: left !important; }
-.text-right   { text-align: right !important; }
-.text-center  { text-align: center !important; }
-.text-justify { text-align: justify !important; }
-
-@media #{$small-only} {
-    .small-only-text-left    { text-align: left !important; }
-    .small-only-text-right   { text-align: right !important; }
-    .small-only-text-center  { text-align: center !important; }
-    .small-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$small-up} {
-    .small-text-left    { text-align: left !important; }
-    .small-text-right   { text-align: right !important; }
-    .small-text-center  { text-align: center !important; }
-    .small-text-justify { text-align: justify !important; }
-}
-
-@media #{$medium-only} {
-    .medium-only-text-left    { text-align: left !important; }
-    .medium-only-text-right   { text-align: right !important; }
-    .medium-only-text-center  { text-align: center !important; }
-    .medium-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$medium-up} {
-    .medium-text-left    { text-align: left !important; }
-    .medium-text-right   { text-align: right !important; }
-    .medium-text-center  { text-align: center !important; }
-    .medium-text-justify { text-align: justify !important; }
-}
-
-@media #{$large-only} {
-    .large-only-text-left    { text-align: left !important; }
-    .large-only-text-right   { text-align: right !important; }
-    .large-only-text-center  { text-align: center !important; }
-    .large-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$large-up} {
-    .large-text-left    { text-align: left !important; }
-    .large-text-right   { text-align: right !important; }
-    .large-text-center  { text-align: center !important; }
-    .large-text-justify { text-align: justify !important; }
-}
-
-@media #{$xlarge-only} {
-    .xlarge-only-text-left    { text-align: left !important; }
-    .xlarge-only-text-right   { text-align: right !important; }
-    .xlarge-only-text-center  { text-align: center !important; }
-    .xlarge-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$xlarge-up} {
-    .xlarge-text-left    { text-align: left !important; }
-    .xlarge-text-right   { text-align: right !important; }
-    .xlarge-text-center  { text-align: center !important; }
-    .xlarge-text-justify { text-align: justify !important; }
-}
-
-@media #{$xxlarge-only} {
-    .xxlarge-only-text-left    { text-align: left !important; }
-    .xxlarge-only-text-right   { text-align: right !important; }
-    .xxlarge-only-text-center  { text-align: center !important; }
-    .xxlarge-only-text-justify { text-align: justify !important; }
-}
-
-@media #{$xxlarge-up} {
-    .xxlarge-text-left    { text-align: left !important; }
-    .xxlarge-text-right   { text-align: right !important; }
-    .xxlarge-text-center  { text-align: center !important; }
-    .xxlarge-text-justify { text-align: justify !important; }
-}
 
 //
 // Typography Placeholders
@@ -246,6 +170,8 @@ $align-class-breakpoints:
 }
 @include exports("type") {
   @if $include-html-type-classes {
+    // Responsive Text alignment
+    @include align-classes;
 
     /* Typography resets */
     div,


### PR DESCRIPTION
text align and justify classes generation pushed to a mixin
importing type generated text align classes as they were outside of export. The commit fixes this issue #4499
