### PR TITLE
Same spacing between links in top bar

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -630,7 +630,7 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
 
         .has-form {
           background: $topbar-link-bg;
-          padding: 0 ($topbar-height / 3);
+          padding: 0 $topbar-link-padding;
           height: $topbar-height;
         }
 


### PR DESCRIPTION
Changing the value of $topbar-link-padding will change the padding between links, but not between e.g. buttons.
