### PR TITLE
Added missing variable declaration

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -578,6 +578,7 @@
     },
 
     events : function (instance) {
+      var self = this;
       var orbit_instance = new Orbit(this.S(instance), this.S(instance).data('orbit-init'));
       this.S(instance).data(self.name + '-instance', orbit_instance);
     },


### PR DESCRIPTION
This should really fix the "reflow-bug" that produced the error message "compute_dimensions could not be found on undefined". https://github.com/zurb/foundation/issues/4651
