### PR TITLE
active first li element no working in firefox

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -284,8 +284,10 @@
         var $init_target = slides_container.find("." + settings.active_slide_class),
             animation_speed = settings.animation_speed;
         settings.animation_speed = 1;
-        $init_target.removeClass('active');
-        self._goto($init_target.index());
+        if (idx != $init_target.index()) {
+            $init_target.removeClass('active');
+            self._goto($init_target.index());
+        }
         settings.animation_speed = animation_speed;
       }
 


### PR DESCRIPTION
In firefox the slide is not showing when first li is marked with class="active".
If none of the li elements is marked or other than the first, everything works as expected.
Do removeClass('active') and self._goto($init_target.index()) only if idx != $init_target.index()
