### PR TITLE
Enable data-options for clearing plugin

### DIFF
--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -35,9 +35,9 @@
       var self = this;
       Foundation.inherit(this, 'throttle image_loaded');
 
-        this.settings = $.extend({}, this.settings, this.data_options(self.S('[' + this.attr_name() + ']', this.scope)));
+      this.settings = $.extend({}, this.settings, this.data_options(self.S('[' + this.attr_name() + ']', this.scope)));
 
-        this.bindings(method, options);
+      this.bindings(method, options);
 
       if (self.S(this.scope).is('[' + this.attr_name() + ']')) {
         this.assemble(self.S('li', this.scope));

--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -35,7 +35,9 @@
       var self = this;
       Foundation.inherit(this, 'throttle image_loaded');
 
-      this.bindings(method, options);
+        this.settings = $.extend({}, this.settings, this.data_options(self.S('[' + this.attr_name() + ']', this.scope)));
+
+        this.bindings(method, options);
 
       if (self.S(this.scope).is('[' + this.attr_name() + ']')) {
         this.assemble(self.S('li', this.scope));


### PR DESCRIPTION
Currently its not working to override the default settings in html with the data-options attribute.
With this patch, it works as suggested.

Example:

<ul class="clearing-thumbs small-block-grid-2" data-clearing
        data-options="close_selectors:.clearing-close, div.clearing-blackout, div.visible-img;">
  <li>...</li>
</ul>
