### PR TITLE
Allow '#/home/start' magellen targets

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -34,7 +34,7 @@
                 settings = expedition.data('magellan-expedition-init');
 
             var hash = this.hash.split('#').join(''),
-                target = $('a[name='+hash+']');
+                target = $("a[name='"+hash+"']");
             if (target.length === 0) target = $('#'+hash);
 
             // Account for expedition height if fixed position


### PR DESCRIPTION
Problem:

If we are using a URL listener to change the content dynamically, Magellan doesn't allow www.domain.com/#home/subContent URLs.
eg:
Homepage url = www.domain.com/#home
other content url = www.domain.com/#page1
Homepage 'why' section using magellan = www.domain.com/#why
*\* the url listener treats magellan links as a new page and not a section on the home page **

FIX:
Wrapped the hash inside quotations so it treats special characters as string literals
