### PR TITLE
Stacking <button>'s

### DIFF
--- a/scss/foundation/components/_button-groups.scss
+++ b/scss/foundation/components/_button-groups.scss
@@ -70,6 +70,9 @@ $button-group-border-width: 1px !default;
       margin:0;
       display: block;
     }
+    > button {
+        width: 100%;
+    }
 
     &:first-child {
       button, .button {


### PR DESCRIPTION
`<button>`'s won't get expanded to full width if stacked (orientation == vertical).
