### PR TITLE
Fixed Orbit height issues

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -359,9 +359,10 @@
       });
       
       $(document).on('click', '[data-orbit-link]', self.link_custom);
-      $(window).on('resize', self.compute_dimensions);
-      Foundation.utils.image_loaded(this.slides().children('img'), self.compute_dimensions);
-      Foundation.utils.image_loaded(this.slides().children('img'), function() {
+      $(window).on('load resize', self.compute_dimensions);
+      var children = this.slides().find('img');
+      Foundation.utils.image_loaded(children, self.compute_dimensions);
+      Foundation.utils.image_loaded(children, function() {
         container.prev('.preloader').css('display', 'none');
         self.update_slide_number(idx);
         self.update_active_link(idx);


### PR DESCRIPTION
This solves problems with instances of Orbit that do not have direct image children.

compute_dimensions is now also called on window.load() since this event get triggered after all assets on the page have been loaded.

I changed the children() search to use find(). We cannot always guarantee that there will be direct image children. So find will find all of the child images. I know that children() is faster than find() but we are talking about micro seconds here. I think that the added functionality is worth it.

Also the children are stored in a variable. This way find() is only called once and not twice like children() was.
