### PR TITLE
Update _tables.scss

### DIFF
--- a/scss/foundation/components/_tables.scss
+++ b/scss/foundation/components/_tables.scss
@@ -1,7 +1,3 @@
-// Foundation by ZURB
-// foundation.zurb.com
-// Licensed under MIT Open Source
-
 @import "global";
 
 //
@@ -31,6 +27,13 @@ $table-head-font-color: #222 !default;
 $table-head-font-weight: bold !default;
 $table-head-padding: rem-calc(8 10 10) !default;
 
+// These control the table foot styles
+$table-foot-bg: $table-head-bg !default;
+$table-foot-font-size: $table-head-font-size !default;
+$table-foot-font-color: $table-head-font-color !default;
+$table-foot-font-weight: $table-head-font-weight !default;
+$table-foot-padding: $table-head-padding !default;
+
 // These control the row padding and font styles
 $table-row-padding: rem-calc(9 10) !default;
 $table-row-font-size: rem-calc(14) !default;
@@ -51,9 +54,8 @@ $table-margin-bottom: rem-calc(20) !default;
   margin-bottom: $table-margin-bottom;
   border: $table-border-style $table-border-size $table-border-color;
 
-  thead,
-  tfoot {
-    background: $table-head-bg;    
+  thead {
+    background: $table-head-bg;
 
     tr {
       th,
@@ -62,7 +64,20 @@ $table-margin-bottom: rem-calc(20) !default;
         font-size: $table-head-font-size;
         font-weight: $table-head-font-weight;
         color: $table-head-font-color;
-        text-align: $default-float;
+      }
+    }
+  }
+
+  tfoot {
+    background: $table-foot-bg;
+
+    tr {
+      th,
+      td {
+        padding: $table-foot-padding;
+        font-size: $table-foot-font-size;
+        font-weight: $table-foot-font-weight;
+        color: $table-foot-font-color;
       }
     }
   }
@@ -73,6 +88,7 @@ $table-margin-bottom: rem-calc(20) !default;
       padding: $table-row-padding;
       font-size: $table-row-font-size;
       color: $table-row-font-color;
+      text-align: $default-float;
     }
 
     &.even,
@@ -82,9 +98,10 @@ $table-margin-bottom: rem-calc(20) !default;
 
   thead tr th,
   tfoot tr th,
+  tfoot tr td,
+  tbody tr th,
   tbody tr td,
-  tr td,
-  tfoot tr td { display: $table-display; line-height: $table-line-height; }
+  tr td { display: $table-display; line-height: $table-line-height; }
 }
 
 


### PR DESCRIPTION
Allow different background colours anf font size and weight in header and footer (default is use the same as defined by the $table-head-\* variables, so is backwards compatible.

Also reduces the depth of cascade needed to override text alignment in td and th elements by moving the text-align directive out of tfoot and thead definitions
