### PR TITLE
Orbit anchored image breaks timer - bugfix

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -275,7 +275,7 @@
       self.build_markup();
       if (settings.timer) {
         self.cache.timer = self.create_timer(); 
-        Foundation.utils.image_loaded(this.slides().children('img'), self.cache.timer.start);
+        Foundation.utils.image_loaded(this.slides().find('img'), self.cache.timer.start);
       }
       
       animate = new CSSAnimation(settings, slides_container);


### PR DESCRIPTION
If the slider image is wrapped in an anchor tag the timer never starts because line 278 was looking for a direct child image. changed to .find('img') to locate inner images
