### PR TITLE
Support 3.4-index() in exports() function

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -9,7 +9,8 @@ $rem-base: 16px !default;
 // We use this to prevent styles from being loaded multiple times for compenents that rely on other components. 
 $modules: () !default;
 @mixin exports($name) {
-  @if (index($modules, $name) == false) {
+  $module_index: index($modules, $name);
+  @if (($module_index == null) or ($module_index == false)) {
     $modules: append($modules, $name);
     @content;
   }


### PR DESCRIPTION
Updating the exports() function to work with Sass 3.2/3.3 and libsass 2.0 which return false for index() AND add support for Sass 3.4 and libsass 3.0 with the new behaviour.

Discussed in issue #5932 and sass/libsass#538
