### PR TITLE
Updated sass-import-once to the latest version

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -6,11 +6,11 @@
 $rem-base: 16px !default;
 
 // IMPORT ONCE
-// We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
+// We use this to prevent styles from being loaded multiple times for components that rely on other components.
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
-    $modules: append($modules, $name);
+  @if (not index($modules, $name)) {
+    $modules: append($modules, $name) !global;
     @content;
   }
 }


### PR DESCRIPTION
The [sass-import-once](https://github.com/wilsonpage/sass-import-once/blob/master/_sass-import-once.scss) code included in `functions.scss` has been updated a month ago, it would be nice to update it in Foundation.

For a reason I don't understand, the old version currently in use does not include any of the blocks prepended with `@include exports(...)` in my CSS output (using `scss.bat` on Windows), whereas the new version works as expected.

The [relevant commit](https://github.com/wilsonpage/sass-import-once/commit/a86c6f364a5a3a577c5357ebd21fa7a7aa583437) suggests it's about supporting `null` values and not just `false`.
