### PR TITLE
Update foundation.dropdown.js - geting target when resize

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -176,8 +176,8 @@
     },
 
     resize : function () {
-      var dropdown = this.S('[' + this.attr_name() + '-content].open'),
-          target = this.S('[' + this.attr_name() + '="' + dropdown.attr('id') + '"]');
+      var dropdown = this.S('[' + this.attr_name() + '-content].open');
+      var target = $(dropdown.data("target"));
 
       if (dropdown.length && target.length) {
         this.css(dropdown, target);


### PR DESCRIPTION
That change fix bug when we have 2 or more elements that trigger dropdown, we have target on data atrr so we can get this element directly from data when resize window (not search by id)
