### PR TITLE
Hide the select arrow on Firefox

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -346,8 +346,15 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     }
 
     @-moz-document url-prefix() {
-      select { background: $select-bg-color; }
-      select:hover { background: $select-hover-bg-color }
+      select {
+        background-color: $select-bg-color;
+        text-indent: 0.01px;
+        text-overflow: '';
+        -moz-appearance: none;
+      }
+      select:hover {
+        background-color: $select-hover-bg-color;
+      }
     }
     /* Attach elements to the beginning or end of an input */
     .prefix,

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -346,15 +346,8 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     }
 
     @-moz-document url-prefix() {
-      select {
-        background-color: $select-bg-color;
-        text-indent: 0.01px;
-        text-overflow: '';
-        -moz-appearance: none;
-      }
-      select:hover {
-        background-color: $select-hover-bg-color;
-      }
+      select { background: $select-bg-color; }
+      select:hover { background: $select-hover-bg-color }
     }
     /* Attach elements to the beginning or end of an input */
     .prefix,

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -345,15 +345,12 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
       display:none;
     }
 
+    /* Workaround to hide the select arrow on Firefox */
     @-moz-document url-prefix() {
       select {
-        background-color: $select-bg-color;
         text-indent: 0.01px;
         text-overflow: '';
         -moz-appearance: none;
-      }
-      select:hover {
-        background-color: $select-hover-bg-color;
       }
     }
     /* Attach elements to the beginning or end of an input */


### PR DESCRIPTION
Refers #5115 and #4236.

Hides the native arrow on `<select>` elements on Firefox. This workaround _might_ stop working when Firefox 31 is released, but even if this happens, the native arrow will cover up the background one.

It's worth mentioning that the guys at Mozilla are [now proposing](https://bugzilla.mozilla.org/show_bug.cgi?id=649849#c111) a definitive fix. I wrote [this gist](https://gist.github.com/joaocunha/6273016) which gives the full lowdown on the subject. It's a safe workaround to use, nevertheless.

mdo is using the workaround [on his wtf-forms](https://github.com/mdo/wtf-forms/blob/master/wtf-forms.css#L171) as well.

Before:
![screenshot 2014-06-08 18 46 55](https://cloud.githubusercontent.com/assets/766837/3211553/77c75f18-ef1f-11e3-948c-879310507f29.png)

After:
![screenshot 2014-06-08 18 46 16](https://cloud.githubusercontent.com/assets/766837/3211556/7e9b4962-ef1f-11e3-96e6-71ec9d7f3e1e.png)
