### PR TITLE
No !important for .hide

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -428,7 +428,7 @@ $cursor-text-value: text !default;
 
     // Hide visually and from screen readers
     .hide {
-      display: none !important;
+      display: none;
       visibility: hidden;
     }
 


### PR DESCRIPTION
`.hide` should not be that !important, as it breaks a heck lot of jquery/JS-Code using .show(), .hide() or .toggle()!
https://github.com/zurb/foundation/issues/6024
