### PR TITLE
Collapse/uncollapse row

### DIFF
--- a/doc/includes/grid/examples_grid_row_collapse.html
+++ b/doc/includes/grid/examples_grid_row_collapse.html
@@ -1,0 +1,12 @@
+{{#markdown}}
+```html
+<div class="row small-collapse medium-uncollapse">
+	<div class="small-12 meidum-6 columns">
+		Adds gutter at medium media query
+	</div>
+	<div class="small-12 meidum-6 columns">
+		Adds gutter at medium media query
+	</div>
+</div>
+```
+{{/markdown}}

--- a/doc/includes/grid/examples_grid_row_collapse_rendered.html
+++ b/doc/includes/grid/examples_grid_row_collapse_rendered.html
@@ -1,0 +1,8 @@
+<div class="row small-collapse medium-uncollapse">
+	<div class="small-12 meidum-6 columns">
+		Adds gutter at medium media query
+	</div>
+	<div class="small-12 meidum-6 columns">
+		Adds gutter at medium media query
+	</div>
+</div>

--- a/doc/pages/components/grid.html
+++ b/doc/pages/components/grid.html
@@ -89,6 +89,20 @@ In order to work around browsers' different rounding behaviors, Foundation will 
 
 ***
 
+### Collapse/Uncollapse Rows
+
+There are times when you won't want each media query to be collapsed or uncollapsed. In this case, use the media query size you want and collapse or uncollapse and add that to your `row` element. Example shows no gutter at small media size and then adds the gutter to columns at medium.
+
+<h4>HTML</h4>
+
+{{> examples_grid_row_collapse}}
+
+<h4>Rendered HTML</h4>
+
+{{> examples_grid_row_collapse_rendered}}
+
+***
+
 ### Centered Columns
 
 Center your columns by adding a class of `small-centered` to your `column`. Large will inherit small centering by default, but you can also center solely on large by applying a `large-centered` class. To uncenter on large screens use `large-uncentered`.

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -211,14 +211,19 @@ $last-child-float: $opposite-direction !default;
     float: $opposite-direction;
   }
 
-	.row.#{$size}-collapse {
-		> .column,
-		> .columns { @include grid-column($collapse:true, $float:false); }
-	}
+	.row {
+		&.#{$size}-collapse {
+			> .column,
+			> .columns { @include grid-column($collapse:true, $float:false); }
 
-	.row.#{$size}-uncollapse {
-		> .column,
-		> .columns { @include grid-column; }
+			.row {margin-left:0; margin-right:0;}
+		}
+		&.#{$size}-uncollapse {
+			> .column,
+			> .columns {
+				@include grid-column;
+			}
+		}
 	}
 }
 

--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -210,6 +210,16 @@ $last-child-float: $opposite-direction !default;
   .columns.#{$size}-uncentered.opposite {
     float: $opposite-direction;
   }
+
+	.row.#{$size}-collapse {
+		> .column,
+		> .columns { @include grid-column($collapse:true, $float:false); }
+	}
+
+	.row.#{$size}-uncollapse {
+		> .column,
+		> .columns { @include grid-column; }
+	}
 }
 
 @include exports("grid") {


### PR DESCRIPTION
I needed the ability to add/remove padding (`.collapse`) on the columns based on the size at which browser was at. Similary to `.small-centered`/`.medium-uncentered` you can use `.small-collapse`/`.medium-uncollapse`. Since I needed it, thought someone else may, too.
