### PR TITLE
Orbit: Fix for links not working on some devices

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -188,6 +188,8 @@ $orbit-timer-hide-for-small: true !default;
           width: 100%;
           @include translate3d(100%,0,0);
 
+          > a { display: block; }
+
           &.active {
             opacity: 1;
             // "relative" positioning is required for variable height of children.


### PR DESCRIPTION
When a user wraps an image in a link inside Orbit, the link should be set to display:block. I have limited this styles to only links that are direct children of the <li>. We don't want to set all links inside Orbit to be display:block (such as links inside a caption).
