### PR TITLE
handle empty settings in reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -149,6 +149,7 @@
       }
 
       var settings = modal.data(self.attr_name(true) + '-init');
+      settings = settings || this.settings;
 
       if (!modal.hasClass('open')) {
         var open_modal = self.S('[' + self.attr_name() + '].open');
@@ -246,6 +247,8 @@
       // is modal
       if (css) {
         var settings = el.data(this.attr_name(true) + '-init');
+        settings = settings || this.settings;
+
         if (el.parent('body').length === 0) {
           var placeholder = el.wrap('<div style="display: none;" />').parent(),
               rootElement = this.settings.rootElement || 'body';
@@ -314,6 +317,8 @@
       // is modal
       if (css) {
         var settings = el.data(this.attr_name(true) + '-init');
+        settings = settings || this.settings;
+
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
           this.locked = false;


### PR DESCRIPTION
this fixes http://foundation.zurb.com/forum/posts/8287-capybara-test-fails-after-upgrade-to-5 as well as a few other issues e.g. the 'Uncaught TypeError: Cannot read property '{css,open}' of undefined' problems mentioned in #3702
