### PR TITLE
Fix topbar dropdown unitless addition

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -48,6 +48,7 @@ $topbar-link-bg-active-hover: scale-color($primary-color, $lightness: -14%) !def
 $topbar-link-font-family: $body-font-family !default;
 $topbar-link-text-transform: none !default;
 $topbar-link-padding: $topbar-height / 3 !default;
+$topbar-link-dropdown-padding: 20px;
 
 $topbar-button-font-size: 0.75rem !default;
 $topbar-button-top: 7px !default;
@@ -515,7 +516,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
           @if($topbar-arrows){
 
             & > a {
-              padding-#{$opposite-direction}: $topbar-link-padding + 20 !important;
+              padding-#{$opposite-direction}: $topbar-link-padding + $topbar-link-dropdown-padding !important;
               &:after {
                 @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), top);
                 margin-top: -($topbar-dropdown-toggle-size / 2);


### PR DESCRIPTION
I encountered a problem with the arrow padding while specifying the
topbar height in rems.

Previously, the topbar adds an extra 20 to the $topbar-link-padding which
is derived from $topbar-height. Adding an extra 20rem is very different
from adding the desired 20px.

This commit extracts that 20 unitless value into a variable so that the
units may change as needed.

Also considered having this commit set the height in rem so that it
adjusts with $rem-base, but I felt that it was specified in pixels for a
good reason.
