### PR TITLE
Emit data interchange event to all elements

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -126,15 +126,17 @@
 
           if (passed) {
             this.settings.directives[passed
-              .scenario[1]].call(this, passed.el, passed.scenario[0], function () {
+              .scenario[1]].call(this, passed.el, passed.scenario[0], (function (passed) {
                 if (arguments[0] instanceof Array) { 
                   var args = arguments[0];
                 } else { 
                   var args = Array.prototype.slice.call(arguments, 0);
                 }
 
-                passed.el.trigger(passed.scenario[1], args);
-              });
+                return function() {
+                  passed.el.trigger(passed.scenario[1], args);
+                }
+              }(passed)));
           }
         }
       }

--- a/spec/interchange/interchange.js
+++ b/spec/interchange/interchange.js
@@ -70,4 +70,47 @@ describe('interchange:', function() {
       expect($('div[data-interchange]').data('data-interchange-last-path')).toMatch(/.+html$/)
     });
   });
+
+  describe('events', function() {
+    beforeEach(function() {
+      document.body.innerHTML = __html__['spec/interchange/basic.html'];
+      Foundation.libs.interchange.cache = {};
+    });
+
+    it('should handle emitting one event', function() {
+      var callback = jasmine.createSpy('callback');
+
+      $('div[data-interchange]').on('replace', callback);
+
+      Foundation.libs.interchange.update_nodes();
+      Foundation.libs.interchange.resize();
+
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it('should handle emitting multiple events', function() {
+      var $element0 = $('div[data-interchange]').attr('id', 'element0'),
+          $element1 = $element0.clone().attr('id', 'element1').appendTo('body'),
+          callback0 = jasmine.createSpy('callback0'),
+          callback1 = jasmine.createSpy('callback1');
+
+      $.get.isSpy = false;
+      spyOn($, 'get').andCallFake(function(path, callback) {
+        runs(function() {
+          callback('<h1>TWO EVENTS</h1>')
+        });
+      });
+
+      $element0.on('replace', callback0);
+      $element1.on('replace', callback1);
+
+      Foundation.libs.interchange.update_nodes();
+      Foundation.libs.interchange.resize();
+
+      runs(function() {
+        expect(callback0).toHaveBeenCalled();
+        expect(callback1).toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
When there are multiple `data-interchange` elements on the page, during the time that the `$.get` is executing its request it is possible that the value of `passed` used in the trigger function passed to `replace` can change and so not all elements will receive the `replace` event.
