### PR TITLE
Create variable for callout panel background

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -807,6 +807,7 @@
 // $panel-bg: scale-color(#fff, $lightness: -5%);
 // $panel-border-style: solid;
 // $panel-border-size: 1px;
+// $callout-panel-bg: scale-color($primary-color, $lightness: 94%);
 
 // We use this % to control how much we darken things on hover
 // $panel-function-factor: -11%;

--- a/scss/foundation/components/_panels.scss
+++ b/scss/foundation/components/_panels.scss
@@ -13,6 +13,7 @@ $include-html-panel-classes: $include-html-classes !default;
 $panel-bg: scale-color(#fff, $lightness: -5%) !default;
 $panel-border-style: solid !default;
 $panel-border-size: 1px !default;
+$callout-panel-bg: scale-color($primary-color, $lightness: 94%) !default;
 
 // We use this % to control how much we darken things on hover
 $panel-function-factor: -11% !default;
@@ -74,7 +75,7 @@ $callout-panel-link-color: $primary-color !default;
     .panel { @include panel;
 
       &.callout {
-        @include panel(scale-color($primary-color, $lightness: 94%));
+        @include panel($callout-panel-bg);
         a:not(.button) {
           color: $callout-panel-link-color;
         }


### PR DESCRIPTION
I wanted to be able to set the callout panel background color to one of my choosing, it seemed a bit odd that this was tied to a specific shade of the `$primary-color` variable. I couldn't find any reason for it to be so specific so I've added a variable in.
