### PR TITLE
[Magellan] Check for arrivals after setting expedition position

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -93,6 +93,7 @@
         expedition.data(self.data_attr('magellan-top-offset'), top_offset);
         expedition.attr('style', styles);
       });
+      self.check_for_arrivals();
     },
 
     update_expedition_positions : function() {


### PR DESCRIPTION
I ran into an issue where any time a page was loaded scrolled to a position other than the top, the following sequence would occur:
1. `set_expedition_position()` was called initially on line 31
2. the `scroll.fndtn.magellan` event triggered `check_for_arrivals()`
3. the `resize.fndtn.magellan` event triggered `set_expedition_position()` again

Because the scroll occurred before the resize, `check_for_arrivals()` (and therefore `update_expedition_positions()`) was never called again and my nav bar would disappear off screen.

I've added `check_for_arrivals()` to the end of `set_expedition_position()`, since it's currently not guaranteed to be called otherwise.
