### PR TITLE
Remove relative import in _global.scss

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -2,7 +2,7 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
-@import "../functions";
+@import "foundation/functions";
 //
 // Foundation Variables
 //


### PR DESCRIPTION
It is not a really a bug but eg. pyScss doesn't handle well relative imports.
Additionally this import is a single case - in whole scss project there is none other, just absolute `foundation/functions` in `_settings.scss`.
