### PR TITLE
_panel.scss: apply automated color adjustment also to dl, ol, ul

### DIFF
--- a/scss/foundation/components/_panels.scss
+++ b/scss/foundation/components/_panels.scss
@@ -54,9 +54,8 @@ $callout-panel-link-color: $primary-color !default;
 
     @if $adjust {
       // We set the font color based on the darkness of the bg.
-      @if $bg-lightness >= 50% and $bg == blue { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color-alt; } }
-      @else if $bg-lightness >= 50%            { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color; } }
-      @else                                    { h1,h2,h3,h4,h5,h6,p { color: $panel-font-color-alt; } }
+      @if $bg-lightness >= 50% { h1,h2,h3,h4,h5,h6,p,dl,ol,ul { color: $panel-font-color; } }
+      @else                    { h1,h2,h3,h4,h5,h6,p,dl,ol,ul { color: $panel-font-color-alt; } }
 
       // reset header line-heights for panels
       h1,h2,h3,h4,h5,h6 {


### PR DESCRIPTION
_panel.scss offers automated color adjustment for the font only for
`<h...>` and `<p>` elements. Now, `<dl>`, `<ol>`, and `<ul>` are added and also
automatically change color. Check especially for `blue` color was
removed.
