### PR TITLE
Interchange regex

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -58,13 +58,10 @@
           if (last_path == path) return;
 
 
-          var regex = "/(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)$/";
-
-          if (new RegExp(regex,'i').test(path)){
-
-              $(el).css('background-image', 'url('+path+')');
-              el.data('interchange-last-path', path);
-              return trigger(path);
+          if (/\.(jpg|jpeg|png|gif|tiff|bmp)$/i.test(path)) {
+            $(el).css('background-image', 'url('+path+')');
+            el.data('interchange-last-path', path);
+            return trigger(path);
           }
 
           return $.get(path, function (response) {

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -58,7 +58,7 @@
           if (last_path == path) return;
 
 
-          var regex = "/^.(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)\??|#?./";
+          var regex = "/(\.jpg|\.jpeg|\.png|\.gif|\.tiff|\.bmp)$/";
 
           if (new RegExp(regex,'i').test(path)){
 


### PR DESCRIPTION
The regex used to look for CSS background images matches some paths that do not contain images, specifically it matches paths that contain a /. This is because - I think - the author has used the JavaScript literal format of the regex in a Regex object constructor which uses a string, hence the / delimiters are actually part of the regex - not what was intended.

I have simplified the regex to match on image extensions at the end of the path variable and have used the literal format; saves a variable that is only used once and a line of code. All other paths now fail to match and drop through to replace the content of the interchange div.
