### PR TITLE
Orbit: `min-height` for slides_container (instead of `height`)

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -152,7 +152,7 @@
           
         };
         if (slides_container.height() != next.height() && settings.variable_height) {
-          slides_container.animate({'height': next.height()}, 250, 'linear', unlock);
+          slides_container.animate({'min-height': next.height()}, 250, 'linear', unlock);
         } else {
           unlock();
         }
@@ -166,7 +166,7 @@
       };
 
       if (next.height() > slides_container.height() && settings.variable_height) {
-        slides_container.animate({'height': next.height()}, 250, 'linear', start_animation);
+        slides_container.animate({'min-height': next.height()}, 250, 'linear', start_animation);
       } else {
         start_animation();
       }
@@ -237,7 +237,7 @@
           if ($(this).height() > h) { h = $(this).height(); }
         });
       }
-      slides_container.height(h);
+      slides_container.css('minHeight', String(h)+'px');
     };
 
     self.create_timer = function() {

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -190,6 +190,8 @@ $orbit-timer-hide-for-small: true !default;
 
           &.active {
             opacity: 1;
+            // "relative" positioning is required for variable height of children.
+            position:relative;
             top: 0;
             left: 0;
             @include translate3d(0,0,0);


### PR DESCRIPTION
Using `min-height` (with `position:relative`) allows the slide container
to get expanded, in case it contains elements of variable height (e.g.
accordions).

I could not find any problems, which I might have expected from changing the `position` attribute.
