### PR TITLE
Wrap _visibility.scss exported html in the export function

### DIFF
--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -276,8 +276,8 @@ $visibility-breakpoint-queries:
   }
 }
 
-
-@if $include-html-visibility-classes != false {
+@include exports("visibility"){
+  @if $include-html-visibility-classes != false {
 
   @include visibility-loop;
 
@@ -471,4 +471,5 @@ $visibility-breakpoint-queries:
       td.show-for-print { display: table-cell !important; }
       th.show-for-print { display: table-cell !important; }
   }
+}
 }


### PR DESCRIPTION
I found when multiple components referenced the _visibility.scss it was pulled into the css multiple times.
Wrapping '@if $include-html-visibility-classes{}'  with the exports mixin, stopped this problem.
