### PR TITLE
Alert css3 animation docs update for PR #4573

### DIFF
--- a/doc/includes/alert/examples_alert_variables.html
+++ b/doc/includes/alert/examples_alert_variables.html
@@ -33,5 +33,9 @@ $alert-close-padding: 5px 4px 4px;
 
 /* We use this to control border radius */
 $alert-radius: $global-radius;
+
+/* We use this to control transition effects */
+$alert-transition-speed: 300ms;
+$alert-transition-ease: ease-out;
 ```
 {{/markdown}}

--- a/doc/includes/examples_javascript_data_options.html
+++ b/doc/includes/examples_javascript_data_options.html
@@ -23,15 +23,6 @@
       <td>true</td>
     </tr>
     <tr>
-      <td rowspan="2">Alert</td>
-      <td>animation</td>
-      <td>'fadeOut'</td>
-    </tr>
-    <tr>
-      <td>speed</td>
-      <td>300</td>
-    </tr>
-    <tr>
       <td rowspan="2">Clearing</td>
       <td>close_selectors</td>
       <td>'.clearing-close'</td>

--- a/doc/includes/examples_sass_variables.html
+++ b/doc/includes/examples_sass_variables.html
@@ -529,6 +529,10 @@ $alert-close-padding: 5px 4px 4px;
 
 $alert-radius: $global-radius;
 
+// Transition effects
+
+$alert-transition-speed: 300ms;
+$alert-transition-ease: ease-out;
 
 // Breadcrumb Variables
 

--- a/doc/pages/components/alert_boxes.html
+++ b/doc/pages/components/alert_boxes.html
@@ -125,6 +125,10 @@ $alert-close-padding: 5px 4px 4px;
 
 // We use this to control border radius
 $alert-radius: $global-radius;
+
+// We use this to control close animation
+// $alert-transition-speed: 300ms;
+// $alert-transition-ease: ease-out;
 ```
 {{/markdown}}
 
@@ -202,40 +206,6 @@ It's easy to configure alert boxes using our provided Javascript. You can use wi
 <script src="js/jquery.js"></script>
 <script src="js/foundation.js"></script>
 <script src="js/foundation.alert.js"></script>
-```
-{{/markdown}}
-
-<h3>Basic</h3>
-
-Using data-attributes is the preferred method of making changes to our Javascript.
-
-<br />
-
-<h4>HTML</h4>
-
-{{#markdown}}
-```html
-<div data-alert data-options="animation_speed:500;" class="custom-alert-box">
-  ...
-</div>
-```
-{{/markdown}}
-
-
-<h3>Advanced</h3>
-
-You can adjust many settings. For example:
-
-<h4>JS</h4>
-
-{{#markdown}}
-```js
-$(document).foundation({
-  alert: {
-    animation_speed: 500,
-    animation: 'fadeOut'
-  }
-});
 ```
 {{/markdown}}
 

--- a/doc/pages/components/alert_boxes.html
+++ b/doc/pages/components/alert_boxes.html
@@ -126,9 +126,9 @@ $alert-close-padding: 5px 4px 4px;
 // We use this to control border radius
 $alert-radius: $global-radius;
 
-// We use this to control close animation
-// $alert-transition-speed: 300ms;
-// $alert-transition-ease: ease-out;
+// We use this to control transition effects
+$alert-transition-speed: 300ms;
+$alert-transition-ease: ease-out;
 ```
 {{/markdown}}
 


### PR DESCRIPTION
Updated docs to reflect changes in PR #4573
TODO: The following example of alert in docs needs to be changed

```
Configure on the fly

New to Foundation 5, you can now reconfigure instances of your plugin after the page has loaded and Foundation has already been initialized.

Lets pretend that we have an alert that was on our page when Foundation was first initialized:
HTML

<div data-alert class="alert-box" id="myAlert"> This is a standard alert. <a href="#" class="close">&times;</a> </div>

The default fade out speed is 300 miliseconds, if we wanted to change this to 3 seconds we could do the following:
JS

$('#myAlert').foundation({alert: {speed: 3000}});

You can set any configuration option or callback this way.
```
