### PR TITLE
Adding more list variables for flexibility

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -174,6 +174,10 @@
 // $hr-margin: rem-calc(20);
 
 // We use these to style lists
+// $list-font-family: $paragraph-font-family;
+// $list-font-size: $paragraph-font-size;
+// $list-line-height: $paragraph-line-height;
+// $list-margin-bottom: $paragraph-margin-bottom;
 // $list-style-position: outside;
 // $list-side-margin: 1.1rem;
 // $list-ordered-side-margin: 1.4rem;

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -63,6 +63,10 @@ $hr-border-color: #ddd !default;
 $hr-margin: rem-calc(20) !default;
 
 // We use these to style lists
+$list-font-family: $paragraph-font-family !default;
+$list-font-size: $paragraph-font-size !default;
+$list-line-height: $paragraph-line-height !default;
+$list-margin-bottom: $paragraph-margin-bottom !default;
 $list-style-position: outside !default;
 $list-side-margin: 1.1rem !default;
 $list-ordered-side-margin: 1.4rem !default;
@@ -288,11 +292,11 @@ $align-class-breakpoints:
     ul,
     ol,
     dl {
-      font-size: $paragraph-font-size;
-      line-height: $paragraph-line-height;
-      margin-bottom: $paragraph-margin-bottom;
+      font-size: $list-font-size;
+      line-height: $list-line-height;
+      margin-bottom: $list-margin-bottom;
       list-style-position: $list-style-position;
-      font-family: $paragraph-font-family;
+      font-family: $list-font-family;
     }
 
     ul {


### PR DESCRIPTION
Hi there, love Foundation! First time pull request here. 

I love that you have `body-*` style for font option for general and now `paragraph-*` style for `<p>` tag, and was using them, but encountered an issue where list items inherited `paragraph-*` and not `body-*`.

This change will add flexibility by either keeping the current setup or overriding it.

Thanks for your consideration.
