### PR TITLE
add !default to $switch-active-color

### DIFF
--- a/doc/includes/switch/examples_switch_variables.html
+++ b/doc/includes/switch/examples_switch_variables.html
@@ -16,6 +16,6 @@ $switch-bottom-margin: 1.5rem !default;
 $switch-paddle-bg: #fff !default;
 $switch-paddle-transition-speed: .15s !default;
 $switch-paddle-transition-ease: ease-out !default;
-$switch-active-color: $primary-color;
+$switch-active-color: $primary-color !default;
 ```
 {{/markdown}}

--- a/scss/foundation/components/_switches.scss
+++ b/scss/foundation/components/_switches.scss
@@ -29,7 +29,7 @@ $switch-bottom-margin: 1.5rem !default;
 $switch-paddle-bg: #fff !default;
 $switch-paddle-transition-speed: .15s !default;
 $switch-paddle-transition-ease: ease-out !default;
-$switch-active-color: $primary-color;
+$switch-active-color: $primary-color !default;
 
 
 //


### PR DESCRIPTION
Fix for lack of $switch-active-color override
