### PR TITLE
fix bug with radio and checkbox validation

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -228,8 +228,8 @@
             }
             $(el).triggerHandler('invalid');
           }
-          validations.push(el_validations[0]);
         }
+        validations.push(el_validations[0]);
       }
       validations = [validations.every(function(valid){return valid;})];
       return validations;


### PR DESCRIPTION
This was introduced with #5738.

The statement was in the wrong line. This fixes a bug where the validation of radios and checkboxes was not recognized in the final validation result.

Now it works great :)
