### PR TITLE
Added prefix and postfix classes which also change the radius of inputs accordingly

### DIFF
--- a/doc/includes/form/examples_form_labels.html
+++ b/doc/includes/form/examples_form_labels.html
@@ -23,7 +23,7 @@
     <div class="large-6 columns">
       <div class="row collapse prefix-radius">
         <div class="small-3 columns">
-          <span class="prefix radius">Label</span>
+          <span class="prefix">Label</span>
         </div>
         <div class="small-9 columns">
           <input type="text" placeholder="Value">
@@ -36,7 +36,29 @@
           <input type="text" placeholder="Value">
         </div>
         <div class="small-3 columns">
-          <span class="postfix radius">Label</span>
+          <span class="postfix">Label</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="large-6 columns">
+      <div class="row collapse prefix-round">
+        <div class="small-3 columns">
+          <a href="#" class="button prefix">Go</a>
+        </div>
+        <div class="small-9 columns">
+          <input type="text" placeholder="Value">
+        </div>
+      </div>
+    </div>
+    <div class="large-6 columns">
+      <div class="row collapse postfix-round">
+        <div class="small-9 columns">
+          <input type="text" placeholder="Value">
+        </div>
+        <div class="small-3 columns">
+          <a href="#" class="button postfix">Go</a>
         </div>
       </div>
     </div>

--- a/doc/includes/form/examples_form_labels.html
+++ b/doc/includes/form/examples_form_labels.html
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="large-6 columns">
+    <div class="large-12 columns">
       <div class="row collapse">
         <div class="small-10 columns">
           <input type="text" placeholder="Hex Value">
@@ -18,8 +18,20 @@
         </div>
       </div>
     </div>
+  </div>
+  <div class="row">
     <div class="large-6 columns">
-      <div class="row collapse">
+      <div class="row collapse prefix-radius">
+        <div class="small-3 columns">
+          <span class="prefix radius">Label</span>
+        </div>
+        <div class="small-9 columns">
+          <input type="text" placeholder="Value">
+        </div>
+      </div>
+    </div>
+    <div class="large-6 columns">
+      <div class="row collapse postfix-radius">
         <div class="small-9 columns">
           <input type="text" placeholder="Value">
         </div>

--- a/doc/includes/form/examples_form_labels_rendered.html
+++ b/doc/includes/form/examples_form_labels_rendered.html
@@ -25,7 +25,7 @@
     <div class="large-6 columns">
       <div class="row collapse prefix-radius">
         <div class="small-3 columns">
-          <span class="prefix radius">Label</span>
+          <span class="prefix">Label</span>
         </div>
         <div class="small-9 columns">
           <input type="text" placeholder="Value">
@@ -38,7 +38,29 @@
           <input type="text" placeholder="Value">
         </div>
         <div class="small-3 columns">
-          <span class="postfix radius">Label</span>
+          <span class="postfix">Label</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="large-6 columns">
+      <div class="row collapse prefix-round">
+        <div class="small-3 columns">
+          <a href="#" class="button prefix">Go</a>
+        </div>
+        <div class="small-9 columns">
+          <input type="text" placeholder="Value">
+        </div>
+      </div>
+    </div>
+    <div class="large-6 columns">
+      <div class="row collapse postfix-round">
+        <div class="small-9 columns">
+          <input type="text" placeholder="Value">
+        </div>
+        <div class="small-3 columns">
+          <a href="#" class="button postfix">Go</a>
         </div>
       </div>
     </div>

--- a/doc/includes/form/examples_form_labels_rendered.html
+++ b/doc/includes/form/examples_form_labels_rendered.html
@@ -10,7 +10,7 @@
     </div>
   </div>
   <div class="row">
-    <div class="large-6 columns">
+    <div class="large-12 columns">
       <div class="row collapse">
         <div class="small-10 columns">
           <input type="text" placeholder="Hex Value">
@@ -20,8 +20,20 @@
         </div>
       </div>
     </div>
+  </div>
+  <div class="row">
     <div class="large-6 columns">
-      <div class="row collapse">
+      <div class="row collapse prefix-radius">
+        <div class="small-3 columns">
+          <span class="prefix radius">Label</span>
+        </div>
+        <div class="small-9 columns">
+          <input type="text" placeholder="Value">
+        </div>
+      </div>
+    </div>
+    <div class="large-6 columns">
+      <div class="row collapse postfix-radius">
         <div class="small-9 columns">
           <input type="text" placeholder="Value">
         </div>

--- a/doc/pages/components/forms.html
+++ b/doc/pages/components/forms.html
@@ -83,7 +83,7 @@ We don't see them too much, but one of the useful form elements included with Fo
 
 ### Pre/Postfix Labels &amp; Actions
 
