### PR TITLE
active first li element no working in firefox

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -284,8 +284,10 @@
         var $init_target = slides_container.find("." + settings.active_slide_class),
             animation_speed = settings.animation_speed;
         settings.animation_speed = 1;
-        $init_target.removeClass('active');
-        self._goto($init_target.index());
+        if current != $init_target.index() {
+            $init_target.removeClass('active');
+            self._goto($init_target.index());
+        }
         settings.animation_speed = animation_speed;
       }
 

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -285,7 +285,7 @@
             animation_speed = settings.animation_speed;
         settings.animation_speed = 1;
         if current != $init_target.index() {
-            $init_target.removeClass('active');
+            $init_target.removeClass(settings.active_slide_class);
             self._goto($init_target.index());
         }
         settings.animation_speed = animation_speed;


### PR DESCRIPTION
Orbit slider not working correctly if the first li is marked with class="active" (in Firefox 29.0.1).
Do removeClass("active") and goto("$init_target.index()) only if current != $init_target.index()
