### PR TITLE
disabled background on readonly input fields

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -128,7 +128,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   }
 
   // Disabled background input background color
-  &[disabled], fieldset[disabled] & { background-color: $input-disabled-bg; }
+  &[disabled], &[readonly], fieldset[disabled] & { background-color: $input-disabled-bg; }
 }
 
 // @MIXIN


### PR DESCRIPTION
Input fields which are set to **disabled** are not submitted with the form (http://www.w3.org/TR/html401/interact/forms.html#disabled). Fields which are set to **readonly** are. However readonly fields are not recognizeable for the user yet! 
Therefore i set the background of readonly-fields to `$input-disabled-bg`.

@thedeerchild resubmitted as requested in https://github.com/zurb/foundation/pull/5197
