### PR TITLE
Prevent Event propagation on split if main button opens a modal

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -31,6 +31,9 @@
           var settings = S(this).data(self.attr_name(true) + '-init') || self.settings;
           if (!settings.is_hover || Modernizr.touch) {
             e.preventDefault();
+            if (S(this).parent('[data-reveal-id]')) {
+              e.stopPropagation();
+            }
             self.toggle($(this));
           }
         })


### PR DESCRIPTION
Ref an [old discussion](https://github.com/zurb/foundation/issues/4530).

Doesn't break any karma tests.
