### PR TITLE
Sass compile of _reveal.scss results in empty z-index property

### DIFF
--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -55,7 +55,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
   right: 0;
   background: $reveal-overlay-bg-old; // Autoprefixer should be used to avoid such variables needed when Foundation for Sites can do so in the near future.
   background: $reveal-overlay-bg;
-  z-index: if( $include-z-index-value, 1004, null );
+  z-index: if( $include-z-index-value, 1004, auto );
   display: none;
   #{$default-float}: 0;
 }

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -209,7 +209,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
       }
     }
 
-    // Reveal Print Styles: It should be invislbe, adds no value being printed.
+    // Reveal Print Styles: It should be invisible, adds no value being printed.
     @media print {
       dialog, .#{$reveal-modal-class} { 
         display: none;


### PR DESCRIPTION
When compiled, you get a z-index property that has no value. This is a problem if you use something like Uncss in your build process to remove unused CSS. Also fixes a typo.

This fix simply gives the property a value of 'auto' rather than nothing at all.
