### PR TITLE
Update foundation.dropdown.js

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -162,6 +162,8 @@
     },
 
     css : function (dropdown, target) {
+      var left_offset = (target.width() - dropdown.width()) / 2;
+      
       this.clear_idx();
 
       if (this.small()) {
@@ -174,7 +176,7 @@
           top: p.top
         });
 
-        dropdown.css(Foundation.rtl ? 'right':'left', '2.5%');
+        dropdown.css(Foundation.rtl ? 'right':'left', left_offset);
       } else {
         var settings = target.data(this.attr_name(true) + '-init') || this.settings;
 
@@ -226,7 +228,7 @@
       bottom: function (t, s) {
         var self = Foundation.libs.dropdown,
             p = self.dirs._base.call(this, t),
-            pip_offset_base = (t.outerWidth() / 2) - 8;
+            pip_offset_base = (this.outerWidth() / 2) - 8;
 
         if (t.outerWidth() < this.outerWidth() || self.small()) {
           self.adjust_pip(pip_offset_base, p);


### PR DESCRIPTION
To center the drop down box with the target element, I implemented a "left_offset" variable which took the difference of the target element's width (the drop down's parent) and the drop down's width and divided by 2.  I then stored this variable in the "drop down css function", which uses this calculated value to set the offset of the drop down box. This allowed for the drop down box to center with the target element no matter what the size of the page.

Similarly, i changed the t parameter of the "bottom" function to "this." t was the parent of the drop down box, which therefore was causing the pip to be placed outside the drop down box once the page was shrunk. I instead performed foundation's algebraic procedure with "this", which grabs the actual drop down box, centering the pip correctly no matter what the size of the page.
