### PR TITLE
Orbit: Added prefixed transition-duration properties

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -63,6 +63,13 @@ $orbit-timer-hide-for-small: true !default;
           transform: translate3d($x,$y,$z);
 }
 
+@mixin transition-duration($x) {
+  -webkit-transition-duration: $x;
+     -moz-transition-duration: $x;
+       -o-transition-duration: $x;
+          transition-duration: $x;
+}
+
 @mixin rotate($d) {
   -webkit-transform: rotate($d);
      -moz-transform: rotate($d);
@@ -161,11 +168,11 @@ $orbit-timer-hide-for-small: true !default;
           @include translate3d(100%,0,0);
           &.animate-in {
             @include translate3d(0,0,0);
-            transition-duration:$orbit-animation-speed;
+            @include transition-duration($orbit-animation-speed);
           }
           &.animate-out {
             @include translate3d(-100%,0,0);
-            transition-duration:$orbit-animation-speed;
+            @include transition-duration($orbit-animation-speed);
           }
         }
 
@@ -173,11 +180,11 @@ $orbit-timer-hide-for-small: true !default;
           @include translate3d(-100%,0,0);
           &.animate-in {
             @include translate3d(0,0,0);
-            transition-duration:$orbit-animation-speed;
+            @include transition-duration($orbit-animation-speed);
           }
           &.animate-out {
             @include translate3d(100%,0,0);
-            transition-duration:$orbit-animation-speed;
+            @include transition-duration($orbit-animation-speed);
           }
         }
 


### PR DESCRIPTION
This will resolve #5140, which I've replicated in Mobile Safari on a first gen iPad (iOS5). Without this patch animations do not run, which means that the [transitionEnd event](https://github.com/zurb/foundation/blob/master/js/foundation/foundation.orbit.js#L454) does not fire, which breaks the slider after the initial transition has occurred.

I've not tested in older versions of Opera or Firefox but I expect this fix improves compatibility for those browsers too.
