### PR TITLE
Performance issue with top bar on mobile with touch devices. 

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -232,7 +232,7 @@
           return;
         }
 
-        S('[' + self.attr_name() + '] li').removeClass('hover');
+        S('[' + self.attr_name() + '] li.hover').removeClass('hover');
       });
 
       // Go up a level on Click


### PR DESCRIPTION
We had a top bar with 400 + menu items with children which caused performance problems on mobile devices when scrolling or touching webpage. We tracked this down to code that removed hover class on touch. This commit fixes the performance by only finding li's that have the hover class since removing hover from an li that doesn't have it is a no-op. This avoids jquery creating and processing object with menu items.
