### PR TITLE
Moving through tiers on mobile nav improved

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -225,6 +225,7 @@
               section.find('>.name').css({right: 100 * topbar.data('index') + '%'});
             }
 
+            window.scrollTo(0, topbar.data('height'));
             topbar.css('height', $this.siblings('ul').outerHeight(true) + topbar.data('height'));
           }
         });


### PR DESCRIPTION
When moving through tiers of navigation on the mobile nav, the browser window now sets the scroll height.  Effectively locking the viewport during the process of moving through the mobile tree, making for a more consistent experience.

Before, if you moved through a tier of navigation which had a lot of links, you'd have to scroll down, then selecting a child with fewer, the updated child tier would be displayed above and outside the viewport, leading to the user having to scroll back up just to continue browsing the menu tree, an inconsistent experience.

Now, each time the user moves between tiers on the mobile nav, the viewport is shifted (if necessary) to show the new tier, making the moving between tiers consistent and easier on a small device.

Give it a try!