-Foundation forms support actions tied to buttons, and prefix / postfix labels, through a versatile approach using special grid properties. Essentially you can use `<div class="row collapse">` to create label / action / input combinations. You use the Foundation columns to define the size of the pre/postfix `<span class="postfix">` or `<span class="prefix">`. Keep in mind, if you also want to make sure the input has a radius then you can wrap your input and prefix/postfix in `<div class="row collapse prefix-radius">` or `<div class="row collapse postfix-radius">` accordingly. Here are a few examples:
+Foundation forms support actions tied to buttons, and prefix / postfix labels, through a versatile approach using special grid properties. Essentially you can use `<div class="row collapse">` to create label / action / input combinations. You use the Foundation columns to define the size of the pre/postfix `<span class="postfix">` or `<span class="prefix">`. Keep in mind, if you also want to make sure the input has a radius then you can wrap your input and prefix/postfix in `<div class="row collapse prefix-radius">` or `<div class="row collapse postfix-radius">` accordingly, this way you don't also have to include the `.radius` class anywhere except on the parent element. Likewise, you can also use either `<div class="row collapse prefix-round">` or `<div class="row collapse postfix-round">`. Here are a few examples:
 
 <div class="row">
   <div class="large-6 columns">

--- a/doc/pages/components/forms.html
+++ b/doc/pages/components/forms.html
@@ -83,7 +83,7 @@ We don't see them too much, but one of the useful form elements included with Fo
 
 ### Pre/Postfix Labels &amp; Actions
 
-Foundation forms support actions tied to buttons, and prefix / postfix labels, through a versatile approach using special grid properties. Essentially you can use `<div class="row collapse">` to create label / action / input combinations. You use the Foundation columns to define the size of the pre/postfix `<span class="postfix">` or `<span class="prefix">`. Here are a few examples:
+Foundation forms support actions tied to buttons, and prefix / postfix labels, through a versatile approach using special grid properties. Essentially you can use `<div class="row collapse">` to create label / action / input combinations. You use the Foundation columns to define the size of the pre/postfix `<span class="postfix">` or `<span class="prefix">`. Keep in mind, if you also want to make sure the input has a radius then you can wrap your input and prefix/postfix in `<div class="row collapse prefix-radius">` or `<div class="row collapse postfix-radius">` accordingly. Here are a few examples:
 
 <div class="row">
   <div class="large-6 columns">

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -321,14 +321,14 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   -webkit-appearance: none !important;
   -webkit-border-radius: 0px;
   background-color: $select-bg-color;
-  
+
   // The custom arrow have some fake horizontal padding so we can align it
   // from the right side of the element without relying on CSS3
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMTJweCIgeT0iMHB4IiB3aWR0aD0iMjRweCIgaGVpZ2h0PSIzcHgiIHZpZXdCb3g9IjAgMCA2IDMiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDYgMyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBvbHlnb24gcG9pbnRzPSI1Ljk5MiwwIDIuOTkyLDMgLTAuMDA4LDAgIi8+PC9zdmc+);
-  
+
   // We can safely use leftmost and rightmost now
   background-position: if($text-direction == 'rtl', 0%, 100%) center;
-  
+
   background-repeat: no-repeat;
   border: $input-border-width $input-border-style $input-border-color;
   padding: $form-spacing / 2;
@@ -427,6 +427,21 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
       }
       &.radius {
         @include radius($input-border-radius);
+      }
+    }
+
+    form {
+      .row {
+        .prefix-radius.row.collapse {
+          input,
+          textarea,
+          select { @include radius(0); @include side-radius($opposite-direction, $global-radius); }
+        }
+        .postfix-radius.row.collapse {
+          input,
+          textarea,
+          select { @include radius(0); @include side-radius($default-float, $global-radius); }
+        }
       }
     }
 

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -397,12 +397,8 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     .postfix.button.round { @include radius(0); @include side-radius($opposite-direction, $button-round); }
 
     /* Separate prefix and postfix styles when on span or label so buttons keep their own */
-    span.prefix,label.prefix { @include prefix();
-      &.radius { @include radius(0); @include side-radius($default-float, $global-radius); }
-    }
-    span.postfix,label.postfix { @include postfix();
-      &.radius { @include radius(0); @include side-radius($opposite-direction, $global-radius); }
-    }
+    span.prefix,label.prefix { @include prefix(); }
+    span.postfix,label.postfix { @include postfix(); }
 
     /* We use this to get basic styling on all basic form elements */
     input[type="text"],
@@ -435,12 +431,26 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
         .prefix-radius.row.collapse {
           input,
           textarea,
-          select { @include radius(0); @include side-radius($opposite-direction, $global-radius); }
+          select { @include radius(0); @include side-radius($opposite-direction, $button-radius); }
+          .prefix { @include radius(0); @include side-radius($default-float, $button-radius); }
         }
         .postfix-radius.row.collapse {
           input,
           textarea,
-          select { @include radius(0); @include side-radius($default-float, $global-radius); }
+          select { @include radius(0); @include side-radius($default-float, $button-radius); }
+          .postfix { @include radius(0); @include side-radius($opposite-direction, $button-radius); }
+        }
+        .prefix-round.row.collapse {
+          input,
+          textarea,
+          select { @include radius(0); @include side-radius($opposite-direction, $button-round); }
+          .prefix { @include radius(0); @include side-radius($default-float, $button-round); }
+        }
+        .postfix-round.row.collapse {
+          input,
+          textarea,
+          select { @include radius(0); @include side-radius($default-float, $button-round); }
+          .postfix { @include radius(0); @include side-radius($opposite-direction, $button-round); }
         }
       }
     }


### PR DESCRIPTION
Adding `prefix-radius` or `postfix-radius` to your container `div` will now also round the `input` as well as the postfix/prefix itself.
