### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,7 +9,7 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name)) {
+  @if not index($modules, $name) {
     $modules: append($modules, $name) !global;
     @content;
   }

--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,8 +9,8 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
-    $modules: append($modules, $name);
+  @if (index($modules, $name)) {
+    $modules: append($modules, $name) !global;
     @content;
   }
 }

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -243,11 +243,11 @@ $text-direction: ltr !default;
 $default-float: left !default;
 $opposite-direction: right !default;
 @if $text-direction == ltr {
-  $default-float: left;
-  $opposite-direction: right;
+  $default-float: left !global;
+  $opposite-direction: right !global; 
 } @else {
-  $default-float: right;
-  $opposite-direction: left;
+  $default-float: right !global;
+  $opposite-direction: left !global;
 }
 // We use these as default colors throughout
 $primary-color: #008CBA !default;


### PR DESCRIPTION
A few lines in the Scss files for foundation cause the current version of Sass (3.3.8) to display deprecation warnings. These commits fix those as outlined by Sass. 

edit: Travis CI fails to build this as it is using an old version of Sass
