### PR TITLE
Properly extending dropdown library

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -19,6 +19,7 @@
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');
 
+      $.extend(true, this.settings, method, options);
       this.bindings(method, options);
     },
 


### PR DESCRIPTION
Fixing #5931, the dropdown library never extended settings whenever someone tried to hook into it.
