### PR TITLE
Fix docs subheader demo html render issue

### DIFF
--- a/doc/pages/components/typography.html
+++ b/doc/pages/components/typography.html
@@ -44,7 +44,9 @@ Lighten up your headers by adding a class of .subheader to any header element.
   </div>
   <div class="large-6 columns">
   <h4>Rendered HTML</h4>
+  	<div class="type-demo">
 			{{> examples_typography_subheader_rendered}}
+		</div>
   </div>
 </div>
 


### PR DESCRIPTION
Subheader rendered html section is missing the container: http://foundation.zurb.com/docs/components/typography.html
