### PR TITLE
Off canvas cleanup and event triggering

### DIFF
--- a/doc/pages/components/offcanvas.html
+++ b/doc/pages/components/offcanvas.html
@@ -329,6 +329,18 @@ $(document)
 })
 
 ```
+
+### Programmatic open / close / toggle
+
+The `.off-canvas-wrap` container can be targeted for javascript methods. At this time, the presentational open class needs to be included: either `move-right`, `move-left`, or `offcanvas-overlap`.
+
+```js
+$('.off-canvas-wrap').foundation('offcanvas', 'open', 'move-right');
+$('.off-canvas-wrap').foundation('offcanvas', 'close', 'move-right');
+$('.off-canvas-wrap').foundation('offcanvas', 'toggle', 'move-right');
+
+```
+
 ***
 
 ### Sass Errors?

--- a/doc/pages/components/offcanvas.html
+++ b/doc/pages/components/offcanvas.html
@@ -259,6 +259,36 @@ We've included a nice list pattern for list in the off-canvas menu. Include `ul.
 
 ***
 
+### Event Bindings
+
+There are a series of events that you can bind to for triggering callbacks:
+
+```js
+$(document).on('open', '[data-offcanvas]', function () {
+  var off_canvas_wrap = $(this);
+});
+
+$(document).on('close', '[data-offcanvas]', function () {
+  var off_canvas_wrap = $(this);
+});
+
+```
+
+For example, to freeze scrolling when active:
+
+```js
+$(document)
+.on('open', '[data-offcanvas]', function() {
+  $('html').css('overflow', 'hidden');
+})
+.on('close', '[data-offcanvas]', function() {
+  $('html').css('overflow', 'auto');
+})
+
+```
+
+***
+
 ## Customize With Sass
 
 Off-canvas layouts can be easily customized using our provided Sass variables.

--- a/doc/pages/components/offcanvas.html
+++ b/doc/pages/components/offcanvas.html
@@ -259,36 +259,6 @@ We've included a nice list pattern for list in the off-canvas menu. Include `ul.
 
 ***
 
-### Event Bindings
-
-There are a series of events that you can bind to for triggering callbacks:
-
-```js
-$(document).on('open', '[data-offcanvas]', function () {
-  var off_canvas_wrap = $(this);
-});
-
-$(document).on('close', '[data-offcanvas]', function () {
-  var off_canvas_wrap = $(this);
-});
-
-```
-
-For example, to freeze scrolling when active:
-
-```js
-$(document)
-.on('open', '[data-offcanvas]', function() {
-  $('html').css('overflow', 'hidden');
-})
-.on('close', '[data-offcanvas]', function() {
-  $('html').css('overflow', 'auto');
-})
-
-```
-
-***
-
 ## Customize With Sass
 
 Off-canvas layouts can be easily customized using our provided Sass variables.
@@ -332,6 +302,33 @@ Required Foundation Library: `foundation.offcanvas.js`
 
 {{> examples_offcanvas_javascript_options}}
 
+### Event Bindings
+
+There are a series of events that you can bind to for triggering callbacks:
+
+```js
+$(document).on('open', '[data-offcanvas]', function () {
+  var off_canvas_wrap = $(this);
+});
+
+$(document).on('close', '[data-offcanvas]', function () {
+  var off_canvas_wrap = $(this);
+});
+
+```
+
+For example, to freeze scrolling when active:
+
+```js
+$(document)
+.on('open', '[data-offcanvas]', function() {
+  $('html').css('overflow', 'hidden');
+})
+.on('close', '[data-offcanvas]', function() {
+  $('html').css('overflow', 'auto');
+})
+
+```
 ***
 
 ### Sass Errors?

--- a/js/foundation/foundation.offcanvas.js
+++ b/js/foundation/foundation.offcanvas.js
@@ -22,7 +22,7 @@
           right_postfix = '',
           left_postfix = '';
 
