### PR TITLE
Fixed issue #4588. <select> background position incorrect on Mobile Safari 5/6.

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -331,7 +331,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
       background-color: $select-bg-color;
       background-image: url('data:image/svg+xml;base64, PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iM3B4IiB2aWV3Qm94PSIwIDAgNiAzIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA2IDMiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwb2x5Z29uIHBvaW50cz0iNS45OTIsMCAyLjk5MiwzIC0wLjAwOCwwICIvPjwvc3ZnPg==');
       background-repeat: no-repeat;
-      background-position: center $opposite-direction 3%;
+      background-position: if($text-direction == 'rtl', 3%, 97%) center;
       border: $input-border-width $input-border-style $input-border-color;
       padding: $form-spacing / 2;
       font-size: $input-font-size;


### PR DESCRIPTION
Fixed issue #4588. Background position on &lt;select&gt; no longer relies on support for offsets i.e. the four value syntax.
