### PR TITLE
Fix twitter handle, should be @zurbfoundation, not @foundationzurb

### DIFF
--- a/doc/includes/footer.html
+++ b/doc/includes/footer.html
@@ -46,7 +46,7 @@
           <div class="medium-4 columns">
             <div class="support-links">
               <h4 class="hide-for-small">Talk to us</h4>
-              <p>Tweet us at <br> <a href="https://twitter.com/foundationzurb">@foundationzurb</a></p>
+              <p>Tweet us at <br> <a href="https://twitter.com/zurbfoundation">@zurbfoundation</a></p>
               <p>Email us at <br> <a href="mailto:foundation@zurb.com">foundation@zurb.com</a><br> or check our <a href="{{relative absolute 'dist/support/support.html'}}">support page</a></p>
             </div>
           </div>

--- a/doc/pages/components/faq.html
+++ b/doc/pages/components/faq.html
@@ -38,7 +38,7 @@ This is an active group of Foundation users who can answer questions about imple
 
 If you've found a bug in the framework (or think you have) you can file it here. We try and address these as part of ongoing development. **Please use this only for bugs or things that seem incorrect**, support requests will not be addressed quickly here.
 
-##### [@foundationzurb](http://twitter.com/foundationzurb)
+##### [@zurbfoundation](http://twitter.com/zurbfoundation)
 
 [Follow us on Twitter](http://twitter.com/foundationzurb) to hear about new sites using Foundation, code examples, playground pieces from ZURB and more. You can also ping us with quick questions or other support issues, we're usually pretty speedy.</p>
 
@@ -53,4 +53,3 @@ If you're totally stuck and need some help, shoot us [an email](mailto:foundatio
   <h5 class="subheader">Foundation is the most advanced front-end framework in existence. We've ditched IE7 so that we can do more awesome things and push the web to where it needs to be. Take a look at our changelog to know what's recently been changed or updated.</h5>
   <a class="button" href="support.html">Browser Support &raquo;</a> <a class="secondary button" href="changelog.html">See the Version Changelog &raquo;</a>
 </div>
-


### PR DESCRIPTION
There's a typo in the twitter handle listed in the footer and faq. Should be `@zurbfoundation`.