-      if (this.settings.open_method === 'move'){
+      if (this.settings.open_method === 'move') {
         move_class = 'move-';
         right_postfix = 'right';
         left_postfix = 'left';
@@ -32,40 +32,68 @@
 
       S(this.scope).off('.offcanvas')
         .on('click.fndtn.offcanvas', '.left-off-canvas-toggle', function (e) {
-        self.click_toggle_class(e, move_class + right_postfix);
+          self.click_toggle_class(e, move_class + right_postfix);
         })
         .on('click.fndtn.offcanvas', '.left-off-canvas-menu a', function (e) {
-          var settings = self.get_settings(e)
-          if (settings.close_on_click)
-          S(".off-canvas-wrap").removeClass(move_class + right_postfix);
+          var settings = self.get_settings(e);
+          if (settings.close_on_click) {
+            self.hide.call(self, move_class + right_postfix);
+          }
         })
         .on('click.fndtn.offcanvas', '.right-off-canvas-toggle', function (e) {
-        self.click_toggle_class(e, move_class + left_postfix);
+          self.click_toggle_class(e, move_class + left_postfix);
         })
         .on('click.fndtn.offcanvas', '.right-off-canvas-menu a', function (e) {
-          var settings = self.get_settings(e)
-          if (settings.close_on_click)
-          S(".off-canvas-wrap").removeClass(move_class + left_postfix);
+          var settings = self.get_settings(e);
+          if (settings.close_on_click) {
+            self.hide.call(self, move_class + left_postfix);
+          }
         })
         .on('click.fndtn.offcanvas', '.exit-off-canvas', function (e) {
-        self.click_remove_class(e, move_class + left_postfix);
-        if (right_postfix) self.click_remove_class(e, move_class + right_postfix);
-      });
+          self.click_remove_class(e, move_class + left_postfix);
+          if (right_postfix) self.click_remove_class(e, move_class + right_postfix);
+        });
+
+    },
+
+    toggle: function(class_name) {
+      if (this.get_wrapper().is(class_name)) {
+        this.hide(class_name);
+      } else {
+        this.show(class_name);
+      }
+    },
+
+    show: function(class_name) {
+      var $off_canvas = this.get_wrapper();
+      $off_canvas.trigger('open');
+      $off_canvas.addClass(class_name);
+    },
+
+    hide: function(class_name) {
+      var $off_canvas = this.get_wrapper();
+      $off_canvas.trigger('close');
+      $off_canvas.removeClass(class_name);
     },
 
     click_toggle_class: function(e, class_name) {
       e.preventDefault();
-      this.S(e.target).closest('.off-canvas-wrap').toggleClass(class_name);
+      this.toggle(class_name);
     },
 
     click_remove_class: function(e, class_name) {
       e.preventDefault();
-      this.S('.off-canvas-wrap').removeClass(class_name);
+      this.hide(class_name);
     },
 
     get_settings: function(e) {
-      var offcanvas  = this.S(e.target).closest('[' + this.attr_name() + ']')
+      var offcanvas  = this.S(e.target).closest('[' + this.attr_name() + ']');
       return offcanvas.data(this.attr_name(true) + '-init') || this.settings;
+    },
+
+    get_wrapper: function() {
+      // TODO - cache this, right?
+      return this.S('.off-canvas-wrap');
     },
 
     reflow : function () {}

