### PR TITLE
Add collapse-left and collapse-right to grid

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -95,7 +95,8 @@ $total-columns: 12 !default;
   $offset:false,
   $push:false,
   $pull:false,
-  $collapse:false,
+  $collapse-left:false,
+  $collapse-right:false,
   $float:true,
   $position:false) {
 
@@ -106,14 +107,17 @@ $total-columns: 12 !default;
   }
 
   // If collapsed, get rid of gutter padding
-  @if $collapse {
+  @if $collapse-left {
     padding-left: 0;
+  }
+
+  @if $collapse-right {
     padding-right: 0;
   }
 
   // Gutter padding whenever a column isn't set to collapse
   // (use $collapse:null to do nothing)
-  @else if $collapse == false {
+  @if $collapse-left == false and $collapse-right == false {
     padding-left: $column-gutter / 2;
     padding-right: $column-gutter / 2;
   }
@@ -154,7 +158,7 @@ $total-columns: 12 !default;
 @mixin grid-html-classes($size) {
 
   .column.#{$size}-centered,
-  .columns.#{$size}-centered { @include grid-column($center:true, $collapse:null, $float:false); }
+  .columns.#{$size}-centered { @include grid-column($center:true, $collapse-left:null, $collapse-right: null, $float:false); }
 
   .column.#{$size}-uncentered,
   .columns.#{$size}-uncentered {
@@ -170,10 +174,10 @@ $total-columns: 12 !default;
 
   @for $i from 0 through $total-columns - 1 {
     .#{$size}-push-#{$i} {
-      @include grid-column($push:$i, $collapse:null, $float:false);
+      @include grid-column($push:$i, $collapse-left:null, $collapse-right:null, $float:false);
     }
     .#{$size}-pull-#{$i} {
-      @include grid-column($pull:$i, $collapse:null, $float:false);
+      @include grid-column($pull:$i, $collapse-left:null, $collapse-right:null, $float:false);
     }
   }
 
@@ -182,7 +186,7 @@ $total-columns: 12 !default;
 
 
   @for $i from 1 through $total-columns {
-    .#{$size}-#{$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
+    .#{$size}-#{$i} { @include grid-column($columns:$i,$collapse-left:null,$collapse-right:null,$float:false); }
   }
 
   [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
@@ -190,7 +194,7 @@ $total-columns: 12 !default;
 
 
   @for $i from 0 through $total-columns - 1 {
-    .#{$size}-offset-#{$i} { @include grid-column($offset:$i, $collapse:null,$float:false); }
+    .#{$size}-offset-#{$i} { @include grid-column($offset:$i, $collapse-left:null,$collapse-right:null,$float:false); }
   }
   .#{$size}-reset-order,
   .#{$size}-reset-order {
@@ -209,7 +213,21 @@ $total-columns: 12 !default;
 
       &.collapse {
          > .column,
-         > .columns { @include grid-column($collapse:true, $float:false); }
+         > .columns { @include grid-column($collapse-left:true, $collapse-right:true, $float:false); }
+
+        .row {margin-left:0; margin-right:0;}
+      }
+
+      &.collapse-left {
+         > .column,
+         > .columns { @include grid-column($collapse-left:true, $collapse-right:null, $float:false); }
+
+        .row {margin-left:0; margin-right:0;}
+      }
+
+      &.collapse-right {
+         > .column,
+         > .columns { @include grid-column($collapse-left:null, $collapse-right:true, $float:false); }
 
         .row {margin-left:0; margin-right:0;}
       }
@@ -231,10 +249,10 @@ $total-columns: 12 !default;
       // Old push and pull classes
       @for $i from 0 through $total-columns - 1 {
         .push-#{$i} {
-          @include grid-column($push:$i, $collapse:null, $float:false);
+          @include grid-column($push:$i, $collapse-left:null, $collapse-right: null, $float:false);
         }
         .pull-#{$i} {
-          @include grid-column($pull:$i, $collapse:null, $float:false);
+          @include grid-column($pull:$i, $collapse-left:null, $collapse-right: null, $float:false);
         }
       }
     }
@@ -242,10 +260,10 @@ $total-columns: 12 !default;
       @include grid-html-classes($size:large);
       @for $i from 0 through $total-columns - 1 {
         .push-#{$i} {
-          @include grid-column($push:$i, $collapse:null, $float:false);
+          @include grid-column($push:$i, $collapse-left:null, $collapse-right:null, $float:false);
         }
         .pull-#{$i} {
-          @include grid-column($pull:$i, $collapse:null, $float:false);
+          @include grid-column($pull:$i, $collapse-left:null, $collapse-right:null, $float:false);
         }
       }
     }


### PR DESCRIPTION
This PR adds more granularity to the collapse feature of the row class. It allows you to collapse either side of the column rather than being forced to collapse both at the same time.
