### PR TITLE
Fixes input element animation

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -415,7 +415,11 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
       border-radius: 0;
       @include form-element;
       @if $input-include-glowing-effect == false {
-          @include single-transition(all, .15s, linear);
+        -webkit-transition: border-color 0.15s linear, background 0.15s linear;
+        -moz-transition: border-color 0.15s linear, background 0.15s linear;
+        -ms-transition: border-color 0.15s linear, background 0.15s linear;
+        -o-transition: border-color 0.15s linear, background 0.15s linear;
+        transition: border-color 0.15s linear, background 0.15s linear;
       }
       &.radius {
         @include radius($input-border-radius);


### PR DESCRIPTION
When $input-include-glowing-effect == false, adding the .error class to an input element resulted in unwanted animation of the input bottom margin down to zero.  The error message div would appear (without animation) with a gap between it and the input element, then quickly animate up to its desired position along the bottom of the input....pretty jarring.  Proposed fix is to replace the single-transition mixin with specific animation of the border-color and background properties.  Not sure whether Foundation relies on animating any other input properties when $input-include-glowing-effect is false, but these are the only two I could find.
