### PR TITLE
Tooltip missing argument in event function call

### DIFF
--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -27,7 +27,7 @@
       this.bindings(method, options);
     },
 
-    events : function () {
+    events : function (instance) {
       var self = this,
           S = self.S;
 


### PR DESCRIPTION
Missing argument instance in function call to event during event
Fixes error introduced by PR #4567
Fixes issue pointed by #4580
