### PR TITLE
No scroll animation when scroll_speed = 0

### DIFF
--- a/js/foundation/foundation.joyride.js
+++ b/js/foundation/foundation.joyride.js
@@ -460,7 +460,7 @@
       window_half = $(window).height() / 2;
       tipOffset = Math.ceil(this.settings.$target.offset().top - window_half + this.settings.$next_tip.outerHeight());
 
-      if (tipOffset != 0) {
+      if (this.settings.scroll_speed !== 0 && tipOffset != 0) {
         $('html, body').stop().animate({
           scrollTop: tipOffset
         }, this.settings.scroll_speed, 'swing');


### PR DESCRIPTION
While implementing Joyride on our site we noticed when setting scroll_speed to 0 per your documentation, Joyride would still scroll, but do it instantly. This small adjustment fixed the issue for us.

No documentation changes are necessary, as it now works as depicted.
