### PR TITLE
Fixed broken regex from previous commit

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -235,10 +235,6 @@
       return $(window).trigger('resize');
     },
 
-    parse_params : function (path, directive, mq) {
-      return [this.trim(path), this.convert_directive(directive), this.trim(mq)];
-    },
-
     convert_directive : function (directive) {
 
       var trimmed = this.trim(directive);
@@ -248,6 +244,25 @@
       }
 
       return 'replace';
+    },
+
+    parse_scenario : function (scenario) {
+      // This logic had to be made more complex since some users were using commas in the url path
+      // So we cannot simply just split on a comma
+      var directive_match = scenario[0].match(/(.+),\s*(\w+)\s*$/),
+      media_query         = scenario[1];
+
+      if (directive_match) {
+        var path  = directive_match[1],
+        directive = directive_match[2];
+      }
+      else {
+        var cached_split = scenario[0].split(/,\s*$/),
+        path             = cached_split[0],
+        directive        = '';               
+      }
+
+      return [this.trim(path), this.convert_directive(directive), this.trim(media_query)];
     },
 
     object : function(el) {
@@ -260,10 +275,7 @@
           var split = raw_arr[i].split(/\((.*?)(\))$/);
 
           if (split.length > 1) {
-            var cached_split = split[0].split(/\, /),
-                params = this.parse_params(cached_split[0],
-                  cached_split[1], split[1]);
-
+            var params = this.parse_scenario(split);
             scenarios.push(params);
           }
         }


### PR DESCRIPTION
There was a previous commit that broke some existing interchange instances because it was trying to add the ability to support commas inside the url path. In order to support backwards compatibility and this new edge case, more logic needed to be added. This should work in all cases now.

I also made sure that I left support in for defining new directives outside of the default 'replace'
