### PR TITLE
Look at currentTarget instead of target in dropdown

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -52,7 +52,7 @@
 
           var settings = target.data(self.attr_name(true) + '-init') || self.settings;
 
-          if(S(e.target).data(self.data_attr()) && settings.is_hover) {
+          if(S(e.currentTarget).data(self.data_attr()) && settings.is_hover) {
             self.closeall.call(self);
           }
 


### PR DESCRIPTION
As noted in #5275, if you had content other than text in your dropdown trigger, moving quickly leaves multiple hovers active. If you move faster than the timeout (150ms), the timeout is cleared, but because e.target is the inner element, it doesn't call closeall().

Problem: http://codepen.io/anon/pen/uGotr
My fix: http://codepen.io/anon/pen/wdIik
