### PR TITLE
add validate_on_blur option to abide - for #5760

### DIFF
--- a/doc/includes/abide/examples_abide_javascript_options.html
+++ b/doc/includes/abide/examples_abide_javascript_options.html
@@ -3,6 +3,7 @@
 $(document).foundation({
   abide : {
     live_validate : true,
+    validate_on_blur : true,
     focus_on_invalid : true,
     error_labels: true, // labels with a for="inputId" will recieve an `error` class
     timeout : 1000,

--- a/doc/includes/examples_javascript_data_options.html
+++ b/doc/includes/examples_javascript_data_options.html
@@ -1,8 +1,12 @@
 <table class="plugin-options">
   <tbody>
     <tr>
-      <td rowspan="3">Abide</td>
+      <td rowspan="4">Abide</td>
       <td>live_validate</td>
+      <td>true</td>
+    </tr>
+    <tr>
+      <td>validate_on_blur</td>
       <td>true</td>
     </tr>
     <tr>

--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -8,6 +8,7 @@
 
     settings : {
       live_validate : true,
+      validate_on_blur: true,
       focus_on_invalid : true,
       error_labels: true, // labels with a for="inputId" will recieve an `error` class
       timeout : 1000,
@@ -78,7 +79,9 @@
         .find('input, textarea, select')
           .off('.abide')
           .on('blur.fndtn.abide change.fndtn.abide', function (e) {
-            self.validate([this], e);
+            if (settings.validate_on_blur === true) {
+              self.validate([this], e);
+            }
           })
           .on('keydown.fndtn.abide', function (e) {
             if (settings.live_validate === true) {

--- a/spec/abide/abide.js
+++ b/spec/abide/abide.js
@@ -89,6 +89,19 @@ describe('abide:', function() {
       expect('invalid').not.toHaveBeenTriggeredOn('input[name="user_name"]');
       expect('invalid').not.toHaveBeenTriggeredOn('input[name="user_email"]');
     });
+
+    it('should not validate on blur or change events when validate_on_blur is false', function() {
+      $(document).foundation({
+        abide: {
+          validate_on_blur: false
+        }
+      });
+
+      $('input[name="user_name"]').blur();
+
+      expect($('input[name="user_name"]')).not.toHaveData('invalid');
+    });
+
   });
 
   describe('advanced validation', function() {


### PR DESCRIPTION
This adds an option `validate_on_blur` to `abide` to toggle validation on the `blur.fndtn.abide` and `change.fndtn.abide` events. 

Changes to docs and tests are included!

Ref: #5760 
