### PR TITLE
Set max normalized percentage value to 1

### DIFF
--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -141,7 +141,7 @@
     },
 
     normalized_percentage : function(val, start, end) {
-      return (val - start)/(end - start);
+      return Math.min(1, (val - start)/(end - start));
     },
 
     normalized_value : function(val, start, end, step) {


### PR DESCRIPTION
If a value greater than the end value is set for the range slider, the handle and bar width should not be greater than the container
