### PR TITLE
added data attribute to support internal ajax container in reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -52,7 +52,8 @@
 
           if (!self.locked) {
             var element = S(this),
-                ajax = element.data(self.data_attr('reveal-ajax'));
+                ajax = element.data(self.data_attr('reveal-ajax'))
+                replaceContentSel = element.data(self.data_attr('reveal-replace-content'));
 
             self.locked = true;
 
@@ -61,7 +62,7 @@
             } else {
               var url = ajax === true ? element.attr('href') : ajax;
 
-              self.open.call(self, element, {url : url});
+              self.open.call(self, element, {url : url}, { replaceContentSel : replaceContentSel });
             }
           }
         });
@@ -201,7 +202,12 @@
                 }
               }
 
-              modal.html(data);
+              if (typeof options !== 'undefined' && typeof options.replaceContentSel !== 'undefined') {
+                modal.find(options.replaceContentSel).html(data);
+              } else {
+                modal.html(data);
+              }
+
               self.S(modal).foundation('section', 'reflow');
               self.S(modal).children().foundation();
 
@@ -231,12 +237,12 @@
         this.locked = true;
         this.key_up_off(modal);   // PATCH #3: turning on key up capture only when a reveal window is open
         modal.trigger('close').trigger('close.fndtn.reveal');
-        
+
         if ((settings.multiple_opened && open_modals.length === 1) || !settings.multiple_opened || modal.length > 1) {
           this.toggle_bg(modal, false);
           this.to_front(modal);
         }
-        
+
         if (settings.multiple_opened) {
           this.hide(modal, settings.css.close, settings);
           this.to_front($($.makeArray(open_modals).reverse()[1]));
@@ -340,11 +346,11 @@
 
       return el.show();
     },
-    
+
     to_back : function(el) {
       el.addClass('toback');
     },
-    
+
     to_front : function(el) {
       el.removeClass('toback');
     },


### PR DESCRIPTION
Resolves #5523

Usage:

``` html
<a href="#" data-reveal-id="formModal" data-reveal-replace-content=".reveal-modal-content" data-reveal-ajax="http://some.url">Open</a>

<div id="my-modal" class="reveal-modal" data-reveal>
    <h2>New Something</h2>
    <div class="reveal-modal-content">
    <!-- ...content will be inserted here... -->
    </div>
    <a class="close-reveal-modal">&#215;</a>
</div>
```
