### PR TITLE
Restoring namespaced events for Abide

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -107,14 +107,14 @@
       for (var i=0; i < validation_count; i++) {
         if (!validations[i] && (submit_event || is_ajax)) {
           if (this.settings.focus_on_invalid) els[i].focus();
-          form.trigger('invalid');
+          form.trigger('invalid').trigger('invalid.fndtn.abide');
           this.S(els[i]).closest('form').attr(this.invalid_attr, '');
           return false;
         }
       }
 
       if (submit_event || is_ajax) {
-        form.trigger('valid');
+        form.trigger('valid').trigger('valid.fndtn.abide');
       }
 
       form.removeAttr(this.invalid_attr);


### PR DESCRIPTION
Namespaced events were added by @thedeerchild  here: https://github.com/zurb/foundation/commit/179f3d1fc2a0bc785438ec1a74faf5ef86855f81
Then they were removed here (probably by mistake): https://github.com/zurb/foundation/commit/179f3d1fc2a0bc785438ec1a74faf5ef86855f81
That commit was partially undone here: https://github.com/zurb/foundation/commit/4e164cc29cedf8e9bd5c312483a90f454c69dc72
But the namespaced events weren't restored.  This commit re-adds them, as specified in that first commit.  
Without namespaced events, Abide doesn't act like the Events section of its documentation says it should here: http://foundation.zurb.com/docs/components/abide.html#events
