### PR TITLE
Remove topbar from off-canvas

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -4,7 +4,6 @@
 
 @import "global";
 @import "type";
-@import "top-bar";
 
 // Off Canvas Tab Bar Variables
 $include-html-off-canvas-classes: $include-html-classes !default;
@@ -337,7 +336,7 @@ $menu-slide: "transform 500ms ease" !default;
       display: block;
       line-height: $tabbar-menu-icon-line-height;
       padding: $tabbar-menu-icon-padding;
-      color: $topbar-menu-link-color;
+      color: $tabbar-menu-icon-color;
       position: relative;
       @include translate3d(0,0,0);
 

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -34,9 +34,9 @@ $visibility-breakpoint-queries:
   @each $current-visibility-breakpoint in $visibility-breakpoint-sizes {
     $visibility-inherit-list: ();
     $visibility-none-list: ();
-    
+
     $visibility-visible-list: ();
-    $visbility-hidden-list: ();
+    $visibility-hidden-list: ();
 
     $visibility-table-list: ();
     $visibility-table-header-group-list: ();
@@ -57,7 +57,7 @@ $visibility-breakpoint-queries:
         $visibility-visible-list: append($visibility-visible-list, unquote(
           '.hidden-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
-        $visbility-hidden-list: append($visbility-hidden-list, unquote(
+        $visibility-hidden-list: append($visibility-hidden-list, unquote(
           '.visible-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
         $visibility-table-list: append($visibility-table-list, unquote(
@@ -89,7 +89,7 @@ $visibility-breakpoint-queries:
           $visibility-visible-list: append($visibility-visible-list, unquote(
             '.hidden-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
-          $visbility-hidden-list: append($visbility-hidden-list, unquote(
+          $visibility-hidden-list: append($visibility-hidden-list, unquote(
             '.visible-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
           ), comma);
           $visibility-table-list: append($visibility-table-list, unquote(
@@ -121,7 +121,7 @@ $visibility-breakpoint-queries:
         $visibility-visible-list: append($visibility-visible-list, unquote(
           '.hidden-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
-        $visbility-hidden-list: append($visbility-hidden-list, unquote(
+        $visibility-hidden-list: append($visibility-hidden-list, unquote(
           '.visible-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
         ), comma);
         $visibility-table-list: append($visibility-table-list, unquote(
@@ -251,7 +251,7 @@ $visibility-breakpoint-queries:
         #{$visibility-visible-list} {
           @include element-invisible-off;
         }
-        #{$visbility-hidden-list} {
+        #{$visibility-hidden-list} {
           @include element-invisible;
         }
       }


### PR DESCRIPTION
There is no need to have the topbar component added to off-canvas (as shown in the docs with the minimal example).

There was also a misspelling in the visibility component which was causing an error during the build, which I fixed.
