### PR TITLE
Use a normal for loop in tabs.js

### DIFF
--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -102,7 +102,7 @@
             }
           } else {
             // Reference the default tab hashes which were initialized in the init function
-            for (var ind in self.default_tab_hashes) {
+            for (var ind = 0; ind < self.default_tab_hashes.length; ind++) {
               self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href=' + self.default_tab_hashes[ind] + ']').parent());
             }
           }


### PR DESCRIPTION
The alternative being combining `for…in` with `hasOwnProperty` I thought using the vanilla loop was preferable.

This PR comes from an actual bug, due to the fact that the Array prototype had some additions.
