### PR TITLE
Move grid to top of components

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -7,6 +7,7 @@
 
 // Behold, here are all the Foundation components.
 @import
+  "foundation/components/grid",
   "foundation/components/accordion",
   "foundation/components/alert-boxes",
   "foundation/components/block-grid",
@@ -18,7 +19,6 @@
   "foundation/components/dropdown-buttons",
   "foundation/components/flex-video",
   "foundation/components/forms",
-  "foundation/components/grid",
   "foundation/components/inline-lists",
   "foundation/components/joyride",
   "foundation/components/keystrokes",

--- a/scss/foundation/components/_accordion.scss
+++ b/scss/foundation/components/_accordion.scss
@@ -3,7 +3,6 @@
 // Licensed under MIT Open Source
 
 @import "global";
-@import "grid";
 
 //
 // @variables


### PR DESCRIPTION
Excluding _accordion.scss from the list of components causes errors, as it is the only component to reference _grid.scss. This change removes the import from _accordion.scss and places _grid.scss as the first component, thereby making it available to the other components.
