### PR TITLE
CSSStyleSheet.insertRule() deprecation and Firefox error fix

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -553,7 +553,7 @@
 
           if (query !== undefined) {
             Foundation.stylesheet.insertRule('@media ' +
-              Foundation.media_queries[media] + '{ ' + rule + ' }');
+              Foundation.media_queries[media] + '{ ' + rule + ' }', Foundation.stylesheet.cssRules.length);
           }
         }
       },

--- a/spec/utilities/add_custom_rule/add_custom_rule.js
+++ b/spec/utilities/add_custom_rule/add_custom_rule.js
@@ -1,0 +1,34 @@
+describe('add_custom_rule:', function() {
+  beforeEach(function() {
+    this.addMatchers({
+      // Place add_custom_rule-specific matchers here...
+    });
+
+    var origFunc = $.fn.foundation;
+    spyOn($.fn, 'foundation').andCallFake(function() {
+      var result = origFunc.apply(this, arguments);
+      jasmine.Clock.tick(1000); // Let things settle...
+      return result;
+    });
+  });
+
+  describe('adding custom CSS rules', function() {
+    beforeEach(function() {
+      document.body.innerHTML = __html__['spec/utilities/add_custom_rule/basic.html'];
+    });
+
+    it('Applies custom rules unspecified breakpoint', function() {
+      $(document).foundation();
+
+      Foundation.utils.add_custom_rule('div#toggledContent { display:none;}');
+      expect($('div#toggledContent')).toBeHidden();
+    });
+
+    it('Applies custom rules for small and up breakpoint', function() {
+      $(document).foundation();
+
+      Foundation.utils.add_custom_rule('div#toggledContent { display:none;}', 'small');
+      expect($('div#toggledContent')).toBeHidden();
+    });
+  });
+});

--- a/spec/utilities/add_custom_rule/basic.html
+++ b/spec/utilities/add_custom_rule/basic.html
@@ -1,0 +1,1 @@
+<div id="toggledContent">Toggled content</div>


### PR DESCRIPTION
This is a fix for the deprecated one argument call to CSSStyleSheet.insertRule(). The current approach causes a failure in Firefox for add_custom_rule and a deprecation warning in Chrome. It also causes unexpected behavior for overlapping rules (where the order of the method calls is not respected).
