### PR TITLE
Fixes #5492: Switch now respects -speed and -ease in animation

### DIFF
--- a/scss/foundation/components/_switches.scss
+++ b/scss/foundation/components/_switches.scss
@@ -79,9 +79,9 @@ $switch-active-color: $primary-color;
     position: absolute; top: .25rem; left: .25rem;
     width: $switch-height-med - 0.5rem; height: $switch-height-med - 0.5rem;
 
-    -webkit-transition: left 0.15s ease-out;
-    -moz-transition: left 0.15s ease-out;
-    transition: left 0.15s ease-out;
+    -webkit-transition: left $transition-speed $transition-ease;
+    -moz-transition: left $transition-speed $transition-ease;
+    transition: left $transition-speed $transition-ease;
   }
 
   input:checked + label {


### PR DESCRIPTION
This should fix the issue, at least now the global settings are respected. Tested on Chrome Canary as follows:

$switch-paddle-transition-speed: 5s !default;
$switch-paddle-transition-ease: linear !default;
