### PR TITLE
Added "down" media queries

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -222,18 +222,23 @@ $portrait: "#{$screen} and (orientation: portrait)" !default;
 
 $small-up: $screen !default;
 $small-only: "#{$screen} and (max-width: #{upper-bound($small-range)})" !default;
+$small-down: "#{$screen} and (max-width:#{upper-bound($small-range)})" !default;
 
 $medium-up: "#{$screen} and (min-width:#{lower-bound($medium-range)})" !default;
 $medium-only: "#{$screen} and (min-width:#{lower-bound($medium-range)}) and (max-width:#{upper-bound($medium-range)})" !default;
+$medium-down: "#{$screen} and (max-width:#{upper-bound($medium-range)})" !default;
 
 $large-up: "#{$screen} and (min-width:#{lower-bound($large-range)})" !default;
 $large-only: "#{$screen} and (min-width:#{lower-bound($large-range)}) and (max-width:#{upper-bound($large-range)})" !default;
+$large-down: "#{$screen} and (max-width:#{upper-bound($large-range)})" !default;
 
 $xlarge-up: "#{$screen} and (min-width:#{lower-bound($xlarge-range)})" !default;
 $xlarge-only: "#{$screen} and (min-width:#{lower-bound($xlarge-range)}) and (max-width:#{upper-bound($xlarge-range)})" !default;
+$xlarge-down: "#{$screen} and (max-width:#{upper-bound($xlarge-range)})" !default;
 
 $xxlarge-up: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)})" !default;
 $xxlarge-only: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (max-width:#{upper-bound($xxlarge-range)})" !default;
+$xxlarge-down: "#{$screen} and (max-width:#{upper-bound($xxlarge-range)})" !default;
 
 // Legacy
 $small: $medium-up;


### PR DESCRIPTION
Added media queries with a max-width and no min-width.

It would be nice to have media queries that catch everything less than a given size. I know the philosophy of Zurb Foundation is mobile first, but there are times when the default/existing styles are correct for desktop, but need to be adjusted only for mobile. Having the appropriate media queries will save excess code.

I know $small-down, and $xxlarge-down are both redundant, but so are $small-up, and $xxlarge-up, so I've included them here for completeness sake, perhaps they could be ommited.

Also, in the guidlines for contributing, it was instructed to update the documentation, but I didn't see where the documentation is, so I haven't done so (sorry). Perhaps that could be added to the instructions.
