### PR TITLE
New Reveal radius and collapse options

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -878,6 +878,7 @@
 // $reveal-default-width: 80%;
 // $reveal-modal-padding: rem-calc(20);
 // $reveal-box-shadow: 0 0 10px rgba(#000,.4);
+// $reveal-radius: $global-radius;
 
 // We use these to style the reveal close button
 // $reveal-close-font-size: rem-calc(22);

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -175,6 +175,10 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
       dialog, .#{$reveal-modal-class} {
         @include reveal-modal-style(false, $reveal-modal-padding * 1.5, false, $box-shadow: false, $top-offset: $reveal-position-top);
 
+        // Remove all padding with collapse class
+        &.collapse { padding:0; }
+
+        // Add radius to modal
         &.radius { @include radius($reveal-radius); }
 
         &.tiny  { @include reveal-modal-base(false, 30%); }

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -34,6 +34,9 @@ $reveal-border-style: solid !default;
 $reveal-border-width: 1px !default;
 $reveal-border-color: #666 !default;
 
+// We use this to set the default radius used throughout the core.
+$reveal-radius: $global-radius !default;
+
 $reveal-modal-class: "reveal-modal" !default;
 $close-reveal-modal-class: "close-reveal-modal" !default;
 
@@ -172,6 +175,8 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
       dialog, .#{$reveal-modal-class} {
         @include reveal-modal-style(false, $reveal-modal-padding * 1.5, false, $box-shadow: false, $top-offset: $reveal-position-top);
 
+        &.radius { @include radius($reveal-radius); }
+
         &.tiny  { @include reveal-modal-base(false, 30%); }
         &.small { @include reveal-modal-base(false, 40%); }
         &.medium  { @include reveal-modal-base(false, 60%); }
@@ -182,6 +187,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
       dialog, .#{$reveal-modal-class} {
         &.full {
           @include reveal-modal-base(false, 100vw);
+          @include radius(0);
           top:0;
           left:0;
           height: 100vh;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -4,6 +4,7 @@
 
 @import "global";
 @import "grid";
+@import "buttons";
 
 //
 // Top Bar Variables
@@ -318,34 +319,16 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           text-transform: $topbar-link-text-transform;
           background: $topbar-dropdown-bg;
 
-          &.button {
-            background: $primary-color;
-            font-size: $topbar-link-font-size;
-             padding-#{$opposite-direction}: $topbar-link-padding;
-             padding-#{$default-float}: $topbar-link-padding;
-            &:hover {
-              background: scale-color($primary-color, $lightness: -27%);
-            }
-          }
-          &.button.secondary {
-            background: $secondary-color;
-            &:hover {
-              background: scale-color($secondary-color, $lightness: -11%);
-            }
-          }
-          &.button.success {
-            background: $success-color;
-            &:hover {
-              background: scale-color($success-color, $lightness: -21%);
-            }
-          }
-          &.button.alert {
-            background: $alert-color;
-            &:hover {
-              background: scale-color($alert-color, $lightness: -18%);
-            }
-          }
 
+          &.button {
+            font-size: $topbar-link-font-size;
+            padding-#{$opposite-direction}: $topbar-link-padding;
+            padding-#{$default-float}: $topbar-link-padding;
+            @include button-style($bg:$primary-color);
+          }
+          &.button.secondary { @include button-style($bg:$secondary-color); }
+          &.button.success   { @include button-style($bg:$success-color); }
+          &.button.alert     { @include button-style($bg:$alert-color); }
         }
 
         // Apply the hover link color when it has that class

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -4,7 +4,6 @@
 
 @import "global";
 @import "grid";
-@import "buttons";
 
 //
 // Top Bar Variables
@@ -319,16 +318,34 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           text-transform: $topbar-link-text-transform;
           background: $topbar-dropdown-bg;
 
-
           &.button {
+            background: $primary-color;
             font-size: $topbar-link-font-size;
-            padding-#{$opposite-direction}: $topbar-link-padding;
-            padding-#{$default-float}: $topbar-link-padding;
-            @include button-style($bg:$primary-color);
+             padding-#{$opposite-direction}: $topbar-link-padding;
+             padding-#{$default-float}: $topbar-link-padding;
+            &:hover {
+              background: scale-color($primary-color, $lightness: -27%);
+            }
           }
-          &.button.secondary { @include button-style($bg:$secondary-color); }
-          &.button.success   { @include button-style($bg:$success-color); }
-          &.button.alert     { @include button-style($bg:$alert-color); }
+          &.button.secondary {
+            background: $secondary-color;
+            &:hover {
+              background: scale-color($secondary-color, $lightness: -11%);
+            }
+          }
+          &.button.success {
+            background: $success-color;
+            &:hover {
+              background: scale-color($success-color, $lightness: -21%);
+            }
+          }
+          &.button.alert {
+            background: $alert-color;
+            &:hover {
+              background: scale-color($alert-color, $lightness: -18%);
+            }
+          }
+
         }
 
         // Apply the hover link color when it has that class


### PR DESCRIPTION
This adds two new features to Reveal. 
1. Adding a `radius` class will add a border radius to the modal. There are new variables to adjust the radius but the default is the global-radius. 
2. Adding a `collapse` class to the modal will remove all padding. This is useful if you want a particular modal's content to fill the entire modal. 
