### PR TITLE
Be able to equalize by groups when nesting + stack check improvement

### DIFF
--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -27,24 +27,27 @@
 
     equalize : function (equalizer) {
       var isStacked = false,
-          vals = equalizer.find('[' + this.attr_name() + '-watch]:visible'),
-          settings = equalizer.data(this.attr_name(true) + '-init');
+          group = equalizer.data('equalizer'),
+          vals = group ? equalizer.find('['+this.attr_name()+'-watch="'+group+'"]:visible') : equalizer.find('['+this.attr_name()+'-watch]:visible'),
+          settings = equalizer.data(this.attr_name(true)+'-init'),
+          firstTopOffset;
 
       if (vals.length === 0) {
         return;
       }
-      var firstTopOffset = vals.first().offset().top;
+      
       settings.before_height_change();
       equalizer.trigger('before-height-change').trigger('before-height-change.fndth.equalizer');
       vals.height('inherit');
-      vals.each(function () {
-        var el = $(this);
-        if (el.offset().top !== firstTopOffset) {
-          isStacked = true;
-        }
-      });
-
+      
       if (settings.equalize_on_stack === false) {
+        firstTopOffset = vals.first().offset().top;
+        vals.each(function () {
+          if ($(this).offset().top !== firstTopOffset) {
+            isStacked = true;
+            return false;
+          }
+        });
         if (isStacked) {
           return;
         }
@@ -59,6 +62,7 @@
         var min = Math.min.apply(null, heights);
         vals.css('height', min);
       }
+      
       settings.after_height_change();
       equalizer.trigger('after-height-change').trigger('after-height-change.fndtn.equalizer');
     },

--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -51,7 +51,7 @@
         if (isStacked) {
           return;
         }
-      };
+      }
 
       var heights = vals.map(function () { return $(this).outerHeight(false) }).get();
 


### PR DESCRIPTION
- Add feature for equalize groups of elements (just add a unique name to the data-equalizer and data-equalizer-watch attributes)
- Improve performance when checking for stacked elements
  - if settings.equalize_on_stack!==false, there's not need to check if elements are stacked
  - if we find one element that is stacked, just break the each loop
