### PR TITLE
Interchange: reload images/nodes on init

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -80,8 +80,7 @@
       this.data_attr = this.set_data_attr();
       $.extend(true, this.settings, method, options);
       this.bindings(method, options);
-      this.load('images');
-      this.load('nodes');
+      this.reflow();
     },
 
     get_media_hash : function() {

--- a/spec/interchange/interchange.js
+++ b/spec/interchange/interchange.js
@@ -15,10 +15,13 @@ describe('interchange:', function() {
       switch(path) {
         case 'default.html':
           callback('<h1 id="default">DEFAULT</h1>');
+          break;
         case 'medium.html':
           callback('<h1 id="medium">MEDIUM</h1>');
+          break;
         case 'large.html':
           callback('<h1 id="large">LARGE</h1>');
+          break;
       }
     });
   });
@@ -59,15 +62,18 @@ describe('interchange:', function() {
   }));
 
   describe('setting data-interchange-last-path', function() {
-    beforeEach(function() {
-      document.body.innerHTML = __html__['spec/interchange/basic.html'];
-    });
-
-    it('should set data-interchange-last-path on element when replace occurs', function() {
-      Foundation.libs.interchange.update_nodes();
-      Foundation.libs.interchange.resize();
-
-      expect($('div[data-interchange]').data('data-interchange-last-path')).toMatch(/.+html$/)
-    });
+    describe('when below the large breakpoint', when_not('large', function() {
+      beforeEach(function() {
+        document.body.innerHTML = __html__['spec/interchange/basic.html'];
+      });
+      
+      it('should set data-interchange-last-path on element when replace occurs', function() {
+        expect($('div[data-interchange]').data('data-interchange-last-path')).toBe(undefined);
+        
+        // Last path shouldn't be set until we initialize foundation
+        $(document).foundation();        
+        expect($('div[data-interchange]').data('data-interchange-last-path')).toMatch('default.html');
+      });
+    }))
   });
 });


### PR DESCRIPTION
Fixes #5180 

cached_images and cached_nodes get set on the first call to init(). They then are always returned instead of calling update_[images/nodes](). This would force update on any call to init().

The problem can be seen here: http://jsfiddle.net/bblackwood/twqpx1nb/
Fiddle with fix: http://jsfiddle.net/bblackwood/wLkdcL65/1/
