### PR TITLE
Renaming local jQuery variable in requestAnimationFrame polyfill

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -201,7 +201,7 @@
    * Licensed under the MIT license.
    */
 
-  (function($) {
+  (function(jQuery) {
 
   // requestAnimationFrame polyfill adapted from Erik Möller
   // fixes from Paul Irish and Tino Zijdel
@@ -267,7 +267,7 @@
 
   }
 
-  }( jQuery ));
+  }( $ ));
 
 
   function removeQuotes (string) {


### PR DESCRIPTION
This is an incredibly small changeset, but I thought it was important to point out a possible issue when referring to the global `jQuery` variable with the included `requestAnimationFrame` polyfill.

In the case that `jQuery.noConflict(true)` is invoked after foundation.js is loaded, the global `jQuery` that's referred to in the polyfill will be undefined, thus causing a "Cannot read property 'timers' of undefined" error.  We only encountered this bug with a certain offending third-party advertisement script (which admittedly should be rectified on its own), but I think this is a good, small step for future-proofing Foundation.
