### PR TITLE
Adjust globals for sass 3.2 compatibility

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,8 +9,8 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
-    $modules: append($modules, $name);
+  @if not index($modules, $name) {
+    $modules: append($modules, $name) !global;
     @content;
   }
 }

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -239,8 +239,8 @@ $text-direction: ltr !default;
 $default-float: left !default;
 $opposite-direction: right !default;
 @if $text-direction == ltr {
-  $default-float: left;
-  $opposite-direction: right;
+  $default-float: left !global;
+  $opposite-direction: right !global;
 } @else {
   $default-float: right;
   $opposite-direction: left;


### PR DESCRIPTION
Minor adjustments to global declarations so that Sass 3.2 doesn't throw deprecation errors/warnings when compiling to css.
