### PR TITLE
Capitalize P in WordPress in docs.

### DIFF
--- a/doc/pages/index.html
+++ b/doc/pages/index.html
@@ -187,7 +187,7 @@ title: Getting Started
           </div>
           <div class="medium-4 columns">
             <h4>Development Tools</h4>
-            <p>The Foundation community has put together <a href="http://foundation.zurb.com/develop/resources.html">free themes</a> for Wordpress, Drupal, Shopify, Jekyll, and more! Or if you're looking for <a href="http://madmimi.github.io/angular-foundation/">Angular directives for Foundation</a>, <a href="https://github.com/zurb/foundation-5-sublime-snippets">Sublime Text Snippets</a>, or <a href="http://zacksmash.github.io/foundation-5-coda-2-clips/">Clips for Coda</a> we can help you out.</p>
+            <p>The Foundation community has put together <a href="http://foundation.zurb.com/develop/resources.html">free themes</a> for WordPress, Drupal, Shopify, Jekyll, and more! Or if you're looking for <a href="http://madmimi.github.io/angular-foundation/">Angular directives for Foundation</a>, <a href="https://github.com/zurb/foundation-5-sublime-snippets">Sublime Text Snippets</a>, or <a href="http://zacksmash.github.io/foundation-5-coda-2-clips/">Clips for Coda</a> we can help you out.</p>
           </div>
           <div class="medium-4 columns">
             <h4>Inspiration</h4>


### PR DESCRIPTION
The official spelling is a capital P.
