### PR TITLE
Removing 'resize' event when launching a Reveal modal.

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -211,7 +211,6 @@
           $.ajax(ajax_settings);
         }
       }
-      self.S(window).trigger('resize');
     },
 
     close : function (modal) {


### PR DESCRIPTION
The window is not resized when a modal launches, therefore a resize event should not be triggered. There may be use cases where it would be helpful for a resize event to fire when a modal is launched, but it should be up to the individual developer to handle the event themselves.

Triggering a resize when a resize doesn't actually happen can mess up code that is looking for a real resize event.
