### PR TITLE
Reveal new classes: radius, round & collapse

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -879,6 +879,8 @@
 // $reveal-default-width: 80%;
 // $reveal-modal-padding: rem-calc(20);
 // $reveal-box-shadow: 0 0 10px rgba(#000,.4);
+// $reveal-radius: $global-radius;
+// $reveal-round: $global-rounded;
 
 // We use these to style the reveal close button
 // $reveal-close-font-size: rem-calc(22);

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -111,15 +111,15 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
 // $radius - If true, set to modal radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
 // $top-offset - Default: $reveal-position-top || 50px
 @mixin reveal-modal-style(
-  $bg:$reveal-modal-bg,
-  $padding:$reveal-modal-padding,
-  $border:true,
+  $bg:false,
+  $padding:false,
+  $border:false,
   $border-style:$reveal-border-style,
   $border-width:$reveal-border-width,
   $border-color:$reveal-border-color,
-  $box-shadow:true,
+  $box-shadow:false,
   $radius:false,
-  $top-offset:$reveal-position-top) {
+  $top-offset:false) {
 
   @if $bg { background-color: $bg; }
   @if $padding != false { padding: $padding; }
@@ -167,25 +167,31 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
 
     dialog, .#{$reveal-modal-class} {
       @include reveal-modal-base;
-      @include reveal-modal-style;
+      @include reveal-modal-style(
+        $bg:$reveal-modal-bg,
+        $padding:$reveal-modal-padding,
+        $border:true,
+        $box-shadow:true,
+        $radius:false,
+        $top-offset:$reveal-position-top);
 
       .#{$close-reveal-modal-class} { @include reveal-close; }
     }
 
     dialog[open] {
-    	display:block;
-    	visibility: visible;
+      display:block;
+      visibility: visible;
     }
 
     @media #{$medium-up} {
 
       dialog, .#{$reveal-modal-class} {
-        @include reveal-modal-style($bg: false, $padding: $reveal-modal-padding * 1.5, $border: false, $box-shadow: false, $top-offset: $reveal-position-top);
+        @include reveal-modal-style($padding:$reveal-modal-padding * 1.5);
 
-        &.radius { @include reveal-modal-style($bg: false, $padding: false, $border: false, $box-shadow: false, $radius: true, $top-offset: false); }
-        &.round  { @include reveal-modal-style($bg: false, $padding: false, $border: false, $box-shadow: false, $radius: $reveal-round, $top-offset: false); }
+        &.radius { @include reveal-modal-style($radius:true); }
+        &.round  { @include reveal-modal-style($radius:$reveal-round); }
         
-        &.collapse { @include reveal-modal-style($bg: false, $padding: 0, $top-offset: false); }
+        &.collapse { @include reveal-modal-style($padding:0); }
 
         &.tiny  { @include reveal-modal-base(false, 30%); }
         &.small { @include reveal-modal-base(false, 40%); }

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -29,6 +29,10 @@ $reveal-close-side: rem-calc(11) !default;
 $reveal-close-color: #aaa !default;
 $reveal-close-weight: bold !default;
 
+// We use this to set the default radius used throughout the core.
+$reveal-radius: $global-radius !default;
+$reveal-round: $global-rounded !default;
+
 // We use these to control the modal border
 $reveal-border-style: solid !default;
 $reveal-border-width: 1px !default;
@@ -104,6 +108,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
 // $border-width - Width of border (i.e. 1px). Default: $reveal-border-width.
 // $border-color - Color of border. Default: $reveal-border-color.
 // $box-shadow - Choose whether or not to include the default box-shadow. Default: true, Options: false
+// $radius - If true, set to modal radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
 // $top-offset - Default: $reveal-position-top || 50px
 @mixin reveal-modal-style(
   $bg:$reveal-modal-bg,
@@ -113,10 +118,11 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
   $border-width:$reveal-border-width,
   $border-color:$reveal-border-color,
   $box-shadow:true,
+  $radius:false,
   $top-offset:$reveal-position-top) {
 
   @if $bg { background-color: $bg; }
-  @if $padding { padding: $padding; }
+  @if $padding != false { padding: $padding; }
 
   @if $border { border: $border-style $border-width $border-color; }
 
@@ -127,6 +133,10 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     }
     box-shadow: $reveal-box-shadow;
   }
+
+  // We can control how much radius is used on the modal
+  @if $radius == true { @include radius($reveal-radius); }
+  @else if $radius { @include radius($radius); }
 
   @if $top-offset {
     @media #{$medium-up} {
@@ -163,14 +173,19 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     }
 
     dialog[open] {
-	display:block;
-	visibility: visible;
+    	display:block;
+    	visibility: visible;
     }
 
     @media #{$medium-up} {
 
       dialog, .#{$reveal-modal-class} {
-        @include reveal-modal-style(false, $reveal-modal-padding * 1.5, false, $box-shadow: false, $top-offset: $reveal-position-top);
+        @include reveal-modal-style($bg: false, $padding: $reveal-modal-padding * 1.5, $border: false, $box-shadow: false, $top-offset: $reveal-position-top);
+
+        &.radius { @include reveal-modal-style($bg: false, $padding: false, $border: false, $box-shadow: false, $radius: true, $top-offset: false); }
+        &.round  { @include reveal-modal-style($bg: false, $padding: false, $border: false, $box-shadow: false, $radius: $reveal-round, $top-offset: false); }
+        
+        &.collapse { @include reveal-modal-style($bg: false, $padding: 0, $top-offset: false); }
 
         &.tiny  { @include reveal-modal-base(false, 30%); }
         &.small { @include reveal-modal-base(false, 40%); }


### PR DESCRIPTION
I added these 3 new classes to the Reveal modal. The styles are applied via the `reveal-modal-style` mixin. 

I also refactored the `reveal-modal-style` mixin. 

The previous version of this mixin required that you define a ton of parameters each time you wanted to apply a style. When the mixin is first called in order to apply the default styles, those default styles are passed as parameters. Therefore in subsequent calls, you are only passing the particular attribute that you want to override.

This new version of the mixin seems to remove a small amount of duplicate styles that were not needed.

I made this a separate commit in case this reflector was not desired but you still wanted to accept the new radius, round and collapse classes.
