### PR TITLE
change nth-child to nth-of-type for block grid

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -80,7 +80,7 @@ $block-grid-media-queries: true !default;
       @if $per-row == $i {
         $grid-column: '';
       }
-      &:nth-child(#{$per-row}n#{unquote($grid-column)}) {
+      &:nth-of-type(#{$per-row}n#{unquote($grid-column)}) {
         padding-left: ($spacing - (($spacing / $per-row) * ($per-row - ($i - 1))));
         padding-right: ($spacing - (($spacing / $per-row) * $i));
       }


### PR DESCRIPTION
When using foundation and emberjs, the added script tags that are placed inside the ul cause layout issues when using nth-child.
