### PR TITLE
JS media queries

### DIFF
--- a/doc/pages/javascript-utilities.html
+++ b/doc/pages/javascript-utilities.html
@@ -254,6 +254,7 @@ Foundation.utils.is_xlarge_up();
 // XXLarge queries
 Foundation.utils.is_xxlarge_only();
 Foundation.utils.is_xxlarge_up();
+{{/markdown}}
 
 <div class="row">
   <div class="large-6 columns">

--- a/doc/pages/javascript-utilities.html
+++ b/doc/pages/javascript-utilities.html
@@ -231,6 +231,30 @@ Media queries are the backbone of most responsive CSS techniques, though they ca
 
 <strong>Match Media</strong> can be used to check if the browser currently matches the media query passed in as a string. To use the function, call <code>matchMedia()</code> with the media query as an argument, and check the <code>matches</code> property (see example below).
 
+<p>In addition to this, you can also check the default Foundation media queries. The available methods are:</p>
+
+{{#markdown}}
+```javascript
+// Small queries
+Foundation.utils.is_small_only();
+Foundation.utils.is_small_up();
+
+// Medium queries
+Foundation.utils.is_medium_only();
+Foundation.utils.is_medium_up();
+
+// Large queries
+Foundation.utils.is_large_only();
+Foundation.utils.is_large_up();
+
+// XLarge queries
+Foundation.utils.is_xlarge_only();
+Foundation.utils.is_xlarge_up();
+
+// XXLarge queries
+Foundation.utils.is_xxlarge_only();
+Foundation.utils.is_xxlarge_up();
+
 <div class="row">
   <div class="large-6 columns">
     <h4>CSS</h4>

--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -609,6 +609,64 @@
         this.prefix = this.prefix || [(this.name || 'F'), (+new Date).toString(36)].join('-');
 
         return this.prefix + (this.fidx++).toString(36);
+      },
+
+      // Description:
+      //    Helper for window.matchMedia
+      //
+      // Arguments:
+      //    mq (String): Media query
+      //
+      // Returns:
+      //    (Boolean): Whether the media query passes or not
+      match : function (mq) {
+        return window.matchMedia(mq).matches;
+      },
+
+      // Description:
+      //    Helpers for checking Foundation default media queries with JS
+      //
+      // Returns:
+      //    (Boolean): Whether the media query passes or not
+
+      is_small_up : function () {
+        return this.match(Foundation.media_queries.small);
+      },
+
+      is_medium_up : function () {
+        return this.match(Foundation.media_queries.medium);
+      },
+
+      is_large_up : function () {
+        return this.match(Foundation.media_queries.large);
+      },
+
+      is_xlarge_up : function () {
+        return this.match(Foundation.media_queries.xlarge);
+      },
+
+      is_xxlarge_up : function () {
+        return this.match(Foundation.media_queries.xxlarge);
+      },
+
+      is_small_only : function () {
+        return !this.is_medium_up() && !this.is_large_up() && !this.is_xlarge_up() && !this.is_xxlarge_up();
+      },
+
+      is_medium_only : function () {
+        return this.is_medium_up() && !this.is_large_up() && !this.is_xlarge_up() && !this.is_xxlarge_up();
+      },
+
+      is_large_only : function () {
+        return this.is_medium_up() && this.is_large_up() && !this.is_xlarge_up() && !this.is_xxlarge_up();
+      },
+
+      is_xlarge_only : function () {
+        return this.is_medium_up() && this.is_large_up() && this.is_xlarge_up() && !this.is_xxlarge_up();
+      },
+
+      is_xxlarge_only : function () {
+        return this.is_medium_up() && this.is_large_up() && this.is_xlarge_up() && this.is_xxlarge_up();
       }
     }
   };


### PR DESCRIPTION
See issue #6003 

Examples:

```
// Small queries
Foundation.utils.is_small_only();
Foundation.utils.is_small_up();

// Medium queries
Foundation.utils.is_medium_only();
Foundation.utils.is_medium_up();

// Large queries
Foundation.utils.is_large_only();
Foundation.utils.is_large_up();

// XLarge queries
Foundation.utils.is_xlarge_only();
Foundation.utils.is_xlarge_up();

// XXLarge queries
Foundation.utils.is_xxlarge_only();
Foundation.utils.is_xxlarge_up();
```
