### PR TITLE
When deep_linking:true, allow tab a[href] to have full url, only matching the anchor in the end.

### DIFF
--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -80,7 +80,7 @@
               // containing tab and toggle it as active.
               var hash_tab_container_id = hash_element.closest('.content').attr('id');
               if (hash_tab_container_id != undefined) {
-                self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href=#' + hash_tab_container_id + ']').parent(), hash);
+                self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href$=#' + hash_tab_container_id + ']').parent(), hash);
               }
             }
           } else {


### PR DESCRIPTION
Setting `data-options="deep_linking:true"` for tabs would not work unless `href` attribute had only the anchor part. This is not sufficient when the user wants to deep link tabs across pages. Simple change to CSS selector fixes this problem (only match the end of `href` attribute).
