### PR TITLE
Fix #5209: use cursor pointer

### DIFF
--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -343,6 +343,7 @@ $orbit-timer-hide-for-small: true !default;
         float: none;
         text-align: center;
         display: block;
+        cursor: pointer;
 
         li {
           display: inline-block;


### PR DESCRIPTION
Use cursor pointer on orbit bullets, clickable elements should look clickable.
