### PR TITLE
Dropdown pips can now be centered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.ruby-version
 *.scssc
 *.sublime-*
+*.swp
+*.swo
 .bundle
 .config
 .grunt

--- a/doc/includes/dropdown/examples_dropdown_directions.html
+++ b/doc/includes/dropdown/examples_dropdown_directions.html
@@ -1,11 +1,11 @@
-<a href="#" class="button" data-dropdown="topDrop" data-options="align: top">Top &raquo;</a>
-<ul id="topDrop" class="f-dropdown" data-dropdown-content>
+<a href="#" class="button" data-dropdown="rightDrop" data-options="align: right">Right &raquo;</a>
+<ul id="rightDrop" class="f-dropdown" data-dropdown-content>
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
-<a href="#" class="button" data-dropdown="leftDrop" data-options="align: left">Left &raquo;</a>
-<ul id="leftDrop" class="f-dropdown" data-dropdown-content>
+<a href="#" class="button" data-dropdown="topDrop" data-options="align: top">Top &raquo;</a>
+<ul id="topDrop" class="f-dropdown" data-dropdown-content>
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
@@ -16,8 +16,8 @@
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
-<a href="#" class="button" data-dropdown="rightDrop" data-options="align: right">Right &raquo;</a>
-<ul id="rightDrop" class="f-dropdown" data-dropdown-content>
+<a href="#" class="button" data-dropdown="leftDrop" data-options="align: left">Left &raquo;</a>
+<ul id="leftDrop" class="f-dropdown" data-dropdown-content>
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>

--- a/doc/includes/dropdown/examples_dropdown_pip_directions.html
+++ b/doc/includes/dropdown/examples_dropdown_pip_directions.html
@@ -1,0 +1,24 @@
+<a href="#" class="button" data-dropdown="rightDropCenter" data-options="align: right; pip: center">Right &raquo;</a>
+<ul id="rightDropCenter" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<a href="#" class="button" data-dropdown="topDropCenter" data-options="align: top; pip: center">Top &raquo;</a>
+<ul id="topDropCenter" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<a href="#" class="button" data-dropdown="downDropCenter" data-options="pip: center">Down &raquo;</a>
+<ul id="downDropCenter" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<a href="#" class="button" data-dropdown="leftDropCenter" data-options="align: left; pip: center">Left &raquo;</a>
+<ul id="leftDropCenter" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>

--- a/doc/includes/dropdown/examples_dropdown_pip_expand.html
+++ b/doc/includes/dropdown/examples_dropdown_pip_expand.html
@@ -1,0 +1,6 @@
+<a href="#" class="button expand" data-dropdown="dropExpand" data-options="pip: center">Expanded Dropdown</a>
+<ul id="dropExpand" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>

--- a/doc/pages/components/dropdown.html
+++ b/doc/pages/components/dropdown.html
@@ -8,9 +8,9 @@ title: Dropdowns
 
 {{> examples_dropdown_basic}}
 
-***
+<hr>
 
-<h3>Basic</h3>
+<h2>Basic</h2>
 
 You can create a dropdown using minimal markup. <strong>On a small device, the tooltips are full-width and bottom aligned.</strong>
 
@@ -25,11 +25,22 @@ You can create a dropdown using minimal markup. <strong>On a small device, the t
   </div>
 </div>
 
-***
+<hr>
 
-<h3>Advanced</h3>
+<h2>Advanced</h2>
+
+<h3>Dropdown Classes</h3>
 
 Additional classes can be added to your dropdown to change its appearance.
+
+
+*  `tiny`: Make the dropdown have a max-width of 200px
+*  `small`: Make the dropdown have a max-width of 300px
+*  `medium`: Make the dropdown have a max-width of 500px
+*  `large`: Make the dropdown have a max-width of 800px
+*  `mega`: Make the dropdown go full 100% width
+*  `content`: Add padding inside the dropdown for better-looking content
+
 
 <div class="row">
   <div class="large-6 columns">
@@ -83,6 +94,50 @@ To set other alignments, just specify the <code>align</code> property in <code>d
 
 ***
 
