### PR TITLE
[Orbit] use outerHeight() instead of height()

### DIFF
--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -122,8 +122,8 @@
           slides_container.trigger('after-slide-change.fndtn.orbit',[{slide_number: idx, total_slides: slides.length}]);
           settings.after_slide_change(idx, slides.length);
         };
-        if (slides_container.height() != next.height() && settings.variable_height) {
-          slides_container.animate({'height': next.height()}, 250, 'linear', unlock);
+        if (slides_container.outerHeight() != next.outerHeight() && settings.variable_height) {
+          slides_container.animate({'height': next.outerHeight()}, 250, 'linear', unlock);
         } else {
           unlock();
         }
@@ -136,8 +136,8 @@
         if (dir === 'prev') {animate.prev(current, next, callback);}
       };
 
-      if (next.height() > slides_container.height() && settings.variable_height) {
-        slides_container.animate({'height': next.height()}, 250, 'linear', start_animation);
+      if (next.outerHeight() > slides_container.outerHeight() && settings.variable_height) {
+        slides_container.animate({'height': next.outerHeight()}, 250, 'linear', start_animation);
       } else {
         start_animation();
       }
@@ -186,10 +186,10 @@
 
     self.compute_dimensions = function() {
       var current = $(self.slides().get(idx));
-      var h = current.height();
+      var h = current.outerHeight();
       if (!settings.variable_height) {
         self.slides().each(function(){
-          if ($(this).height() > h) { h = $(this).height(); }
+          if ($(this).outerHeight() > h) { h = $(this).outerHeight(); }
         });
       }
       slides_container.height(h);


### PR DESCRIPTION
I had some slides with an 1px-border and there were 2px missing on the container.

see http://codepen.io/alfredbez/pen/KwaKBp
