### PR TITLE
remove uft-8 charset from foundation.scss

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 // Foundation by ZURB
 // foundation.zurb.com
 // Licensed under MIT Open Source


### PR DESCRIPTION
See http://www.w3.org/International/questions/qa-css-charset.en.php?changelang=en

> Note! It is not enough to simply put @charset "utf-8"; at the top of the style sheet – you need to also save your style sheet in the UTF-8 character encoding.

You already ensure `utf-8` charset in `.editorconfig`
