### PR TITLE
Use rem-calc to add a number to other rem on _top-bar.scss

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -514,7 +514,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           @if($topbar-arrows){
 
             & > a {
-              padding-#{$opposite-direction}: $topbar-link-padding + 20 !important;
+              padding-#{$opposite-direction}: $topbar-link-padding + rem-calc(20) !important;
               &:after {
                 @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), top);
                 margin-top: -($topbar-dropdown-toggle-size / 2);


### PR DESCRIPTION
The padding that separates the text of a .has-dropdown menu item with their arrow is calculated incorrectly. The unit of measurement resulting in rem, and to this is added 20 (without units) going to alter the resulting rem. The solution is to use rem-calc (20). 

I took two screenshots of the problem, before and after this fix I propose.

Before:
![resulted](https://cloud.githubusercontent.com/assets/346224/3255194/bb10a650-f206-11e3-905f-49efe89f5317.PNG)

After:
![expected](https://cloud.githubusercontent.com/assets/346224/3255196/bea8bb7c-f206-11e3-9416-58d1095d789f.PNG)
