### PR TITLE
Added grunt-autoprefixer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,14 +57,22 @@ module.exports = function(grunt) {
           'dist/assets/css/normalize.css': 'scss/normalize.scss',
           'dist/docs/assets/css/docs.css': 'doc/assets/scss/docs.scss'
         }
+      }
+    },
+
+    autoprefixer: {
+      options: {
+        browsers: ['Explorer >= 9', 'Android >= 2', 'iOS >= 5', '> 1%']
       },
+      dist: {
+        src: ['dist/assets/css/foundation.css', 'dist/docs/assets/css/docs.css']
+      }
+    },
+
+    cssmin: {
       dist_compressed: {
-        options: {
-          outputStyle:'compressed',
-          includePaths: ['scss']
-        },
         files: {
-          'dist/assets/css/foundation.min.css': '<%= foundation.scss %>'
+          'dist/assets/css/foundation.min.css': 'dist/assets/css/foundation.css'
         }
       }
     },
@@ -155,7 +163,7 @@ module.exports = function(grunt) {
       },
       sass: {
         files: ['scss/**/*.scss', 'doc/assets/**/*.scss'],
-        tasks: ['sass'],
+        tasks: ['sass', 'cssmin'],
         options: {
           livereload: false
         }
@@ -222,9 +230,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-rsync');
   grunt.loadNpmTasks('assemble');
   grunt.loadNpmTasks('grunt-newer');
+  grunt.loadNpmTasks('grunt-autoprefixer');
+  grunt.loadNpmTasks('grunt-contrib-cssmin');
 
   grunt.task.registerTask('watch_start', ['karma:dev_watch:start', 'watch']);
-  grunt.registerTask('build:assets', ['clean', 'sass', 'concat', 'uglify', 'copy', 'jst']);
+  grunt.registerTask('build:assets', ['clean', 'sass', 'autoprefixer', 'cssmin', 'concat', 'uglify', 'copy', 'jst']);
   grunt.registerTask('build', ['build:assets', 'assemble']);
   grunt.registerTask('travis', ['build', 'karma:continuous']);
   grunt.registerTask('develop', ['travis', 'watch_start']);

--- a/doc/assets/scss/_footer.scss
+++ b/doc/assets/scss/_footer.scss
@@ -12,7 +12,7 @@
   }
   .row.collapse form {
     input[type="text"] { font-size: 17px; font-weight: 200; color: #999; border: 0; }
-    .button { border: 0; -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; background: #257696; }
+    .button { border: 0; box-shadow: none; background: #257696; }
     .button:hover { background: #1b566d; }
   }
 }
@@ -30,7 +30,7 @@
     h2 {
       margin: 0; padding: 0 !important; 
       a {
-        -webkit-transition: all .25s ease-in-out; -moz-transition: all .25s ease-in-out; -o-transition: all .25s ease-in-out; transition: all .25s ease-in-out; font-family: "zurb-logo"; font-weight: normal; font-size: em-calc(18px); padding: 0; 
+        transition: all .25s ease-in-out; font-family: "zurb-logo"; font-weight: normal; font-size: em-calc(18px); padding: 0; 
         &:hover { @include opacity(0.8); }
         &.services { width: 190px; }
         span { display: none; }
@@ -55,7 +55,7 @@
     .support-links { background-position: center -635px; }
     .connect-links {
       padding: 50px 20px 0; background-position: center -9px;
-      .button { font-size: 12px; font-weight: normal; background: rgba(0, 0, 0, 0.1); color: #FFF !important; font-weight: bold; text-shadow: none; box-shadow: none; -webkit-box-shadow: none; -moz-box-shadow: none; border: none; padding: 6px 16px; } 
+      .button { font-size: 12px; font-weight: normal; background: rgba(0, 0, 0, 0.1); color: #FFF !important; font-weight: bold; text-shadow: none; box-shadow: none; border: none; padding: 6px 16px; } 
     }
 
     .global {

--- a/doc/assets/scss/_marketing-off-canvas.scss
+++ b/doc/assets/scss/_marketing-off-canvas.scss
@@ -19,14 +19,14 @@ $marketing-oc-width: 84%;
   // These classes are added with JS and trigger the actual animation.
   &.move-right {
     > .inner-wrap {
-      @include translate3d(83.5%,0,0);
+      transform: translate3d(83.5%,0,0);
     }
     a.exit-off-canvas { @include back-link;}
   }
 
   &.move-left {
     > .inner-wrap {
-      @include translate3d(-(83.5%),0,0);
+      transform: translate3d(-(83.5%),0,0);
 
     }
     a.exit-off-canvas { @include back-link; }

--- a/doc/assets/scss/_sidebar.scss
+++ b/doc/assets/scss/_sidebar.scss
@@ -73,8 +73,6 @@ $panel-bg-color: #FAFAFA;
 }
 .sidebar {
   input[type="search"]:focus {
-    -moz-box-shadow: 0 0 0 !important;
-    -webkit-box-shadow: 0 0 0 !important;
     box-shadow: 0 0 0 !important;
   }
 }

--- a/doc/includes/examples_global_rendered.html
+++ b/doc/includes/examples_global_rendered.html
@@ -1,13 +1,20 @@
 {{#markdown}}
 ```scss
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import "../functions";
 //
 // Foundation Variables
 //
 
-$experimental: true !default;
+// Data attribute namespace
+// styles get applied to [data-mysite-plugin], etc
+$namespace: false !default;
 
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
-// for compatibility with brower-based text zoom or user-set defaults.
+// for compatibility with browser-based text zoom or user-set defaults.
 
 // Since the typical default browser font-size is 16px, that makes the calculation for grid size.
 // If you want your base font-size to be different and not have it affect the grid breakpoints,
@@ -16,9 +23,6 @@ $base-font-size: 100% !default;
 
 // $base-line-height is 24px while $base-font-size is 16px
 $base-line-height: 150% !default;
-
-// This is the default html and body font-size for the base rem value.
-$rem-base: 16px !default;
 
 //
 // Global Foundation Mixins
@@ -30,9 +34,6 @@ $rem-base: 16px !default;
 // $radius - Default: $global-radius || 4px
 @mixin radius($radius:$global-radius) {
   @if $radius {
-    @if $experimental {
-      -webkit-border-radius: $radius;
-    }
     border-radius: $radius;
   }
 }
@@ -42,45 +43,12 @@ $rem-base: 16px !default;
 // We use this to create equal side border radius on elements.
 // $side - Options: left, right, top, bottom
 @mixin side-radius($side, $radius:$global-radius) {
-  @if $side == left {
-    @if $experimental {
-      -moz-border-radius-bottomleft: $radius;
-      -moz-border-radius-topleft: $radius;
-      -webkit-border-bottom-left-radius: $radius;
-      -webkit-border-top-left-radius: $radius;
-    }
-    border-bottom-left-radius: $radius;
-    border-top-left-radius: $radius;
-  }
-  @else if $side == right {
-    @if $experimental {
-      -moz-border-radius-topright: $radius;
-      -moz-border-radius-bottomright: $radius;
-      -webkit-border-top-right-radius: $radius;
-      -webkit-border-bottom-right-radius: $radius;
-    }
-    border-top-right-radius: $radius;
-    border-bottom-right-radius: $radius;
-  }
-  @else if $side == top {
-    @if $experimental {
-      -moz-border-radius-topright: $radius;
-      -moz-border-radius-topleft: $radius;
-      -webkit-border-top-right-radius: $radius;
-      -webkit-border-top-left-radius: $radius;
-    }
-    border-top-right-radius: $radius;
-    border-top-left-radius: $radius;
-  }
-  @else if $side == bottom {
-    @if $experimental {
-      -moz-border-radius-bottomright: $radius;
-      -moz-border-radius-bottomleft: $radius;
-      -webkit-border-bottom-right-radius: $radius;
-      -webkit-border-bottom-left-radius: $radius;
-    }
-    border-bottom-right-radius: $radius;
-    border-bottom-left-radius: $radius;
+  @if ($side == left or $side == right) {
+    border-bottom-#{$side}-radius: $radius;
+    border-top-#{$side}-radius: $radius;
+  } @else {
+    border-#{$side}-left-radius: $radius;
+    border-#{$side}-right-radius: $radius;
   }
 }
 
@@ -89,15 +57,9 @@ $rem-base: 16px !default;
 // We can control whether or not we have inset shadows edges.
 // $active - Default: true, Options: false
 @mixin inset-shadow($active:true) {
-  @if $experimental {
-    -webkit-box-shadow: $shiny-edge-size $shiny-edge-color inset;
-  }
   box-shadow: $shiny-edge-size $shiny-edge-color inset;
 
   @if $active { &:active {
-    @if $experimental {
-      -webkit-box-shadow: $shiny-edge-size $shiny-edge-active-color inset;
-    }
     box-shadow: $shiny-edge-size $shiny-edge-active-color inset; } }
 }
 
@@ -108,10 +70,6 @@ $rem-base: 16px !default;
 // $speed - Default: 300ms
 // $ease - Default:ease-out, Options: http://css-tricks.com/almanac/properties/t/transition-timing-function/
 @mixin single-transition($property:all, $speed:300ms, $ease:ease-out) {
-  @if $experimental {
-    -webkit-transition: $property $speed $ease;
-    -moz-transition: $property $speed $ease;
-  }
   transition: $property $speed $ease;
 }
 
@@ -119,16 +77,12 @@ $rem-base: 16px !default;
 //
 // We use this to add box-sizing across browser prefixes
 @mixin box-sizing($type:border-box) {
-  @if $experimental {
-    -moz-box-sizing: $type;
-    -webkit-box-sizing: $type;
-  }
   box-sizing: $type;
 }
 
 // @mixins
 //
-// We use this to create equilateral triangles
+// We use this to create isosceles triangles
 // $triangle-size - Used to set border-size. No default, set a px or em size.
 // $triangle-color - Used to set border-color which makes up triangle. No default
 // $triangle-direction - Used to determine which direction triangle points. Options: top, bottom, left, right
@@ -170,20 +124,44 @@ $rem-base: 16px !default;
 // $fade-time - Default: 300ms
 // $glowing-effect-color - Default: fade-out($primary-color, .25)
 @mixin block-glowing-effect($selector:focus, $fade-time:300ms, $glowing-effect-color:fade-out($primary-color, .25)) {
-  @if $experimental {
-    -webkit-transition: -webkit-box-shadow $fade-time, border-color $fade-time ease-in-out;
-    -moz-transition: -moz-box-shadow $fade-time, border-color $fade-time ease-in-out;
-  }
   transition: box-shadow $fade-time, border-color $fade-time ease-in-out;
 
   &:#{$selector} {
-    @if $experimental {
-      -webkit-box-shadow: 0 0 5px $glowing-effect-color;
-      -moz-box-shadow: 0 0 5px $glowing-effect-color;
-    }
     box-shadow: 0 0 5px $glowing-effect-color;
     border-color: $glowing-effect-color;
   }
+}
+
+// @mixins
+//
+// We use this to translate elements in 2D
+// $horizontal: Default: 0
+// $vertical: Default: 0
+@mixin translate2d($horizontal:0, $vertical:0) {
+  transform: translate($horizontal,$vertical)
+}
+
+// @mixins
+//
+// Makes an element visually hidden, but accessible.
+// @see http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+@mixin element-invisible {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
+// @mixins
+//
+// Turns off the element-invisible effect.
+@mixin element-invisible-off {
+  position: static !important;
+  height: auto;
+  width: auto;
+  overflow: visible;
+  clip: auto;
 }
 
 // We use these to control various global styles
@@ -198,8 +176,6 @@ $font-smoothing: antialiased !default;
 
 // We use these to control text direction settings
 $text-direction: ltr !default;
-
-// NOTE: No need to change this conditional statement, $text-direction variable controls it all.
 $default-float: left !default;
 $opposite-direction: right !default;
 @if $text-direction == ltr {
@@ -209,12 +185,13 @@ $opposite-direction: right !default;
   $default-float: right;
   $opposite-direction: left;
 }
-
 // We use these as default colors throughout
 $primary-color: #008CBA !default;
 $secondary-color: #e7e7e7 !default;
 $alert-color: #f04124 !default;
 $success-color: #43AC6A !default;
+$warning-color: #f08a24 !default;
+$info-color: #a0d3e8 !default;
 
 // We use these to make sure border radius matches unless we want it different.
 $global-radius: 3px !default;
@@ -230,19 +207,14 @@ $include-html-classes: true !default;
 $include-print-styles: true !default;
 $include-html-global-classes: $include-html-classes !default;
 
+$column-gutter: rem-calc(30) !default;
 
 // Media Query Ranges
-// $small-range: (rem-calc(0), rem-calc(640));
-// $medium-range: (rem-calc(641), rem-calc(1024));
-// $large-range: (rem-calc(1025), rem-calc(1440));
-// $xlarge-range: (rem-calc(1441), rem-calc(1920));
-// $xxlarge-range: (rem-calc(1921));
-
-$small-range: (0em, 40em);
-$medium-range: (40.063em, 64em);
-$large-range: (64.063em, 90em);
-$xlarge-range: (90.063em, 120em);
-$xxlarge-range: (120.063em);
+$small-range: (0em, 40em) !default;
+$medium-range: (40.063em, 64em) !default;
+$large-range: (64.063em, 90em) !default;
+$xlarge-range: (90.063em, 120em) !default;
+$xxlarge-range: (120.063em, 99999999em) !default;
 
 
 $screen: "only screen" !default;
@@ -280,36 +252,45 @@ $cursor-text-value: text !default;
 
 
 @include exports("global") {
-  @import url("http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");
-  
-  // Used to provide media query values for javascript components.
-  // Forward slash placed around everything to convince PhantomJS to read the value.
-  meta.foundation-mq-small {
-    font-family: "/" + unquote($small-only) + "/";
-    width: lower-bound($small-range);
-  }
-
-  meta.foundation-mq-medium {
-    font-family: "/" + unquote($medium-only) + "/";
-    width: lower-bound($medium-range);
-  }
-
-  meta.foundation-mq-large {
-    font-family: "/" + unquote($large-up) + "/";
-    width: lower-bound($large-range);
-  }
-
-  meta.foundation-mq-xlarge {
-    font-family: "/" + unquote($xlarge-up) + "/";
-    width: lower-bound($xlarge-range);
-  }
-
-  meta.foundation-mq-xxlarge {
-    font-family: "/" + unquote($xxlarge-up) + "/";
-    width: lower-bound($xxlarge-range);
-  }
 
   @if $include-html-global-classes {
+
+    meta.foundation-version {
+      font-family: "/5.2.1/";
+    }
+    // Used to provide media query values for javascript components.
+    // Forward slash placed around everything to convince PhantomJS to read the value.
+    meta.foundation-mq-small {
+      font-family: "/" + unquote($small-up) + "/";
+      width: lower-bound($small-range);
+    }
+
+    meta.foundation-mq-medium {
+      font-family: "/" + unquote($medium-up) + "/";
+      width: lower-bound($medium-range);
+    }
+
+    meta.foundation-mq-large {
+      font-family: "/" + unquote($large-up) + "/";
+      width: lower-bound($large-range);
+    }
+
+    meta.foundation-mq-xlarge {
+      font-family: "/" + unquote($xlarge-up) + "/";
+      width: lower-bound($xlarge-range);
+    }
+
+    meta.foundation-mq-xxlarge {
+      font-family: "/" + unquote($xxlarge-up) + "/";
+      width: lower-bound($xxlarge-range);
+    }
+
+    meta.foundation-data-attribute-namespace {
+      font-family: #{$namespace};
+    }
+
+    // Must be 100% for off canvas to work
+    html, body { height: 100%; }
 
     // Set box-sizing globally to handle padding and border widths
     *,
@@ -338,12 +319,8 @@ $cursor-text-value: text !default;
   a:hover { cursor: $cursor-pointer-value; }
 
     // Grid Defaults to get images and embeds to work properly
-    img,
-    object,
-    embed { max-width: 100%; height: auto; }
+    img { max-width: 100%; height: auto; }
 
-    object,
-    embed { height: 100%; }
     img { -ms-interpolation-mode: bicubic; }
 
     #map_canvas,
@@ -358,17 +335,13 @@ $cursor-text-value: text !default;
     .left   { float: left !important; }
     .right  { float: right !important; }
     .clearfix     { @include clearfix; }
-    .text-left    { text-align: left !important; }
-    .text-right   { text-align: right !important; }
-    .text-center  { text-align: center !important; }
-    .text-justify { text-align: justify !important; }
     .hide         { display: none; }
 
     // Font smoothing
     // Antialiased font smoothing works best for light text on a dark background.
     // Apply to single elements instead of globally to body.
-    // Note this only applies to webkit-based desktop browsers on the Mac.
-    .antialiased { -webkit-font-smoothing: antialiased; }
+    // Note this only applies to webkit-based desktop browsers and Firefox 25 (and later) on the Mac.
+    .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
     // Get rid of gap under images by making them display: inline-block; by default
     img {

--- a/doc/includes/examples_sass_variables.html
+++ b/doc/includes/examples_sass_variables.html
@@ -61,9 +61,6 @@ $rem-base: 16px !default;
 //   @return $pxWidth / $rem-base * 1rem;
 // }
 
-// Change whether or not you include browser prefixes
-$experimental: true !default;
-
 // Various global styles
 
 $default-float: left;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "grunt-karma": "~0.6.2",
     "grunt-rsync": "~0.2.1",
     "grunt-contrib-jst": "~0.5.1",
-    "jasmine-jquery": "~1.3.3"
+    "jasmine-jquery": "~1.3.3",
+    "grunt-autoprefixer": "~0.7.2",
+    "grunt-contrib-cssmin": "~0.9.0"
   },
   "repository" : { 
     "type" : "git",

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -12,8 +12,6 @@
 // Allows the use of rem-calc() or lower-bound() in your settings
 @import "foundation/functions";
 
-// $experimental: true;
-
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -12,6 +12,8 @@
 // Allows the use of rem-calc() or lower-bound() in your settings
 @import "foundation/functions";
 
+// $experimental: true;
+
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -148,9 +148,6 @@ $button-disabled-opacity: 0.7 !default;
   @if $disabled {
     cursor: $cursor-default-value;
     opacity: $button-disabled-opacity;
-    @if $experimental {
-      -webkit-box-shadow: none;
-    }
     box-shadow: none;
     &:hover,
     &:focus { background-color: $bg; }

--- a/scss/foundation/components/_clearing.scss
+++ b/scss/foundation/components/_clearing.scss
@@ -211,10 +211,7 @@ $clearing-carousel-thumb-active-border: 1px solid rgb(255,255,255) !default;
 
               a.th {
                 border: none;
-                @if $experimental {
-                  -webkit-box-shadow: none;
-                }
-                        box-shadow: none;
+                box-shadow: none;
                 display: block;
               }
 

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -110,9 +110,6 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   background-color: $input-bg-color;
   font-family: $input-font-family;
   border: $input-border-width $input-border-style $input-border-color;
-  @if $experimental {
-    -webkit-box-shadow: $input-box-shadow;
-  }
   box-shadow: $input-box-shadow;
   color: $input-font-color;
   display: block;

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -89,10 +89,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
       .column,
       .columns { padding: 0; }
       input {
-        -moz-border-radius-bottom#{$opposite-direction}: 0;
-        -moz-border-radius-top#{$opposite-direction}: 0;
-        -webkit-border-bottom-#{$opposite-direction}-radius: 0;
-        -webkit-border-top-#{$opposite-direction}-radius: 0;
+        @include side-radius($opposite-direction, 0);
       }
 
     }

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -11,6 +11,9 @@
 // styles get applied to [data-mysite-plugin], etc
 $namespace: false !default;
 
+// Control the inclusion of experimental properties
+$experimental: true !default;
+
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 
@@ -25,6 +28,16 @@ $base-line-height: 150% !default;
 //
 // Global Foundation Mixins
 //
+
+// @mixins
+//
+// We use this to optionally include experimental or 
+// explicitly vendor prefixed properties
+@mixin experimental() {
+  @if $experimental {
+    @content;
+  }
+}
 
 // @mixins
 //

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -11,7 +11,7 @@
 // styles get applied to [data-mysite-plugin], etc
 $namespace: false !default;
 
-$experimental: true !default;
+$experimental: false !default;
 
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
@@ -34,9 +34,6 @@ $base-line-height: 150% !default;
 // $radius - Default: $global-radius || 4px
 @mixin radius($radius:$global-radius) {
   @if $radius {
-    @if $experimental {
-      -webkit-border-radius: $radius;
-    }
     border-radius: $radius;
   }
 }
@@ -47,21 +44,9 @@ $base-line-height: 150% !default;
 // $side - Options: left, right, top, bottom
 @mixin side-radius($side, $radius:$global-radius) {
   @if ($side == left or $side == right) {
-    @if $experimental {
-      -moz-border-radius-bottom#{$side}: $radius;
-      -moz-border-radius-top#{$side}: $radius;
-      -webkit-border-bottom-#{$side}-radius: $radius;
-      -webkit-border-top-#{$side}-radius: $radius;
-    }
     border-bottom-#{$side}-radius: $radius;
     border-top-#{$side}-radius: $radius;
   } @else {
-    @if $experimental {
-      -moz-border-radius-#{$side}left: $radius;
-      -moz-border-radius-#{$side}right: $radius;
-      -webkit-border-#{$side}-left-radius: $radius;
-      -webkit-border-#{$side}-right-radius: $radius;
-    }
     border-#{$side}-left-radius: $radius;
     border-#{$side}-right-radius: $radius;
   }
@@ -72,15 +57,9 @@ $base-line-height: 150% !default;
 // We can control whether or not we have inset shadows edges.
 // $active - Default: true, Options: false
 @mixin inset-shadow($active:true) {
-  @if $experimental {
-    -webkit-box-shadow: $shiny-edge-size $shiny-edge-color inset;
-  }
   box-shadow: $shiny-edge-size $shiny-edge-color inset;
 
   @if $active { &:active {
-    @if $experimental {
-      -webkit-box-shadow: $shiny-edge-size $shiny-edge-active-color inset;
-    }
     box-shadow: $shiny-edge-size $shiny-edge-active-color inset; } }
 }
 
@@ -91,10 +70,6 @@ $base-line-height: 150% !default;
 // $speed - Default: 300ms
 // $ease - Default:ease-out, Options: http://css-tricks.com/almanac/properties/t/transition-timing-function/
 @mixin single-transition($property:all, $speed:300ms, $ease:ease-out) {
-  @if $experimental {
-    -webkit-transition: $property $speed $ease;
-    -moz-transition: $property $speed $ease;
-  }
   transition: $property $speed $ease;
 }
 
@@ -102,10 +77,6 @@ $base-line-height: 150% !default;
 //
 // We use this to add box-sizing across browser prefixes
 @mixin box-sizing($type:border-box) {
-  @if $experimental {
-    -moz-box-sizing: $type;
-    -webkit-box-sizing: $type;
-  }
   box-sizing: $type;
 }
 
@@ -153,17 +124,9 @@ $base-line-height: 150% !default;
 // $fade-time - Default: 300ms
 // $glowing-effect-color - Default: fade-out($primary-color, .25)
 @mixin block-glowing-effect($selector:focus, $fade-time:300ms, $glowing-effect-color:fade-out($primary-color, .25)) {
-  @if $experimental {
-    -webkit-transition: -webkit-box-shadow $fade-time, border-color $fade-time ease-in-out;
-    -moz-transition: -moz-box-shadow $fade-time, border-color $fade-time ease-in-out;
-  }
   transition: box-shadow $fade-time, border-color $fade-time ease-in-out;
 
   &:#{$selector} {
-    @if $experimental {
-      -webkit-box-shadow: 0 0 5px $glowing-effect-color;
-      -moz-box-shadow: 0 0 5px $glowing-effect-color;
-    }
     box-shadow: 0 0 5px $glowing-effect-color;
     border-color: $glowing-effect-color;
   }
@@ -175,12 +138,6 @@ $base-line-height: 150% !default;
 // $horizontal: Default: 0
 // $vertical: Default: 0
 @mixin translate2d($horizontal:0, $vertical:0) {
-  @if $experimental {
-    -webkit-transform: translate($horizontal,$vertical);
-    -moz-transform: translate($horizontal,$vertical);
-    -ms-transform: translate($horizontal,$vertical);
-    -o-transform: translate($horizontal,$vertical);
-  }
   transform: translate($horizontal,$vertical)
 }
 

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -11,8 +11,6 @@
 // styles get applied to [data-mysite-plugin], etc
 $namespace: false !default;
 
-$experimental: false !default;
-
 // The default font-size is set to 100% of the browser style sheet (usually 16px)
 // for compatibility with browser-based text zoom or user-set defaults.
 

--- a/scss/foundation/components/_joyride.scss
+++ b/scss/foundation/components/_joyride.scss
@@ -172,10 +172,6 @@ $joyride-screenfill: rgba(0,0,0,0.5) !default;
       position: absolute;
       border-radius: 3px;
       z-index: 102;
-      @if $experimental {
-        -moz-box-shadow: 0 0 30px #ffffff;
-        -webkit-box-shadow: 0 0 15px #ffffff;
-      }
       box-shadow: 0 0 15px #ffffff;
     }
 

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -301,24 +301,14 @@ $menu-slide: "transform 500ms ease" !default;
     @else {
       left: ($tabbar-menu-icon-width - $width)/2;
     }
-    @if $experimental {
-      -webkit-box-shadow: 1px 0px                       1px $thickness $color,
-                          1px ($gap + $thickness)       1px $thickness $color,
-                          1px (2*$gap + 2*$thickness)   1px $thickness $color;
-    }
-      box-shadow:         0   0px                       0   $thickness $color,
-                          0   $gap + $thickness         0   $thickness $color,
-                          0   (2 * $gap + 2*$thickness) 0   $thickness $color;
+    box-shadow: 0   0px                       0   $thickness $color,
+                0   $gap + $thickness         0   $thickness $color,
+                0   (2 * $gap + 2*$thickness) 0   $thickness $color;
   }
   &:hover span {
-    @if $experimental {
-      -webkit-box-shadow: 1px 0px                       1px $thickness $hover-color,
-                          1px ($gap + $thickness)       1px $thickness $hover-color,
-                          1px (2*$gap + 2*$thickness)   1px $thickness $hover-color;
-    }
-      box-shadow:         0   0px                       0   $thickness $hover-color,
-                          0   $gap + $thickness         0   $thickness $hover-color,
-                          0   (2 * $gap + 2*$thickness) 0   $thickness $hover-color;
+    box-shadow: 0   0px                       0   $thickness $hover-color,
+                0   $gap + $thickness         0   $thickness $hover-color,
+                0   (2 * $gap + 2*$thickness) 0   $thickness $hover-color;
   }
 }
 

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -97,22 +97,13 @@ $menu-slide: "transform 500ms ease" !default;
   box-sizing: content-box;
   -webkit-overflow-scrolling: touch;
   @if $position == left {
-    @include translate3d(-100%,0,0);
+    transform: translate3d(-100%,0,0);
     left: 0;
   }
   @if $position == right {
-    @include translate3d(100%,0,0);
+    transform: translate3d(100%,0,0);
     right: 0;
   }
-}
-
-// TRANSLATE 3D
-@mixin translate3d($tx,$ty,$tz) {
-  -webkit-transform: translate3d($tx,$ty,$tz);
-  -moz-transform: translate3d($tx,$ty,$tz);
-  -ms-transform: translate3d($tx,$ty,$tz);
-  -o-transform: translate3d($tx,$ty,$tz);
-  transform: translate3d($tx,$ty,$tz)
 }
 
 // OFF CANVAS WRAP
@@ -355,14 +346,14 @@ $menu-slide: "transform 500ms ease" !default;
     // These classes are added with JS and trigger the actual animation.
     .move-right {
       > .inner-wrap {
-        @include translate3d($off-canvas-width,0,0);
+        transform: translate3d($off-canvas-width,0,0);
       }
       .exit-off-canvas { @include back-link;}
     }
 
     .move-left {
       > .inner-wrap {
-        @include translate3d(-($off-canvas-width),0,0);
+        transform: translate3d(-($off-canvas-width),0,0);
 
       }
       .exit-off-canvas { @include back-link; }

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -326,7 +326,7 @@ $menu-slide: "transform 500ms ease" !default;
       padding: $tabbar-menu-icon-padding;
       color: $topbar-menu-link-color;
       position: relative;
-      @include translate3d(0,0,0);
+      transform: translate3d(0,0,0);
 
       // this is the actual hamburger icon
       @include hamburger();

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -122,10 +122,6 @@ $menu-slide: "transform 500ms ease" !default;
   @include kill-flicker;
   @include wrap-base;
   @include clearfix;
-  -webkit-transition: -webkit-#{$menu-slide};
-  -moz-transition: -moz-#{$menu-slide};
-  -ms-transition: -ms-#{$menu-slide};
-  -o-transition: -o-#{$menu-slide};
   transition: #{$menu-slide};
 }
 

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -44,20 +44,6 @@ $preloader-class: "preloader" !default;
 @include exports("orbit") {
   @if $include-html-orbit-classes {
 
-    @if $experimental {
-      @-webkit-keyframes rotate {
-        from { -webkit-transform: rotate(0deg); }
-        to { -webkit-transform: rotate(360deg); }
-      }
-      @-moz-keyframes rotate {
-        from { -moz-transform: rotate(0deg); }
-        to { -moz-transform: rotate(360deg); }
-      }
-      @-o-keyframes rotate {
-        from { -o-transform: rotate(0deg); }
-        to { -o-transform: rotate(360deg); }
-      }
-    }
     @keyframes rotate {
       from { transform: rotate(0deg); }
       to { transform: rotate(360deg); }
@@ -103,20 +89,6 @@ $preloader-class: "preloader" !default;
       border: solid 3px;
       border-color: #555 #fff;
       @include radius(1000px);
-      @if $experimental {
-        -webkit-animation-name: rotate;
-        -webkit-animation-duration: 1.5s;
-        -webkit-animation-iteration-count: infinite;
-        -webkit-animation-timing-function: linear;
-        -moz-animation-name: rotate;
-        -moz-animation-duration: 1.5s;
-        -moz-animation-iteration-count: infinite;
-        -moz-animation-timing-function: linear;
-        -o-animation-name: rotate;
-        -o-animation-duration: 1.5s;
-        -o-animation-iteration-count: infinite;
-        -o-animation-timing-function: linear;
-      }
       animation-name: rotate;
       animation-duration: 1.5s;
       animation-iteration-count: infinite;

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -116,75 +116,37 @@ $preloader-class: "preloader" !default;
           -webkit-transform: translate3d(0,0,0);
           opacity: 0.01;
           transition: opacity .25s ease-in-out;
-          -moz-transition: opacity .25s ease-in-out;
-          -webkit-transition: opacity .25s ease-in-out;
           &.animate-in {
             opacity: 1;
             z-index: 20;
             transition: opacity 500ms ease-in-out;
-            -moz-transition: opacity 500ms ease-in-out;
-            -webkit-transition: opacity 500ms ease-in-out;
           }
           &.animate-out {
             opacity: 0.01;
             z-index: 10;
             transition: opacity 500ms ease-in-out;
-            -moz-transition: opacity 500ms ease-in-out;
-            -webkit-transition: opacity 500ms ease-in-out;
           }
         }
         &.swipe-next > * {
           -webkit-transform: translate3d(100%,0,0);
           &.animate-in {
-            -webkit-transform:translate3d(0,0,0);
-            -moz-transform:translate3d(0,0,0);
-            -ms-transform:translate3d(0,0,0);
-            -o-transform:translate3d(0,0,0);
             transform:translate3d(0,0,0);
-            -webkit-transition-duration:500ms;
-            -moz-transition-duration:500ms;
-            -o-transition-duration:500ms;
             transition-duration:500ms;
           }
           &.animate-out {
-            -webkit-transform:translate3d(-100%,0,0);
-            -moz-transform:translate3d(-100%,0,0);
-            -ms-transform:translate3d(-100%,0,0);
-            -o-transform:translate3d(-100%,0,0);
             transform:translate3d(-100%,0,0);
-            -webkit-transition-duration:500ms;
-            -moz-transition-duration:500ms;
-            -o-transition-duration:500ms;
             transition-duration:500ms;
           }
         }
 
         &.swipe-prev > * {
-          -webkit-transform:translate3d(-100%,0,0);
-          -moz-transform:translate3d(-100%,0,0);
-          -ms-transform:translate3d(-100%,0,0);
-          -o-transform:translate3d(-100%,0,0);
           transform:translate3d(-100%,0,0);
           &.animate-in {
-            -webkit-transform:translate3d(0,0,0);
-            -moz-transform:translate3d(0,0,0);
-            -ms-transform:translate3d(0,0,0);
-            -o-transform:translate3d(0,0,0);
             transform:translate3d(0,0,0);
-            -webkit-transition-duration:500ms;
-            -moz-transition-duration:500ms;
-            -o-transition-duration:500ms;
             transition-duration:500ms;
           }
           &.animate-out {
-            -webkit-transform:translate3d(100%,0,0);
-            -moz-transform:translate3d(100%,0,0);
-            -ms-transform:translate3d(100%,0,0);
-            -o-transform:translate3d(100%,0,0);
             transform:translate3d(100%,0,0);
-            -webkit-transition-duration:500ms;
-            -moz-transition-duration:500ms;
-            -o-transition-duration:500ms;
             transition-duration:500ms;
           }
         }
@@ -194,20 +156,12 @@ $preloader-class: "preloader" !default;
           top: 0;
           left: 0;
           width: 100%;
-          -webkit-transform:translate3d(100%,0,0);
-          -moz-transform:translate3d(100%,0,0);
-          -ms-transform:translate3d(100%,0,0);
-          -o-transform:translate3d(100%,0,0);
           transform:translate3d(100%,0,0);
 
           &.active {
             opacity: 1;
             top: 0;
             left: 0;
-            -webkit-transform:translate3d(0,0,0);
-            -moz-transform:translate3d(0,0,0);
-            -ms-transform:translate3d(0,0,0);
-            -o-transform:translate3d(0,0,0);
             transform:translate3d(0,0,0);
           }
 

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -128,9 +128,6 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
 
   // We can choose whether or not to include the default box-shadow.
   @if $box-shadow {
-    @if $experimental {
-      -webkit-box-shadow: $reveal-box-shadow;
-    }
     box-shadow: $reveal-box-shadow;
   }
 

--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -143,16 +143,6 @@ $switch-label-outline: 1px dotted #888 !default;
   // Hiding custom form spans since we auto-create them
   span.custom { display: none !important; }
 
-  // FIXME We should be able to remove this going forward.
-  // Bugfix for older Webkit, including mobile Webkit. Adapted from:
-  // http://css-tricks.com/webkit-sibling-bug/
-  // @media only screen and (-webkit-min-device-pixel-ratio:0) and (max-device-width:480px) {
-  //   @if $experimental { -webkit-animation: webkitSiblingBugfix infinite 1s; }
-  // }
-  // @media only screen and (-webkit-min-device-pixel-ratio:1.5) {
-  //   @if $experimental { -webkit-animation: none 0; }
-  // }
-
   form.custom & .hidden-field {
     margin-left: auto;
     position: absolute;
@@ -300,7 +290,5 @@ $switch-label-outline: 1px dotted #888 !default;
         }
 
       }
-
-      // @if $experimental { @-webkit-keyframes webkitSiblingBugfix { from { position: relative; } to { position: relative; } } }
   }
 }

--- a/scss/foundation/components/_switch.scss
+++ b/scss/foundation/components/_switch.scss
@@ -214,33 +214,19 @@ $switch-label-outline: 1px dotted #888 !default;
     span:last-child {
       border-color: scale-color($paddle-bg, $lightness: -30%);
       background: $paddle-bg;
-      @if $experimental {
-        background: -moz-linear-gradient(top, $paddle-bg 0%, scale-color($paddle-bg, $lightness: -5%) 100%);
-        background: -webkit-linear-gradient(top, $paddle-bg 0%, scale-color($paddle-bg, $lightness: -5%) 100%);
-      }
       background: linear-gradient(to bottom, $paddle-bg 0%, scale-color($paddle-bg, $lightness: -5%) 100%);
 
       // Building the alternating colored sides of the switch
-      @if $experimental {
-        -webkit-box-shadow: 2px 0 10px 0 rgba(0,0,0,0.07),
-                            1000px 0 0 1000px $positive-color,
-                            -2px 0 10px 0 rgba(0,0,0,0.07),
-                            -1000px 0 0 1000px $negative-color;
-      }
-      box-shadow:         2px 0 10px 0 rgba(0,0,0,0.07),
-                          1000px 0 0 980px $positive-color,
-                          -2px 0 10px 0 rgba(0,0,0,0.07),
-                          -1000px 0 0 1000px $negative-color;
+      box-shadow: 2px 0 10px 0 rgba(0,0,0,0.07),
+                  1000px 0 0 980px $positive-color,
+                  -2px 0 10px 0 rgba(0,0,0,0.07),
+                  -1000px 0 0 1000px $negative-color;
     }
 
     &:hover,
     &:focus {
       span:last-child {
         background: $paddle-bg;
-        @if $experimental {
-          background: -moz-linear-gradient(top, $paddle-bg 0%, scale-color($paddle-bg, $lightness: -10%) 100%);
-          background: -webkit-linear-gradient(top, $paddle-bg 0%, scale-color($paddle-bg, $lightness: -10%) 100%);
-        }
         background: linear-gradient(to bottom, $paddle-bg 0%, scale-color($paddle-bg, $lightness: -10%) 100%);
       }
     }
@@ -315,6 +301,6 @@ $switch-label-outline: 1px dotted #888 !default;
 
       }
 
-      @if $experimental { @-webkit-keyframes webkitSiblingBugfix { from { position: relative; } to { position: relative; } } }
+      // @if $experimental { @-webkit-keyframes webkitSiblingBugfix { from { position: relative; } to { position: relative; } } }
   }
 }

--- a/scss/foundation/components/_thumbs.scss
+++ b/scss/foundation/components/_thumbs.scss
@@ -45,16 +45,10 @@ $thumb-transition-speed: 200ms !default;
   display: inline-block;
   border: $thumb-border-style $border-width $thumb-border-color;
   max-width: 100%;
-  @if $experimental {
-    -webkit-box-shadow: $box-shadow;
-  }
   box-shadow: $box-shadow;
 
   &:hover,
   &:focus {
-    @if $experimental {
-      -webkit-box-shadow: $box-shadow-hover;
-    }
     box-shadow: $box-shadow-hover;
   }
 }

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -241,14 +241,9 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               top:0;
               height: 0;
               // Shh, don't tell, but box-shadows create the menu icon :)
-              @if $experimental {
-                -webkit-box-shadow: 1px 10px 1px 1px $topbar-menu-icon-color,
-                                    1px 16px 1px 1px $topbar-menu-icon-color,
-                                    1px 22px 1px 1px $topbar-menu-icon-color;
-              }
-              box-shadow:         0 10px 0 1px $topbar-menu-icon-color,
-                                  0 16px 0 1px $topbar-menu-icon-color,
-                                  0 22px 0 1px $topbar-menu-icon-color;
+              box-shadow: 0 10px 0 1px $topbar-menu-icon-color,
+                          0 16px 0 1px $topbar-menu-icon-color,
+                          0 22px 0 1px $topbar-menu-icon-color;
             }
           }
         }
@@ -265,14 +260,9 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           a { color: $topbar-menu-link-color-toggled;
             &::after {
               // Shh, don't tell, but box-shadows create the menu icon :)
-              @if $experimental {
-                -webkit-box-shadow: 1px 10px 1px 1px $topbar-menu-icon-color-toggled,
-                                    1px 16px 1px 1px $topbar-menu-icon-color-toggled,
-                                    1px 22px 1px 1px $topbar-menu-icon-color-toggled;
-              }
-              box-shadow:         0 10px 0 1px $topbar-menu-icon-color-toggled,
-                                  0 16px 0 1px $topbar-menu-icon-color-toggled,
-                                  0 22px 0 1px $topbar-menu-icon-color-toggled;
+              box-shadow: 0 10px 0 1px $topbar-menu-icon-color-toggled,
+                          0 16px 0 1px $topbar-menu-icon-color-toggled,
+                          0 22px 0 1px $topbar-menu-icon-color-toggled;
             }
           }
         }

--- a/scss/foundation/components/_xy-center.scss
+++ b/scss/foundation/components/_xy-center.scss
@@ -10,15 +10,11 @@
 @mixin x-center() {
   position:absolute;
   left:50%;
-  -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
   transform: translateX(-50%);
 }
 @mixin y-center() {
   position:relative;
   top:50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 
@@ -26,8 +22,6 @@
   position:absolute;
   top:50%;
   left:50%;
-  -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 }
 


### PR DESCRIPTION
As per #4123, I've added **grunt-autoprefixer** and **grunt-contrib-cssmin** (to create a minified version instead of running the sass and autoprefix tasks twice). All vendor prefixed properties and associated mixins have been removed, except those that have been included: 
- to work around specific browser issues (several places in `_offcanvas.scss` for example)
- as a hack to target particular browsers  (`@-moz-document url-prefix()` in `_forms.scss` for example)
- or because they're for non standard properties (`-webkit-font-smoothing` and `-webkit-appearance` for example)

As discussed in the [associated issue](https://github.com/zurb/foundation/issues/4123), I've also added a mixin to control the inclusion of the aforementioned explicitly vendor prefixed properties (repurposing the  `$experimental` flag). Though I've not used the mixin in this PR, the intended use would be something like the following:

``` scss
@include experimental {
  -webkit-appearance: none !important;
}
```

I've tested it as much as I can with the browsers/devices that I have access to. Let me know if you'd like the changes squashed in to a single commit.
