### PR TITLE
Tabs heavy-handed tabindex setting fix

### DIFF
--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -142,9 +142,9 @@
                 'aria-selected' : null
               });
               $target.attr({
+                'tabindex' : '0',
                 'aria-selected' : true
-              }).removeAttr('tabindex')
-                .focus();
+              }).focus();
             }
 
             // Hide panels
@@ -190,12 +190,12 @@
       // window (notably in Chrome).
       // Clean up multiple attr instances to done once
       tab.addClass(settings.active_class).triggerHandler('opened');
-      tab_link.attr({"aria-selected": "true"}).removeAttr('tabindex');
+      tab_link.attr({"aria-selected": "true",  tabindex: 0});
       siblings.removeClass(settings.active_class)
       siblings.find('a').attr({"aria-selected": "false",  tabindex: -1});
-      target.siblings().removeClass(settings.active_class).attr({"aria-hidden": "true",  tabindex: -1}).end().addClass(settings.active_class).attr('aria-hidden', 'false').find(':first-child').removeAttr('tabindex');
+      target.siblings().removeClass(settings.active_class).attr({"aria-hidden": "true",  tabindex: -1});
+      target.addClass(settings.active_class).attr('aria-hidden', 'false').removeAttr("tabindex");
       settings.callback(tab);
-      target.children().removeAttr('tabindex');
       target.triggerHandler('toggled', [tab]);
       tabs.triggerHandler('toggled', [target]);
 

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -142,9 +142,9 @@
                 'aria-selected' : null
               });
               $target.attr({
-                'tabindex' : '0',
                 'aria-selected' : true
-              }).focus();
+              }).removeAttr('tabindex')
+                .focus();
             }
 
             // Hide panels
@@ -190,12 +190,12 @@
       // window (notably in Chrome).
       // Clean up multiple attr instances to done once
       tab.addClass(settings.active_class).triggerHandler('opened');
-      tab_link.attr({"aria-selected": "true",  tabindex: 0});
+      tab_link.attr({"aria-selected": "true"}).removeAttr('tabindex');
       siblings.removeClass(settings.active_class)
       siblings.find('a').attr({"aria-selected": "false",  tabindex: -1});
-      target.siblings().removeClass(settings.active_class).attr({"aria-hidden": "true",  tabindex: -1}).end().addClass(settings.active_class).attr('aria-hidden', 'false').find(':first-child').attr('tabindex', 0);
+      target.siblings().removeClass(settings.active_class).attr({"aria-hidden": "true",  tabindex: -1}).end().addClass(settings.active_class).attr('aria-hidden', 'false').find(':first-child').removeAttr('tabindex');
       settings.callback(tab);
-      target.children().attr('tab-index', 0);
+      target.children().removeAttr('tabindex');
       target.triggerHandler('toggled', [tab]);
       tabs.triggerHandler('toggled', [target]);
 

--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -121,3 +121,7 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
     }
   }
 }
+
+[tabindex="-1"] {
+  outline: none;
+}

--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -121,7 +121,3 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
     }
   }
 }
-
-[tabindex="-1"] {
-  outline: none;
-}


### PR DESCRIPTION
This change is to remove the tabindex attrs instead of setting them to zero on change of tab.

The problem with having a zero tabindex (on a div for example) is that Chrome highlights the area on click and includes it in the tabbable items, so removing the tabindex is a better option as it reverts the tab section to its default tab behaviour.
