### PR TITLE
Wrong HTML example on Tabs documentation

### DIFF
--- a/doc/includes/tabs/examples_tabs_vertical_basic.html
+++ b/doc/includes/tabs/examples_tabs_vertical_basic.html
@@ -1,10 +1,10 @@
-<ul class="tabs" data-tab role="tablist">
+<ul class="tabs vertical" data-tab role="tablist">
   <li class="tab-title active" role="presentational"><a href="#panel2-1" role="tab" tabindex="0" aria-selected="true" controls="panel2-1">Tab 1</a></li>
   <li class="tab-title" role="presentational"><a href="#panel2-2" role="tab" tabindex="0" aria-selected="false" controls="panel2-2">Tab 2</a></li>
   <li class="tab-title" role="presentational"><a href="#panel2-3" role="tab" tabindex="0" aria-selected="false" controls="panel2-3">Tab 3</a></li>
   <li class="tab-title" role="presentational"><a href="#panel2-4" role="tab" tabindex="0" aria-selected="false" controls="panel2-4">Tab 4</a></li>
 </ul>
-<div class="tabs-content vertical">
+<div class="tabs-content">
   <section role="tabpanel" aria-hidden="false" class="content active" id="panel2-1">
     <p>First panel content goes here...</p>
   </section>


### PR DESCRIPTION
### Vertical Tabs

The html code example says that you should include the **vertical** class on the DIV tag. 
But to work, it needs to be on the UL tag.

[examples_tab_vertical_basic.html](https://github.com/zurb/foundation/blob/master/doc/includes/tabs/examples_tabs_vertical_basic.html#L1) has the wrong way of doing it.
 [examples_tab_vertical_basic_rendered.html](https://github.com/zurb/foundation/blob/master/doc/includes/tabs/examples_tabs_vertical_basic_rendered.html#L1) has the correct way of doing it. 
