### PR TITLE
Ensure that the validate function returns the full list of validations

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -242,7 +242,6 @@
         }
         validations.push(el_validations[0]);
       }
-      validations = [validations.every(function (valid) {return valid;})];
       return validations;
     },
 

--- a/spec/abide/abide.js
+++ b/spec/abide/abide.js
@@ -102,6 +102,20 @@ describe('abide:', function() {
       expect($('input[name="user_name"]')).not.toHaveData('invalid');
     });
 
+    it('should not focus hidden fields that are not required', function() {
+      $(document).foundation();
+      hidden_element = 'input[name="utf8"]';
+      first_element = 'input[name="user_name"]';
+
+      spyOnEvent(hidden_element, 'focus');
+      spyOnEvent(first_element, 'focus');
+
+      $('form').submit();
+
+      expect('focus').not.toHaveBeenTriggeredOn(hidden_element);
+      expect('focus').toHaveBeenTriggeredOn(first_element);
+    });
+
   });
 
   describe('advanced validation', function() {

--- a/spec/abide/basic.html
+++ b/spec/abide/basic.html
@@ -1,4 +1,5 @@
 <form data-abide="ajax">
+  <input name="utf8" type="hidden" value="&#x2713;" />
   <div class="name-field">
     <label>Your name <small>required</small></label>
     <input name="user_name" type="text" required pattern="[a-zA-Z]+">


### PR DESCRIPTION
The validate method is expected to return an array of validation checks(true/false), the line of code that I've removed set the array to the entire set of validations status. The original selector is `S(this).find('input, textarea, select')` which will indeed select hidden elements regardless of if you've specified that they should be validated. When we go to call `focus()` if you have `focus_on_invalid`(the default) and you have a hidden element it's going to grab that first field if any field has failed validation. I've demonstrated this in a spec as well, let me know if you have any questions.

Related commit and comment: https://github.com/zurb/foundation/commit/0436102f90741556db2a69c33129316eed00842e

Thanks to @laantorchaweb for bringing it up in that commit, much appreciated. 
