### PR TITLE
Add support for multi_expand back to accordion.

### DIFF
--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -8,6 +8,7 @@
 
     settings : {
       active_class: 'active',
+      multi_expand: false,
       toggleable: true
     },
 
@@ -32,13 +33,16 @@
 
         if (! S(this).closest('dl').is(accordion)) { return; }
 
-        if (active_content[0] == target[0] && settings.toggleable) {
+        if (settings.toggleable && target.is(active_content)) {
           active_parent.toggleClass(settings.active_class, false);
           return target.toggleClass(settings.active_class, false);
         }
 
-        siblings.removeClass(settings.active_class);
-        aunts.removeClass(settings.active_class);
+        if (!settings.multi_expand) {
+          siblings.removeClass(settings.active_class);
+          aunts.removeClass(settings.active_class);
+        }
+
         target.addClass(settings.active_class).parent().addClass(settings.active_class);
       });
     },


### PR DESCRIPTION
I had already coded this up before I saw #3720, but since it's a small change, and it allows for much greater flexibility with accordions, I thought I'd send a pull request anyway.

Sure, it can be argued that the "point" of accordions is to have only one active at a time, but I believe that's a limited view. Nothing about the design of accordions prohibits multiple being open (I'd argue that's the point of tabs, and the point of accordions is the animation effects). In any case, the `multi_expand` option allows for greater flexibility with accordions.

I could always just code up some custom accordion toggle buttons myself, but since this plugin already provides 95% of what I need, let's extend it. Adding this option enables switching between accordion types with a minor change.

If this is a go, I'll gladly write tests and docs too...
