### PR TITLE
Added classes 'checkbox-group' and 'radio-group' to allow clean vertical formatting of checkbox and radio input types

### DIFF
--- a/doc/includes/form/examples_form_basic.html
+++ b/doc/includes/form/examples_form_basic.html
@@ -54,6 +54,22 @@
     </div>
   </div>
   <div class="row">
+    <div class="large-6 columns">
+      <label>Vertical Radio List</label>
+      <div class="radio-group">
+        <label for="pokemonRed"><input type="radio" name="pokemon" value="Red" id="pokemonRed">Radio 1</label>
+        <label for="pokemonBlue"><input type="radio" name="pokemon" value="Blue" id="pokemonBlue">Radio 2</label>
+      </div>
+    </div>
+    <div class="large-6 columns">
+      <label>Vertical Checkbox List</label>
+      <div class="checkbox-group">
+        <label for="checkbox1"><input id="checkbox1" type="checkbox">Checkbox 1</label>
+        <label for="checkbox2"><input id="checkbox2" type="checkbox">Checkbox 2</label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
     <div class="large-12 columns">
       <label>Textarea Label
         <textarea placeholder="small-12.columns"></textarea>

--- a/doc/includes/form/examples_form_basic_rendered.html
+++ b/doc/includes/form/examples_form_basic_rendered.html
@@ -56,6 +56,22 @@
     </div>
   </div>
   <div class="row">
+    <div class="large-6 columns">
+      <label>Vertical Radio List</label>
+      <div class="radio-group">
+        <label for="pokemonRed"><input type="radio" name="pokemon" value="Red" id="pokemonRed">Radio 1</label>
+        <label for="pokemonBlue"><input type="radio" name="pokemon" value="Blue" id="pokemonBlue">Radio 2</label>
+      </div>
+    </div>
+    <div class="large-6 columns">
+      <label>Vertical Checkbox List</label>
+      <div class="checkbox-group">
+        <label for="checkbox1"><input id="checkbox1" type="checkbox">Checkbox 1</label>
+        <label for="checkbox2"><input id="checkbox2" type="checkbox">Checkbox 2</label>
+      </div>
+    </div>
+  </div>
+  <div class="row">
     <div class="large-12 columns">
       <label>Textarea Label
         <textarea placeholder="small-12.columns"></textarea>

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -432,6 +432,24 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
       vertical-align: baseline;
     }
 
+    /*  Vertical formatting for a group of checkboxes and radio buttons */
+    .checkbox-group, .radio-group {
+      label {
+        padding-left: 20px;
+        margin-bottom: 0;
+        font-weight: normal;
+        cursor: pointer;
+    
+        input[type="checkbox"], input[type="radio"] {
+          float: left;
+          margin-left: -20px;
+          margin-top: 4px;
+        }
+      }
+    
+      margin: 0 0 $form_spacing 0;
+    }
+
     /* Normalize file input width */
     input[type="file"] {
       width:100%;


### PR DESCRIPTION
Allows a group of checkboxes or radio buttons to be aligned vertically.  An example from the new output:

![screen shot 2014-06-28 at 11 58 51 pm](https://cloud.githubusercontent.com/assets/6226188/3422711/0a29be5e-ff5c-11e3-8651-a667219b362c.png)

Once a div with class "checkbox-group" or "radio-group" is created, any number of checkbox or radio combos can be wrapped inside it.  The 'input' tag MUST be wrapped inside of the 'label' opening and closing tags, unlike the horizontal example in the docs, which as the 'input' tag outside of the 'label' element.

In all of my use cases, this has worked wonderfully in any grid setting and screen size.
