### PR TITLE
Fix: Modal does not have background outside viewport on small medias

### DIFF
--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -75,7 +75,6 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     top:0;
     #{$default-float}: 0;
     @media #{$small-only} {
-      height: 100vh;
       min-height:100vh;
     }
     @media #{$medium-up} {


### PR DESCRIPTION
If the reval modal is larger then the viewport the background disappears
when scrolling the modal up. The cause is the the height: 100vh, that
limits the height of the modal to the viewport height.
