### PR TITLE
Reveal - consolidation of verbose animation options

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -313,25 +313,16 @@
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
           this.locked = false;
-        }
-        if (animData.pop) {
-          var end_css = {
-            top: - $(window).scrollTop() - el.data('offset') + 'px',
-            opacity: 0
-          };
-
-          return setTimeout(function () {
-            return el
-              .animate(end_css, settings.animation_speed, 'linear', function () {
-                this.locked = false;
-                el.css(css).trigger('closed');
-              }.bind(this))
-              .removeClass('open');
-          }.bind(this), settings.animation_speed / 2);
-        }
-
-        if (animData.fade) {
-          var end_css = {opacity: 0};
+        } else {
+          var end_css;
+          if (animData.pop) {
+            end_css = {
+              top: - $(window).scrollTop() - el.data('offset') + 'px',
+              opacity: 0
+            };
+          } else if (animData.fade) {
+            end_css = {opacity: 0};
+          }
 
           return setTimeout(function () {
             return el

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -261,6 +261,8 @@
           el.detach().appendTo(rootElement);
         }
 
+        css.top = $(window).scrollTop() + el.data('css-top') + 'px';
+
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
           this.locked = false;
@@ -284,7 +286,6 @@
         }
 
         if (animData.fade) {
-          css.top = $(window).scrollTop() + el.data('css-top') + 'px';
           var end_css = {opacity: 1};
 
           return setTimeout(function () {

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -249,6 +249,7 @@
         var settings = el.data(this.attr_name(true) + '-init');
         settings = settings || this.settings;
 
+        // Relocate element temporarily
         if (el.parent('body').length === 0) {
           var placeholder = el.wrap('<div style="display: none;" />').parent(),
               rootElement = this.settings.rootElement || 'body';
@@ -261,23 +262,29 @@
           el.detach().appendTo(rootElement);
         }
 
+        // Calculate top offset
         css.top = $(window).scrollTop() + el.data('css-top') + 'px';
 
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
+          // No animation - unlock immediately
           this.locked = false;
         } else {
+          // Animate with $.animate
           var end_css;
           if (animData.pop) {
+            // "Pop" in from top, and fade in
             end_css = {
               top: css.top,
               opacity: 1
             };
             css.top = $(window).scrollTop() - el.data('offset') + 'px';
           } else if (animData.fade) {
+            // Just fade in - no position animation
             end_css = {opacity: 1};
           }
 
+          // Delay momentarily while background enters
           return setTimeout(function () {
             return el
               .css(css)
@@ -312,18 +319,23 @@
 
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
+          // No animation - unlock immediately
           this.locked = false;
         } else {
+          // Animate with $.animate
           var end_css;
           if (animData.pop) {
+            // "Pop" out to top
             end_css = {
               top: - $(window).scrollTop() - el.data('offset') + 'px',
               opacity: 0
             };
           } else if (animData.fade) {
+            // Just fade out
             end_css = {opacity: 0};
           }
 
+          // Delay momentarily while background exits
           return setTimeout(function () {
             return el
               .animate(end_css, settings.animation_speed, 'linear', function () {

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -266,27 +266,17 @@
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
           this.locked = false;
-        }
-        if (animData.pop) {
-          css.top = $(window).scrollTop() - el.data('offset') + 'px';
-          var end_css = {
-            top: $(window).scrollTop() + el.data('css-top') + 'px',
-            opacity: 1
-          };
-
-          return setTimeout(function () {
-            return el
-              .css(css)
-              .animate(end_css, settings.animation_speed, 'linear', function () {
-                this.locked = false;
-                el.trigger('opened');
-              }.bind(this))
-              .addClass('open');
-          }.bind(this), settings.animation_speed / 2);
-        }
-
-        if (animData.fade) {
-          var end_css = {opacity: 1};
+        } else {
+          var end_css;
+          if (animData.pop) {
+            end_css = {
+              top: css.top,
+              opacity: 1
+            };
+            css.top = $(window).scrollTop() - el.data('offset') + 'px';
+          } else if (animData.fade) {
+            end_css = {opacity: 1};
+          }
 
           return setTimeout(function () {
             return el


### PR DESCRIPTION
Consolidated a bit of code (duplicated `setTimout` blocks)

My intent was not to change the effect of the code, but the first commit addresses issue #2767:
If no animation options are set, the `show` method returns [here at line 301](https://github.com/zurb/foundation/blob/master/js/foundation/foundation.reveal.js#L301), but it never gets the calculated top offset from fade or fade&pop. This reduces code and allows `animation:none` to get the proper offset.

The other two commits are purely consolidation.
