### PR TITLE
Fix: disabled dropdown buttons should not open

### DIFF
--- a/doc/includes/dropdown/examples_dropdown_advanced.html
+++ b/doc/includes/dropdown/examples_dropdown_advanced.html
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="large-6 columns">
+    <h4>HTML</h4>
+{{#markdown}}
+```html
+<button data-dropdown="drop" aria-controls="drop", aria-expanded="false" class="large alert round button dropdown">Dropdown Button</button><br>
+<ul id="drop" data-dropdown-content class="f-dropdown" role="menu", aria-hidden="false" tabindex="-1">
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+
+```
+{{/markdown}}
+  </div>
+  <div class="large-6 columns">
+    <h4>Rendered HTML</h4>
+    <button data-dropdown="drop-advanced" aria-controls="drop-advanced", aria-expanded="false" class="large alert round button dropdown">Dropdown Button</button><br>
+    <ul id="drop-advanced" data-dropdown-content class="f-dropdown" role="menu", aria-hidden="false" tabindex="-1">
+      <li><a href="#">This is a link</a></li>
+      <li><a href="#">This is another</a></li>
+      <li><a href="#">Yet another</a></li>
+    </ul>
+  </div>
+</div>

--- a/doc/includes/dropdown/examples_dropdown_disabled.html
+++ b/doc/includes/dropdown/examples_dropdown_disabled.html
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="large-6 columns">
+    <h4>HTML</h4>
+{{#markdown}}
+```html
+<button data-dropdown="drop" aria-controls="drop", aria-expanded="false" class="disabled button dropdown">Disabled Dropdown Button</button><br>
+<ul id="drop" data-dropdown-content class="f-dropdown" role="menu", aria-hidden="false" tabindex="-1">
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">But they don't show up!</a></li>
+</ul>
+
+```
+{{/markdown}}
+  </div>
+  <div class="large-6 columns">
+    <h4>Rendered HTML</h4>
+    <button data-dropdown="drop-disabled" aria-controls="drop-disabled", aria-expanded="false" class="disabled button dropdown">Disabled Dropdown Button</button><br>
+    <ul id="drop-disabled" data-dropdown-content class="f-dropdown" role="menu", aria-hidden="false" tabindex="-1">
+      <li><a href="#">This is a link</a></li>
+      <li><a href="#">This is another</a></li>
+      <li><a href="#">But they don't show up!</a></li>
+    </ul>
+  </div>
+</div>

--- a/doc/includes/dropdown_buttons/examples_dropdown_button_intro.html
+++ b/doc/includes/dropdown_buttons/examples_dropdown_button_intro.html
@@ -32,3 +32,10 @@
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
+
+<a data-dropdown="drop6" aria-controls="drop6" aria-expanded="false" class="disabled button dropdown">Disabled Dropdown Button</a><br>
+<ul id="drop6" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1" >
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>

--- a/doc/pages/components/dropdown_buttons.html
+++ b/doc/pages/components/dropdown_buttons.html
@@ -33,32 +33,13 @@ You can create a dropdown using minimal markup.
 
 <h2>Advanced</h2>
 
-Additional classes can be added to your dropdown buttons to change their appearance.
+Additional classes can be added to your dropdown buttons to change their appearance and behavior.
 
-<div class="row">
-  <div class="large-6 columns">
-    <h4>HTML</h4>
-{{#markdown}}
-```html
-<button data-dropdown="drop" aria-controls="drop", aria-expanded="false" class="large alert round button dropdown">Dropdown Button</button><br>
-<ul id="drop" data-dropdown-content class="f-dropdown" role="menu", aria-hidden="false" tabindex="-1">
-  <li><a href="#">This is a link</a></li>
-  <li><a href="#">This is another</a></li>
-  <li><a href="#">Yet another</a></li>
-</ul>
-```
-{{/markdown}}
-  </div>
-  <div class="large-6 columns">
-    <h4>Rendered HTML</h4>
-    <button data-dropdown="dropE" aria-controls="dropE", aria-expanded="false" class="large alert round button dropdown">Dropdown Button</button><br>
-    <ul id="dropE" data-dropdown-content class="f-dropdown" role="menu" aria-hidden="false" tabindex="-1">
-      <li><a href="#">This is a link</a></li>
-      <li><a href="#">This is another</a></li>
-      <li><a href="#">Yet another</a></li>
-    </ul>
-  </div>
-</div>
+{{> examples_dropdown_advanced}}
+
+Disabled dropdown buttons will not open when tapped:
+
+{{> examples_dropdown_disabled}}
 
 ***
 

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -8,6 +8,7 @@
 
     settings : {
       active_class: 'open',
+      disabled_class: 'disabled',
       mega_class: 'mega',
       align: 'bottom',
       is_hover: false,
@@ -147,6 +148,9 @@
     },
 
     toggle : function (target) {
+      if (target.hasClass(this.settings.disabled_class)) {
+        return;
+      }
       var dropdown = this.S('#' + target.data(this.data_attr()));
       if (dropdown.length === 0) {
         // No dropdown found, not continuing

--- a/spec/dropdown/basic.html
+++ b/spec/dropdown/basic.html
@@ -14,3 +14,7 @@
 <div id="drop3" data-dropdown-content class="f-dropdown content">
   <p>Some text that people will think is awesome! Some text that people will think is awesome! Some text that people will think is awesome!</p>
 </div>
+<a id="drop4link" href="#" class="disabled" data-dropdown="drop4">Disabled Dropdown</a>
+<div id="drop4" data-dropdown-content class="f-dropdown content">
+  <p>Some text that people will think is awesome! Some text that people will think is awesome! Some text that people will think is awesome!</p>
+</div>

--- a/spec/dropdown/dropdown.js
+++ b/spec/dropdown/dropdown.js
@@ -23,6 +23,7 @@ describe('dropdown:', function() {
       expect($('#drop1').hasClass('open')).toBe(false);
       expect($('#drop2').hasClass('open')).toBe(false);
       expect($('#drop3').hasClass('open')).toBe(false);
+      expect($('#drop4').hasClass('open')).toBe(false);
     });
 
     it('displays the dropdown on click', function() {
@@ -33,6 +34,7 @@ describe('dropdown:', function() {
       expect($('#drop1').hasClass('open')).toBe(true);
       expect($('#drop2').hasClass('open')).toBe(false);
       expect($('#drop3').hasClass('open')).toBe(false);
+      expect($('#drop4').hasClass('open')).toBe(false);
     });
 
     it('displays the content dropdown on click', function() {
@@ -43,6 +45,7 @@ describe('dropdown:', function() {
       expect($('#drop1').hasClass('open')).toBe(false);
       expect($('#drop2').hasClass('open')).toBe(true);
       expect($('#drop3').hasClass('open')).toBe(false);
+      expect($('#drop4').hasClass('open')).toBe(false);
     });
 
     it('closes an open dropdown when another is clicked', function() {
@@ -54,6 +57,7 @@ describe('dropdown:', function() {
       expect($('#drop1').hasClass('open')).toBe(false);
       expect($('#drop2').hasClass('open')).toBe(true);
       expect($('#drop3').hasClass('open')).toBe(false);
+      expect($('#drop4').hasClass('open')).toBe(false);
     });
 
     it('closes an open dropdown when the document is clicked elsewhere', function() {
@@ -65,6 +69,7 @@ describe('dropdown:', function() {
       expect($('#drop1').hasClass('open')).toBe(false);
       expect($('#drop2').hasClass('open')).toBe(false);
       expect($('#drop3').hasClass('open')).toBe(false);
+      expect($('#drop4').hasClass('open')).toBe(false);
     });
 
     it('displays a dropdown even if the dropdown button has deeply nested content', function() {
@@ -75,6 +80,18 @@ describe('dropdown:', function() {
       expect($('#drop1').hasClass('open')).toBe(false);
       expect($('#drop2').hasClass('open')).toBe(false);
       expect($('#drop3').hasClass('open')).toBe(true);
+      expect($('#drop4').hasClass('open')).toBe(false);
+    });
+
+    it('does not display a disabled dropdown', function() {
+      $(document).foundation();
+
+      $('#drop4link').click();
+
+      expect($('#drop1').hasClass('open')).toBe(false);
+      expect($('#drop2').hasClass('open')).toBe(false);
+      expect($('#drop3').hasClass('open')).toBe(false);
+      expect($('#drop4').hasClass('open')).toBe(false);
     });
  });
 });


### PR DESCRIPTION
When clicking a dropdown button with `class="disabled"` the corresponding dropdown content will not be opened.

Fixes #5370
