### PR TITLE
Progress bar should use $progress-bar-border-radius instead of $global-r...

### DIFF
--- a/scss/foundation/components/_progress-bars.scss
+++ b/scss/foundation/components/_progress-bars.scss
@@ -65,8 +65,8 @@ $progress-meter-alert-color: $alert-color !default;
       &.success .meter { @include progress-meter($bg:$progress-meter-success-color); }
       &.alert .meter { @include progress-meter($bg:$progress-meter-alert-color); }
 
-      &.radius { @include radius($global-radius);
-        .meter { @include radius($global-radius - 1); }
+      &.radius { @include radius($progress-bar-border-radius);
+        .meter { @include radius($progress-bar-border-radius - 1); }
       }
 
       &.round { @include radius(1000px);


### PR DESCRIPTION
This is a bugfix. 
The variable $progress-bar-border-radius was not used, where it was supposed to be used.
In fact, the variable was never read.
