### PR TITLE
Add radius text to first alert box in kitchen sink

### DIFF
--- a/doc/includes/kitchen/examples_kitchen_alert.html
+++ b/doc/includes/kitchen/examples_kitchen_alert.html
@@ -1,5 +1,5 @@
 <div data-alert class="alert-box radius">
-  This is a standard alert (div.alert-box).
+  This is a standard alert (div.alert-box.radius).
   <a href="" class="close">&times;</a>
 </div>
 


### PR DESCRIPTION
Having the radius class on the first standard alert box without showing it in the code listing could be confusing for new users, especially since the second alert box doesn't have the radius.

I know it's super short and simple, but it was just something I noticed while browsing the docs.
