### PR TITLE
Fixed exports mixin bug

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,7 +9,7 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
+  @if (index($modules, $name) == null) {
     $modules: append($modules, $name);
     @content;
   }


### PR DESCRIPTION
Refering to the SASS doc (http://sass-lang.com/documentation/Sass/Script/Functions.html#index-instance_method), the index function will never return **false** but **null**.

This resulted in modules that never generate html classes.
