### PR TITLE
Fix: topbar title h1 disappers behind menu item.

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -189,7 +189,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           a {
             font-weight: $topbar-title-weight;
             color: $topbar-link-color;
-            width: 50%;
+            width: 75%;
             display: block;
             padding: 0 $topbar-link-padding;
           }


### PR DESCRIPTION
This is only a small issue and I am not sure whether it really matters
in a really life context. When pulling the browser window smaller, the
title disappears behind the Menu item. This can be remedied by giving
the title a little more space. There is still sufficient space for the
Menu item.
