### PR TITLE
Protect reveal node restoration against other 'closed' events

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -254,8 +254,11 @@
               rootElement = this.settings.rootElement || 'body';
 
           el.on('closed.fndtn.reveal.wrapped', function() {
-            el.detach().appendTo(placeholder);
-            el.unwrap().unbind('closed.fndtn.reveal.wrapped');
+            // Unwrap the reveal & put it back where it came from, but only if the close event is for the reveal object itself
+            if ($(el)[0] == ev.target) {
+              el.detach().appendTo(placeholder);
+              el.unwrap().unbind('closed.fndtn.reveal.wrapped');
+            }
           });
 
           el.detach().appendTo(rootElement);


### PR DESCRIPTION
Protect reveal node restoration against other 'closed' events, such as generated by foundation.dropdown.  This bug prevented Foundation Dropdown from being used within a Reveal dialog.
