### PR TITLE
Provide default settings when none exist

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -70,7 +70,7 @@
           e.preventDefault();
 
           if (!self.locked) {
-            var settings = S('[' + self.attr_name() + '].open').data(self.attr_name(true) + '-init'),
+            var settings = S('[' + self.attr_name() + '].open').data(self.attr_name(true) + '-init') || self.settings,
                 bg_clicked = S(e.target)[0] === S('.' + settings.bg_class)[0];
 
             if (bg_clicked) {


### PR DESCRIPTION
For modals that are generated after foundation is initialized, it is
possible that their `reveal-init` settings do not exist. In this case, the
default settings should be used.

This should fix the issue in #5281 and #3766.
