### PR TITLE
Fix for Orbit slide animation for RTL

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -354,10 +354,12 @@
     var is_rtl = ($('html[dir=rtl]').length === 1);
     var margin = is_rtl ? 'marginRight' : 'marginLeft';
     var animMargin = {};
+    var animMarginEnd = {};
     animMargin[margin] = '0%';
+    animMarginEnd[margin] = '-100%';
 
     this.next = function(current, next, callback) {
-      current.animate({marginLeft:'-100%'}, duration);
+      current.animate(animMarginEnd, duration);
       next.animate(animMargin, duration, function() {
         current.css(margin, '100%');
         callback();
@@ -365,7 +367,7 @@
     };
 
     this.prev = function(current, prev, callback) {
-      current.animate({marginLeft:'100%'}, duration);
+      current.animate(animMarginEnd, duration);
       prev.css(margin, '-100%');
       prev.animate(animMargin, duration, function() {
         current.css(margin, '100%');


### PR DESCRIPTION
Orbit slide animation was setting a rtl-dependent margin for the next
slide, but not using this flipmode for the current slide animation.
This fix makes both animations apply to the same margin.
