### PR TITLE
Fixed incorrect class name

### DIFF
--- a/doc/pages/components/block_grid.html
+++ b/doc/pages/components/block_grid.html
@@ -12,7 +12,7 @@ title: Block grid
 
 <h3>Basic</h3>
 
-Use a simple `small-block-#` class to code up the block grid and specify the number of items in a row.
+Use a simple `small-block-grid-#` class to code up the block grid and specify the number of items in a row.
 
 <div class="row">
   <div class="large-6 columns">


### PR DESCRIPTION
Class name was missing "-grid"; didn't want the documentation to mislead anyone.
