### PR TITLE
Fixed broken link in Reveal docs

### DIFF
--- a/doc/pages/components/reveal.html
+++ b/doc/pages/components/reveal.html
@@ -214,7 +214,7 @@ $(document).on('closed.fndtn.reveal', '[data-reveal]', function () {
 <h2>Using the Javascript</h2>
 
 <div class="panel">
-  Before you can use Reveal you'll want to verify that jQuery and `foundation.min.js` are available on your page. You can refer to the [Javascript documentation](../Javascript.html) on setting that up.
+  Before you can use Reveal you'll want to verify that jQuery and `foundation.min.js` are available on your page. You can refer to the [Javascript documentation](../javascript.html) on setting that up.
 </div>
 
 <p>If you are not using foundation.min.js and individually adding plugins, include `foundation.reveal.js` AFTER the `foundation.js` file. Your markup should look something like this:</p>


### PR DESCRIPTION
This is broken on the [published docs](http://foundation.zurb.com/docs/components/reveal.html) as well (under the section "Using the JavaScript").
