### PR TITLE
Changing from window.outerWidth to window.innerWidth

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -263,17 +263,17 @@
         if (document.getElementsByClassName('row')[0]) {
           actualBodyWidth = document.getElementsByClassName('row')[0].clientWidth;
         } else {
-          actualBodyWidth = window.outerWidth;
+          actualBodyWidth = window.innerWidth;
         }
 
-        var actualMarginWidth = (window.outerWidth - actualBodyWidth) / 2;
+        var actualMarginWidth = (window.innerWidth - actualBodyWidth) / 2;
         var actualBoundary = actualBodyWidth;
 
         if (!this.hasClass('mega')) {
           //miss top
           if (t.offset().top <= this.outerHeight()) {
             p.missTop = true;
-            actualBoundary = window.outerWidth - actualMarginWidth;
+            actualBoundary = window.innerWidth - actualMarginWidth;
             p.leftRightFlag = true;
           }
 


### PR DESCRIPTION
Changing from window.outerWidth to window.innerWidth as positioning should be done in relation to viewport, not including developer tools, toolbars, scrollbars etc.

Currently the behavior is that e.g. dropdowns' positions are affected by whether developer tools in Chrome are visible or not (provided they're using the same window and are positioned to the right). 
