### PR TITLE
added ability to customize split button pip

### DIFF
--- a/doc/includes/split_button/examples_split_button_custom_pip.html
+++ b/doc/includes/split_button/examples_split_button_custom_pip.html
@@ -1,0 +1,1 @@
+<a href="#" class="button split no-pip">Custom Pip<span><i class="fi-arrow-down"></i></span></a>

--- a/doc/includes/split_button/examples_split_button_custom_pip_rendered.html
+++ b/doc/includes/split_button/examples_split_button_custom_pip_rendered.html
@@ -1,0 +1,5 @@
+{{#markdown}}
+```html
+<a href="#" class="button split no-pip">Custom Pip<span><i class="fi-arrow-down"></i></span></a>
+```
+{{/markdown}}

--- a/doc/pages/components/split_buttons.html
+++ b/doc/pages/components/split_buttons.html
@@ -50,6 +50,23 @@ Additional classes can be added to your split buttons to change its appearance.
 
 ***
 
+<h2>Custom Pip</h2>
+
+If you desire to use your own pip in the split button, the `no-pip` class will remove ours and allow you to place any icon inside of the pip span
+
+<div class="row">
+  <div class="large-6 columns">
+    <h4>HTML</h4>
+{{> examples_split_button_custom_pip_rendered}}
+  </div>
+  <div class="large-6 columns">
+    <h4>HTML Rendered</h4>
+{{> examples_split_button_custom_pip}}
+  </div>
+</div>
+
+***
+
 ## Accessibility
 
 <p class="panel">This component is not yet accessible. Stay tuned for updates in future releases.</p>

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -185,6 +185,18 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
 
       &.radius span { @include side-radius($opposite-direction, $global-radius); }
       &.round span { @include side-radius($opposite-direction, 1000px); }
+      &.no-pip{
+        span:before{ border-style:none; }
+        span:after{ border-style:none; }
+        span{
+          i:before{
+            position: absolute;
+            top: -10%;
+            margin-left: -10%;
+            margin-top: 47%;
+          }
+        }
+      }
     }
 
   }


### PR DESCRIPTION
Saw [this question online](http://foundation.zurb.com/forum/posts/21102-split-button-with-close-icon-instead-of-dropdown), thought I'd add in the ability to replace the pip with font icon.
