### PR TITLE
FIX for reveal-bg mixin that created an empty z-index parameter

### DIFF
--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -55,7 +55,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
   right: 0;
   background: $reveal-overlay-bg-old; // Autoprefixer should be used to avoid such variables needed when Foundation for Sites can do so in the near future.
   background: $reveal-overlay-bg;
-  z-index: if( $include-z-index-value, 1004, null );
+  @if $include-z-index-value { z-index: 1004; }
   display: none;
   #{$default-float}: 0;
 }


### PR DESCRIPTION
The current implementation broke our grunt build because it creates an empty z-index parameter when compiled.

This should fix that problem.
