### PR TITLE
Add !important to .hide

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -425,7 +425,7 @@ $cursor-text-value: text !default;
     .left   { float: left !important; }
     .right  { float: right !important; }
     .clearfix     { @include clearfix; }
-    .hide         { display: none; }
+    .hide         { display: none !important; }
 
     // Font smoothing
     // Antialiased font smoothing works best for light text on a dark background.


### PR DESCRIPTION
Currently, `_global.scss` is imported by `_alert-boxes.scss`, so the CSS output order is:

```
.hide {
  display: none;
}
.alert-box {
  display: block;
}
```

Which leads to unexpected behaviour, namely this div:

```
<div class="alert-box hide">
    ...
</div>
```

being currently visible!

Adding `!important` ensures that `.hide` will always override the default `display`.
