### PR TITLE
Adding smooth transition when showing the topbar menu items in small resolution

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -17,6 +17,7 @@ $topbar-bg: $topbar-bg-color !default;
 
 // Height and margin
 $topbar-height: 45px !default;
+$topbar-max-height: 999px !default;
 $topbar-margin-bottom: 0 !default;
 
 // Controlling the styles for the title in the top bar
@@ -144,11 +145,12 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
     .top-bar {
       overflow: hidden;
-      height: $topbar-height;
+      max-height: $topbar-height;
       line-height: $topbar-height;
       position: relative;
       background: $topbar-bg;
       margin-bottom: $topbar-margin-bottom;
+      @include single-transition(max-height, $topbar-transition-speed);
 
       // Topbar Global list Styles
       ul {
@@ -256,8 +258,9 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
       // Change things up when the top-bar is expanded
       &.expanded {
-        height: auto;
+        max-height: $topbar-max-height;
         background: transparent;
+        @include single-transition(max-height, $topbar-transition-speed * 10);
 
         .title-area { background: $topbar-bg; }
 


### PR DESCRIPTION
Right now the menu items from the top-bar shows up abruptly without any transition when revealing it using the Menu button in small resolution. This PR adds a smooth transition using CSS3 animation giving it a smooth transition as such:

![azr5g5umxe](https://cloud.githubusercontent.com/assets/498669/4366950/e4767614-42c9-11e4-91c8-dc4e69c2e802.gif)
