### PR TITLE
Fixed closing tags on drop3 and drop4 buttons in documentation

### DIFF
--- a/doc/includes/dropdown_buttons/examples_dropdown_button_intro.html
+++ b/doc/includes/dropdown_buttons/examples_dropdown_button_intro.html
@@ -12,14 +12,14 @@
   <li><a href="#">Yet another</a></li>
 </ul>
 
-<button data-dropdown="drop3" aria-controls="drop3" aria-expanded="false" class="button alert round dropdown">Dropdown Button</a><br>
+<button data-dropdown="drop3" aria-controls="drop3" aria-expanded="false" class="button alert round dropdown">Dropdown Button</button><br>
 <ul id="drop3" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
 
-<button  data-dropdown="drop4" aria-controls="drop4" aria-expanded="false" class="large success button dropdown">Dropdown Button</a><br>
+<button  data-dropdown="drop4" aria-controls="drop4" aria-expanded="false" class="large success button dropdown">Dropdown Button</button><br>
 <ul id="drop4" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>


### PR DESCRIPTION
The a couple of the example buttons on http://foundation.zurb.com/docs/components/dropdown_buttons.html had the wrong closing tag and it was disrupting the page. 
