### PR TITLE
Sidenav font weight unused: fixes #5710

### DIFF
--- a/scss/foundation/components/_side-nav.scss
+++ b/scss/foundation/components/_side-nav.scss
@@ -70,6 +70,7 @@ $side-nav-divider-color: scale-color($white, $lightness: 10%) !default;
   li {
     margin: $side-nav-list-margin;
     font-size: $font-size;
+    font-weight: $side-nav-font-weight;
 
     a:not(.button) {
       display: block;


### PR DESCRIPTION
Link: 

https://github.com/zurb/foundation/issues/5710

Problem: 

_settings.scss and _side_nav.scss defined the variable $side-nav-font-weight with a default value of "$font-weight-normal !default" but didn't use it.

Fix:

Added the font-weight definition to the list element of the side navigation.
