### PR TITLE
Add !important keyword to float: none; rule of centered columns in grid system

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -140,7 +140,7 @@ $total-columns: 12 !default;
   @if $center {
     margin-#{$default-float}: auto;
     margin-#{$opposite-direction}: auto;
-    float: none;
+    float: none !important;
   }
 
   // If offset, calculate appropriate margins


### PR DESCRIPTION
Currently selectors:
[class_="column"] + [class_="column"]:last-child { float: $opposite-direction; }
[class_="column"] + [class_="column"].end { float: $default-float; }
are more specific (specifity= 3) than rules for centered columns (specifity=2), and if centered
column is the last one in a row it will use f.e. float: right; rule instead of
float: none; from centered classes

![issue_centered](https://cloud.githubusercontent.com/assets/1146430/2834376/14e5467e-cfdc-11e3-83f4-8bcceb452298.png)
