### PR TITLE
Added topbar dropdown arrows switch

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -82,6 +82,7 @@ $topbar-divider-border-top: solid 1px scale-color($topbar-bg-color, $lightness: 
 // Sticky Class
 $topbar-sticky-class: ".sticky" !default;
 $topbar-arrows: true !default; //Set false to remove the triangle icon from the menu item
+$topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text from dropdown subnavigation li
 
 // Accessibility mixins for hiding and showing the menu dropdown items
 @mixin topbar-hide-dropdown {
@@ -552,13 +553,15 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
           .dropdown li.has-dropdown {
             & > a {
-              &:after {
-                border: none;
-                content: "\00bb";
-                top: 1rem;
-                margin-top: -1px;
-                #{$opposite-direction}: 5px;
-                line-height: 1.2;
+            @if ($topbar-dropdown-arrows){
+				&:after {
+				border: none;
+				content: "\00bb";
+				top: 1rem;
+				margin-top: -1px;
+				#{$opposite-direction}: 5px;
+				line-height: 1.2;
+				}
               }
             }
           }

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -247,9 +247,9 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               // $thickness - thickness of lines in hamburger icon, set value in px
               // $gap - spacing between the lines in hamburger icon, set value in px
               // $color - icon color
-              // $hover-color - icon color during hover, here it is set the same as $color because the values are changed on line 264
+              // $hover-color - icon color during hover, here it isn't set b/c it would override $topbar-menu-icon-color-toggled
               // $offcanvas - Set to false of @include in topbar
-              @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, $topbar-menu-icon-color, false);
+              @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, $offcanvas:false);
             }
           }
         }
@@ -264,11 +264,12 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
 
         .toggle-topbar {
           a { color: $topbar-menu-link-color-toggled;
-            &::after {
+			span::after {
               // Shh, don't tell, but box-shadows create the menu icon :)
-              box-shadow: 0 10px 0 1px $topbar-menu-icon-color-toggled,
-                          0 16px 0 1px $topbar-menu-icon-color-toggled,
-                          0 22px 0 1px $topbar-menu-icon-color-toggled;
+              // Change the color of the bars when the menu is expanded, using given thickness from hamburger() above
+              box-shadow: 0 0px 0 1px $topbar-menu-icon-color-toggled,
+                          0 7px 0 1px $topbar-menu-icon-color-toggled,
+                          0 14px 0 1px $topbar-menu-icon-color-toggled;
             }
           }
         }

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -249,7 +249,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               // $color - icon color
               // $hover-color - icon color during hover, here it isn't set b/c it would override $topbar-menu-icon-color-toggled
               // $offcanvas - Set to false of @include in topbar
-              @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, $offcanvas:false);
+              @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, "", false);
             }
           }
         }

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -23,15 +23,6 @@ $topbar-margin-bottom: 0 !default;
 $topbar-title-weight: $font-weight-normal !default;
 $topbar-title-font-size: rem-calc(17) !default;
 
-// Style the top bar dropdown elements
-$topbar-dropdown-bg: $oil !default;
-$topbar-dropdown-link-color: $white !default;
-$topbar-dropdown-link-bg: $oil !default;
-$topbar-dropdown-link-weight: $font-weight-normal !default;
-$topbar-dropdown-toggle-size: 5px !default;
-$topbar-dropdown-toggle-color: $white !default;
-$topbar-dropdown-toggle-alpha: 0.4 !default;
-
 // Set the link colors and styles for top-level nav
 $topbar-link-color: $white !default;
 $topbar-link-color-hover: $white !default;
@@ -52,6 +43,16 @@ $topbar-back-link-size: rem-calc(18) !default;
 $topbar-link-dropdown-padding: 20px;
 $topbar-button-font-size: 0.75rem !default;
 $topbar-button-top: 7px !default;
+
+// Style the top bar dropdown elements
+$topbar-dropdown-bg: $oil !default;
+$topbar-dropdown-link-color: $white !default;
+$topbar-dropdown-link-color-hover: $topbar-link-color-hover !default;
+$topbar-dropdown-link-bg: $oil !default;
+$topbar-dropdown-link-weight: $font-weight-normal !default;
+$topbar-dropdown-toggle-size: 5px !default;
+$topbar-dropdown-toggle-color: $white !default;
+$topbar-dropdown-toggle-alpha: 0.4 !default;
 
 $topbar-dropdown-label-color: $monsoon !default;
 $topbar-dropdown-label-text-transform: uppercase !default;
@@ -585,7 +586,7 @@ $topbar-arrows: true !default; //Set false to remove the triangle icon from the 
               }
 
               &:hover > a:not(.button) {
-                color: $topbar-link-color-hover;
+                color: $topbar-dropdown-link-color-hover;
                 background-color: $topbar-link-bg-color-hover;
                 @if ($topbar-link-bg-hover) {
                   background: $topbar-link-bg-hover;


### PR DESCRIPTION
There is $topbar-arrows boolean switch, but no $topbar-dropdown-arrows switch to turn off dropdown sub nav arrows (\00bb). Added that with an if statement and variable.
