### PR TITLE
Allow data manipulation of AJAX response in Reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -193,7 +193,8 @@
           $.extend(ajax_settings, {
             success: function (data, textStatus, jqXHR) {
               if ( $.isFunction(old_success) ) {
-                old_success(data, textStatus, jqXHR);
+                var result = old_success(data, textStatus, jqXHR);
+                if (typeof result == 'string') data = result;
               }
 
               modal.html(data);


### PR DESCRIPTION
This adds the possibility to manipulate the data that is returned from the ajax request in the custom success handler.

This is useful if your API/Website returns JSON and you open the modal from custom javascript like:

```
$modal.foundation('reveal', 'open', {
    url: href+'.json',
    success: function(data) {
    console.log('succesfully loaded '+data.title);
        return data.content;
    },
    error: function(jqXHR, textStatus, errorThorn){
        window.location.href = href;
    }
});
```

Here you can now `return data.content;` to let reveal add only the html content part of the response.
