### PR TITLE
Firefox inner focus fix

### DIFF
--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -212,6 +212,9 @@ $button-disabled-opacity: 0.7 !default;
       }
     }
 
+    //firefox 2px fix
+    button::-moz-focus-inner {border:0; padding:0;}
+
     @media #{$medium-up} {
       button, .button {
         @include button-base($style:false, $display:inline-block);


### PR DESCRIPTION
Firefox adds 2px padding/border to a button element. when you have a
.button and a button element next to each other this shows. (button is
2px taller). resetting -moz-focus-inner fixes this
