### PR TITLE
Update description of CSS triangle mixin to reflect it's less equal nature

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -111,7 +111,7 @@ $base-line-height: 150% !default;
 
 // @mixins
 //
-// We use this to create equilateral triangles
+// We use this to create isosceles triangles
 // $triangle-size - Used to set border-size. No default, set a px or em size.
 // $triangle-color - Used to set border-color which makes up triangle. No default
 // $triangle-direction - Used to determine which direction triangle points. Options: top, bottom, left, right


### PR DESCRIPTION
This is rather pedantic, but hopefully it will help clear up some confusion when using the `css-triangle` mixin. 

The triangle created by the mixin is [isosceles](http://en.wikipedia.org/wiki/Isosceles_triangle) rather than [equilateral](http://en.wikipedia.org/wiki/Equilateral_triangle). 
