### PR TITLE
Custom Validation didn't work with error labels.

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -194,9 +194,11 @@
           if (valid) {
             this.S(el).removeAttr(this.invalid_attr);
             parent.removeClass('error');
+            if (label.length > 0 && settings.error_labels) label.removeClass('error');
           } else {
             this.S(el).attr(this.invalid_attr, '');
             parent.addClass('error');
+            if (label.length > 0 && settings.error_labels) label.addClass('error');
           }
 
         } else {


### PR DESCRIPTION
A new feature was added in 588b9bc commit/patch that allowed a wrapping `<label>` tag to obtain a 'error' class. Without this, you couldn't use `prefix`/`postfix` and show an error message.

Unfortunately, it only worked for pattern validation. I just added in the necessary code to make it work for Custom Validation.
