### PR TITLE
Replace top-level this keywords with window for usage with CommonJS and Browserify

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -296,4 +296,4 @@
       return valid;
     }
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -51,4 +51,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.alert.js
+++ b/js/foundation/foundation.alert.js
@@ -40,4 +40,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -533,4 +533,4 @@
     }
   };
 
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -303,4 +303,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -65,4 +65,4 @@
       });
     }
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -328,4 +328,4 @@
 
   };
 
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -846,4 +846,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -606,4 +606,4 @@
     });
   };
 
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -170,4 +170,4 @@
       $('[' + self.add_namespace('data-magellan-expedition-clone') + ']', self.scope).remove();
     }
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.offcanvas.js
+++ b/js/foundation/foundation.offcanvas.js
@@ -58,4 +58,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -602,4 +602,4 @@
   };
 
     
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -427,4 +427,4 @@
       fade: fade
     };
   }
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -197,4 +197,4 @@
 
   };
 
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -165,4 +165,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -269,4 +269,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -419,4 +419,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));


### PR DESCRIPTION
I tried using foundation in combination with [browserify](https://github.com/substack/node-browserify), however I noticed that all modules use `this` at the top level. 

However, when using CommonJS modules, which browserify does, `this` at the top level refers to the current `module.exports` object, instead of the `window` object. So unfortunately foundation will no longer load correctly in that context.

By replacing `this` with `window`, which has no drawbacks as far as I am aware, this problem is solved, and foundation can be used in a CommonJS module format as an additional benefit.
