### PR TITLE
Add Accessibility Classes

### DIFF
--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -36,7 +36,7 @@ $visibility-breakpoint-queries:
     $visibility-none-list: ();
     
     $visibility-visible-list: ();
-    $visbility-hidden-list:();
+    $visbility-hidden-list: ();
 
     $visibility-table-list: ();
     $visibility-table-header-group-list: ();

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -218,7 +218,7 @@ $visibility-breakpoint-queries:
             '.visible-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
           $visibility-hidden-list: append($visibility-hidden-list, unquote(
-            '.hidden-for-#{$visibility-comparison-breakpoint}, .hiddne-for-#{$visibility-comparison-breakpoint}-down'
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
           $visibility-table-list: append($visibility-table-list, unquote(
             'table.show-for-#{$visibility-comparison-breakpoint}, table.show-for-#{$visibility-comparison-breakpoint}-down'

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -249,10 +249,10 @@ $visibility-breakpoint-queries:
       }
       @if $include-accessibility-classes != false {
         #{$visibility-visible-list} {
-          @include element-invisible-off();
+          @include element-invisible-off;
         }
         #{$visbility-hidden-list} {
-          @include element-invisible();
+          @include element-invisible;
         }
       }
       @if $include-table-visibility-classes != false {

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -8,6 +8,7 @@
 // Foundation Visibility Classes
 //
 $include-html-visibility-classes: $include-html-classes !default;
+$include-accessibility-classes: true !default;
 $include-table-visibility-classes: true !default;
 $include-legacy-visibility-classes: true !default;
 
@@ -33,6 +34,9 @@ $visibility-breakpoint-queries:
   @each $current-visibility-breakpoint in $visibility-breakpoint-sizes {
     $visibility-inherit-list: ();
     $visibility-none-list: ();
+    
+    $visibility-visible-list: ();
+    $visbility-hidden-list:();
 
     $visibility-table-list: ();
     $visibility-table-header-group-list: ();
@@ -49,6 +53,12 @@ $visibility-breakpoint-queries:
         ), comma);
         $visibility-none-list: append($visibility-none-list, unquote(
           '.show-for-#{$visibility-comparison-breakpoint}-only, .hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-visible-list: append($visibility-visible-list, unquote(
+          '.hidden-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visbility-hidden-list: append($visbility-hidden-list, unquote(
+          '.visible-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
         $visibility-table-list: append($visibility-table-list, unquote(
           'table.hide-for-#{$visibility-comparison-breakpoint}-only, table.show-for-#{$visibility-comparison-breakpoint}-up'
@@ -76,6 +86,12 @@ $visibility-breakpoint-queries:
           $visibility-none-list: append($visibility-none-list, unquote(
             '.show-for-#{$visibility-comparison-breakpoint}, .show-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
+          $visibility-visible-list: append($visibility-visible-list, unquote(
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visbility-hidden-list: append($visbility-hidden-list, unquote(
+            '.visible-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
           $visibility-table-list: append($visibility-table-list, unquote(
             'table.hide-for-#{$visibility-comparison-breakpoint}, table.hide-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
@@ -101,6 +117,12 @@ $visibility-breakpoint-queries:
         ), comma);
         $visibility-none-list: append($visibility-none-list, unquote(
           '.show-for-#{$visibility-comparison-breakpoint}-only, .show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-visible-list: append($visibility-visible-list, unquote(
+          '.hidden-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visbility-hidden-list: append($visbility-hidden-list, unquote(
+          '.visible-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
         $visibility-table-list: append($visibility-table-list, unquote(
           'table.hide-for-#{$visibility-comparison-breakpoint}-only, table.hide-for-#{$visibility-comparison-breakpoint}-up'
@@ -128,6 +150,12 @@ $visibility-breakpoint-queries:
           $visibility-none-list: append($visibility-none-list, unquote(
             '.show-for-#{$visibility-comparison-breakpoint}, .hide-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
+          $visibility-visible-list: append($visibility-visible-list, unquote(
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-hidden-list: append($visibility-hidden-list, unquote(
+            '.visible-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
           $visibility-table-list: append($visibility-table-list, unquote(
             'table.hide-for-#{$visibility-comparison-breakpoint}, table.show-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
@@ -153,6 +181,12 @@ $visibility-breakpoint-queries:
         ), comma);
         $visibility-none-list: append($visibility-none-list, unquote(
           '.hide-for-#{$visibility-comparison-breakpoint}-only, .hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-visible-list: append($visibility-visible-list, unquote(
+          '.visible-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-hidden-list: append($visibility-hidden-list, unquote(
+          '.hidden-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
         $visibility-table-list: append($visibility-table-list, unquote(
           'table.show-for-#{$visibility-comparison-breakpoint}-only, table.show-for-#{$visibility-comparison-breakpoint}-up'
@@ -180,6 +214,12 @@ $visibility-breakpoint-queries:
           $visibility-none-list: append($visibility-none-list, unquote(
             '.hide-for-#{$visibility-comparison-breakpoint}, .hide-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
+          $visibility-visible-list: append($visibility-visible-list, unquote(
+            '.visible-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-hidden-list: append($visibility-hidden-list, unquote(
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .hiddne-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
           $visibility-table-list: append($visibility-table-list, unquote(
             'table.show-for-#{$visibility-comparison-breakpoint}, table.show-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
@@ -206,6 +246,14 @@ $visibility-breakpoint-queries:
       }
       #{$visibility-none-list} {
         display: none !important;
+      }
+      @if $include-accessibility-classes != false {
+        #{$visibility-visible-list} {
+          @include element-invisible-off();
+        }
+        #{$visbility-hidden-list} {
+          @include element-invisible();
+        }
       }
       @if $include-table-visibility-classes != false {
         #{$visibility-table-list} {


### PR DESCRIPTION
Add Accessibility Classes. `.hidden` hides element but allows screenreaders to read. Do not confuse with `.hide`. `.visible` reverses effect of `.hidden`. Less confusion with `.show`.

See https://github.com/zurb/foundation/issues/3597 for some background information.

Many thanks to @mmikitka for starting to improve accessibility and for defining the mixin used here. The rules within that mixin come from here: http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
