### PR TITLE
Fixed visibility of numbers on basic grid example from Docs

### DIFF
--- a/doc/includes/grid/examples_grid_rendered.html
+++ b/doc/includes/grid/examples_grid_rendered.html
@@ -1,31 +1,31 @@
 <div class="row display">
-  <div class="small-2 large-4 columns"><span class="show-for-small">2</span><span class="hide-for-small">4</span></div>
+  <div class="small-2 large-4 columns"><span class="hide-for-large">2</span><span class="show-for-large">4</span></div>
   <div class="small-4 large-4 columns">4</div>
-  <div class="small-6 large-4 columns"><span class="show-for-small">6</span><span class="hide-for-small">4</span></div>
+  <div class="small-6 large-4 columns"><span class="hide-for-large">6</span><span class="show-for-large">4</span></div>
 </div>
 <div class="row display">
-  <div class="large-3 columns"><span class="show-for-small">full</span><span class="hide-for-small">3</span></div>
-  <div class="large-6 columns"><span class="show-for-small">full</span><span class="hide-for-small">6</span></div>
-  <div class="large-3 columns"><span class="show-for-small">full</span><span class="hide-for-small">3</span></div>
+  <div class="large-3 columns"><span class="hide-for-large">full</span><span class="show-for-large">3</span></div>
+  <div class="large-6 columns"><span class="hide-for-large">full</span><span class="show-for-large">6</span></div>
+  <div class="large-3 columns"><span class="hide-for-large">full</span><span class="show-for-large">3</span></div>
 </div>
 <div class="row display">
-  <div class="small-6 large-2 columns"><span class="show-for-small">6</span><span class="hide-for-small">2</span></div>
-  <div class="small-6 large-8 columns"><span class="show-for-small">6</span><span class="hide-for-small">8</span></div>
-  <div class="small-12 large-2 columns"><span class="show-for-small">full</span><span class="hide-for-small">2</span></div>
+  <div class="small-6 large-2 columns"><span class="hide-for-large">6</span><span class="show-for-large">2</span></div>
+  <div class="small-6 large-8 columns"><span class="hide-for-large">6</span><span class="show-for-large">8</span></div>
+  <div class="small-12 large-2 columns"><span class="hide-for-large">full</span><span class="show-for-large">2</span></div>
 </div>
 <div class="row display">
   <div class="small-3 columns">3</div>
   <div class="small-9 columns">9</div>
 </div>
 <div class="row display">
-  <div class="large-4 columns"><span class="show-for-small">full</span><span class="hide-for-small">4</span></div>
-  <div class="large-8 columns"><span class="show-for-small">full</span><span class="hide-for-small">8</span></div>
+  <div class="large-4 columns"><span class="hide-for-large">full</span><span class="show-for-large">4</span></div>
+  <div class="large-8 columns"><span class="hide-for-large">full</span><span class="show-for-large">8</span></div>
 </div>
 <div class="row display">
-  <div class="small-6 large-5 columns"><span class="show-for-small">6</span><span class="hide-for-small">5</span></div>
-  <div class="small-6 large-7 columns"><span class="show-for-small">6</span><span class="hide-for-small">7</span></div>
+  <div class="small-6 large-5 columns"><span class="hide-for-large">6</span><span class="show-for-large">5</span></div>
+  <div class="small-6 large-7 columns"><span class="hide-for-large">6</span><span class="show-for-large">7</span></div>
 </div>
 <div class="row display">
-  <div class="large-6 columns"><span class="show-for-small">full</span><span class="hide-for-small">6</span></div>
-  <div class="large-6 columns"><span class="show-for-small">full</span><span class="hide-for-small">6</span></div>
+  <div class="large-6 columns"><span class="hide-for-large">full</span><span class="show-for-large">6</span></div>
+  <div class="large-6 columns"><span class="hide-for-large">full</span><span class="show-for-large">6</span></div>
 </div>


### PR DESCRIPTION
I noticed that for a medium-sized screen, the incorrect numbers were appearing. So I checked, and it's just a small difference in the visibility class wording that should fix that.
