### PR TITLE
Grunt option to run basic static files server for "dist" files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,6 @@ module.exports = function(grunt) {
       }
     },
 
-
     karma: {
       options: {
         configFile: 'karma.conf.js',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,6 +113,16 @@ module.exports = function(grunt) {
 
     clean: ['dist/'],
 
+    connect: {
+      server: {
+        options: {
+          port: 9001,
+          base: 'dist/'
+        }
+      }
+    },
+
+
     karma: {
       options: {
         configFile: 'karma.conf.js',
@@ -203,6 +213,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('assemble');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -219,4 +230,5 @@ module.exports = function(grunt) {
   grunt.registerTask('develop', ['travis', 'watch_start']);
   grunt.registerTask('deploy', ['build', 'rsync:dist']);
   grunt.registerTask('default', ['build', 'watch']);
+  grunt.registerTask('server', ['connect:server:keepalive']);
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compress": "~0.7.0",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jasmine": "~0.6.3",
     "grunt-contrib-jst": "~0.6.0",


### PR DESCRIPTION
I was thinking that it would be handy to have an option to automatically serve the `dist` files over a port.  This way you can really quickly check on a phone over a local network, or make better use of IE virtualization locally.

Feel free to reject this, or play with the idea.

Thanks!
