### PR TITLE
Fix hamburger for topbar and offcanvas

### DIFF
--- a/doc/includes/off_canvas/examples_offcanvas_variables.html
+++ b/doc/includes/off_canvas/examples_offcanvas_variables.html
@@ -43,7 +43,6 @@ $tabbar-menu-icon-hover: scale-color($tabbar-menu-icon-color, $lightness: -30%);
 $tabbar-menu-icon-text-indent: rem-calc(35) !default;
 $tabbar-menu-icon-width: $tabbar-height !default;
 $tabbar-menu-icon-height: $tabbar-height !default;
-$tabbar-menu-icon-line-height: rem-calc(33) !default;
 $tabbar-menu-icon-padding: 0 !default;
 
 $tabbar-hamburger-icon-width: rem-calc(16) !default;

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -716,7 +716,6 @@
 // $tabbar-menu-icon-text-indent: rem-calc(35);
 // $tabbar-menu-icon-width: $tabbar-height;
 // $tabbar-menu-icon-height: $tabbar-height;
-// $tabbar-menu-icon-line-height: rem-calc(33);
 // $tabbar-menu-icon-padding: 0;
 
 // $tabbar-hamburger-icon-width: rem-calc(16);

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -31,7 +31,7 @@ $base-line-height: 150% !default;
 
 // @mixins
 //
-// We use this to optionally include experimental or 
+// We use this to optionally include experimental or
 // explicitly vendor prefixed properties
 @mixin experimental() {
   @if $experimental {
@@ -135,12 +135,12 @@ $base-line-height: 150% !default;
 // $hover-color - icon color during hover
 // $offcanvas - Set to true of @include in offcanvas
 @mixin hamburger($width, $left, $top, $thickness, $gap, $color, $hover-color, $offcanvas) {
-  span:after {
-    content: '';
+  span::after {
+    content: "";
     position: absolute;
     display: block;
     height: 0;
-    
+
     @if $offcanvas {
       @if $top {
         top: $top;
@@ -156,7 +156,12 @@ $base-line-height: 150% !default;
     	  left: ($tabbar-menu-icon-width - $width)/2;
     	}
     }
-    	
+    @else {
+      top: 50%;
+      margin-top: -$width/2;
+      #{$opposite-direction}: $topbar-link-padding;
+    }
+
     box-shadow:
       0 0px 0 $thickness $color,
       0 $gap + $thickness 0 $thickness $color,
@@ -320,11 +325,11 @@ $cursor-text-value: text !default;
   // Meta styles are included in all builds, as they are a dependancy of the Javascript.
   // Used to provide media query values for javascript components.
   // Forward slash placed around everything to convince PhantomJS to read the value.
-  
+
   meta.foundation-version {
     font-family: "/5.2.3/";
   }
-  
+
   meta.foundation-mq-small {
     font-family: "/" + unquote($small-up) + "/";
     width: lower-bound($small-range);

--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -50,7 +50,6 @@ $tabbar-menu-icon-hover: scale-color($tabbar-menu-icon-color, $lightness: -30%) 
 $tabbar-menu-icon-text-indent: rem-calc(35) !default;
 $tabbar-menu-icon-width: $tabbar-height !default;
 $tabbar-menu-icon-height: $tabbar-height !default;
-$tabbar-menu-icon-line-height: rem-calc(33) !default;
 $tabbar-menu-icon-padding: 0 !default;
 
 $tabbar-hamburger-icon-width: rem-calc(16) !default;
@@ -288,7 +287,6 @@ $menu-slide: "transform 500ms ease" !default;
       width: $tabbar-height;
       height: $tabbar-height;
       display: block;
-      line-height: $tabbar-menu-icon-line-height;
       padding: $tabbar-menu-icon-padding;
       color: $tabbar-menu-icon-color;
       position: relative;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -216,10 +216,8 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
         // Adding the class "menu-icon" will add the 3-line icon people love and adore.
         &.menu-icon {
-          #{$opposite-direction}: $topbar-link-padding;
           top: 50%;
           margin-top: -16px;
-          padding-#{$default-float}: 40px;
 
           a {
             @if $text-direction == rtl {
@@ -227,11 +225,11 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
             }
             height: 34px;
             line-height: 33px;
-            padding: 0;
+            padding: 0 $topbar-link-padding+25 0 $topbar-link-padding;
             color: $topbar-menu-link-color;
             position: relative;
 
-            &::after {
+            & {
               // @include hamburger icon
               //
               // We use this to create the icon with three lines aka the hamburger icon, the menu-icon or the navicon
@@ -243,8 +241,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               // $color - icon color
               // $hover-color - icon color during hover, here it is set the same as $color because the values are changed on line 264
               // $offcanvas - Set to false of @include in topbar
-              @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, $topbar-menu-icon-color, false );
-              #{$opposite-direction}: 0;
+              @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, $topbar-menu-icon-color, false);
             }
           }
         }


### PR DESCRIPTION
Hi,

this PR is to fix 2 bugs :
- offcanvas text positioning next to the hamburger (removing the line-height)

before: ![offcanvas_bug](https://cloud.githubusercontent.com/assets/6872180/3183119/7a15452e-ec62-11e3-88f3-a8d75e73de0d.png)
after: ![offcanvas_fix](https://cloud.githubusercontent.com/assets/6872180/3183122/7ec365a6-ec62-11e3-9b8b-3bb310976c70.png)
- hamburger positioning in the topbar

before: 
![menu_bug](https://cloud.githubusercontent.com/assets/6872180/3183128/af6312b0-ec62-11e3-8c8f-44a1d90fd202.png)
after: 
![menu_fix](https://cloud.githubusercontent.com/assets/6872180/3183129/b84cac60-ec62-11e3-9e90-ad6137226096.png)

related issues : https://github.com/zurb/foundation/issues/5199 and https://github.com/zurb/foundation/issues/5263
