### PR TITLE
Add -webkit-appearance reset for submit input

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -381,6 +381,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     input[type="tel"],
     input[type="time"],
     input[type="url"],
+    input[type="submit"],
     textarea {
       -webkit-appearance: none;
       @include form-element;


### PR DESCRIPTION
This reset was present on previous versions of Foundation but missing on 5.2.1
