### PR TITLE
Add ability to set namespace globally via js. 

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -359,10 +359,19 @@
     },
 
     set_namespace: function () {
-      var namespace = $('.foundation-data-attribute-namespace').css('font-family');
+
+      // Don't bother reading the namespace out of the meta tag
+      // if the namespace has been set globally in javascript
+      //
+      // Example: something like Foundation.global.namespace = 'my-namespace';
+      //
+      // Otherwise, if the namespace hasn't been set globally,
+      // read it out of the meta tag
+      //
+      var namespace = this.global.namespace || $('.foundation-data-attribute-namespace').css('font-family');
 
       if (/false/i.test(namespace)) return;
-
+      
       this.global.namespace = namespace;
     },
 


### PR DESCRIPTION
Add ability to set namespace globally via js. 
Use global namespace if it has been set otherwise default to meta.foundation-data-attribute-namespace. 

I ran into some issues when the foundation sass project was a tiny version behind the .js project. the .foundation-data-attribute-namespace class name did not exist in my version of the foundation sass project. Which caused the js to make poo. Setting Foundation.global.namespace = 'my-namespace' would get overridden by 'sans-serif', since I didn't have the .foundation-data-attribute-namespace class defined. This pull request ensures that the .js global.namespace property always takes precedence. 

So now one can do something like: 

```
<div class="reveal-modal" data-my-namsespace-reveal>Super awesome modal</div>
```

....

```
<script>
    Foundation.global.namespace = 'my-namespace';

    // Go go gadget, reveal!
    $(document).foundation( 'reveal' );
</script>
```
