### PR TITLE
Fix Duble scroll if using Pizza Pie

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -118,7 +118,7 @@ $menu-slide: "transform 500ms ease" !default;
 @mixin off-canvas-wrap {
   @include kill-flicker;
   @include wrap-base;
-  overflow-x: hidden;
+  overflow: hidden;
   &.move-right,
   &.move-left { height: 100%; }
 }


### PR DESCRIPTION
If pizza pie uzing in last row. Then appears double scroll.

![ds](https://f.cloud.github.com/assets/6079787/2373078/b5ded030-a846-11e3-8bb2-e2ad7062939c.PNG)
