### PR TITLE
Semantic Tabs

### DIFF
--- a/doc/includes/tabs/examples_tabs_basic.html
+++ b/doc/includes/tabs/examples_tabs_basic.html
@@ -1,9 +1,9 @@
-<dl class="tabs" data-tab>
-  <dd class="active"><a href="#panel1">Tab 1</a></dd>
-  <dd><a href="#panel2">Tab 2</a></dd>
-  <dd><a href="#panel3">Tab 3</a></dd>
-  <dd><a href="#panel4">Tab 4</a></dd>
-</dl>
+<ul class="tabs" data-tab>
+  <li class="active"><a href="#panel1">Tab 1</a></li>
+  <li><a href="#panel2">Tab 2</a></li>
+  <li><a href="#panel3">Tab 3</a></li>
+  <li><a href="#panel4">Tab 4</a></li>
+</ul>
 <div class="tabs-content">
   <div class="content active" id="panel1">
     <p>This is the first panel of the basic tab example. This is the first panel of the basic tab example.</p>

--- a/doc/includes/tabs/examples_tabs_basic_rendered.html
+++ b/doc/includes/tabs/examples_tabs_basic_rendered.html
@@ -1,9 +1,9 @@
-<dl class="tabs" data-tab>
-  <dd class="active"><a href="#tab1">Tab 1</a></dd>
-  <dd><a href="#tab2">Tab 2</a></dd>
-  <dd><a href="#tab3">Tab 3</a></dd>
-  <dd><a href="#tab4">Tab 4</a></dd>
-</dl>
+<ul class="tabs" data-tab>
+  <li class="active"><a href="#tab1">Tab 1</a></li>
+  <li><a href="#tab2">Tab 2</a></li>
+  <li><a href="#tab3">Tab 3</a></li>
+  <li><a href="#tab4">Tab 4</a></li>
+</ul>
 <div class="tabs-content">
   <div class="content active" id="tab1">
     <p>This is the first panel of the basic tab example. This is the first panel of the basic tab example.</p>

--- a/doc/includes/tabs/examples_tabs_vertical_basic.html
+++ b/doc/includes/tabs/examples_tabs_vertical_basic.html
@@ -1,9 +1,9 @@
-<dl class="tabs vertical" data-tab>
-  <dd class="active"><a href="#panel1">Tab 1</a></dd>
-  <dd><a href="#panel2">Tab 2</a></dd>
-  <dd><a href="#panel3">Tab 3</a></dd>
-  <dd><a href="#panel4">Tab 4</a></dd>
-</dl>
+<ul class="tabs vertical" data-tab>
+  <li class="active"><a href="#panel1">Tab 1</a></li>
+  <li><a href="#panel2">Tab 2</a></li>
+  <li><a href="#panel3">Tab 3</a></li>
+  <li><a href="#panel4">Tab 4</a></li>
+</ul>
 <div class="tabs-content vertical">
   <div class="content active" id="panel1">
     <p>This is the first panel of the basic tab example. This is the first panel of the basic tab example.</p>

--- a/doc/includes/tabs/examples_tabs_vertical_intro.html
+++ b/doc/includes/tabs/examples_tabs_vertical_intro.html
@@ -1,9 +1,9 @@
-<dl class="tabs vertical" data-tab>
-  <dd class="active"><a href="#panel3-1">Tab 1</a></dd>
-  <dd><a href="#panel3-2">Tab 2</a></dd>
-  <dd><a href="#panel3-3">Tab 3</a></dd>
-  <dd><a href="#panel3-4">Tab 4</a></dd>
-</dl>
+<ul class="tabs vertical" data-tab>
+  <li class="active"><a href="#panel3-1">Tab 1</a></li>
+  <li><a href="#panel3-2">Tab 2</a></li>
+  <li><a href="#panel3-3">Tab 3</a></li>
+  <li><a href="#panel3-4">Tab 4</a></li>
+</ul>
 <div class="tabs-content vertical">
   <div class="content active" id="panel3-1">
     <p>Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>


### PR DESCRIPTION
I swapped out the dl and dd's for a ul and li's for the tabs to make them more semantic. Per the [spec](http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-dl-element), the dl element must contain one or more dt element, each followed by one or more dd elements.

Using list items (li's) allows the tabs to be used with unordered and ordered lists, as well as in a menu element if necessary.
