### PR TITLE
Removing the margin-bottom from select.error

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -495,7 +495,8 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     }
 
     input.error,
-    textarea.error {
+    textarea.error,
+    select.error {
       margin-bottom: 0;
     }
     label.error { @include form-label-error-color; }


### PR DESCRIPTION
There's currently an inconsistency in the way error classes are handled:

When a `select` is within an element with a class of 'error', they are treated the same as other inputs:
(Line 58)

``` css
.error {
      input,
      textarea,
      select {
        margin-bottom: 0;
      }
```

...but when the error class is on the element itself, only inputs and textareas are styled. This can lead to a gap being displayed between a select and it's error message.
