### PR TITLE
Remove unused attribute in Tooltips Advanced doc

### DIFF
--- a/doc/pages/components/tooltips.html
+++ b/doc/pages/components/tooltips.html
@@ -35,7 +35,7 @@ Additional classes can be added to your tooltips to change its appearance.
 
 {{#markdown}}
 ```html
-<span data-tooltip aria-haspopup="true" data-options="disable_for_touch:true" class="has-tip [tip-top tip-bottom tip-left tip-right] [radius round]" title="Tooltips are awesome, you should totally use them!">extended information</span>
+<span data-tooltip aria-haspopup="true" class="has-tip [tip-top tip-bottom tip-left tip-right] [radius round]" title="Tooltips are awesome, you should totally use them!">extended information</span>
 ```
 {{/markdown}}
 


### PR DESCRIPTION
The Advanced section on the Tooltips doc has the attribute `data-options="disable_for_touch:true"` in the sample HTML, which is not used in the rendered HTML (the opposite effect is happening actually) or is relevant to this section.

Link to doc:
http://foundation.zurb.com/docs/components/tooltips.html