+<h3>Pip Alignment</h3>
+
+By default, the pip connecting the dropdown to the button is positioned at the left edge of the dropdown for top and bottom aligned dropdowns on the left half of the screen, at the right edge of the dropdown for top and bottom aligned dropdowns on the right half of the screen, and at the top edge of the dropdown for left and right aligned dropdowns.
+
+Adding <code>pip: center</code> to the <code>data-options</code> attribute will override this behavior and align the pip to the center of the button for all dropdown alignments.
+<div class="row">
+  <div class="large-6 columns">
+{{#markdown}}
+```html
+<a href="#" data-options="align:[left right top bottom]; pip: center" data-dropdown="drop" class="button">Link Dropdown &raquo;</a>
+<ul id="drop" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+```
+{{/markdown}}
+  </div>
+  <div class="large-6 columns">
+    {{> examples_dropdown_pip_directions}}
+  </div>
+</div>
+
+For buttons wider than the dropdown, the entire dropdown is centered.
+<div class="row">
+  <div class="large-6 columns">
+{{#markdown}}
+```html
+<a href="#" class="button expand" data-options="pip: center" data-dropdown="drop" class="button">Expanded Dropdown</a>
+<ul id="drop" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+```
+{{/markdown}}
+  </div>
+  <div class="large-6 columns">
+    {{> examples_dropdown_pip_expand}}
+  </div>
+</div>
+
+***
+
 <h3>Autoclose</h3>
 
 There is an autoclose option that you can include in the mark up. This is an option that enables the dropdown to close automatically when a link is clicked within the dropdown. 
@@ -108,16 +163,7 @@ This option is enabled by default, but to disable (keep dropdowns persisting), s
 
 ***
 
-Available class options:
-
-* `tiny`: Make the dropdown have a max-width of 200px
-* `small`: Make the dropdown have a max-width of 300px
-* `medium`: Make the dropdown have a max-width of 500px
-* `large`: Make the dropdown have a max-width of 800px
-* `mega`: Make the dropdown go full 100% width
-* `content`: Add padding inside the dropdown for better-looking content
-
-##### Hoverable Dropdown Option
+<h3>Hoverable Dropdown</h3>
 
 If you'd rather have your dropdown be accessible by hover, you can add a data-option to the target element. There is also an optional setting `hover_delay` that you can set to a time (in milliseconds) that will set your own custom delay to the element. The default setting for `hover_delay` is 150ms.
 
@@ -134,13 +180,14 @@ If you'd rather have your dropdown be accessible by hover, you can add a data-op
 
 ***
 
-## Accessibility
+<h2>Accessibility</h2>
 
 <p class="panel">This component is not yet accessible. Stay tuned for updates in future releases.</p>
 
 ***
 
-## Customize with Sass
+<h2>Customize with Sass</h2>
+
 
 Dropdowns can be easily customized using our Sass variables.
 
@@ -150,7 +197,7 @@ Dropdowns can be easily customized using our Sass variables.
 
 ***
 
-## Semantic Markup With Sass
+<h2>Semantic Markup With Sass</h2>
 
 You can create your own dropdowns using our Sass mixins.
 
@@ -158,7 +205,7 @@ You can create your own dropdowns using our Sass mixins.
 
 You can use the `dropdown-container()` and `dropdown-style()` mixins to create your own dropdowns, like so:
 
-##### The Container Mixin
+<h5>The Container Mixin</h5>
 
 <h4>SCSS</h4>
 
@@ -170,7 +217,7 @@ You can use the `dropdown-container()` and `dropdown-style()` mixins to create y
 ```
 {{/markdown}}
 
-##### The List Style Mixin
+<h5>The List Style Mixin</h5>
 
 <h4>SCSS</h4>
 
@@ -184,7 +231,7 @@ You can use the `dropdown-container()` and `dropdown-style()` mixins to create y
 ```
 {{/markdown}}
 
-<h3>Advanced</h3>
+<h4>Advanced</h4>
 
 You can further customize your dropdowns with the options in the `dropdown-container()` mixin:
 
@@ -209,7 +256,7 @@ You can further customize your dropdowns with the options in the `dropdown-conta
 
 ***
 
-## Configure With Javascript
+<h2>Configure With Javascript</h2>
 
 It's easy to configure dropdowns using our provided Javascript. You can use data-attributes or plain old Javascript. Make sure `jquery.js`, `foundation.js` and `foundation.dropdown.js` have been included on your page before continuing. For example, add the following before the closing `<body>` tag:
 
@@ -221,9 +268,9 @@ It's easy to configure dropdowns using our provided Javascript. You can use data
   ```
 {{/markdown}}
 
-### Optional Javascript Configuration
+<h3>Optional Javascript Configuration</h3>
 
-#### JS
+<h4>JS</h4>
 
 {{#markdown}}
 ```js
@@ -238,7 +285,7 @@ $(document).foundation({
 
 ***
 
-### Adding New Dropdown Content After Page Load
+<h3>Adding New Dropdown Content After Page Load</h3>
 
 If you add new content after the page has been loaded, you will need to reinitialize the Foundation JavaScript by running the following:
 
@@ -258,7 +305,7 @@ $(document).foundation('dropdown', 'reflow');
 
 ***
 
-### Sass Errors?
+<h3>Sass Errors?</h3>
 
 If the default "foundation" import was commented out, then make sure you import this file:
 

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -11,6 +11,7 @@
       disabled_class: 'disabled',
       mega_class: 'mega',
       align: 'bottom',
+      pip: 'default',
       is_hover: false,
       hover_timeout: 150,
       opened: function(){},
@@ -198,8 +199,7 @@
     },
 
     css : function (dropdown, target) {
-      var left_offset = Math.max((target.width() - dropdown.width()) / 2, 8),
-          settings = target.data(this.attr_name(true) + '-init') || this.settings;
+      var settings = target.data(this.attr_name(true) + '-init') || this.settings;
 
       this.clear_idx();
 
@@ -213,7 +213,7 @@
           top: p.top
         });
 
-        dropdown.css(Foundation.rtl ? 'right':'left', left_offset);
+        dropdown.css(Foundation.rtl ? 'right':'left', 8);
       } else {
 
         this.style(dropdown, target, settings);
@@ -240,6 +240,7 @@
 
         p.top -= o.top;
         p.left -= o.left;
+        p.offset = 0;
         
         //set some flags on the p object to pass along
         p.missRight = false;
@@ -249,133 +250,157 @@
     
         //lets see if the panel will be off the screen
         //get the actual width of the page and store it
-        var actualBodyWidth;
+        p.bodyWidth = window.outerWidth;
         if (document.getElementsByClassName('row')[0]) {
-          actualBodyWidth = document.getElementsByClassName('row')[0].clientWidth;
-        } else {
-          actualBodyWidth = window.outerWidth;
-        }
-
-        var actualMarginWidth = (window.outerWidth - actualBodyWidth) / 2;
-        var actualBoundary = actualBodyWidth;
-    
-        if (!this.hasClass('mega')) {
-          //miss top
-          if (t.offset().top <= this.outerHeight()) {
-            p.missTop = true;
-            actualBoundary = window.outerWidth - actualMarginWidth;
-            p.leftRightFlag = true;
-          }
-          
-          //miss right
-          if (t.offset().left + this.outerWidth() > t.offset().left + actualMarginWidth && t.offset().left - actualMarginWidth > this.outerWidth()) {
-            p.missRight = true;
-            p.missLeft = false;
-          }
-          
-          //miss left
-          if (t.offset().left - this.outerWidth() <= 0) {
-            p.missLeft = true;
-            p.missRight = false;
-          }
+          p.bodyWidth = document.getElementsByClassName('row')[0].clientWidth;
         }
 
         return p;
       },
 
-      top: function (t, s) {
+      _position_bottom : function(d,t,s,p) {
+        if(d.outerWidth() > t.outerWidth()) {
+          //miss right
+          if (p.left + d.outerWidth() > p.bodyWidth) {
+            //miss left
+            if(p.left - (d.outerWidth() - t.outerWidth()) < 0) {
+              // set triggered right if the dropdown won't fit inside the first .row
+              // in either the left or right orientation.
+              p.triggeredRight = true;
+              p.missLeft = true;
+            } else {
+              p.missRight = true;
+            }
+          }
+        }
+
+        if (t.outerWidth() > d.outerWidth() && s.pip == 'center') {
+          p.offset = (t.outerWidth() - d.outerWidth()) / 2;
+        }
+        else if (p.triggeredRight) {
+          if(d.outerWidth() < p.bodyWidth) {
+            p.offset = (p.bodyWidth - p.left) - d.outerWidth();
+          } else {
+            p.offset = -p.left;
+          }
+        }
+        else if (p.missRight || self.rtl) {
+          p.offset = -d.outerWidth() + t.outerWidth();
+        } else {
+          p.offset = 0;
+        }
+
+        return p;
+      },
+
+      top : function (t, s) {
         var self = Foundation.libs.dropdown,
-            p = self.dirs._base.call(this, t);
+            p = self.dirs._base.call(this, t),
+            offsetTop = -this.outerHeight();
+        
+        p = self.dirs._position_bottom(this,t,s,p);       
 
         this.addClass('drop-top');
         
-        if (p.missTop == true) {
-          p.top = p.top + t.outerHeight() + this.outerHeight();
+        //miss top
+        if (t.offset().top <= this.outerHeight()) {
+          p.missTop = true;
+          p.leftRightFlag = true;
           this.removeClass('drop-top');
-        }
-    
-        if (p.missRight == true) {
-          p.left = p.left - this.outerWidth() + t.outerWidth();
+          offsetTop = t.outerHeight();
         }
 
-        if (t.outerWidth() < this.outerWidth() || self.small() || this.hasClass(s.mega_menu)) {
+        if (self.rtl || t.outerWidth() < this.outerWidth() || self.small() || this.hasClass(s.mega_menu)) {
           self.adjust_pip(this,t,s,p);
         }
 
-        if (Foundation.rtl) {
-          return {left: p.left - this.outerWidth() + t.outerWidth(),
-            top: p.top - this.outerHeight()};
-        }
-
-        return {left: p.left, top: p.top - this.outerHeight()};
+        return {left: p.left + p.offset, top: p.top + offsetTop};
       },
 
       bottom: function (t,s) {
         var self = Foundation.libs.dropdown,
             p = self.dirs._base.call(this, t);
+        
+        p = self.dirs._position_bottom(this,t,s,p);       
 
-        if (p.missRight == true) {
-          p.left = p.left - this.outerWidth() + t.outerWidth();
-        }
-
-        if (t.outerWidth() < this.outerWidth() || self.small() || this.hasClass(s.mega_menu)) {
+        // Is this if statement really worth it?
+        // I assume it is here to avoid unnecessary sheet.insertRule calls, but how expensive are they?
+        if (p.offset || t.outerWidth() < this.outerWidth() || self.small() || this.hasClass(s.mega_menu)) {
           self.adjust_pip(this,t,s,p);
         }
 
-        if (self.rtl) {
-          return {left: p.left - this.outerWidth() + t.outerWidth(), top: p.top + t.outerHeight()};
-        }
-
-        return {left: p.left, top: p.top + t.outerHeight()};
+        return {left: p.left + p.offset, top: p.top + t.outerHeight()};
       },
 
       left: function (t, s) {
-        var p = Foundation.libs.dropdown.dirs._base.call(this, t);
+        var self = Foundation.libs.dropdown,
+            p = self.dirs._base.call(this, t);
+        p.offset = -this.outerWidth();
 
         this.addClass('drop-left');
         
-        if (p.missLeft == true) {
-          p.left =  p.left + this.outerWidth();
+        //miss left
+        if (p.left - this.outerWidth() <= 0) {
+          p.missLeft = true;
+          p.missRight = false;
           p.top = p.top + t.outerHeight();
           this.removeClass('drop-left');
+          p = self.dirs._position_bottom(this,t,s,p);
+          self.adjust_pip(this,t,s,p);
+        } else {
+          self.adjust_pip_vertical(this,t,s,p);
         }
 
-        return {left: p.left - this.outerWidth(), top: p.top};
+        return {left: p.left + p.offset, top: p.top};
       },
 
       right: function (t, s) {
-        var p = Foundation.libs.dropdown.dirs._base.call(this, t);
+        var self = Foundation.libs.dropdown,
+            p = self.dirs._base.call(this, t);
+        p.offset = t.outerWidth();
 
         this.addClass('drop-right');
         
-        if (p.missRight == true) {
-          p.left = p.left - this.outerWidth();
+        //miss right
+        if (p.left + this.outerWidth() + t.outerWidth() > p.bodyWidth) {
+          p.missRight = true;
+          p.missLeft = false;
           p.top = p.top + t.outerHeight();
           this.removeClass('drop-right');
+          p = self.dirs._position_bottom(this,t,s,p);
+          self.adjust_pip(this,t,s,p);
         } else {
           p.triggeredRight = true;
-        }
-    
-        var self = Foundation.libs.dropdown;
-
-        if (t.outerWidth() < this.outerWidth() || self.small() || this.hasClass(s.mega_menu)) {
-          self.adjust_pip(this,t,s,p);
+          self.adjust_pip_vertical(this,t,s,p);
         }
 
-        return {left: p.left + t.outerWidth(), top: p.top};
+        return {left: p.left + p.offset, top: p.top};
       }
     },
 
     // Insert rule to style psuedo elements
     adjust_pip : function (dropdown,target,settings,position) {
       var sheet = Foundation.stylesheet,
-          pip_offset_base = 8;
+          pip_offset_base = 8 - position.offset;
 
       if (dropdown.hasClass(settings.mega_class)) {
         pip_offset_base = position.left + (target.outerWidth()/2) - 8;
       }
       else if (this.small()) {
-        pip_offset_base += position.left - 8;
+        pip_offset_base = position.left;
+        if (settings.pip == 'center') {
+          pip_offset_base += (target.outerWidth()/2) - 15;
+        }
+      }
+      else if (settings.pip == 'center') {
+        if(target.outerWidth() < dropdown.outerWidth()){
+          pip_offset_base = (target.outerWidth()/2) - position.offset - 7;
+        } else {
+          pip_offset_base = (dropdown.outerWidth()/2) - 7;
+        }
+      }
+      else if (position.missRight) {
+        pip_offset_base += target.outerWidth() - 30;
       }
 
       this.rule_idx = sheet.cssRules.length;
@@ -386,8 +411,11 @@
           css_before = 'left: ' + pip_offset_base + 'px;',
           css_after  = 'left: ' + (pip_offset_base - 1) + 'px;';
         
-      if (position.missRight == true) {
+      /*if (position.missRight == true) {
         pip_offset_base = dropdown.outerWidth() - 23;
+        if(settings.pip == 'center') {
+          pip_offset_base = pip_offset_base - target.outerWidth()/2 + (23 - 8);
+        }
         sel_before = '.f-dropdown.open:before',
         sel_after  = '.f-dropdown.open:after',
         css_before = 'left: ' + pip_offset_base + 'px;',
@@ -395,12 +423,54 @@
       }
     
       //just a case where right is fired, but its not missing right
-      if (position.triggeredRight == true) {
+      if (settings.pip != 'center' && position.triggeredRight == true) {
         sel_before = '.f-dropdown.open:before',
         sel_after  = '.f-dropdown.open:after',
         css_before = 'left:-12px;',
         css_after  = 'left:-14px;';
+      }*/
+
+      if (sheet.insertRule) {
+        sheet.insertRule([sel_before, '{', css_before, '}'].join(' '), this.rule_idx);
+        sheet.insertRule([sel_after, '{', css_after, '}'].join(' '), this.rule_idx + 1);
+      } else {
+        sheet.addRule(sel_before, css_before, this.rule_idx);
+        sheet.addRule(sel_after, css_after, this.rule_idx + 1);
       }
+    },
+
+    adjust_pip_vertical : function (dropdown,target,settings,position) {
+      var sheet = Foundation.stylesheet,
+          pip_offset_base = 10,
+          pip_halfheight = 14;
+
+      if (settings.pip == 'center') {
+        pip_offset_base = (target.outerHeight() - pip_halfheight) / 2;
+      }
+
+      this.rule_idx = sheet.cssRules.length;
+
+      //default
+      var sel_before = '.f-dropdown.open:before',
+          sel_after  = '.f-dropdown.open:after',
+          css_before = 'top: ' + pip_offset_base + 'px;',
+          css_after  = 'top: ' + (pip_offset_base - 1) + 'px;';
+        
+      /*if (position.missRight == true) {
+        pip_offset_base = dropdown.outerWidth() - 23;
+        sel_before = '.f-dropdown.open:before',
+        sel_after  = '.f-dropdown.open:after',
+        css_before = 'top: ' + pip_offset_base + 'px;',
+        css_after  = 'top: ' + (pip_offset_base - 1) + 'px;';
+      }
+    
+      //just a case where right is fired, but its not missing right
+      if (position.triggeredRight == true) {
+        sel_before = '.f-dropdown.open:before',
+        sel_after  = '.f-dropdown.open:after',
+        css_before = 'top:-12px;',
+        css_after  = 'top:-14px;';
+      }*/
 
       if (sheet.insertRule) {
         sheet.insertRule([sel_before, '{', css_before, '}'].join(' '), this.rule_idx);

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -411,25 +411,6 @@
           css_before = 'left: ' + pip_offset_base + 'px;',
           css_after  = 'left: ' + (pip_offset_base - 1) + 'px;';
         
-      /*if (position.missRight == true) {
-        pip_offset_base = dropdown.outerWidth() - 23;
-        if(settings.pip == 'center') {
-          pip_offset_base = pip_offset_base - target.outerWidth()/2 + (23 - 8);
-        }
-        sel_before = '.f-dropdown.open:before',
-        sel_after  = '.f-dropdown.open:after',
-        css_before = 'left: ' + pip_offset_base + 'px;',
-        css_after  = 'left: ' + (pip_offset_base - 1) + 'px;';
-      }
-    
-      //just a case where right is fired, but its not missing right
-      if (settings.pip != 'center' && position.triggeredRight == true) {
-        sel_before = '.f-dropdown.open:before',
-        sel_after  = '.f-dropdown.open:after',
-        css_before = 'left:-12px;',
-        css_after  = 'left:-14px;';
-      }*/
-
       if (sheet.insertRule) {
         sheet.insertRule([sel_before, '{', css_before, '}'].join(' '), this.rule_idx);
         sheet.insertRule([sel_after, '{', css_after, '}'].join(' '), this.rule_idx + 1);
@@ -456,22 +437,6 @@
           css_before = 'top: ' + pip_offset_base + 'px;',
           css_after  = 'top: ' + (pip_offset_base - 1) + 'px;';
         
-      /*if (position.missRight == true) {
-        pip_offset_base = dropdown.outerWidth() - 23;
-        sel_before = '.f-dropdown.open:before',
-        sel_after  = '.f-dropdown.open:after',
-        css_before = 'top: ' + pip_offset_base + 'px;',
-        css_after  = 'top: ' + (pip_offset_base - 1) + 'px;';
-      }
-    
-      //just a case where right is fired, but its not missing right
-      if (position.triggeredRight == true) {
-        sel_before = '.f-dropdown.open:before',
-        sel_after  = '.f-dropdown.open:after',
-        css_before = 'top:-12px;',
-        css_after  = 'top:-14px;';
-      }*/
-
       if (sheet.insertRule) {
         sheet.insertRule([sel_before, '{', css_before, '}'].join(' '), this.rule_idx);
         sheet.insertRule([sel_after, '{', css_after, '}'].join(' '), this.rule_idx + 1);

--- a/spec/dropdown/dropdown.js
+++ b/spec/dropdown/dropdown.js
@@ -94,4 +94,144 @@ describe('dropdown:', function() {
       expect($('#drop4').hasClass('open')).toBe(false);
     });
  });
+
+  describe('miss sides of container', when('medium', function() {
+    beforeEach(function() {
+      document.body.innerHTML = __html__['spec/dropdown/miss.html'];
+    });
+
+    it('displays top-aligned dropdowns below when close to the top', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="missTop"]').click();
+
+      expect($('#missTop').hasClass('drop-top')).toBe(false);
+    });
+
+    it('displays right-aligned dropdowns below when close to the right', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="missRight"]').click();
+
+      expect($('#missRight').hasClass('drop-right')).toBe(false);
+    });
+
+    it('displays left-aligned dropdowns below when close to the left', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="missLeft"]').click();
+
+      expect($('#missLeft').hasClass('drop-left')).toBe(false);
+    });
+
+    it('displays top-aligned dropdowns above when there is space', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="top"]').click();
+
+      expect($('#top').hasClass('drop-top')).toBe(true);
+    });
+
+    it('displays right-aligned dropdowns right when there is space', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="right"]').click();
+
+      expect($('#right').hasClass('drop-right')).toBe(true);
+    });
+
+    it('displays left-aligned dropdowns left when there is space', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="left"]').click();
+
+      expect($('#left').hasClass('drop-left')).toBe(true);
+    });
+
+    it('fits dropdowns into the top-level .row element', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="trigRight"]').click();
+
+      expect($('#trigRight').offset().left).toBeGreaterThan($('.row:first').offset().left);
+      expect($('#trigRight').offset().left).toBeLessThan($('a[data-dropdown="trigRight"]').offset().left);
+    });
+  }));
+
+  describe('pip alignment', function() {
+    beforeEach(function() {
+      document.body.innerHTML = __html__['spec/dropdown/pips.html'];
+    });
+
+    it('horizontally centers pips', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="left"]').click();
+      expect($('#left').hasClass('open')).toBe(true);
+      var pipstyle = window.getComputedStyle(document.querySelector('#left'),':before');
+      var pip_position = parseFloat(pipstyle.left);
+
+      $('a[data-dropdown="leftCenterPip"]').click();
+      expect($('#leftCenterPip').hasClass('open')).toBe(true);
+      var pipcenterstyle = window.getComputedStyle(document.querySelector('#leftCenterPip'),':before');
+      var pipcenter_position = parseFloat(pipcenterstyle.left);
+
+      expect(pip_position).toBeLessThan(pipcenter_position);
+    });
+
+    // This test works when it is run manually line-by-line in an inspector
+    // window, but not in Jasmine.  Timing problem?
+    xit('horizontally centers right-aligned pips', when('medium', function() {
+      $('a[data-dropdown="right"]').click();
+      expect($('#right').hasClass('open')).toBe(true);
+      var pipstyle = window.getComputedStyle(document.querySelector('#right'),':before');
+      var pip_position = parseFloat(pipstyle.left);
+
+      $('a[data-dropdown="rightCenterPip"]').click();
+      expect($('#rightCenterPip').hasClass('open')).toBe(true);
+      var pipcenterstyle = window.getComputedStyle(document.querySelector('#rightCenterPip'),':before');
+      var pipcenter_position = parseFloat(pipcenterstyle.left);
+
+      expect(pip_position).toBeGreaterThan(pipcenter_position);
+    }));
+
+    it('is globally settable', function() {
+      $(document).foundation({
+        dropdown: {
+          pip: 'center'
+        }
+      });
+
+      $('a[data-dropdown="left"]').click();
+      expect($('#left').hasClass('open')).toBe(true);
+      var pipstyle = window.getComputedStyle(document.querySelector('#left'),':before');
+      var pip_position = parseFloat(pipstyle.left);
+
+      $('a[data-dropdown="leftCenterPip"]').click();
+      expect($('#leftCenterPip').hasClass('open')).toBe(true);
+      var pipcenterstyle = window.getComputedStyle(document.querySelector('#leftCenterPip'),':before');
+      var pipcenter_position = parseFloat(pipcenterstyle.left);
+
+      expect(pip_position).toEqual(pipcenter_position);
+
+      $('a[data-dropdown="right"]').click();
+      expect($('#right').hasClass('open')).toBe(true);
+      var pipstyle = window.getComputedStyle(document.querySelector('#right'),':before');
+      var pip_position = parseFloat(pipstyle.left);
+
+      $('a[data-dropdown="rightCenterPip"]').click();
+      expect($('#rightCenterPip').hasClass('open')).toBe(true);
+      var pipcenterstyle = window.getComputedStyle(document.querySelector('#rightCenterPip'),':before');
+      var pipcenter_position = parseFloat(pipcenterstyle.left);
+
+      expect(pip_position).toEqual(pipcenter_position);
+    });
+
+    it('centers small dropdowns on large buttons', when('medium', function() {
+      $(document).foundation();
+
+      $('a[data-dropdown="largeButton"]').click();
+      expect($('#largeButton').offset().left).toBeGreaterThan($('a[data-dropdown="largeButton"]').offset().left);
+    }));
+  });
 });

--- a/spec/dropdown/miss.html
+++ b/spec/dropdown/miss.html
@@ -1,0 +1,61 @@
+<!-- to test this correctly, set the window width to 650 -->
+<div class="row" style="max-width:650px">
+  <div class="small-12 columns">
+    <p>
+    <a href="#" style="width:20%" class="button" data-options="align:top" data-dropdown="missTop" aria-controls="missTop" aria-expanded="false">missTop</a>
+    <span style="display:inline-block;width:55%">&nbsp;</span>
+    <a href="#" style="width:20%" class="button" data-options="align:right" data-dropdown="missRight" aria-controls="missRight" aria-expanded="false">missRight</a>
+    </p>
+    <p>
+    <a href="#" style="width:20%" class="button" data-options="align:left" data-dropdown="missLeft" aria-controls="missLeft" aria-expanded="false">missLeft</a>
+    <span style="display:inline-block;width:10%">&nbsp;</span>
+    <a href="#" style="width:20%" class="button" data-options="align:left" data-dropdown="left" aria-controls="left" aria-expanded="false">Left</a>
+    </p>
+    <p>
+    <span style="display:inline-block;width:30%">&nbsp;</span>
+    <a href="#" class="button" data-dropdown="trigRight" aria-controls="trigRight" aria-expanded="false">trigRight</a>
+    </p>
+    <p>
+    <a href="#" class="button" data-options="align:top" data-dropdown="top" aria-controls="top" aria-expanded="false">Top</a>
+    </p>
+    <p>
+    <a href="#" class="button" data-options="align:right" data-dropdown="right" aria-controls="right" aria-expanded="false">Right</a>
+    </p>
+    <div id="dropdowns">
+<ul id="missTop" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+</ul>
+<ul id="missRight" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<ul id="missLeft" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<ul id="left" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<div id="trigRight" class="f-dropdown content medium" data-dropdown-content aria-hidden="true" tabindex="-1">
+  <h4>Title</h4>
+  <p>Some text that people will think is awesome! Some text that people will think is awesome! Some text that people will think is awesome!</p>
+  <img width="300" height="300" src="nonexistent.jpg" alt="a flying comment">
+  <p>More test.</p>
+</div>
+<ul id="top" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<ul id="right" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+    </div>
+  </div>
+</div>

--- a/spec/dropdown/pips.html
+++ b/spec/dropdown/pips.html
@@ -1,0 +1,55 @@
+<!-- to test this correctly, set the window width to 650 -->
+<div class="row" style="max-width:650px">
+  <div class="small-12 columns">
+    <p>
+    <a href="#" style="width:20%" class="button" data-options="" data-dropdown="left" aria-controls="left" aria-expanded="false">left</a>
+    <span style="display:inline-block;width:55%">&nbsp;</span>
+    <a href="#" style="width:20%" class="button" data-options="" data-dropdown="right" aria-controls="right" aria-expanded="false">right</a>
+    </p>
+    <p>
+    <a href="#" style="width:20%" class="button" data-options="pip:center" data-dropdown="leftCenterPip" aria-controls="leftCenterPip" aria-expanded="false">left</a>
+    <span style="display:inline-block;width:55%">&nbsp;</span>
+    <a href="#" style="width:20%" class="button" data-options="pip:center" data-dropdown="rightCenterPip" aria-controls="rightCenterPip" aria-expanded="false">right</a>
+    </p>
+    <p>
+    <a href="#" class="button expand" data-options="pip:center" data-dropdown="largeButton" aria-controls="largeButton" aria-expanded="false">largeButton</a>
+    </p>
+    <p>
+    <span style="display:inline-block;width:30%">&nbsp;</span>
+    <a href="#" class="button" data-dropdown="trigRight" aria-controls="trigRight" aria-expanded="false">trigRight</a>
+    </p>
+    <div id="dropdowns">
+<ul id="right" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<ul id="left" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<ul id="rightCenterPip" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<ul id="leftCenterPip" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+<div id="trigRight" class="f-dropdown content medium" data-dropdown-content aria-hidden="true" tabindex="-1">
+  <h4>Title</h4>
+  <p>Some text that people will think is awesome! Some text that people will think is awesome! Some text that people will think is awesome!</p>
+  <img width="300" height="300" src="nonexistent.jpg" alt="a flying comment">
+  <p>More test.</p>
+</div>
+<ul id="largeButton" class="f-dropdown" data-dropdown-content>
+  <li><a href="#">This is a link</a></li>
+  <li><a href="#">This is another</a></li>
+  <li><a href="#">Yet another</a></li>
+</ul>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Issue #6026 contained a request for an option to center the pips on dropdowns.  This pull request implements that feature.

While working on centering pips, I rewrote most of Arthur's (arthur at zurb dot com) miss[Right/Left/Top] code.  There are now Jasmine tests for correct behavior in this case, but someone from Zurb should probably review this to make sure I interpreted the intent of the original code correctly.
- rewrote miss[Right/Left/Top] calculations to work better with different dropdown alignments
- created jasmine tests for miss[Right/Left/Top]
- added option `pip: center` to dropdown settings
- created jasmine tests for new pip centering feature
