### PR TITLE
Make foundation.accordion.js more generic

### DIFF
--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -22,23 +22,23 @@
       var S = this.S;
       S(this.scope)
       .off('.fndtn.accordion')
-      .on('click.fndtn.accordion', '[' + this.attr_name() + '] > dd > a', function (e) {
+      .on('click.fndtn.accordion', '[' + this.attr_name() + '] > .accordion-navigation > a', function (e) {
         var accordion = S(this).closest('[' + self.attr_name() + ']'),
             groupSelector = self.attr_name() + '=' + accordion.attr(self.attr_name()),
             settings = accordion.data(self.attr_name(true) + '-init'),
             target = S('#' + this.href.split('#')[1]),
-            aunts = $('> dd', accordion),
+            aunts = $('> .accordion-navigation', accordion),
             siblings = aunts.children('.content'),
             active_content = siblings.filter('.' + settings.active_class);
         e.preventDefault();
 
         if (accordion.attr(self.attr_name())) {
-          siblings = siblings.add('[' + groupSelector + '] dd > .content');
-          aunts = aunts.add('[' + groupSelector + '] dd');
+          siblings = siblings.add('[' + groupSelector + '] .accordion-navigation > .content');
+          aunts = aunts.add('[' + groupSelector + '] .accordion-navigation');
         }
 
         if (settings.toggleable && target.is(active_content)) {
-          target.parent('dd').toggleClass(settings.active_class, false);
+          target.parent('.accordion-navigation').toggleClass(settings.active_class, false);
           target.toggleClass(settings.active_class, false);
           settings.callback(target);
           target.triggerHandler('toggled', [accordion]);

--- a/spec/accordion/basic.html
+++ b/spec/accordion/basic.html
@@ -1,5 +1,5 @@
 <dl class="accordion" data-accordion>
-  <dd>
+  <dd class="accordion-navigation">
     <a href="#panel1">Accordion 1</a>
     <div id="panel1" class="content active">
       <dl class="tabs" data-tab>
@@ -24,13 +24,13 @@
       </div>
     </div>
   </dd>
-  <dd>
+  <dd class="accordion-navigation">
     <a href="#panel2">Accordion 2</a>
     <div id="panel2" class="content">
       Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </div>
   </dd>
-  <dd>
+  <dd class="accordion-navigation">
     <a href="#panel3">Accordion 3</a>
     <div id="panel3" class="content">
       Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/spec/accordion/grid.html
+++ b/spec/accordion/grid.html
@@ -1,19 +1,19 @@
 <ul class="small-block-grid-1 medium-block-grid-3">
   <li>
     <dl class="accordion" data-accordion="myAccordionGroup">
-      <dd>
+      <dd class="accordion-navigation">
         <a href="#panel1c">Accordion 1</a>
         <div id="panel1c" class="content">
           Panel 1. Lorem ipsum dolor
         </div>
       </dd>
-      <dd>
+      <dd class="accordion-navigation">
         <a href="#panel2c">Accordion 2</a>
         <div id="panel2c" class="content">
           Panel 2. Lorem ipsum dolor
         </div>
       </dd>
-      <dd>
+      <dd class="accordion-navigation">
         <a href="#panel3c">Accordion 3</a>
         <div id="panel3c" class="content">
           Panel 3. Lorem ipsum dolor
@@ -23,19 +23,19 @@
   </li>
   <li>
     <dl class="accordion" data-accordion="myAccordionGroup">
-      <dd>
+      <dd class="accordion-navigation">
         <a href="#panel4c">Accordion 4</a>
         <div id="panel4c" class="content">
           Panel 4. Lorem ipsum dolor
         </div>
       </dd>
-      <dd>
+      <dd class="accordion-navigation">
         <a href="#panel5c">Accordion 5</a>
         <div id="panel5c" class="content">
           Panel 5. Lorem ipsum dolor
         </div>
       </dd>
-      <dd>
+      <dd class="accordion-navigation">
         <a href="#panel6c">Accordion 6</a>
         <div id="panel6c" class="content">
           Panel 6. Lorem ipsum dolor

--- a/spec/accordion/multiexpand.html
+++ b/spec/accordion/multiexpand.html
@@ -1,17 +1,17 @@
 <dl class="accordion" data-accordion>
-  <dd>
+  <dd class="accordion-navigation">
     <a href="#panel1">Accordion 1</a>
     <div id="panel1" class="content">
       Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </div>
   </dd>
-  <dd>
+  <dd class="accordion-navigation">
     <a href="#panel2">Accordion 2</a>
     <div id="panel2" class="content active">
       Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </div>
   </dd>
-  <dd>
+  <dd class="accordion-navigation">
     <a href="#panel3">Accordion 3</a>
     <div id="panel3" class="content">
       Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.


### PR DESCRIPTION
Removed the references to a specific HTML element, and instead used the class associated with that element in the examples
