### PR TITLE
grunt build should be run inside project folder.

### DIFF
--- a/doc/pages/sass.html
+++ b/doc/pages/sass.html
@@ -48,9 +48,10 @@ Next we'll use the Foundation CLI to create a new project:
 foundation new project_name --libsass
 ```
 
-Boom, your project is created! Now you need to use Grunt to compile everything before you start working. Run this command
+Boom, your project is created! Now you need to use Grunt to compile everything before you start working:
 
 ```bash
+cd project_name
 grunt build
 ```
 


### PR DESCRIPTION
Non grunt users might not figure out that 'grunt build' should be run
inside project folder. This commit improve SASS doc by adding an
explicit 'cd' command before build.
