### PR TITLE
Set Font-Family for Dropdown-Back-Link in Top Bar

### DIFF
--- a/doc/includes/topbar/examples_topbar_variables.html
+++ b/doc/includes/topbar/examples_topbar_variables.html
@@ -22,7 +22,8 @@ $topbar-dropdown-link-color: #fff;
 $topbar-dropdown-link-bg: #333;
 $topbar-dropdown-toggle-size: 5px;
 $topbar-dropdown-toggle-color: #fff;
-$topbar-dropdown-toggle-alpha: 0.5;
+$topbar-dropdown-toggle-alpha: 0.4;
+$topbar-dropdown-back-font-family: $header-font-family;
 
 /* Set the link colors and styles for top-level nav */
 $topbar-link-color: #fff;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -31,6 +31,7 @@ $topbar-dropdown-link-weight: $font-weight-normal !default;
 $topbar-dropdown-toggle-size: 5px !default;
 $topbar-dropdown-toggle-color: #fff !default;
 $topbar-dropdown-toggle-alpha: 0.4 !default;
+$topbar-dropdown-back-font-family: $header-font-family !default;
 
 // Set the link colors and styles for top-level nav
 $topbar-link-color: #fff !default;
@@ -408,6 +409,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
             margin-bottom: 0;
             margin-top: 0;
             a {
+              font-family: $topbar-dropdown-back-font-family;
               color: $topbar-link-color;
               line-height: $topbar-height / 2;
               display: block;


### PR DESCRIPTION
The **Back-Link** in the collapsed Top Bar is rendered in an `<h5>`. Depending on which **font-family** you are using for your Headers, this could look a little bit weird.
I added an additional variable called `$topbar-dropdown-back-font-family` in which you can set the desired font-family. It defaults to `$header-font-family` which reflects the current behaviour.

**Also:** I fixed the documentation for `$topbar-dropdown-toggle-alpha` which is set to 0.4 in SCSS (not 0.5 as currently documented).
