### PR TITLE
Adding support for `is_hover` to Tabs

### DIFF
--- a/doc/includes/examples_javascript_data_options.html
+++ b/doc/includes/examples_javascript_data_options.html
@@ -303,9 +303,13 @@
       <td>1</td>
     </tr>
     <tr>
-      <td rowspan="1">Tab</td>
+      <td rowspan="2">Tab</td>
       <td>active_class</td>
       <td>'active'</td>
+    </tr>
+    <tr>
+      <td>is_hover</td>
+      <td>false</td>
     </tr>
     <tr>
       <td rowspan="6">Tooltip</td>

--- a/doc/includes/examples_progress_variables.html
+++ b/doc/includes/examples_progress_variables.html
@@ -2,7 +2,7 @@
 ```scss
 $include-html-media-classes: $include-html-classes;
 
-// We use this to se the prog bar height
+// We use this to set the prog bar height
 $progress-bar-height: rem-calc(25);
 $progress-bar-color: transparent;
 

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -11,7 +11,8 @@
       active_class: 'active',
       callback : function () {},
       deep_linking: false,
-      scroll_to_content: true
+      scroll_to_content: true,
+      is_hover: false
     },
 
     default_tab_hashes: [],
@@ -35,12 +36,18 @@
       var self = this,
           S = this.S;
 
-      // Click event: tab title
-      S(this.scope).off('.tab').on('click.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        self.toggle_active_tab(S(this).parent());
-      });
+      S(this.scope)
+        .off('.tab')
+        .on('click.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
+          var settings = S(this).closest('[' + self.attr_name() +']').data(self.attr_name(true) + '-init');
+          e.preventDefault();
+          e.stopPropagation();
+          if (!settings.is_hover || Modernizr.touch) self.toggle_active_tab(S(this).parent());
+        })
+        .on('mouseenter.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
+          var settings = S(this).closest('[' + self.attr_name() +']').data(self.attr_name(true) + '-init');
+          if (settings.is_hover) self.toggle_active_tab(S(this).parent());
+        });
 
       // Location hash change event
       S(window).on('hashchange.fndtn.tab', function (e) {

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -38,12 +38,14 @@
 
       S(this.scope)
         .off('.tab')
+        // Click event: tab title
         .on('click.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
           var settings = S(this).closest('[' + self.attr_name() +']').data(self.attr_name(true) + '-init');
           e.preventDefault();
           e.stopPropagation();
           if (!settings.is_hover || Modernizr.touch) self.toggle_active_tab(S(this).parent());
         })
+        // Hover event: tab title
         .on('mouseenter.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
           var settings = S(this).closest('[' + self.attr_name() +']').data(self.attr_name(true) + '-init');
           if (settings.is_hover) self.toggle_active_tab(S(this).parent());

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -41,9 +41,11 @@
         // Click event: tab title
         .on('click.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {
           var settings = S(this).closest('[' + self.attr_name() +']').data(self.attr_name(true) + '-init');
-          e.preventDefault();
-          e.stopPropagation();
-          if (!settings.is_hover || Modernizr.touch) self.toggle_active_tab(S(this).parent());
+          if (!settings.is_hover || Modernizr.touch) {
+            e.preventDefault();
+            e.stopPropagation();
+            self.toggle_active_tab(S(this).parent());
+          }
         })
         // Hover event: tab title
         .on('mouseenter.fndtn.tab', '[' + this.attr_name() + '] > dd > a', function (e) {

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -852,7 +852,7 @@
 
 // $include-html-media-classes: $include-html-classes;
 
-// We use this to se the prog bar height
+// We use this to set the prog bar height
 // $progress-bar-height: rem-calc(25);
 // $progress-bar-color: #f6f6f6  ;
 


### PR DESCRIPTION
Adding `is_hover` support for tabs.

Option already exists for dropdowns, now also applied to tabs. Handy for building megamenus using existing tab functionality, and touch friendly via modernizr.
