### PR TITLE
Allow multiple classes for the next/prev buttons

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -289,8 +289,10 @@
         settings.animation_speed = animation_speed;
       }
 
-      container.on('click', '.'+settings.next_class, self.next);
-      container.on('click', '.'+settings.prev_class, self.prev);
+      var next_class = settings.next_class.split(" ").join('.');
+      var prev_class = settings.prev_class.split(" ").join('.');
+      container.on('click', '.'+next_class, self.next);
+      container.on('click', '.'+prev_class, self.prev);
 
       if (settings.next_on_click) {
         container.on('click', '.'+settings.slides_container_class+' [data-orbit-slide]', self.link_bullet);


### PR DESCRIPTION
It would be nice to specify multiple classes as string within the initialization, something like

```
$(document).foundation({
  orbit: {
      next_class: 'orbit-next fa fa-arrow-left', // Class name given to the next button
      prev_class: 'orbit-prev'
  }
});
```

You can allow multiple classes definition for the next/prev button doing something like this

```
var next_class = settings.next_class.split(" ").join('.');
            var prev_class = settings.prev_class.split(" ").join('.');

            container.on('click', '.'+next_class, self.next);
            container.on('click', '.'+prev_class, self.prev);
```

within the init function
