### PR TITLE
fixed off canvas overflow behavior on android devices - fixes #4787

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -113,7 +113,7 @@ $menu-slide: "transform 500ms ease" !default;
   @include wrap-base;
   overflow: hidden;
   &.move-right,
-  &.move-left { height: 100%; }
+  &.move-left { min-height: 100%; }
 }
 
 @mixin translate3d($tx,$ty,$tz) {


### PR DESCRIPTION
Basically I've got no explanation why this works. But changing `height` to `min-height` solves in #4787 described problems on my android device.
