### PR TITLE
zurb/foundation#6109 - change split regexp to handle urls with parenthes...

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -276,7 +276,7 @@
 
       if (i > 0) {
         while (i--) {
-          var split = raw_arr[i].split(/\((.*?)(\))$/);
+          var split = raw_arr[i].split(/\(([^\)]*?)(\))$/);
 
           if (split.length > 1) {
             var params = this.parse_scenario(split);


### PR DESCRIPTION
this limits the split to the last occurance of opening parenthesis in the raw scenario string, thereby allowing the presence of parenthesis in the url/path
