### PR TITLE
Fixes #5751

### DIFF
--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -88,6 +88,9 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
         width: 100%;
         &.active { display: block; float: none; }
         &.contained { padding: $tabs-content-padding; }
+        > * {
+          outline:none;
+        }
       }
       &.vertical {
         display: block;

--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -38,6 +38,7 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
         list-style: none;
         float: $default-float;
         > a {
+          outline: none;
           display: block;
           background: {
             color: $tabs-navigation-bg-color;
@@ -89,7 +90,7 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
         &.active { display: block; float: none; }
         &.contained { padding: $tabs-content-padding; }
         > * {
-          outline:none;
+          outline: none;
         }
       }
       &.vertical {


### PR DESCRIPTION
Fixes issue #5751 

Adds "outline: none;" to tab anchors and tab-content children.
