### PR TITLE
Fix SCSS in the docs for Alert Boxes > Semantic Markup > Advanced.

### DIFF
--- a/doc/pages/components/alert_boxes.html
+++ b/doc/pages/components/alert_boxes.html
@@ -217,6 +217,12 @@ You can further customize your alert boxes using the provided options in the `al
     // Give a border to the alert box
     $radius: true
   );
+  .close {
+    @include alert-close();
+  }
+  &.alert-close {
+    opacity: 0;
+  }
 }
 ```
 {{/markdown}}


### PR DESCRIPTION
The example didn't work for me. I dug in the SCSS and found how the `alert()` mixin is used by Foundation itself, then I updated the example.

https://github.com/zurb/foundation/blob/master/scss/foundation/components/_alert-boxes.scss#L113

:heart: 
