### PR TITLE
Fix dropdown alignment issue.

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -286,8 +286,9 @@
 
       var sel_before = '.f-dropdown.open:before',
           sel_after  = '.f-dropdown.open:after',
-          css_before = 'left: ' + pip_offset_base + 'px;',
-          css_after  = 'left: ' + (pip_offset_base - 1) + 'px;';
+          dir = dropdown.hasClass("right") ? "right" : "left",
+          css_before = dir + ': ' + pip_offset_base + 'px;',
+          css_after  = dir + ': ' + (pip_offset_base - 1) + 'px;';
 
       if (sheet.insertRule) {
         sheet.insertRule([sel_before, '{', css_before, '}'].join(' '), this.rule_idx);


### PR DESCRIPTION
When the css for a f-dropdown has "right" in it, the caret at the top doesn't reflect it because that code is in the JS.
