### PR TITLE
Allow orbit vertical scrolling events

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -301,7 +301,6 @@
         slides_container.on('touchstart.fndtn.orbit',function(e) {
           if (self.cache.animating) {return;}
           if (!e.touches) {e = e.originalEvent;}
-          e.preventDefault();
           e.stopPropagation();
 
           self.cache.start_page_x = e.touches[0].pageX;
@@ -316,7 +315,7 @@
         .on('touchmove.fndtn.orbit',function(e) {
           if (Math.abs(self.cache.delta_x) > 5) {
             e.preventDefault();
-            e.stopPropagation();
+            if(!self.cache.is_scrolling) e.stopPropagation();
           }
 
           if (self.cache.animating) {return;}          
@@ -360,7 +359,7 @@
         .on('touchend.fndtn.orbit', function(e) {
           if (self.cache.animating) {return;}
           e.preventDefault();
-          e.stopPropagation();
+          if(!self.cache.is_scrolling) e.stopPropagation();
           setTimeout(function(){
             self._goto(self.cache.direction);
           }, 50);


### PR DESCRIPTION
Full-screen slides on touch devices would capture all
touchstart/move/end events and scrolling the slide vertically would be
impossible. This is fixed by allowing the touchstart event to trigger
default behavior on touch screens, and then being more selective about
when we stop propagation on other touch events. (Allowing them to
propagate if the is_scrolling cache variable has been set to true by
vertical deltas).
