### PR TITLE
Fix sticky topbar with browserify

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -422,4 +422,4 @@
 
     reflow : function () {}
   };
-}(jQuery, this, this.document));
+}(jQuery, window, window.document));


### PR DESCRIPTION
At some point the fix introduced in #4971 got lost for this file. As a result, a sticky topbar with foundation 5.2.2 and browserify does not work, because the scroll event does not trigger and there is no error message.
