### PR TITLE
Fix outerHeight for jQuery 1.8.0 version

### DIFF
--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -42,7 +42,7 @@
       });
       if (isStacked) return;
 
-      var heights = vals.map(function(){ return $(this).outerHeight() }).get();
+      var heights = vals.map(function(){ return $(this).outerHeight(false) }).get();
       if (settings.use_tallest) {
         var max = Math.max.apply(null, heights);
         vals.css('height', max);


### PR DESCRIPTION
The parameter 'includeMargin' is set to false by default (https://api.jquery.com/outerHeight/). However due to a bug in jQuery 1.8.0 the outerHeight returns an object instead of an integer: http://bugs.jquery.com/ticket/12159

Adding 'false' fixes the equalizer for jQuery 1.8.0 and wouldn't do harm as it is set to false by default.
