### PR TITLE
_range-slider.scss: added SCSS variable for slider's active segment background colour.

### DIFF
--- a/scss/foundation/components/_range-slider.scss
+++ b/scss/foundation/components/_range-slider.scss
@@ -25,6 +25,7 @@ $range-slider-bar-border-color: #ddd !default;
 $range-slider-radius: $global-radius !default;
 $range-slider-round: $global-rounded !default;
 $range-slider-bar-bg-color: #fafafa !default;
+$range-slider-active-segment-bg-color: scale-color($secondary-color, $lightness: -1%) !default;
 
 // Vertical bar styles
 $range-slider-vertical-bar-width: rem-calc(16) !default;
@@ -138,7 +139,7 @@ $range-slider-handle-cursor: pointer !default;
       display: inline-block;
       position: absolute;
       height: $range-slider-bar-height - rem-calc((strip-unit($range-slider-bar-border-width) * 2));
-      background: scale-color($secondary-color, $lightness: -1%);
+      background: $range-slider-active-segment-bg-color;
     }
     .range-slider-handle {
       @include range-slider-handle-base;


### PR DESCRIPTION
at the moment it cannot be customised and is coupled to $secondary-color. in our project we want another colour for the slider's background. thank you!
