### PR TITLE
Allow clearing to load from closest A not parent

### DIFF
--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -392,7 +392,7 @@
       if ($image[0].nodeName === "A") {
         href = $image.attr('href');
       } else {
-        href = $image.parent().attr('href');
+        href = $image.closest('a').attr('href');
       }
 
       this.preload($image);


### PR DESCRIPTION
Currently clearing loads images from the current item if it's an `a` tag or from the parent of the current item or failing that it falls back to the item it's self. This means that the only way to load an image from the `a` tag is if the `img` tag is the direct descendant. By changing to use `closest('a')` instead of `parent()` then we gain more flexibility in the HTML we can use.
