### PR TITLE
remove padding-right from topbar menu icon

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -228,7 +228,6 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
             height: 34px;
             line-height: 33px;
             padding: 0;
-            padding-right: 25px;
             color: $topbar-menu-link-color;
             position: relative;
 


### PR DESCRIPTION
The rule padding-right: 25px; at line 231 of _top-bar.scss pushes the menu icon half way out of the topbar element, as can be seen at http://foundation.zurb.com/docs/components/topbar.html.
Removing the rule fixes it.
