### PR TITLE
Limit legacy visibility classes to legacy breakpoints

### DIFF
--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -42,7 +42,7 @@ $visibility-breakpoint-queries:
 
     @each $visibility-comparison-breakpoint in $visibility-breakpoint-sizes {
       @if index($visibility-breakpoint-sizes, $visibility-comparison-breakpoint) < index($visibility-breakpoint-sizes, $current-visibility-breakpoint) {
-        // smaller than current breakpoint
+        // Smaller than current breakpoint
 
         $visibility-inherit-list: append($visibility-inherit-list, unquote(
           '.hide-for-#{$visibility-comparison-breakpoint}-only, .show-for-#{$visibility-comparison-breakpoint}-up'
@@ -66,7 +66,10 @@ $visibility-breakpoint-queries:
           'th.hide-for-#{$visibility-comparison-breakpoint}-only, td.hide-for-#{$visibility-comparison-breakpoint}-only, th.show-for-#{$visibility-comparison-breakpoint}-up, td.show-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
 
-        @if $include-legacy-visibility-classes {
+        // Foundation 4 compatibility:
+        // Include .show/hide-for-[size] and .show/hide-for-[size]-down classes
+        // for small, medium, and large breakpoints only
+        @if $include-legacy-visibility-classes and index((small, medium, large), $visibility-comparison-breakpoint) != false {
           $visibility-inherit-list: append($visibility-inherit-list, unquote(
             '.hide-for-#{$visibility-comparison-breakpoint}, .hide-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
@@ -91,7 +94,7 @@ $visibility-breakpoint-queries:
         }
 
       } @else if index($visibility-breakpoint-sizes, $visibility-comparison-breakpoint) > index($visibility-breakpoint-sizes, $current-visibility-breakpoint) {
-        // larger than current breakpoint
+        // Larger than current breakpoint
 
         $visibility-inherit-list: append($visibility-inherit-list, unquote(
           '.hide-for-#{$visibility-comparison-breakpoint}-only, .hide-for-#{$visibility-comparison-breakpoint}-up'
@@ -115,7 +118,10 @@ $visibility-breakpoint-queries:
           'th.hide-for-#{$visibility-comparison-breakpoint}-only, td.hide-for-#{$visibility-comparison-breakpoint}-only, th.hide-for-#{$visibility-comparison-breakpoint}-up, td.hide-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
 
-        @if $include-legacy-visibility-classes {
+        // Foundation 4 compatibility:
+        // Include .show/hide-for-[size] and .show/hide-for-[size]-down classes
+        // for small, medium, and large breakpoints only
+        @if $include-legacy-visibility-classes and index((small, medium, large), $visibility-comparison-breakpoint) != false {
           $visibility-inherit-list: append($visibility-inherit-list, unquote(
             '.hide-for-#{$visibility-comparison-breakpoint}, .show-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
@@ -140,7 +146,7 @@ $visibility-breakpoint-queries:
         }
 
       } @else {
-        // current breakpoint
+        // Current breakpoint
 
         $visibility-inherit-list: append($visibility-inherit-list, unquote(
           '.show-for-#{$visibility-comparison-breakpoint}-only, .show-for-#{$visibility-comparison-breakpoint}-up'
@@ -164,7 +170,10 @@ $visibility-breakpoint-queries:
           'th.show-for-#{$visibility-comparison-breakpoint}-only, td.show-for-#{$visibility-comparison-breakpoint}-only, th.show-for-#{$visibility-comparison-breakpoint}-up, td.show-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
 
-        @if $include-legacy-visibility-classes {
+        // Foundation 4 compatibility:
+        // Include .show/hide-for-[size] and .show/hide-for-[size]-down classes
+        // for small, medium, and large breakpoints only
+        @if $include-legacy-visibility-classes and index((small, medium, large), $visibility-comparison-breakpoint) != false {
           $visibility-inherit-list: append($visibility-inherit-list, unquote(
             '.show-for-#{$visibility-comparison-breakpoint}, .show-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);


### PR DESCRIPTION
When enabled, generating legacy visibility classes only uses small, medium, and large breakpoints. Since those were the only breakpoints that existed in Foundation 4, there is no need to generate visibility classes for any breakpoints beyond those three.

This addresses what I believe was an incomplete merge of #4345, where an older version of _visibility.scss was used.
