### PR TITLE
Add !important to label float: none.

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -152,7 +152,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
 
   // Alignment options
   @if $alignment == right {
-    float: none;
+    float: none !important;
     text-align: right;
   }
   @else if $alignment == inline {


### PR DESCRIPTION
Add !important to label float: none.

Stops .right from _global.scss overwriting this style.

Fixes #4362
