### PR TITLE
No !important & visibility:hidden for .hide

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -427,10 +427,7 @@ $cursor-text-value: text !default;
     .clearfix { @include clearfix; }
 
     // Hide visually and from screen readers
-    .hide {
-      display: none !important;
-      visibility: hidden;
-    }
+    .hide { display: none; }
 
     // Hide visually and from screen readers, but maintain layout
     .invisible { visibility: hidden; }


### PR DESCRIPTION
Removing !important from `.hide` isn't enough to make jquery .show() / .toggle() work again. visibility:hidden has to go to.
#6050 #6024
