### PR TITLE
Remove duplicates from the doc's search

### DIFF
--- a/doc/assets/js/docs.js
+++ b/doc/assets/js/docs.js
@@ -1,20 +1,29 @@
 var components = [];
+var unique_search_terms = {};
+
+function pushSearchTerm(searchTerm, data) {
+  if (!unique_search_terms[searchTerm]) {
+    components.push({
+      value: searchTerm,
+      data: data
+    });
+
+    unique_search_terms[searchTerm] = true
+  }
+}
+
 $("[data-search]")
   .each(function() {
     var self = $(this),
         searchTerm = self.text().trim(),
         otherSearchTerms = self.data("search").trim(),
         url = self.attr("href");
-    components.push({
-      value: searchTerm,
-      data: self.attr("href")
-    });
+
+    pushSearchTerm(searchTerm, self.attr("href"))
+
     if (otherSearchTerms !== "") {
       $.each(otherSearchTerms.split(","), function(idx, el) {
-        components.push({
-          value: el,
-          data: self.attr("href")
-        });
+        pushSearchTerm(el, self.attr("href"))
       });
     }
   });


### PR DESCRIPTION
Hello,

This PR removes the duplicates from the doc's search input.

**Previously:**
![screen shot 2014-09-04 at 16 15 25](https://cloud.githubusercontent.com/assets/1178099/4150462/f7be64a6-343d-11e4-828a-f7053acd9ec0.png)

**After this commit:**
![screen shot 2014-09-04 at 16 14 55](https://cloud.githubusercontent.com/assets/1178099/4150472/012d040c-343e-11e4-9e59-ab16ededa4a7.png)

I hope it doesn't break anything :D

Thanks
