### PR TITLE
Fixed .exit-off-canvas not closing 'overlap' menu

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -150,7 +150,7 @@ $menu-slide: "transform 500ms ease" !default;
   height: $tabbar-height;
   line-height: $tabbar-line-height;
 
-  // make sure it's below the .exit-offcanvas link
+  // make sure it's below the .exit-off-canvas link
   position: relative;
   // z-index: 999;
 
@@ -338,10 +338,7 @@ $menu-slide: "transform 500ms ease" !default;
         transform: none;
         z-index: 1003;
       }
-      .exit-offcanvas-menu {
-        @include back-link;
-        z-index: 1002;
-      }
+      .exit-off-canvas { @include back-link; }
     }
 
     // Older browsers


### PR DESCRIPTION
## Old (buggy) behavior:

When the menu open_type was set to 'overlap', the .exit-off-canvas
link had no effect.
## Cause

The `.offcanvas-overlap .exit-off-canvas` selector was missing. A
selector of `.offcanvas-overlap .exit-offcanvas-menu` was where
the `.offcanvas-overlap .exit-off-canvas` selector should have been
## Fix
- Fix selector in scss/foundation/components/_offcanvas.scss
- No documentation changes are necessary because it now conforms
  to the documentation.  The string "exit-offcanvas-menu" is not
  found anywhere else in the repository.
