### PR TITLE
Alert changed event name from closed to close

### DIFF
--- a/js/foundation/foundation.alert.js
+++ b/js/foundation/foundation.alert.js
@@ -26,7 +26,7 @@
 
         e.preventDefault();
         alertBox[settings.animation](settings.speed, function () {
-          S(this).trigger('closed').remove();
+          S(this).trigger('close').remove();
           settings.callback();
         });
       });


### PR DESCRIPTION
I believe this triggers the event on alert close as mentioned in the docs

```
$(document).on('close.fndtn.alert-box', function(event) {
  console.info('An alert box has been closed!');
});
```
