### PR TITLE
Update _settings.scss for additional Side Nav variables

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -961,13 +961,20 @@
 // $side-nav-link-color: $primary-color;
 // $side-nav-link-color-active: scale-color($side-nav-link-color, $lightness: 30%);
 // $side-nav-link-color-hover: scale-color($side-nav-link-color, $lightness: 30%);
+// $side-nav-link-bg-hover: hsla(0, 0, 0, 0.025);
+// $side-nav-link-margin: 0;
+// $side-nav-link-padding: rem-calc(7 14);
 // $side-nav-font-size: rem-calc(14);
 // $side-nav-font-weight: $font-weight-normal;
 // $side-nav-font-weight-active: $side-nav-font-weight;
 // $side-nav-font-family: $body-font-family;
 // $side-nav-active-font-family: $side-nav-font-family;
 
-
+// We use these to control heading styles.
+// $side-nav-heading-color: $side-nav-link-color;
+// $side-nav-heading-font-size: $side-nav-font-size;
+// $side-nav-heading-font-weight: bold;
+// $side-nav-heading-text-transform: uppercase;
 
 // We use these to control border styles
 // $side-nav-divider-size: 1px;


### PR DESCRIPTION
Hey guys and gals,

I noticed today that a few of the Side Nav variables created in: https://github.com/zurb/foundation/commit/b33075351904bdb8b9404af6eaad0d843ca3b3d2 weren't in _settings.scss so I've added them in this PR.

Even though is only a small PR I did just spend the last 3 hours trying to get
`bundle && bundle exec foreman start` to work in the dist/docs folder as per the [guidelines for contributing](https://github.com/zurb/foundation/blob/master/CONTRIBUTING.md#contributing). I'm on a Windows box though so I tried rolling back different versions of Ruby and installing the RubyDev kit but I didn't have any luck :cry:

Apologies for not being able to do that so here's a plain old PR :smile: 
