### PR TITLE
$reveal-max-width variable missing from _settings.

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -1088,6 +1088,7 @@ $include-html-global-classes: $include-html-classes;
 // $reveal-modal-bg: $white;
 // $reveal-position-top: rem-calc(100);
 // $reveal-default-width: 80%;
+// $reveal-max-width: $row-width;
 // $reveal-modal-padding: rem-calc(20);
 // $reveal-box-shadow: 0 0 10px rgba($black,.4);
 


### PR DESCRIPTION
Although referenced in the Reveal docs, the $reveal-max-width variable is missing from the _settings.scss file.
