### PR TITLE
_tooltip.scss: replaced hard-coded 85% with $tooltip-max-width

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -1166,6 +1166,7 @@
 // $tooltip-radius: $global-radius;
 // $tooltip-rounded: $global-rounded;
 // $tooltip-pip-size: 5px;
+// $tooltip-max-width: 300px;
 
 //
 // TOP BAR

--- a/scss/foundation/components/_tooltips.scss
+++ b/scss/foundation/components/_tooltips.scss
@@ -29,6 +29,7 @@ $tooltip-font-size-sml: rem-calc(14) !default;
 $tooltip-radius: $global-radius !default;
 $tooltip-rounded: $global-rounded !default;
 $tooltip-pip-size: 5px !default;
+$tooltip-max-width: 300px !default;
 
 @include exports("tooltip") {
   @if $include-html-tooltip-classes {
@@ -58,7 +59,7 @@ $tooltip-pip-size: 5px !default;
       font-size: $tooltip-font-size;
       line-height: $tooltip-line-height;
       padding: $tooltip-padding;
-      max-width: 85%;
+      max-width: $tooltip-max-width;
       #{$default-float}: 50%;
       width: 100%;
       color: $tooltip-font-color;


### PR DESCRIPTION
tooltips become too wide on large screens, since their `max-width:
85%` refers to the whole width of the screen. I have added a parameter
`$tooltip-max-width` and chose a default of `300px`.
