### PR TITLE
Reveal modal: Multiple opened

### DIFF
--- a/doc/includes/reveal/examples_reveal_javascript_options.html
+++ b/doc/includes/reveal/examples_reveal_javascript_options.html
@@ -5,6 +5,7 @@
   animation_speed: 250,
   close_on_background_click: true,
   dismiss_modal_class: 'close-reveal-modal',
+  multiple_opened: false,
   bg_class: 'reveal-modal-bg',
   root_element: 'body',
   bg : $('.reveal-modal-bg'),

--- a/doc/pages/components/reveal.html
+++ b/doc/pages/components/reveal.html
@@ -25,7 +25,7 @@ You can create a reveal modal using minimal markup. The anchor tag with the reve
 
 <h2>Intermediate</h2>
 
-You can create a reveal modal with another inside it. You can even put a video into a reveal.
+You can create a reveal modal with another inside it. Setting `reveal.multiple_opened` to `true` will not close previously opened reveal modals. You can even put a video into a reveal.
 
 <div class="row">
   <div class="large-8 columns">

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -236,6 +236,7 @@
         
         if ((settings.multiple_opened && open_modals.length === 1) || !settings.multiple_opened || modal.length > 1) {
           this.toggle_bg(modal, false);
+          this.to_front(modal);
         }
         
         if (settings.multiple_opened) {

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -14,6 +14,7 @@
       close_on_background_click: true,
       close_on_esc: true,
       dismiss_modal_class: 'close-reveal-modal',
+      multiple_opened: false,
       bg_class: 'reveal-modal-bg',
       bg_root_element: 'body',
       root_element: 'body',
@@ -184,7 +185,11 @@
 
         if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
           if (open_modal.length > 0) {
-            this.hide(open_modal, settings.css.close);
+            if (settings.multiple_opened) {
+              this.to_back(open_modal);
+            } else {
+              this.hide(open_modal, settings.css.close);
+            }
           }
 
           this.show(modal, settings.css.open);
@@ -203,7 +208,11 @@
               self.S(modal).children().foundation();
 
               if (open_modal.length > 0) {
-                self.hide(open_modal, settings.css.close);
+                if (settings.multiple_opened) {
+                  this.to_back(open_modal);
+                } else {
+                  this.hide(open_modal, settings.css.close);
+                }
               }
               self.show(modal, settings.css.open);
             }
@@ -224,8 +233,17 @@
         this.locked = true;
         this.key_up_off(modal);   // PATCH #3: turning on key up capture only when a reveal window is open
         modal.trigger('close').trigger('close.fndtn.reveal');
-        this.toggle_bg(modal, false);
-        this.hide(open_modals, settings.css.close, settings);
+        
+        if ((settings.multiple_opened && open_modals.length === 1) || !settings.multiple_opened || modal.length > 1) {
+          this.toggle_bg(modal, false);
+        }
+        
+        if (settings.multiple_opened) {
+          this.hide(modal, settings.css.close, settings);
+          this.to_front($($.makeArray(open_modals).reverse()[1]));
+        } else {
+          this.hide(open_modals, settings.css.close, settings);
+        }
       }
     },
 
@@ -325,6 +343,14 @@
       this.locked = false;
 
       return el.show();
+    },
+    
+    to_back : function(el) {
+      el.addClass('toback');
+    },
+    
+    to_front : function(el) {
+      el.removeClass('toback');
     },
 
     hide : function (el, css) {

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -43,6 +43,9 @@ $reveal-border-color: $steel !default;
 $reveal-modal-class: "reveal-modal" !default;
 $close-reveal-modal-class: "close-reveal-modal" !default;
 
+// Set base z-index
+$z-index-base: 1005;
+
 //
 // @mixins
 //
@@ -57,7 +60,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
   right: 0;
   background: $reveal-overlay-bg-old; // Autoprefixer should be used to avoid such variables needed when Foundation for Sites can do so in the near future.
   background: $reveal-overlay-bg;
-  z-index: if( $include-z-index-value, 1004, auto );
+  z-index: if( $include-z-index-value, $z-index-base - 1, auto );
   display: none;
   #{$default-float}: 0;
 }
@@ -72,7 +75,7 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
     visibility: hidden;
     display: none;
     position: absolute;
-    z-index: 1005;
+    z-index: $z-index-base;
     width: 100vw;
     top:0;
     border-radius: $border-radius;
@@ -164,6 +167,11 @@ $close-reveal-modal-class: "close-reveal-modal" !default;
 
     // Reveal Modals
     .reveal-modal-bg { @include reveal-bg; }
+
+    // Modals pushed to back
+    .toback {
+      z-index: $z-index-base - 2;
+    }
 
     .#{$reveal-modal-class} {
       @include reveal-modal-base;

--- a/scss/foundation/components/_reveal.scss
+++ b/scss/foundation/components/_reveal.scss
@@ -168,11 +168,6 @@ $z-index-base: 1005;
     // Reveal Modals
     .reveal-modal-bg { @include reveal-bg; }
 
-    // Modals pushed to back
-    .toback {
-      z-index: $z-index-base - 2;
-    }
-
     .#{$reveal-modal-class} {
       @include reveal-modal-base;
       @include reveal-modal-style(
@@ -202,6 +197,11 @@ $z-index-base: 1005;
         min-height:100vh;
         max-width: none !important;
         margin-left: 0 !important;
+      }
+      
+      // Modals pushed to back
+      &.toback {
+        z-index: $z-index-base - 2;
       }
 
       .#{$close-reveal-modal-class} { @include reveal-close; }


### PR DESCRIPTION
In my app (marksexpress), I have implemented a wysiwyg editor (summernote-foundation). In admin mode the edit form has been implemented through a modal box, however the editor also uses the modal boxes. So when inserting an image, the editor modal box would be closed. This patch adds an option that allows previous modals to remain open.
![12-24-2014 8-51-49 am](https://cloud.githubusercontent.com/assets/1153495/5548538/3b3766e8-8b4a-11e4-8c34-9997303b207b.jpg)
![12-24-2014 8-53-00 am](https://cloud.githubusercontent.com/assets/1153495/5548543/4b7ac270-8b4a-11e4-8949-28ab7875dfee.jpg)
