### PR TITLE
Fix check for if events have already been bound on an element

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -100,24 +100,20 @@
 
   var bindings = function (method, options) {
     var self = this,
-        should_bind_events = !S(this).data(this.attr_name(true));
+        bind = function(){
+          var $this = S(this),
+              should_bind_events = !$this.data(self.attr_name(true) + '-init');
+          $this.data(self.attr_name(true) + '-init', $.extend({}, self.settings, (options || method), self.data_options($this)));
+
+          if (should_bind_events) {
+            self.events(this);
+          }
+        };
 
     if (S(this.scope).is('[' + this.attr_name() +']')) {
-      S(this.scope).data(this.attr_name(true) + '-init', $.extend({}, this.settings, (options || method), this.data_options(S(this.scope))));
-
-      if (should_bind_events) {
-        this.events(this.scope);
-      }
-
+      bind.call(this.scope);
     } else {
-      S('[' + this.attr_name() +']', this.scope).each(function () {
-        var should_bind_events = !S(this).data(self.attr_name(true) + '-init');
-        S(this).data(self.attr_name(true) + '-init', $.extend({}, self.settings, (options || method), self.data_options(S(this))));
-
-        if (should_bind_events) {
-          self.events(this);
-        }
-      });
+      S('[' + this.attr_name() +']', this.scope).each(bind);
     }
     // # Patch to fix #5043 to move this *after* the if/else clause in order for Backbone and similar frameworks to have improved control over event binding and data-options updating.
     if (typeof method === 'string') {


### PR DESCRIPTION
When calling the initialized function directly on an element that has a plugin set up on it, e.g. `<div data-reveal class="reveal-modal">Hello World</div>`, the events will be reset each time a plugin method is called:

```
var modal = $("[reveal-modal]");
modal.foundation('reveal'); // this will invoke the plugins events method
modal.foundation('open');   // this will also invoke the plugin's events method
modal.on('closed.fndtn.reveal', function(){
  alert('modal closed');
});
modal.foundation('reveal', 'close'); // this will unbind the event that was just attached
```

Currently, the `bindings` method checks the `this` object for to see if events have already been set up, however `this` is the Foundation plugin object, not the element in scope. It also checks for the attribute without the `'-init'` suffix.

```
  should_bind_events = !S(this).data(this.attr_name(true));
```

This patch updates so that if the plugin is called directly on an element, the events won't be reset.
Also, the duplication of code is removed by moving the code into a function that is called with the appropriate context depending on how the library was initialized.
