### PR TITLE
Allow custom error class name for Abide

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -10,6 +10,7 @@
       live_validate : true,
       focus_on_invalid : true,
       error_labels: true, // labels with a for="inputId" will recieve an `error` class
+      error_class: 'abide-error',
       timeout : 1000,
       patterns : {
         alpha: /^[a-zA-Z]+$/,
@@ -91,7 +92,7 @@
     reset : function (form) {
       form.removeAttr(this.invalid_attr);
       $(this.invalid_attr, form).removeAttr(this.invalid_attr);
-      $('.error', form).not('small').removeClass('error');
+      $('.' + this.settings.error_class, form).not('small').removeClass(this.settings.error_class);
     },
 
     validate : function (els, e, is_ajax) {
@@ -185,7 +186,7 @@
         } else if (is_checkbox && required) {
           validations.push(this.valid_checkbox(el, required));
         } else {
-          
+
           if (validator) {
             valid = this.settings.validators[validator].apply(this, [el, required, parent]);
             validations.push(valid);
@@ -202,13 +203,13 @@
 
           if(validations[0]){
             this.S(el).removeAttr(this.invalid_attr);
-            parent.removeClass('error');
-            if (label.length > 0 && this.settings.error_labels) label.removeClass('error');
+            parent.removeClass(this.settings.error_class);
+            if (label.length > 0 && this.settings.error_labels) label.removeClass(this.settings.error_class);
             $(el).triggerHandler('valid');
           } else {
-            parent.addClass('error');
+            parent.addClass(this.settings.error_class);
             this.S(el).attr(this.invalid_attr, '');
-            if (label.length > 0 && this.settings.error_labels) label.addClass('error');
+            if (label.length > 0 && this.settings.error_labels) label.addClass(this.settings.error_class);
             $(el).triggerHandler('invalid');
           }
 
@@ -223,9 +224,9 @@
           valid = (el.is(':checked') || !required);
 
       if (valid) {
-        el.removeAttr(this.invalid_attr).parent().removeClass('error');
+        el.removeAttr(this.invalid_attr).parent().removeClass(this.settings.error_class);
       } else {
-        el.attr(this.invalid_attr, '').parent().addClass('error');
+        el.attr(this.invalid_attr, '').parent().addClass(this.settings.error_class);
       }
 
       return valid;
@@ -245,9 +246,9 @@
       // Has to count up to make sure the focus gets applied to the top error
       for (var i=0; i < count; i++) {
         if (valid) {
-          this.S(group[i]).removeAttr(this.invalid_attr).parent().removeClass('error');
+          this.S(group[i]).removeAttr(this.invalid_attr).parent().removeClass(this.settings.error_class);
         } else {
-          this.S(group[i]).attr(this.invalid_attr, '').parent().addClass('error');
+          this.S(group[i]).attr(this.invalid_attr, '').parent().addClass(this.settings.error_class);
         }
       }
 
@@ -261,10 +262,10 @@
 
       if (valid) {
         this.S(el).removeAttr(this.invalid_attr);
-        parent.removeClass('error');
+        parent.removeClass(this.settings.error_class);
       } else {
         this.S(el).attr(this.invalid_attr, '');
-        parent.addClass('error');
+        parent.addClass(this.settings.error_class);
       }
 
       return valid;
@@ -276,9 +277,9 @@
         valid = others.filter(':checked').length > 0;
 
       if (valid) {
-        el.removeAttr(this.invalid_attr).parent().removeClass('error');
+        el.removeAttr(this.invalid_attr).parent().removeClass(this.settings.error_class);
       } else {
-        el.attr(this.invalid_attr, '').parent().addClass('error');
+        el.attr(this.invalid_attr, '').parent().addClass(this.settings.error_class);
       }
 
       if (!doNotValidateOthers) {


### PR DESCRIPTION
In one project we needed to differentiate between server-side and client-side error messages and the most sensible thing was to change the error class name which Abide puts on the input wrapper element.

There was no configuration option for this, so I added one.

If the error class name is changed then one would of course need to change some CSS classes as well, however that can be done less invasively.
