### PR TITLE
Add seven-up support to icon-bar

### DIFF
--- a/scss/foundation/components/_icon-bar.scss
+++ b/scss/foundation/components/_icon-bar.scss
@@ -326,5 +326,19 @@ $icon-bar-disabled-cursor: $cursor-disabled-value !default;
 				}
 			}
 		}
+		&.seven-up {
+            		.item { width: 14.28%; }
+            		&.vertical .item, &.small-vertical .item { width: auto; }
+            		&.medium-vertical .item {
+                		@media #{$medium-up} {
+                    			width: auto;
+                		}
+            		}
+            		&.large-vertical .item {
+                		@media #{$large-up} {
+                	   		width: auto;
+                		}
+            		}
+        	}
 	}
 }


### PR DESCRIPTION
Add `seven-up` support to icon-bar. 

Math may require work, but the functionality is present.
