### PR TITLE
Trigger window resize on open

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -210,6 +210,7 @@
           $.ajax(ajax_settings);
         }
       }
+      self.S(window).trigger('resize');
     },
 
     close : function (modal) {


### PR DESCRIPTION
Triggering a window resize event when Reveal opens can help when Reveal contains dynamically created content.
