### PR TITLE
Remove `!important` and reorder certain styles in grid system to fix centered grid

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -140,7 +140,7 @@ $total-columns: 12 !default;
   @if $center {
     margin-#{$default-float}: auto;
     margin-#{$opposite-direction}: auto;
-    float: none !important;
+    float: none;
   }
 
   // If offset, calculate appropriate margins
@@ -171,6 +171,7 @@ $total-columns: 12 !default;
   }
 
   [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
+  [class*="column"] + [class*="column"].centered:last-child { float: none; }
   [class*="column"] + [class*="column"].end { float: $default-float; }
 
 
@@ -192,7 +193,7 @@ $total-columns: 12 !default;
   .columns.#{$size}-uncentered {
     margin-#{$default-float}: 0;
     margin-#{$opposite-direction}: 0;
-    float: $default-float !important;
+    float: $default-float;
   }
 
   .column.#{$size}-uncentered.opposite,

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -193,6 +193,18 @@ $total-columns: 12 !default;
     float: $default-float;
   }
 
+  // Fighting [class*="column"] + [class*="column"]:last-child
+  .column.#{$size}-centered:last-child,
+  .columns.#{$size}-centered:last-child{
+    float: none;
+  }
+
+  // Fighting .column.#{$previous-size}-centered:last-child
+  .column.#{$size}-uncentered:last-child,
+  .columns.#{$size}-uncentered:last-child {
+    float: $default-float;
+  }
+
   .column.#{$size}-uncentered.opposite,
   .columns.#{$size}-uncentered.opposite {
     float: $opposite-direction;

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -199,7 +199,7 @@ $total-columns: 12 !default;
     float: none;
   }
 
-  // Fighting .column.#{$previous-size}-centered:last-child
+  // Fighting .column.<previous-size>-centered:last-child
   .column.#{$size}-uncentered:last-child,
   .columns.#{$size}-uncentered:last-child {
     float: $default-float;

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -170,9 +170,6 @@ $total-columns: 12 !default;
     .#{$size}-#{$i} { @include grid-column($columns:$i,$collapse:null,$float:false); }
   }
 
-  [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
-  [class*="column"] + [class*="column"].centered:last-child { float: none; }
-  [class*="column"] + [class*="column"].end { float: $default-float; }
 
 
   @for $i from 0 through $total-columns - 1 {
@@ -221,6 +218,9 @@ $total-columns: 12 !default;
 
     .column,
     .columns { @include grid-column($columns:$total-columns); }
+
+    [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
+    [class*="column"] + [class*="column"].end { float: $default-float; }
 
     @media #{$small-up} {
       @include grid-html-classes($size:small);


### PR DESCRIPTION
Fixes #4624.
1. Move the original `[class*="column"] + [class*="column"]:last-child` out of the mixin `grid-html-classes($size)`, since its styles are irrelevant to the `$size` variable.
2. `[class*="column"] + [class*="column"]:last-child` style rules were [inserted back prior to all media queries](https://github.com/MrOrz/foundation/compare/zurb:master...master#diff-5ad1ec6dd4eb36244de99e0341ae2d55R235), in order to make sure the default behavior, that is `:last-child` floating to opposite direction, stays intact.
3. Since `[class*="column"] + [class*="column"]:last-child` has a specificity of `0,0,3,0`, we need to [add some specificity](https://github.com/MrOrz/foundation/compare/zurb:master...master#diff-5ad1ec6dd4eb36244de99e0341ae2d55R166) to the selector `.column.#{$size}-centered` in mixin `grid-html-classes($size)`, in order to balance out the floating behavior.
4. `.#{$size}-uncentered` should cancel out `.#{<previous-sizes>}-centered` (e.g. `.small-centered` should be canceled out by `.large-centered`). We added some [more selectors to achieve that](https://github.com/MrOrz/foundation/compare/zurb:master...master#diff-5ad1ec6dd4eb36244de99e0341ae2d55R173).
