### PR TITLE
Equalize on stack

### DIFF
--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -133,8 +133,8 @@ Required Foundation Library: `foundation.equalizer.js`
 ```js
 $(document).foundation({
   equalizer:
-    // specify if Equalizer should make elements equal height on the small media query range
-    equalize_on_small: false
+    // specify if Equalizer should make elements equal height once they become stacked
+    equalize_on_stack: false
 });
 ```
 {{/markdown}}

--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -10,7 +10,7 @@
       use_tallest: true,
       before_height_change: $.noop,
       after_height_change: $.noop,
-      equalize_on_small: false
+      equalize_on_stack: false
     },
 
     init : function (scope, method, options) {
@@ -42,7 +42,7 @@
         }
       });
 
-      if (settings.equalize_on_small === false) {
+      if (settings.equalize_on_stack === false) {
         if (isStacked) return;
       };
 


### PR DESCRIPTION
equalize_on_small is now equalize_on_stack since it doesn't matter what the viewport size is, it matters if the elements Equalizer is watching becomes stacked or not.

Update zurb#4978
