### PR TITLE
Add .active class for topbar dropdown items

### DIFF
--- a/doc/includes/topbar/examples_topbar_default.html
+++ b/doc/includes/topbar/examples_topbar_default.html
@@ -15,6 +15,7 @@
         <a href="#">Right Button Dropdown</a>
         <ul class="dropdown">
           <li><a href="#">First link in dropdown</a></li>
+          <li class="active"><a href="#">Active link in dropdown</a></li>
         </ul>
       </li>
     </ul>

--- a/doc/pages/components/topbar.html
+++ b/doc/pages/components/topbar.html
@@ -91,6 +91,7 @@ The top bar is a pretty complex piece of magical UI goodness. We rely on many pr
             <a href="#">Right Button Dropdown</a>
             <ul class="dropdown">
               <li><a href="#">First link in dropdown</a></li>
+              <li class="active"><a href="#">Active link in dropdown</a></li>
             </ul>
           </li>
         </ul>
@@ -101,6 +102,7 @@ The top bar is a pretty complex piece of magical UI goodness. We rely on many pr
             <a href="#">Right Dropdown</a>
             <ul class="dropdown">
               <li><a href="#">First link in dropdown</a></li>
+              <li class="active"><a href="#">Active link in dropdown</a></li>
             </ul>
           </li>
         </ul>

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -567,15 +567,18 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               background: $topbar-dropdown-link-bg;
             }
 
-            &:not(.has-form) a:not(.button) {
-              color: $topbar-dropdown-link-color;
-              background: $topbar-dropdown-link-bg;
-            }
-            &:not(.has-form):hover > a:not(.button) {
-              color: $topbar-link-color-hover;
-              background-color: $topbar-link-bg-color-hover;
-              @if ($topbar-link-bg-hover) {
-                background: $topbar-link-bg-hover;
+            &:not(.has-form):not(.active) {
+              & > a:not(.button) {
+                color: $topbar-dropdown-link-color;
+                background: $topbar-dropdown-link-bg;
+              }
+
+              &:hover > a:not(.button) {
+                color: $topbar-link-color-hover;
+                background-color: $topbar-link-bg-color-hover;
+                @if ($topbar-link-bg-hover) {
+                  background: $topbar-link-bg-hover;
+                }
               }
             }
 


### PR DESCRIPTION
Previously, the `.active` class was being overriden by the `.dropdown`
selectors in the `.top-bar-section`, thus not allowing active dropdown
items to be highlighted.

This commit adds another pseudo-selector to ensure the `.active`
dropdown items get the correct highlight colors. It also works in
dropdowns within dropdowns within dropdowns.
