### PR TITLE
Fixing a vendor-prefixes and outlines

### DIFF
--- a/doc/includes/dropdown_buttons/examples_dropdown_button_basic.html
+++ b/doc/includes/dropdown_buttons/examples_dropdown_button_basic.html
@@ -1,5 +1,5 @@
 <button href="#" data-dropdown="drop1" aria-controls="drop1" aria-expanded="false" class="button dropdown">Dropdown Button</button><br>
-<ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1">
+<ul id="drop1" data-dropdown-content class="f-dropdown" aria-hidden="true">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>

--- a/doc/includes/dropdown_buttons/examples_dropdown_button_intro.html
+++ b/doc/includes/dropdown_buttons/examples_dropdown_button_intro.html
@@ -6,35 +6,35 @@
 </ul>
 
 <button data-dropdown="drop2" class="small secondary radius button dropdown" aria-expanded="false" aria-controls="drop2">Dropdown Button</button><br>
-<ul id="drop2" data-dropdown-content class="f-dropdown" aria-hidden="true" tab-index="-1">
+<ul id="drop2" data-dropdown-content class="f-dropdown" aria-hidden="true">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
 
 <button data-dropdown="drop3" aria-controls="drop3" aria-expanded="false" class="button alert round dropdown">Dropdown Button</button><br>
-<ul id="drop3" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1">
+<ul id="drop3" data-dropdown-content class="f-dropdown" aria-hidden="true">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
 
 <button  data-dropdown="drop4" aria-controls="drop4" aria-expanded="false" class="large success button dropdown">Dropdown Button</button><br>
-<ul id="drop4" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1">
+<ul id="drop4" data-dropdown-content class="f-dropdown" aria-hidden="true">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
 
 <a data-dropdown="drop5" aria-controls="drop5" aria-expanded="false" class="large button dropdown expand">Dropdown Button</a><br>
-<ul id="drop5" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1" >
+<ul id="drop5" data-dropdown-content class="f-dropdown" aria-hidden="true">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>
 </ul>
 
 <a data-dropdown="drop6" aria-controls="drop6" aria-expanded="false" class="disabled button dropdown">Disabled Dropdown Button</a><br>
-<ul id="drop6" data-dropdown-content class="f-dropdown" aria-hidden="true" tabindex="-1" >
+<ul id="drop6" data-dropdown-content class="f-dropdown" aria-hidden="true">
   <li><a href="#">This is a link</a></li>
   <li><a href="#">This is another</a></li>
   <li><a href="#">Yet another</a></li>

--- a/scss/foundation/components/_dropdown-buttons.scss
+++ b/scss/foundation/components/_dropdown-buttons.scss
@@ -58,7 +58,6 @@ $dropdown-button-pip-top-lrg: (-$button-pip-lrg / 2) + rem-calc(3) !default;
   // We add in base styles, but they can be negated by setting to 'false'.
   @if $base-style {
     position: relative;
-    outline: none;
 
     // This creates the base styles for the triangle pip
     &::after {

--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -68,7 +68,6 @@ $f-dropdown-radius: $global-radius !default;
   left: -9999px;
   list-style: $f-dropdown-list-style;
   margin-#{$default-float}: 0;
-  outline: none;
   display: none;
 
   &.open {

--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -322,6 +322,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
 // We use this mixin to style select elements
 @mixin form-select  {
   -webkit-appearance: none !important;
+  -moz-appearance: none !important;
   border-radius: 0;
   background-color: $select-bg-color;
 
@@ -412,6 +413,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
     /* We use this to get basic styling on all basic form elements */
     #{text-inputs(all, 'input')} {
       -webkit-appearance: none;
+      -moz-appearance: none;
       border-radius: 0;
       @include form-element;
       @if $input-include-glowing-effect == false {
@@ -457,6 +459,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
 
     input[type="submit"] {
       -webkit-appearance: none;
+      -moz-appearance: none;
       border-radius: 0;
     }
 

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -80,6 +80,7 @@ $base-line-height: 1.5 !default;
 // We use this to add box-sizing across browser prefixes
 @mixin box-sizing($type:border-box) {
   -webkit-box-sizing: $type; // Android < 2.3, iOS < 4
+     -moz-box-sizing: $type;
           box-sizing: $type; // Chrome, IE 8+, Opera, Safari 5.1
 }
 

--- a/scss/foundation/components/_orbit.scss
+++ b/scss/foundation/components/_orbit.scss
@@ -51,20 +51,30 @@ $orbit-timer-hide-for-small: true !default;
   @if $include-html-orbit-classes {
 
     @-webkit-keyframes rotate {
-      from { -webkit-transform: rotate(0deg); }
-      to { -webkit-transform: rotate(360deg); }
+      from {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      to {
+          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
+      }
     }
-    @-moz-keyframes rotate {
-      from { -moz-transform: rotate(0deg); }
-      to { -moz-transform: rotate(360deg); }
-    }
-    @-o-keyframes rotate {
-      from { -o-transform: rotate(0deg); }
-      to { -o-transform: rotate(360deg); }
-    }
+
+
     @keyframes rotate {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
+      from {
+          -webkit-transform: rotate(0deg);
+          -moz-transform: rotate(0deg);
+          -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+      }
+      to {
+          -webkit-transform: rotate(360deg);
+          -moz-transform: rotate(360deg);
+          -ms-transform: rotate(360deg);
+          transform: rotate(360deg);
+      }
     }
 
     /* Orbit Graceful Loading */
@@ -131,6 +141,10 @@ $orbit-timer-hide-for-small: true !default;
 
         // Prevents images (and captions) from disappearing after first rotation on Chrome for Android
         -webkit-transform: translateZ(0);
+           -moz-transform: translateZ(0);
+            -ms-transform: translateZ(0);
+             -o-transform: translateZ(0);
+                transform: translateZ(0);
 
         img { display: block; max-width: 100%; }
 

--- a/scss/foundation/components/_switches.scss
+++ b/scss/foundation/components/_switches.scss
@@ -47,7 +47,6 @@ $switch-active-color: $primary-color !default;
   padding: 0;
   border: none;
   position: relative;
-  outline: 0;
   -webkit-user-select: none;
      -moz-user-select: none;
       -ms-user-select: none;

--- a/scss/foundation/components/_switches.scss
+++ b/scss/foundation/components/_switches.scss
@@ -50,6 +50,7 @@ $switch-active-color: $primary-color !default;
   outline: 0;
   -webkit-user-select: none;
      -moz-user-select: none;
+      -ms-user-select: none;
           user-select: none;
 
   // Default label styles for type and transition
@@ -100,6 +101,7 @@ $switch-active-color: $primary-color !default;
 
     -webkit-transform: translate3d(0,0,0);
     -moz-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
     -o-transform: translate3d(0,0,0);
     transform: translate3d(0,0,0);
   }

--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -50,9 +50,6 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
               color: $tabs-navigation-hover-bg-color;
             }
           }
-          &:focus{
-              outline: none;
-          }
         }
         &.active a {
           background: {


### PR DESCRIPTION
Adding compatible vendor-prefixes where possible. 
Adjusting usage of "outline: none". This should only be used with :focus and only if other visual changes are made.
