### PR TITLE
Remove redundant $include-html-form-classes

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -991,8 +991,6 @@
 // SWITCH
 //
 
-// $include-html-form-classes: $include-html-classes;
-
 // Controlling border styles and background colors for the switch container
 // $switch-border-color: scale-color(#fff, $lightness: -20%);
 // $switch-border-style: solid;


### PR DESCRIPTION
I haven't used Switch before, but I had to hunt down why adding:

``` scss
@import "foundation/components/buttons";
@import "foundation/components/forms";
```

was leaving out form/input styles. This was the culprit, and I don't see the purpose in defining this variable twice in the settings.

The main issue here, however, is the default form styles are married to the class-based styles in _form.scss. We should decouple them in order to import form styles without the overhead class styles (allowing for sweet-semantic HTML). I'll be adding another pull request respectively.
