### PR TITLE
Fix slider support for floating point initial value

### DIFF
--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -188,7 +188,7 @@
         self.initialize_settings(handle);
 
         if (val) {
-          self.set_ui($(handle), parseInt(val));
+          self.set_ui($(handle), parseFloat(val));
         } else {
           self.set_initial_position($(this));
         }


### PR DESCRIPTION
When using floating point value as initial slider value (e.g. data-slider="4.25") it is getting rounded. I changed parseInt to parseFloat in reflow function. After initialization everything works fine with step being floating point.
