### PR TITLE
Reveal plugin - opened modal close on new ajax reveal

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -207,9 +207,9 @@
 
               if (open_modal.length > 0) {
                 if (settings.multiple_opened) {
-                  self.to_back(open_modal);
+                  this.to_back(open_modal);
                 } else {
-                  self.hide(open_modal, settings.css.close);
+                  this.hide(open_modal, settings.css.close);
                 }
               }
               self.show(modal, settings.css.open);

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -207,9 +207,9 @@
 
               if (open_modal.length > 0) {
                 if (settings.multiple_opened) {
-                  this.to_back(open_modal);
+                  self.to_back(open_modal);
                 } else {
-                  this.hide(open_modal, settings.css.close);
+                  self.hide(open_modal, settings.css.close);
                 }
               }
               self.show(modal, settings.css.open);

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -82,7 +82,7 @@
             }
 
             self.locked = true;
-            self.close.call(self, bg_clicked ? S('[' + self.attr_name() + '].open') : S(this).closest('[' + self.attr_name() + ']'));
+            self.close.call(self, bg_clicked ? S('[' + self.attr_name() + '].open:not(.toback)') : S(this).closest('[' + self.attr_name() + ']'));
           }
         });
 


### PR DESCRIPTION
If a reveal modal is open, and you want to open another one from the current one with ajax-reveal, an error occurs. `Success handler` for ajax uses `this` instead of `self`.
