### PR TITLE
Derive pre- and postfix height from input instead of label

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -179,8 +179,8 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   border-width: $input-prefix-border-size;
   overflow: $input-prefix-overflow;
   font-size: $form-label-font-size;
-  height: ($form-label-font-size + ($form-spacing * 1.5) - rem-calc(1));
-  line-height: ($form-label-font-size + ($form-spacing * 1.5) - rem-calc(1));
+  height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+  line-height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
 }
 
 // @MIXIN


### PR DESCRIPTION
Here you go @rafibomb. That was easy enough.
Fixes https://github.com/zurb/foundation/issues/3418

Wether the font-size should also be from input instead of label feels like a coin-toss for my... could be _what you want_ either way depending on the day.
