### PR TITLE
add next_on_click setting for Orbit

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -271,7 +271,8 @@
       container.on('click', '.'+settings.next_class, self.next);
       container.on('click', '.'+settings.prev_class, self.prev);
 
-      container.on('click', '[data-orbit-slide]', self.link_bullet);
+      if (settings.next_on_click)
+        container.on('click', '[data-orbit-slide]', self.link_bullet);
       container.on('click', self.toggle_timer);
       if (settings.swipe) {
         slides_container.on('touchstart.fndtn.orbit',function(e) {
@@ -457,6 +458,7 @@
       timer_speed: 10000,
       pause_on_hover: true,
       resume_on_mouseout: false,
+      next_on_click: true,
       animation_speed: 500,
       stack_on_small: false,
       navigation_arrows: true,


### PR DESCRIPTION
The next_on_click setting was removed in commit 61fac2ef67a87f4d535cba0f819fc57aa2adaf24 (use css3 animations for orbit and support 1:1 touch movement) - I assume accidentally.  This commit adds it back in.
