### PR TITLE
Add load autoprefixer and cssmin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,7 +234,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-rsync');
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-contrib-jst');
-
+  grunt.loadNpmTasks('grunt-autoprefixer');
+  grunt.loadNpmTasks('grunt-contrib-cssmin');
+  
   grunt.task.registerTask('watch_start', ['karma:dev_watch:start', 'watch']);
   grunt.registerTask('build:assets', ['clean', 'sass', 'autoprefixer', 'cssmin', 'concat', 'uglify', 'copy', 'jst']);
   grunt.registerTask('build', ['build:assets', 'assemble']);


### PR DESCRIPTION
I may be missing something obvious here but grunt returns errors because cssmin and autoprefixer aren't being loaded. This seems to fix the problem.
