### PR TITLE
Change 'document' to 'window' in code example

### DIFF
--- a/doc/pages/javascript-utilities.html
+++ b/doc/pages/javascript-utilities.html
@@ -127,7 +127,7 @@ $('.button').on('click', function(e){
 });
 
 // Resize function
-$(document).on('resize', function(e){
+$(window).on('resize', function(e){
   // Do responsive stuff
 });
 ```
@@ -143,7 +143,7 @@ $('.button').on('click', Foundation.utils.debounce(function(e){
 }, 300, true));
 
 // Throttled resize function
-$(document).on('resize', Foundation.utils.throttle(function(e){
+$(window).on('resize', Foundation.utils.throttle(function(e){
   // Do responsive stuff
 }, 300));
 ```


### PR DESCRIPTION
The current code example of binding a resize event to `document` does not actually work. Binding the  event to `window` does. :)
