### PR TITLE
Extraneous line in foundation.scss file

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -43,5 +43,3 @@
   "foundation/components/type",
   "foundation/components/offcanvas",
   "foundation/components/visibility";
-
-  // * { border-radius: 500px !important; }


### PR DESCRIPTION
I notice that there's this line at the end of scss/foundation.scss:

  // \* { border-radius: 500px !important; }

It was introduced in this changeset:

https://github.com/zurb/foundation/blob/09028fdb8abb171672de760d3173402a76ace32d/scss/foundation.scss#L47

It's a comment and seems like something extraneous that got into the commit by accident, especially considering this file is one that could be replicated by downstream users to include only certain components.
