### PR TITLE
Reverts #5551e12, commit has breaking changes for non-WebKit browsers.

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -15,7 +15,6 @@
       close_on_esc: true,
       dismiss_modal_class: 'close-reveal-modal',
       bg_class: 'reveal-modal-bg',
-      bg_root_element: 'body',
       root_element: 'body',
       open: function(){},
       opened: function(){},
@@ -239,13 +238,10 @@
       return base;
     },
 
-    toggle_bg : function (el, modal, state) {
-      var settings = el.data(this.attr_name(true) + '-init') || this.settings,
-            bg_root_element = settings.bg_root_element; // Adding option to specify the background root element fixes scrolling issue
-      
+    toggle_bg : function (modal, state) {
       if (this.S('.' + this.settings.bg_class).length === 0) {
         this.settings.bg = $('<div />', {'class': this.settings.bg_class})
-          .appendTo(bg_root_element).hide();
+          .appendTo('body').hide();
       }
 
       var visible = this.settings.bg.filter(':visible').length > 0;
@@ -280,9 +276,9 @@
           this.locked = false;
         }
         if (animData.pop) {
-          css.top = $(root_element).scrollTop() - el.data('offset') + 'px'; //adding root_element instead of window for scrolling offset if modal trigger is below the fold
+          css.top = $(window).scrollTop() - el.data('offset') + 'px';
           var end_css = {
-            top: $(root_element).scrollTop() + el.data('css-top') + 'px', //adding root_element instead of window for scrolling offset if modal trigger is below the fold
+            top: $(window).scrollTop() + el.data('css-top') + 'px',
             opacity: 1
           };
 
@@ -298,7 +294,7 @@
         }
 
         if (animData.fade) {
-          css.top = $(root_element).scrollTop() + el.data('css-top') + 'px'; //adding root_element instead of window for scrolling offset if modal trigger is below the fold
+          css.top = $(window).scrollTop() + el.data('css-top') + 'px';
           var end_css = {opacity: 1};
 
           return setTimeout(function () {
@@ -330,8 +326,8 @@
     hide : function (el, css) {
       // is modal
       if (css) {
-        var settings = el.data(this.attr_name(true) + '-init') || this.settings,
-            root_element = settings.root_element;
+        var settings = el.data(this.attr_name(true) + '-init');
+        settings = settings || this.settings;
 
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
@@ -339,7 +335,7 @@
         }
         if (animData.pop) {
           var end_css = {
-            top: - $(root_element).scrollTop() - el.data('offset') + 'px', //adding root_element instead of window for scrolling offset if modal trigger is below the fold
+            top: - $(window).scrollTop() - el.data('offset') + 'px',
             opacity: 0
           };
 


### PR DESCRIPTION
5551e12853bb29de7ba685bea7dcdc8628bc186b introduced a bug to Reveal where page scroll was not taken into account on non-WebKit browsers. This had the effect of launching a modal at the top of a page, even if the user opened it while scrolled to the bottom.

This commit simply reverts the to the last working version and will fix #6154.
