### PR TITLE
Build the Bower package on success only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - git config --global user.name "mhayes"
   - bower install
 script: ./run-tests.sh
-after_script:
+after_success:
   - git clone https://mhayes:${GH_TOKEN}@github.com/zurb/bower-foundation.git
   - rm -rf bower-foundation/*
   - cp -r dist/assets/* bower-foundation/


### PR DESCRIPTION
I use git submodule to include the latest master build of Foundation in my project. This approach is not reliable if the Bower Package is created no matter what happens in the Travis test script. My change avoids broken packages like https://github.com/zurb/bower-foundation/commit/c5be126486e56bda609fbdc7cd0e2430ea650afc
