### PR TITLE
Pagination li float fix

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -767,7 +767,7 @@
 
 // Pagination
 
-// $include-html-nav-classes: $include-html-classes;
+// $include-pagination-classes: $include-html-classes;
 
 // We use these to control the pagination container
 // $pagination-height: rem-calc(24);

--- a/scss/foundation/components/_pagination.scss
+++ b/scss/foundation/components/_pagination.scss
@@ -7,14 +7,14 @@
 //
 // @variables
 //
-$include-html-nav-classes: $include-html-classes !default;
+$include-pagination-classes: $include-html-classes !default;
 
 // We use these to control the pagination container
 $pagination-height: rem-calc(24) !default;
 $pagination-margin: rem-calc(-5) !default;
 
 // We use these to set the list-item properties
-$pagination-li-float: $default-float;
+$pagination-li-float: $default-float !default;
 $pagination-li-height: rem-calc(24) !default;
 $pagination-li-font-color: #222 !default;
 $pagination-li-font-size: rem-calc(14) !default;
@@ -133,7 +133,7 @@ $pagination-link-current-active-bg: $primary-color !default;
 }
 
 @include exports("pagination") {
-  @if $include-html-nav-classes {
+  @if $include-pagination-classes {
     ul.pagination {
       @include pagination;
     }


### PR DESCRIPTION
Current implementation of paginate overwrites the $pagination-li-float setting, this PR fixes it.

Additionally it changes the include-xxx-classes variable name to a pagination dedicated one ($include-pagination-classes) as it was re-using the $include-html-nav-classes.
