### PR TITLE
Allow false to be passed as abort_on_close option

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -827,7 +827,7 @@
       $('.joyride-modal-bg').hide();
       this.settings.$current_tip.hide();
 
-      if (typeof abort === 'undefined') {
+      if (typeof abort === 'undefined' || abort === false) {
         this.settings.post_step_callback(this.settings.$li.index(), this.settings.$current_tip);
         this.settings.post_ride_callback(this.settings.$li.index(), this.settings.$current_tip);
       }


### PR DESCRIPTION
Before as it was only looking to see if the abort var was defined or not you were unable to set the abort_on_close option to false and have the post callbacks trigger.
