### PR TITLE
Use correct 'this' when setting data-interchange-last-path.

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -53,7 +53,8 @@
 
             return trigger(el[0].src);
           }
-          var last_path = el.data(this.data_attr + '-last-path');
+          var last_path = el.data(this.data_attr + '-last-path'),
+              self = this;
 
           if (last_path == path) return;
 
@@ -65,7 +66,7 @@
 
           return $.get(path, function (response) {
             el.html(response);
-            el.data(this.data_attr + '-last-path', path);
+            el.data(self.data_attr + '-last-path', path);
             trigger();
           });
 

--- a/spec/interchange/interchange.js
+++ b/spec/interchange/interchange.js
@@ -57,4 +57,17 @@ describe('interchange:', function() {
         });
       });
   }));
+
+  describe('setting data-interchange-last-path', function() {
+    beforeEach(function() {
+      document.body.innerHTML = __html__['spec/interchange/basic.html'];
+    });
+
+    it('should set data-interchange-last-path on element when replace occurs', function() {
+      Foundation.libs.interchange.update_nodes();
+      Foundation.libs.interchange.resize();
+
+      expect($('div[data-interchange]').data('data-interchange-last-path')).toMatch(/.+html$/)
+    });
+  });
 });


### PR DESCRIPTION
Because the `this` being used was for the wrong scope
`data-interchange-last-path` is not set. This can lead to making multiple
requests for the same content unnecessarily.
