### PR TITLE
top-bar auto-width only for h1 in title-area

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -462,7 +462,10 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
         .toggle-topbar { display: none; }
 
         .title-area { float: $default-float; }
-        .name h1 a { width: auto; }
+        .name h1 a,
+        .name h2 a,
+        .name h3 a,
+        .name h4 a { width: auto; }
 
         input,
         .button,


### PR DESCRIPTION
Search engine optimization (SEO) suggests to only use one `h1` per page. Therefore one should not use up the `h1` element already in the title. If `h2` is used instead the width is not `auto` and there is a line break, if the title name is too long.
