### PR TITLE
Reverse c1c81b

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -329,7 +329,7 @@ $menu-slide: "transform 500ms ease" !default;
 
     // MENU BUTTON
     // This is a little bonus. You don't need it for off canvas to work. Mixins to be written in the future.
-    .menu-icon {
+    .tab-bar .menu-icon {
       text-indent: $tabbar-menu-icon-text-indent;
       width: $tabbar-height;
       height: $tabbar-height;


### PR DESCRIPTION
Reverse commit https://github.com/zurb/foundation/commit/c1c81cbae7f01fbcb9d1df1792c398ac242d21a8

Fix for #5064 until I can think of a better solution for allowing developers to use the menu-icon outside of the topbar or the tabbar.
