### PR TITLE
Fix joyride error

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -111,8 +111,10 @@
           this.end(this.settings.abort_on_close);
         }.bind(this))
 
-        .on("keyup.joyride", function(e) {
-          if (!this.settings.keyboard) return;
+        .on("keyup.fndtn.joyride", function(e) {
+          // Don't do anything if keystrokes are disabled
+          // or if the joyride is not being shown
+          if (!this.settings.keyboard || !this.settings.riding) return;
 
           switch (e.which) {
             case 39: // right arrow


### PR DESCRIPTION
Hi,

Because of #5511, when the joyride is included on the page but hasn't been started yet (with `$(document).foundation('joyride', 'start')` not called on page load but manually),
the keystrokes events are still catched and we end up with a JS error.

This fix checks that the joyride is on screen before calling theses callbacks.

Thanks, and sorry for the error !
