### PR TITLE
Form settings

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -560,6 +560,9 @@ $primary-color: #008CBA;
 // $input-prefix-font-color: #333;
 // $input-prefix-font-color-alt: #fff;
 
+// We use this setting to turn on/off HTML5 number spinners (the up/down arrows)
+// $input-number-spinners: true;
+
 // We use these to style the error states for inputs and labels
 // $input-error-message-padding: rem-calc(6 9 9);
 // $input-error-message-top: -1px;

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -537,7 +537,6 @@ $primary-color: #008CBA;
 // $input-border-radius: $global-radius;
 // $input-disabled-bg: #ddd;
 // $input-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-// $input-include-glowing-effect: true;
 
 // We use these to style the fieldset border and spacing.
 // $fieldset-border-style: solid;
@@ -573,6 +572,7 @@ $primary-color: #008CBA;
 // $input-error-message-font-color-alt: #333;
 
 // We use this to style the glowing effect of inputs when focused
+// $input-include-glowing-effect: true;
 // $glowing-effect-fade-time: 0.45s;
 // $glowing-effect-color: $input-focus-border-color;
 

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -56,6 +56,9 @@ $input-prefix-overflow: hidden !default;
 $input-prefix-font-color: #333 !default;
 $input-prefix-font-color-alt: #fff !default;
 
+// We use this setting to turn on/off HTML5 number spinners (the up/down arrows)
+$input-number-spinners: true !default;
+
 // We use these to style the error states for inputs and labels
 $input-error-message-padding: rem-calc(6 9 9) !default;
 $input-error-message-top: -1px !default;
@@ -329,6 +332,18 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   }
 }
 
+// We use this mixin to turn on/off HTML5 number spinners
+@mixin html5number($browser, $on:true) {
+  @if $on==false {
+      @if $browser==webkit {
+        -webkit-appearance: none;
+        margin: 0;
+      } @else if $browser==moz {
+        -moz-appearance: textfield;
+      }
+  }
+}
+
 @include exports("form") {
   @if $include-html-form-classes {
     /* Standard Forms */
@@ -435,6 +450,15 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     /* Normalize file input width */
     input[type="file"] {
       width:100%;
+    }
+
+    /* HTML5 Number spinners settings */
+    input[type=number] {
+      @include html5number(moz, $input-number-spinners)
+    }
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+      @include html5number(webkit, $input-number-spinners);
     }
 
     /* We add basic fieldset styling */


### PR DESCRIPTION
I changed where the glowing effect on/off setting was located in _settings.scss because when I originally looked to turn off the glow I didn't realize you could because of where it is located in the settings.

I also added in a little mixin to enable/disable the HTML5 number spinners based on the browser, because webkit and mozilla handle them both differently.
