### PR TITLE
Update _accordion.scss

### DIFF
--- a/scss/foundation/components/_accordion.scss
+++ b/scss/foundation/components/_accordion.scss
@@ -38,13 +38,14 @@ $accordion-content-active-bg-color: #fff !default;
           font-size: $accordion-navigation-font-size;
           &:hover { background: $accordion-navigation-hover-bg-color; }
         }
-      }
-      .content {
-        display: none;
-        padding: $accordion-content-padding;
-        &.active {
-          display: block;
-          background: $accordion-content-active-bg-color;
+        
+        > .content {
+          display: none;
+          padding: $accordion-content-padding;
+          &.active {
+            display: block;
+            background: $accordion-content-active-bg-color;
+          }
         }
       }
     }


### PR DESCRIPTION
If the accordion .content div contains a div with the class .content, that div currently gets display:none and so is invisible

Solution: specify the accordion .content div as a child of the dd
