### PR TITLE
[foundation.reveal.js] replace bind(this) with local context variable

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -257,7 +257,8 @@
       // is modal
       if (css) {
         var settings = el.data(this.attr_name(true) + '-init') || this.settings,
-            root_element = settings.root_element;
+            root_element = settings.root_element,
+            context = this;
 
         if (el.parent(root_element).length === 0) {
           var placeholder = el.wrap('<div style="display: none;" />').parent();
@@ -285,11 +286,11 @@
             return el
               .css(css)
               .animate(end_css, settings.animation_speed, 'linear', function () {
-                this.locked = false;
+                context.locked = false;
                 el.trigger('opened').trigger('opened.fndtn.reveal');
-              }.bind(this))
+              })
               .addClass('open');
-          }.bind(this), settings.animation_speed / 2);
+          }, settings.animation_speed / 2);
         }
 
         if (animData.fade) {
@@ -300,11 +301,11 @@
             return el
               .css(css)
               .animate(end_css, settings.animation_speed, 'linear', function () {
-                this.locked = false;
+                context.locked = false;
                 el.trigger('opened').trigger('opened.fndtn.reveal');
-              }.bind(this))
+              })
               .addClass('open');
-          }.bind(this), settings.animation_speed / 2);
+          }, settings.animation_speed / 2);
         }
 
         return el.css(css).show().css({opacity: 1}).addClass('open').trigger('opened').trigger('opened.fndtn.reveal');
@@ -325,7 +326,8 @@
     hide : function (el, css) {
       // is modal
       if (css) {
-        var settings = el.data(this.attr_name(true) + '-init');
+        var settings = el.data(this.attr_name(true) + '-init'),
+            context = this;
         settings = settings || this.settings;
 
         var animData = getAnimationData(settings.animation);
@@ -341,11 +343,11 @@
           return setTimeout(function () {
             return el
               .animate(end_css, settings.animation_speed, 'linear', function () {
-                this.locked = false;
+                context.locked = false;
                 el.css(css).trigger('closed').trigger('closed.fndtn.reveal');
-              }.bind(this))
+              })
               .removeClass('open');
-          }.bind(this), settings.animation_speed / 2);
+          }, settings.animation_speed / 2);
         }
 
         if (animData.fade) {
@@ -354,11 +356,11 @@
           return setTimeout(function () {
             return el
               .animate(end_css, settings.animation_speed, 'linear', function () {
-                this.locked = false;
+                context.locked = false;
                 el.css(css).trigger('closed').trigger('closed.fndtn.reveal');
-              }.bind(this))
+              })
               .removeClass('open');
-          }.bind(this), settings.animation_speed / 2);
+          }, settings.animation_speed / 2);
         }
 
         return el.hide().css(css).removeClass('open').trigger('closed').trigger('closed.fndtn.reveal');


### PR DESCRIPTION
Fix compatibility issue with the use of `.bind(this)` and the Capybara (2.1.0) testing framework. Exceptions were encountered when using the Capybara WebKit driver or PhantomJS  Poltergeist driver.
