### PR TITLE
Fixes multiple inclusions of _global.scss when compiling.

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,7 +9,7 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if(not index($modules, $name)) {
+  @if (index($modules, $name) == false) {
     $modules: append($modules, $name);
     @content;
   }


### PR DESCRIPTION
When compiling the Sass files, you end up with code from _global.scss being included up to 47 times in the app.css file. This fixes #5863 
