### PR TITLE
404 "foundation.css.map" not found

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "5.3.3",
   "main": [
     "css/foundation.css",
+    "css/foundation.css.map",
     "js/foundation.js"
   ],
   "dependencies": {


### PR DESCRIPTION
When using source maps for chrome and pulling in resources for bower it causes a 404. Adding the css.map file resolves this issue.
