### PR TITLE
Add setting for last-child float direction in grid

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -57,6 +57,7 @@ $body-font-weight: $font-weight-normal;
 // $text-direction: ltr;
 // $opposite-direction: right;
 // $default-float: left;
+// $last-child-float: $opposite-direction;
 
 // We use these as default colors throughout
 $primary-color: #008CBA;

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -13,6 +13,8 @@ $include-xl-html-grid-classes: false !default;
 $row-width: rem-calc(1000) !default;
 $total-columns: 12 !default;
 
+$last-child-float: $opposite-direction !default;
+
 //
 // Grid Functions
 //
@@ -231,7 +233,7 @@ $total-columns: 12 !default;
     .column,
     .columns { @include grid-column($columns:$total-columns); }
 
-    [class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }
+    [class*="column"] + [class*="column"]:last-child { float: $last-child-float; }
     [class*="column"] + [class*="column"].end { float: $default-float; }
 
     @media #{$small-up} {


### PR DESCRIPTION
I think this setting is really usefull, it makes it possible to change the floating direction of the last-child element in grids.

Previously it used `$opposite-direction`:
`[class*="column"] + [class*="column"]:last-child { float: $opposite-direction; }`
Which can't be set to `left` if `$default-float` is already `left`.

It's also not possible to add something like
`[class*="column"] + [class*="column"]:last-child { float: left; }` to you own css file, since this creates issues with centered columns where the float gets overridden. Thats why we need a setting!

I've set `$opposite-direction` as default, so it's fully compatible for older projects.
