### PR TITLE
Equalizer fix pictures with predefined height

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -599,7 +599,19 @@
         var self = this,
             unloaded = images.length;
 
-        if (unloaded === 0) {
+        function pictures_has_height(images) {
+          var pictures_number = images.length;
+
+          for (var i = pictures_number - 1; i >= 0; i--) {
+            if(images.attr('height') === undefined) {
+              return false;
+            };
+          };
+
+          return true;
+        }
+
+        if (unloaded === 0 || pictures_has_height(images)) {
           callback(images);
         }
 


### PR DESCRIPTION
After this equaliser doesn't wait until pictures will be loaded if all the
pictures in element to be equalised are provided with ‘height’
attribute.

This fixes the error when using AngularJS and pictures come with 404
error. Before this equaliser didn't work at all.

Also: https://github.com/zurb/foundation/issues/6276
