### PR TITLE
Add an offset_by_height option to Magellan.

### DIFF
--- a/doc/includes/magellan/examples_magellan_options.html
+++ b/doc/includes/magellan/examples_magellan_options.html
@@ -6,7 +6,8 @@ $(document).foundation({
   threshold: 0, // how many pixels until the magellan bar sticks, 0 = auto
   destination_threshold: 20, // pixels from the top of destination for it to be considered active
   throttle_delay: 50, // calculation throttling to increase framerate
-  fixed_top: 0, // top distance in pixels assigned to the fixed element on scroll
+  fixed_top: 0, // top distance in pixels assigend to the fixed element on scroll
+  offset_by_height: true // whether to offset the destination by the expedition height. Usually you want this to be true, unless your expedition is on the side.
 }
 });
 ```

--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -11,7 +11,8 @@
       threshold: 0, // pixels from the top of the expedition for it to become fixes
       destination_threshold: 20, // pixels from the top of destination for it to be considered active
       throttle_delay: 30, // calculation throttling to increase framerate
-      fixed_top: 0 // top distance in pixels assigend to the fixed element on scroll
+      fixed_top: 0, // top distance in pixels assigend to the fixed element on scroll
+      offset_by_height: true // whether to offset the destination by the expedition height. Usually you want this to be true, unless your expedition is on the side.
     },
 
     init : function (scope, method, options) {
@@ -44,7 +45,9 @@
 
           // Account for expedition height if fixed position
           var scroll_top = target.offset().top - settings.destination_threshold + 1;
-          scroll_top = scroll_top - expedition.outerHeight();
+          if (settings.offset_by_height) {
+            scroll_top = scroll_top - expedition.outerHeight();
+          }
 
           $('html, body').stop().animate({
             'scrollTop': scroll_top
@@ -152,7 +155,11 @@
         var name = $(this).data(self.data_attr('magellan-arrival')),
             dest = $('[' + self.add_namespace('data-magellan-destination') + '=' + name + ']');
         if (dest.length > 0) {
-          var top_offset = Math.floor(dest.offset().top - settings.destination_threshold - expedition.outerHeight());
+          var top_offset = dest.offset().top - settings.destination_threshold;
+          if (settings.offset_by_height) {
+            top_offset = top_offset - expedition.outerHeight();
+          }
+          top_offset = Math.floor(top_offset);
           return {
             destination : dest,
             arrival : $(this),


### PR DESCRIPTION
By default, when you click on a link on the Magellan expedition, it offsets the destination by the height of the expedition. This behavior isn't desired when the Magellan is on a sidebar and is vertically oriented (what happens is that the destination seems to be offset for no particular reason).

This commit adds an offset_by_height option to Magellan that when false disables the aforementioned default behavior.
