### PR TITLE
Allowing main breadcrumb color setting to work in nav and ul containers.

### DIFF
--- a/scss/foundation/components/_breadcrumbs.scss
+++ b/scss/foundation/components/_breadcrumbs.scss
@@ -62,12 +62,11 @@ $crumb-slash: "/" !default;
   float: $default-float;
   font-size: $crumb-font-size;
   text-transform: $crumb-font-transform;
+  color: $crumb-font-color;
 
   &:hover a, &:focus a { text-decoration: $crumb-link-decor; }
 
-  a,
-  span {
-    text-transform: $crumb-font-transform;
+  a {
     color: $crumb-font-color;
   }
 


### PR DESCRIPTION
Sort of fixes zurb/foundation#4801

Link color setting variable can now be applied to both `nav` and `ul` markup scenarios. I have removed the extra `text-transform` property as it should bubble up properly.  Text underline on hover will likely not be possible with a `nav > a` xpath because the `:before` content is a child of the link and underlines on hover as well.
