### PR TITLE
Replace static inline-list margin value

### DIFF
--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -14,6 +14,7 @@ $inline-list-top-margin: 0 !default;
 $inline-list-opposite-margin: 0 !default;
 $inline-list-bottom-margin: rem-calc(17) !default;
 $inline-list-default-float-margin: rem-calc(-22) !default;
+$inline-list-default-float-list-margin: rem-calc(22) !default;
 
 $inline-list-padding: 0 !default;
 
@@ -41,7 +42,7 @@ $inline-list-children-display: block !default;
   & > li {
     list-style: none;
     float: $default-float;
-    margin-#{$default-float}: rem-calc(22);
+    margin-#{$default-float}: $inline-list-default-float-list-margin;
     display: $inline-list-display;
     &>* { display: $inline-list-children-display; }
   }


### PR DESCRIPTION
Margin on inline-list always set to rem-calc(22), replaced with $inline-list-default-float-list-margin
