### PR TITLE
Prevent scroll from completing a full cycle

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -394,7 +394,7 @@
       tipOffset = Math.ceil(this.settings.$target.offset().top - window_half + this.settings.$next_tip.outerHeight());
 
       if (tipOffset != 0) {
-        $('html, body').animate({
+        $('html, body').stop().animate({
           scrollTop: tipOffset
         }, this.settings.scroll_speed, 'swing');
       }


### PR DESCRIPTION
Prevent scroll from completing a full cycle when quickly go to the next stop.
Otherwise, the animation will be queued and causes unexpected result.