--- a/js/foundation/foundation.offcanvas.js
+++ b/js/foundation/foundation.offcanvas.js
@@ -17,54 +17,40 @@
 
     events : function () {
       var self = this,
-          S = self.S;
-          
+          S = self.S,
+          move_class = '',
+          right_postfix = '',
+          left_postfix = '';
+
       if (this.settings.open_method === 'move'){
-        S(this.scope).off('.offcanvas')
-          .on('click.fndtn.offcanvas', '.left-off-canvas-toggle', function (e) {
-            self.click_toggle_class(e, 'move-right');
-          })
-          .on('click.fndtn.offcanvas', '.left-off-canvas-menu a', function (e) {
-            var settings = self.get_settings(e)
-            if (settings.close_on_click)
-              S(".off-canvas-wrap").removeClass("move-right");
-          })
-          .on('click.fndtn.offcanvas', '.right-off-canvas-toggle', function (e) {
-            self.click_toggle_class(e, 'move-left');
-          })
-          .on('click.fndtn.offcanvas', '.right-off-canvas-menu a', function (e) {
-            var settings = self.get_settings(e)
-            if (settings.close_on_click)
-              S(".off-canvas-wrap").removeClass("move-left");
-          })
-          .on('click.fndtn.offcanvas', '.exit-off-canvas', function (e) {
-            self.click_remove_class(e, 'move-left');
-            self.click_remove_class(e, 'move-right');
-          })
+        move_class = 'move-';
+        right_postfix = 'right';
+        left_postfix = 'left';
       } else if (this.settings.open_method === 'overlap') {
-        S(this.scope).off('.offcanvas')
-          .on('click.fndtn.offcanvas', '.left-off-canvas-toggle', function (e) {
-            self.click_toggle_class(e, 'offcanvas-overlap');
-          })
-          .on('click.fndtn.offcanvas', '.left-off-canvas-menu a', function (e) {
-            var settings = self.get_settings(e)
-            if (settings.close_on_click)
-              S(".off-canvas-wrap").removeClass("offcanvas-overlap");
-          })
-          .on('click.fndtn.offcanvas', '.right-off-canvas-toggle', function (e) {
-            self.click_toggle_class(e, 'offcanvas-overlap');
-          })
-          .on('click.fndtn.offcanvas', '.right-off-canvas-menu a', function (e) {
-            var settings = self.get_settings(e)
-            if (settings.close_on_click)
-              S(".off-canvas-wrap").removeClass("offcanvas-overlap");
-          })
-          .on('click.fndtn.offcanvas', '.exit-off-canvas', function (e) {
-            self.click_remove_class(e, 'offcanvas-overlap');
-          })
-      } else {
-        return;
+        move_class = 'offcanvas-overlap';
       }
+
+      S(this.scope).off('.offcanvas')
+        .on('click.fndtn.offcanvas', '.left-off-canvas-toggle', function (e) {
+        self.click_toggle_class(e, move_class + right_postfix);
+        })
+        .on('click.fndtn.offcanvas', '.left-off-canvas-menu a', function (e) {
+          var settings = self.get_settings(e)
+          if (settings.close_on_click)
+          S(".off-canvas-wrap").removeClass(move_class + right_postfix);
+        })
+        .on('click.fndtn.offcanvas', '.right-off-canvas-toggle', function (e) {
+        self.click_toggle_class(e, move_class + left_postfix);
+        })
+        .on('click.fndtn.offcanvas', '.right-off-canvas-menu a', function (e) {
+          var settings = self.get_settings(e)
+          if (settings.close_on_click)
+          S(".off-canvas-wrap").removeClass(move_class + left_postfix);
+        })
+        .on('click.fndtn.offcanvas', '.exit-off-canvas', function (e) {
+        self.click_remove_class(e, move_class + left_postfix);
+        if (right_postfix) self.click_remove_class(e, move_class + right_postfix);
+      });
     },
 
     click_toggle_class: function(e, class_name) {

--- a/js/foundation/foundation.offcanvas.js
+++ b/js/foundation/foundation.offcanvas.js
@@ -37,7 +37,7 @@
         .on('click.fndtn.offcanvas', '.left-off-canvas-menu a', function (e) {
           var settings = self.get_settings(e);
           if (settings.close_on_click) {
-            self.hide.call(self, move_class + right_postfix);
+            self.hide.call(self, move_class + right_postfix, self.get_wrapper(e));
           }
         })
         .on('click.fndtn.offcanvas', '.right-off-canvas-toggle', function (e) {
@@ -46,7 +46,7 @@
         .on('click.fndtn.offcanvas', '.right-off-canvas-menu a', function (e) {
           var settings = self.get_settings(e);
           if (settings.close_on_click) {
-            self.hide.call(self, move_class + left_postfix);
+            self.hide.call(self, move_class + left_postfix, self.get_wrapper(e));
           }
         })
         .on('click.fndtn.offcanvas', '.exit-off-canvas', function (e) {
@@ -56,34 +56,37 @@
 
     },
 
-    toggle: function(class_name) {
-      if (this.get_wrapper().is(class_name)) {
-        this.hide(class_name);
+    toggle: function(class_name, $off_canvas) {
+      $off_canvas = $off_canvas || this.get_wrapper();
+      if ($off_canvas.is('.' + class_name)) {
+        this.hide(class_name, $off_canvas);
       } else {
-        this.show(class_name);
+        this.show(class_name, $off_canvas);
       }
     },
 
-    show: function(class_name) {
-      var $off_canvas = this.get_wrapper();
+    show: function(class_name, $off_canvas) {
+      $off_canvas = $off_canvas || this.get_wrapper();
       $off_canvas.trigger('open');
       $off_canvas.addClass(class_name);
     },
 
-    hide: function(class_name) {
-      var $off_canvas = this.get_wrapper();
+    hide: function(class_name, $off_canvas) {
+      $off_canvas = $off_canvas || this.get_wrapper();
       $off_canvas.trigger('close');
       $off_canvas.removeClass(class_name);
     },
 
     click_toggle_class: function(e, class_name) {
       e.preventDefault();
-      this.toggle(class_name);
+      var $off_canvas = this.get_wrapper(e);
+      this.toggle(class_name, $off_canvas);
     },
 
     click_remove_class: function(e, class_name) {
       e.preventDefault();
-      this.hide(class_name);
+      var $off_canvas = this.get_wrapper(e);
+      this.hide(class_name, $off_canvas);
     },
 
     get_settings: function(e) {
@@ -91,9 +94,13 @@
       return offcanvas.data(this.attr_name(true) + '-init') || this.settings;
     },
 
-    get_wrapper: function() {
-      // TODO - cache this, right?
-      return this.S('.off-canvas-wrap');
+    get_wrapper: function(e) {
+      var $off_canvas = this.S(e ? e.target : this.scope).closest('.off-canvas-wrap');
+
+      if ($off_canvas.length === 0) {
+        $off_canvas = this.S('.off-canvas-wrap');
+      }
+      return $off_canvas;
     },
 
     reflow : function () {}


### PR DESCRIPTION
Added events to off-canvas - see included docs page. Includes sample for locking/unlocking document scrolling when menu is open.

Slight bit of code cleanup from @winghouchan's overlap implementation
