### PR TITLE
Add $medium-up sizes for h5 and h6

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -135,6 +135,14 @@
 // $h5-font-size: rem-calc(18);
 // $h6-font-size: 1rem;
 
+// We use these to control header size reduction on small screens
+// $h1-font-reduction: rem-calc(10) !default;
+// $h2-font-reduction: rem-calc(10) !default;
+// $h3-font-reduction: rem-calc(5) !default;
+// $h4-font-reduction: rem-calc(5) !default;
+// $h5-font-reduction: 0 !default;
+// $h6-font-reduction: 0 !default;
+
 // These control how subheaders are styled.
 // $subheader-line-height: 1.4;
 // $subheader-font-color: scale-color($header-font-color, $lightness: 35%);

--- a/scss/foundation/components/_type.scss
+++ b/scss/foundation/components/_type.scss
@@ -445,6 +445,8 @@ $align-class-breakpoints:
       h2 { font-size: $h2-font-size; }
       h3 { font-size: $h3-font-size; }
       h4 { font-size: $h4-font-size; }
+      h5 { font-size: $h5-font-size; }
+      h6 { font-size: $h6-font-size; }
     }
 
     // Only include these styles if you want them.


### PR DESCRIPTION
This code was probably forgotten in https://github.com/zurb/foundation/pull/5170. `h5` and `h6`'s mobile sizes can now be changed by `$h5-font-reduction` and `$h6-font-reduction`, so they need to be set again within `@media #{$medium-up} { ... }`.

This was unnecessary prior to https://github.com/zurb/foundation/pull/5170 because `h5` and `h6` always had the same font sizes for `$small-only` and `$medium-up`.

Also updated `_settings.scss.`
