### PR TITLE
Add missing data-offcanvas initialization attribute

### DIFF
--- a/doc/includes/off_canvas/examples_offcanvas_multiple_level_markup.html
+++ b/doc/includes/off_canvas/examples_offcanvas_multiple_level_markup.html
@@ -1,6 +1,6 @@
 {{#markdown}}
 ```html
-<div class="off-canvas-wrap">
+<div class="off-canvas-wrap" data-offcanvas>
   <div class="inner-wrap">
     <nav class="tab-bar">
       <section class="left-small">


### PR DESCRIPTION
It appears the documentation markup for the [Off Canvas Multilevel Menu](http://foundation.zurb.com/docs/components/offcanvas.html#off-canvas-multilevel-menu) example is missing the data attribute `data-offcanvas`.

The problem has been made apparent from [this StackOverflow question](http://stackoverflow.com/questions/26595170/why-doesnt-zurb-foundation-off-canvas-work-in-my-project/)
