### PR TITLE
Adjust set_namespace to default to using meta if undefined.

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -289,7 +289,7 @@
     stylesheet : $('<style></style>').appendTo('head')[0].sheet,
 
     global: {
-      namespace: ''
+      namespace: undefined
     },
 
     init : function (scope, libraries, method, options, response) {
@@ -362,19 +362,24 @@
 
     set_namespace: function () {
 
-      // Don't bother reading the namespace out of the meta tag
-      // if the namespace has been set globally in javascript
+      // Description:
+      //    Don't bother reading the namespace out of the meta tag
+      //    if the namespace has been set globally in javascript
       //
-      // Example: something like Foundation.global.namespace = 'my-namespace';
+      // Example: 
+      //    Foundation.global.namespace = 'my-namespace';
+      // or make it an empty string:
+      //    Foundation.global.namespace = '';
       //
-      // Otherwise, if the namespace hasn't been set globally,
-      // read it out of the meta tag
       //
-      var namespace = this.global.namespace || $('.foundation-data-attribute-namespace').css('font-family');
 
-      if (/false/i.test(namespace)) return;
+      // If the namespace has not been set (is undefined), try to read it out of the meta element. 
+      // Otherwise use the globally defined namespace, even if it's empty ('')
+      var namespace = ( this.global.namespace === undefined ) ? $('.foundation-data-attribute-namespace').css('font-family') : this.global.namespace;
       
-      this.global.namespace = namespace;
+      // Finally, if the namsepace is either undefined or false, set it to an empty string. 
+      // Otherwise use the namespace value.
+      this.global.namespace = ( namespace === undefined || /false/i.test(namespace) ) ? '' : namespace;
     },
 
     libs : {},


### PR DESCRIPTION
Can be set to namespace string, empty string or false. This patch stemmed from this [commit thread](https://github.com/zurb/foundation/commit/ed4b8fbd9c61f56e06429ee44f9ac433db8c5c96#commitcomment-5840347).

The update better supports overrides via JS, maintaining backward compatibility. It will always default to reading the value out of the `<meta>` tag. If the meta font-family value is 'false', the global namespace value will default to an empty string. It will continue to allow developers to override the namespace via JS.

Override options are:

Custom value:
`Foundation.global.namespace = 'custom-namespace';`

Blank (empty string)
`Foundation.global.namespace = '';`

or False (Boolean or String), will default to empty string
`Foundation.global.namespace = false;`

For example, the following block:

```
Foundation.global.namespace = 'my-app';
$(document).foundation();
```

Will namespace components: `data-my-app-<component>`
