### PR TITLE
Enabled use of space-delimited list of multiple custom validators.

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -184,12 +184,26 @@
           validations.push(this.valid_radio(el, required));
         } else if (is_checkbox && required) {
           validations.push(this.valid_checkbox(el, required));
+        } else if (validator) {
+            // Validate using each of the specified (space-delimited) validators.
+            var validators = validator.split(' ');
+            var last_valid = true, all_valid = true;
+            for (var iv = 0; iv < validators.length; iv++) {
+                valid = this.settings.validators[validators[iv]].apply(this, [el, required, parent])
+                validations.push(valid);
+                all_valid = valid && last_valid;
+                last_valid = valid;
+            }
+
+            if (valid) {
+                this.S(el).removeAttr(this.invalid_attr);
+                parent.removeClass('error');
+            } else {
+                this.S(el).attr(this.invalid_attr, '');
+                parent.addClass('error');
+            }
+
         } else {
-          
-          if (validator) {
-            valid = this.settings.validators[validator].apply(this, [el, required, parent]);
-            validations.push(valid);
-          }
 
           if (el_patterns[i][1].test(value) && valid_length ||
             !required && el.value.length < 1 || $(el).attr('disabled')) {


### PR DESCRIPTION
I found it limiting to only be able to use one custom validator on a field. This patch allows the data-abide-validator attribute to be a space-delimited list of custom validators. The results of the validators are logically ANDed i.e. all validations must pass for the value to be considered valid.
