### PR TITLE
[Interchange] Use RegExp When Parsing Data Attribute Data

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -259,7 +259,7 @@
           var split = raw_arr[i].split(/\((.*?)(\))$/);
 
           if (split.length > 1) {
-            var cached_split = split[0].split(','),
+            var cached_split = split[0].split(/\, /),
                 params = this.parse_params(cached_split[0],
                   cached_split[1], split[1]);
 


### PR DESCRIPTION
There is an issue when using assets (images or html) that contain a `,` in the url. For example: `http://res.cloudinary.com/demo/image/upload/w_800,h_500,c_fit/sample.jpg`. Interchange will mutilate this url and never actually load the asset.

This branch splits using a RegExp instead of just on `,`. This seems to handle this case very well, and loads assets appropriately.
