### PR TITLE
Support custom validators [abide]

### DIFF
--- a/doc/includes/abide/examples_abide_javascript_options.html
+++ b/doc/includes/abide/examples_abide_javascript_options.html
@@ -36,6 +36,12 @@ $(document).foundation({
 
       // #FFF or #FFFFFF
       color: /^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/
+    },
+    validators: {
+      diceRoll: function(el, required, parent) {
+        var possibilities = [true, false];
+        return possibilities[Math.round(Math.random())];
+      }
     }
   }
 });

--- a/doc/pages/components/abide.html
+++ b/doc/pages/components/abide.html
@@ -95,6 +95,35 @@ To handle the `submit` event yourself, use `data-abide="ajax"` instead of `data-
 
 ***
 
+## Custom Validators
+
+`equalTo` is actually an example of a built-in validator. To get an idea of how validators work, check out the implementation of `equalTo`:
+
+{{#markdown}}
+```javascript
+equalTo: function(el, required, parent) {
+  var from  = document.getElementById(el.getAttribute(this.add_namespace('data-equalto'))).value,
+      to    = el.value,
+      valid = (from === to);
+
+  return valid;
+}
+```
+{{/markdown}}
+
+Your function will be passed three arguments: `el`, `required`, and `parent`. These are the elements being validated, whether or not it was marked as required, and the parent of the element being validated, respectively.
+Your function should return `true` if the element is valid, or `false` if it is invalid. You can define your custom validators and pass them into abide options when initializing foundation. See the Configuration section for more details on defining custom validators.
+
+Suppose you've defined a custom validator `diceRoll` which randomly marks your element as valid or invalid. You would use it like so:
+
+{{#markdown}}
+```html
+<input type="text" data-abide-validator="diceRoll">
+```
+{{/markdown}}
+
+***
+
 ## Using the Javascript
 
 <div class="panel">

--- a/spec/abide/advanced.html
+++ b/spec/abide/advanced.html
@@ -1,0 +1,22 @@
+<form data-abide="ajax">
+  <div class="range-start-field">
+    <label>Starting number <small>required</small></label>
+    <input name="user_start_num" type="text">
+    <small class="error">Starting number must be before the end date</small>
+  </div>
+  <div class="range-end-field">
+    <label>Ending number <small>required</small></label>
+    <input name="user_end_num" type="text" data-abide-validator="range">
+    <small class="error">Ending number must be before the end date</small>
+  </div>
+  <div class="password-field">
+    <label>Password <small>required</small></label>
+    <input id="user_password" name="user_password" type="password">
+  </div>
+  <div class="password-confirmation-field">
+    <label>Password confirmation<small>required</small></label>
+    <input name="user_password_confirmation" type="password" data-abide-validator="equalTo" data-equalto="user_password">
+    <small class="error">Password and password confirmation must match.</small>
+  </div>
+  <button type="submit">Submit</button>
+</form>


### PR DESCRIPTION
### Abide custom validators

This pull request adds the ability for developers to define their own custom validators for abide, as well redefines the `equalTo`

See changes to docs for more information.
### Note about jquery's `.data()` function

One note here is I discovered a jquery bug with `data`.  Try this in your browser's console:

``` javascript
div = $("div:first");
div.attr("data-foo", "bar");
// here you notice the attribute data-foo="bar" added to the div
div.data("foo");
// sweet it was "bar"
div.data("foo", "baz");
// hmmm now you notice the attribute data-foo value did not change from "bar"
div.data("foo"); // => "baz"
div.attr("data-foo"); // => "bar"
div.removeAttr("data-foo"); // cool that attr is removed from the element
div.data("foo"); // => "baz"
// wat?
```

What this means is that when we add `data-invalid` attributes to the invalid elements, as far as jquery data is concerned, they're never removed.  This is fine if you're selecting elements like `$("[data-invalid]")` but could cause problems for developers working with `.data()` jquery function.
