### PR TITLE
Update _top-bar.scss

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -49,7 +49,7 @@ $topbar-link-font-family: $body-font-family !default;
 $topbar-link-text-transform: none !default;
 $topbar-link-padding: $topbar-height / 3 !default;
 $topbar-back-link-size: rem-calc(18) !default;
-$topbar-link-dropdown-padding: 20px;
+$topbar-link-dropdown-padding: 20px !default;
 $topbar-button-font-size: 0.75rem !default;
 $topbar-button-top: 7px !default;
 


### PR DESCRIPTION
$topbar-link-dropdown-padding was overriding without the !default, making the variable as available in the settings file useless.

This is important to fix mostly because it breaks rem-based layouts (throws an error: "Incompatible uinits: 'px' and 'rem'" no matter what you do), but also because it is counterintuitive that if this is set in the settings file, it gets ignored.
