### PR TITLE
Add disabled cursor variables with default to Buttons and Forms

### DIFF
--- a/doc/includes/buttons/examples_buttons_variables.html
+++ b/doc/includes/buttons/examples_buttons_variables.html
@@ -34,7 +34,8 @@ $button-border-style: solid;
 $button-radius: $global-radius;
 $button-round: $global-rounded;
 
-// We use this to set default opacity for disabled buttons.
+// We use this to set default opacity and cursor for disabled buttons.
 $button-disabled-opacity: 0.6;
+$button-disabled-cursor: $cursor-default-value;
 ```
 {{/markdown}}

--- a/doc/includes/form/examples_form_variables.html
+++ b/doc/includes/form/examples_form_variables.html
@@ -24,6 +24,7 @@ $input-border-style: solid;
 $input-border-width: 1px;
 $input-border-radius: $global-radius;
 $input-disabled-bg: #ddd;
+$input-disabled-cursor: $cursor-default-value;
 $input-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
 $input-include-glowing-effect: true;
 

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -375,8 +375,9 @@ $primary-color: #008CBA;
 // $button-radius: $global-radius;
 // $button-round: $global-rounded;
 
-// We use this to set default opacity for disabled buttons.
+// We use this to set default opacity and cursor for disabled buttons.
 // $button-disabled-opacity: 0.7;
+// $button-disabled-cursor: $cursor-default-value;
 
 // Button Groups
 
@@ -536,6 +537,7 @@ $primary-color: #008CBA;
 // $input-border-width: 1px;
 // $input-border-radius: $global-radius;
 // $input-disabled-bg: #ddd;
+// $input-disabled-cursor: $cursor-default-value;
 // $input-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
 
 // We use these to style the fieldset border and spacing.

--- a/scss/foundation/components/_buttons.scss
+++ b/scss/foundation/components/_buttons.scss
@@ -45,8 +45,9 @@ $button-hover-color: scale-color($button-bg, $lightness: $button-function-factor
 $button-radius: $global-radius !default;
 $button-round: $global-rounded !default;
 
-// We use this to set default opacity for disabled buttons.
+// We use this to set default opacity and cursor for disabled buttons.
 $button-disabled-opacity: 0.7 !default;
+$button-disabled-cursor: $cursor-default-value !default;
 
 
 //
@@ -152,7 +153,7 @@ $button-disabled-opacity: 0.7 !default;
 
   // We can set $disabled:true to create a disabled transparent button.
   @if $disabled {
-    cursor: $cursor-default-value;
+    cursor: $button-disabled-cursor;
     opacity: $button-disabled-opacity;
     box-shadow: none;
     &:hover,

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -32,6 +32,7 @@ $input-border-style: solid !default;
 $input-border-width: 1px !default;
 $input-border-radius: $global-radius !default;
 $input-disabled-bg: #ddd !default;
+$input-disabled-cursor: $cursor-default-value !default;
 $input-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1) !default;
 $input-include-glowing-effect: true !default;
 
@@ -131,7 +132,12 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   }
 
   // Disabled background input background color
-  &[disabled], &[readonly], fieldset[disabled] & { background-color: $input-disabled-bg; }
+  &[disabled],
+  &[readonly],
+  fieldset[disabled] & {
+    background-color: $input-disabled-bg;
+    cursor: $input-disabled-cursor;
+  }
 }
 
 // @MIXIN


### PR DESCRIPTION
The Buttons component uses the $cursor-default-value even on disabled components. While overriding isn't problematic it does lead to a lot of unnecessary CSS where a custom variable with the $cursor-default-value as a default would be best. Right now I have to do the following to override the cursor for disabled buttons:

``` css
button, .button {
  &.disabled,
  &[disabled] {
    cursor: not-allowed;

    &.secondary,
    &.success,
    &.alert {
      cursor: not-allowed;
    }
  }
}
```

I've added `$button-disabled-cursor` and `$input-disabled-cursor` variables to `_settings.scss`. These affect the Buttons and Forms components as they support the disabled class or attribute. Other components already contain a custom unavailable/disabled cursor variable. These new variables maintain the existing default value so its backwards compatible while also making it easy to customize.
### In _settings.scss

``` scss
$button-disabled-cursor: $cursor-default-value;
$input-disabled-cursor: $cursor-default-value;
```

Example docs have also been updated with the variable. I followed the Contributing guide but no Procfile is in the root or in the doc folder. Not sure if I have to compile docs. I've modified the appropriate example templates though.
