### PR TITLE
without a main, the package doesn't expose contents, breaking bundlers like browserify and webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "zurb-foundation",
   "version": "5.5.0",
+  "main": "js/foundation/foundation.js",
   "devDependencies": {
     "assemble": "~0.4.37",
     "grunt": "~0.4.4",


### PR DESCRIPTION
The reason that [Browserify](https://www.npmjs.com/package/browserify) and [Webpack](https://www.npmjs.com/package/webpack) aren't able to package Zurb Foundation is that the `package.json` is missing its `main` field.

This PR adds said field.
