### PR TITLE
[orbit] Adding ability to select first image shown in orbit via active_slide_class

### DIFF
--- a/doc/includes/orbit/examples_orbit_basic.html
+++ b/doc/includes/orbit/examples_orbit_basic.html
@@ -5,7 +5,7 @@
       Caption One.
     </div>
   </li>
-  <li>
+  <li class="active">
     <img src="{{assets}}/img/examples/andromeda-orbit.jpg" alt="slide 2" />
     <div class="orbit-caption">
       Caption Two.

--- a/doc/includes/orbit/examples_orbit_basic_rendered.html
+++ b/doc/includes/orbit/examples_orbit_basic_rendered.html
@@ -1,19 +1,19 @@
 <div class="orbit-container">
   <ul data-orbit class="example-orbit orbit-slides-container">
     <li>
-      <img src="http://placehold.it/1000x300/A92B48/fff" alt="slide 1" />
+      <img src="{{assets}}/img/examples/satelite-orbit.jpg" alt="slide 1" />
       <div class="orbit-caption">
         Caption One.
       </div>
     </li>
     <li class="active">
-      <img src="http://placehold.it/1000x300/EE964D/fff" alt="slide 2" />
+      <img src="{{assets}}/img/examples/andromeda-orbit.jpg" alt="slide 1" />
       <div class="orbit-caption">
         Caption Two.
       </div>
     </li>
     <li>
-      <img src="http://placehold.it/1000x300/FDC43D/fff" alt="slide 3" />
+      <img src="{{assets}}/img/examples/launch-orbit.jpg" alt="slide 1" />
       <div class="orbit-caption">
         Caption Three.
       </div>

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -17,7 +17,8 @@
         timer_container,
         idx = 0,
         animate,
-        adjust_height_after = false;
+        adjust_height_after = false,
+        has_init_active = slides_container.find("." + settings.active_slide_class).length > 0;
 
     self.cache = {};
 
@@ -25,7 +26,7 @@
       return slides_container.children(settings.slide_selector);
     };
 
-    self.slides().first().addClass(settings.active_slide_class);
+    if (!has_init_active) {self.slides().first().addClass(settings.active_slide_class)};
 
     self.update_slide_number = function(index) {
       if (settings.slide_number) {
@@ -268,6 +269,9 @@
       //   animate = new SlideAnimation(settings, slides_container);
       if(settings.animation === 'fade') {slides_container.addClass('fade');}
       animate = new CSSAnimation(settings, slides_container);
+      if (has_init_active) {
+        self._goto(slides_container.find("." + settings.active_slide_class).index());
+      }
       container.on('click', '.'+settings.next_class, self.next);
       container.on('click', '.'+settings.prev_class, self.prev);
 
@@ -352,8 +356,8 @@
       Foundation.utils.image_loaded(this.slides().children('img'), self.compute_dimensions);
       Foundation.utils.image_loaded(this.slides().children('img'), function() {
         container.prev('.preloader').css('display', 'none');
-        self.update_slide_number(0);
-        self.update_active_link(0);
+        self.update_slide_number(idx);
+        self.update_active_link(idx);
         slides_container.trigger('ready.fndtn.orbit');
       });
     };


### PR DESCRIPTION
For example: 

``` html
<ul data-orbit>
  <li>
     <img src="..."/>
  </li>
  <li class="active">
    <img src="..."/>
  </li>
</ul>
```

Will show the second image after orbit init.

Any feedback is appreciated. There is still an animation from the first image to the image that is selected. I'm not sure of how to get rid of this unless since active_slide_class can't be exposed in the scss. Any ideas?
