### PR TITLE
fix(foundation.slider.js): consider 0 value for `pageX/Y`

### DIFF
--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -46,16 +46,9 @@
               if (!e.pageY) {
                 scroll_offset = window.scrollY;
               }
-              self.calculate_position(self.cache.active, (e.pageY || 
-                                                          e.originalEvent.clientY || 
-                                                          e.originalEvent.touches[0].clientY || 
-                                                          e.currentPoint.y) 
-                                                          + scroll_offset);
+              self.calculate_position(self.cache.active, self.get_cursor_position(e, 'y') + scroll_offset);
             } else {
-              self.calculate_position(self.cache.active, e.pageX || 
-                                                         e.originalEvent.clientX || 
-                                                         e.originalEvent.touches[0].clientX || 
-                                                         e.currentPoint.x);
+              self.calculate_position(self.cache.active, self.get_cursor_position(e, 'x'));
             }
           }
         })
@@ -70,6 +63,26 @@
         .on('resize.fndtn.slider', self.throttle(function(e) {
           self.reflow();
         }, 300));
+    },
+
+    get_cursor_position : function(e, xy) {
+      var pageXY = 'page' + xy.toUpperCase(),
+          clientXY = 'client' + xy.toUpperCase(),
+          position;
+
+      if (typeof e[pageXY] !== 'undefined') {
+        position = e[pageXY];
+      }
+      else if (typeof e.originalEvent[clientXY] !== 'undefined') {
+        position = e.originalEvent[clientXY];
+      }
+      else if (e.originalEvent.touches && e.originalEvent.touches[0] && typeof e.originalEvent.touches[0][clientXY] !== 'undefined') {
+        position = e.originalEvent.touches[0][clientXY];
+      }
+      else if(e.currentPoint && typeof e.currentPoint[xy] !== 'undefined') {
+        position = e.currentPoint[xy];
+      }
+      return position;
     },
 
     set_active_slider : function($handle) {


### PR DESCRIPTION
- fix `Uncaught TypeError: Cannot read property '0' of undefined` if mouse position X/Y is 0
- add `get_cursor_position()` method

If you start dragging the slider and move the mouse position X/Y until it is `0`, it is counted as falsey which means `||` in [line 49](https://github.com/zurb/foundation/blob/master/js/foundation/foundation.slider.js#L49) and in [line 55](https://github.com/zurb/foundation/blob/master/js/foundation/foundation.slider.js#L55) keeps going until it gets to `e.originalEvent.touches[0].clientX/Y` where it raises an error if it is no touch device. I changed it to explicitly checking that the values are `undefined`.

![oq6fzbeh](https://cloud.githubusercontent.com/assets/464300/5014284/cf3519fc-6a94-11e4-8b9a-95149ad64ac5.png)
