### PR TITLE
Prevent equalizer exceptions when using Rails turbolinks

### DIFF
--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -28,7 +28,7 @@
     equalize: function(equalizer) {
       var isStacked = false,
           vals = equalizer.find('[' + this.attr_name() + '-watch]:visible'),
-          settings = equalizer.data(this.attr_name(true)+'-init');
+          settings = equalizer.data(this.attr_name(true)+'-init') || this.settings;
 
       if (vals.length === 0) return;
       var firstTopOffset = vals.first().offset().top;


### PR DESCRIPTION
Equalizer throws exceptions when re-loading through Rails turbolinks because settings are not always set up.  See, for example, https://github.com/zurb/foundation/issues/4275#issuecomment-52917496.
