### PR TITLE
fixed import issue in sass 3.4.0

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,7 +9,7 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
+  @if (index($modules, $name) == false or index($modules, $name) == null) {
     $modules: append($modules, $name);
     @content;
   }


### PR DESCRIPTION
According to http://sass-lang.com/documentation/Sass/Script/Functions.html#index-instance_method
`index($list, $value)` returns `null` if `$value` is not found in `$list`.
Comparing it with `false` causes broken imports with middleman running sass 3.4.0. Comparing with `null` works here.
added it with `or` to stay compatible with older versions and libsass where `index()` seems to be returning `false` on mismatch.

Tested running middleman with sass 3.4.0 and grunt-sass with node-sass 0.9.3
