### PR TITLE
Add missing !default to $topbar-button-font-size

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -48,7 +48,7 @@ $topbar-link-font-family: $body-font-family !default;
 $topbar-link-text-transform: none !default;
 $topbar-link-padding: $topbar-height / 3 !default;
 
-$topbar-button-font-size: 0.75rem;
+$topbar-button-font-size: 0.75rem !default;
 $topbar-button-top: 7px !default;
 
 $topbar-dropdown-label-color: #777 !default;


### PR DESCRIPTION
`$topbar-button-font-size` doesn't allow for overriding in the _settings.scss
file, as it doesn't have the `!default` rule.
