### PR TITLE
Orbit: bullets: call `_prepare_direction` before `_goto`

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -212,19 +212,22 @@
         {
           var slide = container.find('[data-orbit-slide='+index+']');
           if (slide.index() != -1) {
+            index = slide.index() + 1;
+            self._prepare_direction(index);
             setTimeout(function(){
-              self._goto(slide.index() + 1);
+              self._goto(index);
             },100);
           }
         }
         else
         {
+          index = parseInt(index);
+          self._prepare_direction(index);
           setTimeout(function(){
-            self._goto(parseInt(index));
+            self._goto(index);
           },100);
         }
       }
-
     }
 
     self.timer_callback = function() {


### PR DESCRIPTION
This is in line with other calls to `_goto`, which call
`_prepare_direction` before `_goto`.
See commit e577378ae6d772988bfef5f245069be664642fc7.

This fixes the animation when going to a previous slide.
