### PR TITLE
Add "fixed" class

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -98,7 +98,7 @@
           expedition.css({position:'fixed', top: 0}).addClass('fixed');
         } else {
           expedition.prev('[' + self.add_namespace('data-magellan-expedition-clone') + ']').remove();
-          expedition.attr('style','');
+          expedition.attr('style','').removeClass('fixed');
         }
       });
     },

--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -95,7 +95,7 @@
             placeholder.attr(self.add_namespace('data-magellan-expedition-clone'),'');
             expedition.before(placeholder);
           }
-          expedition.css({position:'fixed', top: 0});
+          expedition.css({position:'fixed', top: 0}).addClass('fixed');
         } else {
           expedition.prev('[' + self.add_namespace('data-magellan-expedition-clone') + ']').remove();
           expedition.attr('style','');


### PR DESCRIPTION
Added a "fixed" class to magellan so developers have something to hook to to style it differently when it's position changes to fixed.

Since it gets removed from the dom and re-cloned each time it switches between fixed and static, there's no reason to clean up the fixed class.
