### PR TITLE
Add a the class 'fixed' when navigation is 'stuck'

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -111,7 +111,7 @@
             placeholder.attr(self.add_namespace('data-magellan-expedition-clone'),'');
             expedition.before(placeholder);
           }
-          expedition.css({position:'fixed', top: settings.fixed_top});
+          expedition.css({position:'fixed', top: settings.fixed_top}).addClass('fixed');
         } else {
           expedition.prev('[' + self.add_namespace('data-magellan-expedition-clone') + ']').remove();
           expedition.attr('style',styles).css('position','').css('top','').removeClass('fixed');


### PR DESCRIPTION
In line 117 the class 'fixed' is removed from the navigation without ever being added.

I assume the intention was to add a class to the navigation when it is stuck to the window so that additional skinning via CSS can be done (thats what i actually wanted to do but didn't find this functionality yet).
Browsing through the code i saw that you REMOVE a class 'fixed' when the navigation is 'unstuck' but you never add it.
This fixes that.

When the navigation sticks to the top it has the class 'fixed', as soon as it gets 'unstuck' the class is removed.
