### PR TITLE
Fix: alert-box close button background color issue.

### DIFF
--- a/scss/foundation/components/_alert-boxes.scss
+++ b/scss/foundation/components/_alert-boxes.scss
@@ -38,6 +38,7 @@ $alert-close-font-size: rem-calc(22) !default;
 $alert-close-opacity: 0.3 !default;
 $alert-close-opacity-hover: 0.5 !default;
 $alert-close-padding: 9px 6px 4px !default;
+$alert-close-background: inheret !default;
 
 // We use this to control border radius
 $alert-radius: $global-radius !default;
@@ -91,6 +92,7 @@ $alert-transition-ease: ease-out !default;
   #{$opposite-direction}: $alert-close-position;
   color: $alert-close-color;
   opacity: $alert-close-opacity;
+  background: $alert-close-background;
   &:hover,
   &:focus { opacity: $alert-close-opacity-hover; }
 }


### PR DESCRIPTION
When using a button for the alert-box close button, the background would be a different color than the color of the alert box.

![foundation_fix](https://cloud.githubusercontent.com/assets/2957492/4537554/04c6686e-4ddf-11e4-80a8-f9e82f76f413.PNG)
