### PR TITLE
Fix for Android 4.1 nth-of-type bug

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -65,7 +65,7 @@ $block-grid-media-queries: true !default;
       }
       list-style: none;
 
-      &:nth-of-type(n) { clear: none; }
+      &:nth-of-type(1n) { clear: none; }
       &:nth-of-type(#{$per-row}n+1) { clear: both; }
       @if $align-block-grid-to-grid {
         @include block-grid-aligned($per-row, $spacing);


### PR DESCRIPTION
in the Android 4.1 browser nth-of-type(n) is not recognized by the parser but nth-of-type(1n) apparently is. This fixes an issue where a smaller breakpoint clearing bleeds through to the larger breakpoints and adds additional clears. This can be recreated on the block grid documentation page
