### PR TITLE
Icon bar active state styling

### DIFF
--- a/scss/foundation/components/_icon-bar.scss
+++ b/scss/foundation/components/_icon-bar.scss
@@ -181,6 +181,15 @@ $icon-bar-item-padding: 1.25rem !default;
 
 			i { color: $bar-icon-color-hover; }
 		}
+
+        & > a.active {
+
+			background: $bar-active-color;
+
+			label { color: $bar-font-color-hover; }
+
+			i { color: $bar-icon-color-hover; }
+		}
 	}
 
 }


### PR DESCRIPTION
Actually makes use of the $icon-bar-active-color variable to set the
background when an "active" class is added to the anchor, akin to what
happens with the :hover pseudoclass.
