### PR TITLE
skip keydown validation on tab key

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -82,7 +82,7 @@
             self.validate([this], e);
           })
           .on('keydown.fndtn.abide', function (e) {
-            if (settings.live_validate === true) {
+            if (settings.live_validate === true && e.which != 9) {
               clearTimeout(self.timer);
               self.timer = setTimeout(function () {
                 self.validate([this], e);


### PR DESCRIPTION
Since tab key triggers the blur event, skip it.
It's not a keydown event that needs to be triggered.
