### PR TITLE
fall back to default settings if none have been explicitly set

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -71,7 +71,7 @@
           e.preventDefault();
 
           if (!self.locked) {
-            var settings = S('[' + self.attr_name() + '].open').data(self.attr_name(true) + '-init'),
+            var settings = S('[' + self.attr_name() + '].open').data(self.attr_name(true) + '-init') || self.settings,
                 bg_clicked = S(e.target)[0] === S('.' + settings.bg_class)[0];
 
             if (bg_clicked) {


### PR DESCRIPTION
this is a pretty minor fix. ran into this bug when adding basic reveal modals to the dom via ajax.

all tests continue to pass, but i haven't bothered adding any. 

![screenshot 2014-10-06 15 53 13](https://cloud.githubusercontent.com/assets/921605/4534992/2cb61a28-4dac-11e4-8966-ad1768b75a85.png)
