### PR TITLE
Remove non-namespaced JS events

### DIFF
--- a/doc/pages/components/abide.html
+++ b/doc/pages/components/abide.html
@@ -83,7 +83,7 @@ If a submit event is fired, a `valid.fndtn.abide` event is triggered when the fo
 
 <div class="panel">
   <p><strong>Deprecation Notice</strong></p>
-  <p>Previous versions of the abide plugin emitted un-namespaced `valid` and `invalid` events, however, these have been replaced by the namespaced `valid.fndtn.abide` and `invalid.fndtn.abide` events. The un-namespaced events will be fully deprecated when Foundation 5.4 is released.</p>
+  <p>Previous versions of the abide plugin emitted un-namespaced `valid` and `invalid` events, however, these have been replaced by the namespaced `valid.fndtn.abide` and `invalid.fndtn.abide` events. The un-namespaced events have been fully deprecated.</p>
 </div>
 
 You can bind to these events and fire your own callback:

--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -75,13 +75,13 @@ Perhaps you need to create items that are positioned at the bottom of your input
     <ul class="pricing-table" data-equalizer-watch>
       ...
       <li class="cta-button"><a class="button" href="#">Buy Now</a></li>
-    </ul>    
+    </ul>
   </div>
   <div class="large-6 columns">
     <ul class="pricing-table" data-equalizer-watch>
       ...
       <li class="cta-button"><a class="button" href="#">Buy Now</a></li>
-    </ul>    
+    </ul>
   </div>
 </div>
 ```
@@ -97,7 +97,7 @@ Perhaps you need to create items that are positioned at the bottom of your input
       <li class="bullet-item">5GB Storage</li>
       <li class="bullet-item">20 Users</li>
       <li class="cta-button"><a class="button floor" href="#">Buy Now</a></li>
-    </ul>    
+    </ul>
   </div>
   <div class="small-6 columns">
     <ul class="pricing-table" data-equalizer-watch>
@@ -109,7 +109,7 @@ Perhaps you need to create items that are positioned at the bottom of your input
       <li class="bullet-item">SSL Support</li>
       <li class="bullet-item">24/7 Support</li>
       <li class="cta-button"><a class="button" href="#">Buy Now</a></li>
-    </ul>    
+    </ul>
   </div>
 </div>
 
@@ -149,7 +149,7 @@ There are two ways to bind to callbacks in your equalizers.
 
 <div class="panel">
   <p><strong>Deprecation Notice</strong></p>
-  <p>Previous versions of the equalizer plugin emitted un-namespaced `before-height-change` and `after-height-change` events, however, these have been replaced by the namespaced `before-height-change.fndtn.equalizer` and `after-height-change.fndtn.equalizer` events. The un-namespaced events will be fully deprecated when Foundation 5.4 is released.</p>
+  <p>Previous versions of the equalizer plugin emitted un-namespaced `before-height-change` and `after-height-change` events, however, these have been replaced by the namespaced `before-height-change.fndtn.equalizer` and `after-height-change.fndtn.equalizer` events. The un-namespaced events have been fully deprecated.</p>
 </div>
 
 <div class="row">
@@ -194,7 +194,7 @@ If you add new content after the page has been loaded, you will need to reinitia
 
 {{#markdown}}
 ```javascript
-$(document).foundation(); 
+$(document).foundation();
 ```
 {{/markdown}}
 

--- a/doc/pages/components/offcanvas.html
+++ b/doc/pages/components/offcanvas.html
@@ -343,7 +343,7 @@ There are a series of events that you can bind to for triggering callbacks:
 
 <div class="panel">
   <p><strong>Deprecation Notice</strong></p>
-  <p>Previous versions of the off-canvas plugin emitted un-namespaced `open` and `close` events, however, these have been replaced by the namespaced `open.fndtn.offcanvas` and `close.fndtn.offcanvas` events. The un-namespaced events will be fully deprecated when Foundation 5.4 is released.</p>
+  <p>Previous versions of the off-canvas plugin emitted un-namespaced `open` and `close` events, however, these have been replaced by the namespaced `open.fndtn.offcanvas` and `close.fndtn.offcanvas` events. The un-namespaced events have been fully deprecated.</p>
 </div>
 
 ```js
@@ -389,7 +389,7 @@ If you add new content after the page has been loaded, you will need to reinitia
 
 {{#markdown}}
 ```javascript
-$(document).foundation(); 
+$(document).foundation();
 ```
 {{/markdown}}
 

--- a/doc/pages/components/range_slider.html
+++ b/doc/pages/components/range_slider.html
@@ -178,7 +178,7 @@ You can add a border radius to the range slider by adding the `radius` class to 
       <span class="range-slider-handle" role="slider" tabindex="0"></span>
       <span class="range-slider-active-segment"></span>
       <input type="hidden">
-    </div> 
+    </div>
     <br><br>
     <div class="range-slider round" data-slider>
       <span class="range-slider-handle" role="slider" tabindex="0"></span>
@@ -266,7 +266,7 @@ There are two ways to bind to callbacks in your sliders.
 
 <div class="panel">
   <p><strong>Deprecation Notice</strong></p>
-  <p>Previous versions of the slider plugin emitted an un-namespaced `change` event, however, this has been replaced by the namespaced `change.fndtn.slider` event. The un-namespaced event will be fully deprecated when Foundation 5.4 is released.</p>
+  <p>Previous versions of the slider plugin emitted an un-namespaced `change` event, however, this has been replaced by the namespaced `change.fndtn.slider` event. The un-namespaced event have been fully deprecated.</p>
 </div>
 
 <div class="row">
@@ -383,7 +383,7 @@ If you add new content after the page has been loaded, you will need to reinitia
 
 {{#markdown}}
 ```javascript
-$(document).foundation(); 
+$(document).foundation();
 ```
 {{/markdown}}
 

--- a/doc/pages/components/reveal.html
+++ b/doc/pages/components/reveal.html
@@ -99,7 +99,7 @@ There are a series of events that you can bind to for triggering callbacks:
 
 <div class="panel">
   <p><strong>Deprecation Notice</strong></p>
-  <p>Previous versions of the reveal plugin emitted un-namespaced `open`, `opened`, `close` and `closed` events, however, these have been replaced by the namespaced `open.fndtn.reveal`, `opened.fndtn.reveal`, `close.fndtn.reveal` and `closed.fndtn.reveal` events. The un-namespaced events will be fully deprecated when Foundation 5.4 is released.</p>
+  <p>Previous versions of the reveal plugin emitted un-namespaced `open`, `opened`, `close` and `closed` events, however, these have been replaced by the namespaced `open.fndtn.reveal`, `opened.fndtn.reveal`, `close.fndtn.reveal` and `closed.fndtn.reveal` events. The un-namespaced events have been fully deprecated.</p>
 </div>
 
 ```js
@@ -244,7 +244,7 @@ If you add new content after the page has been loaded, you will need to reinitia
 
 {{#markdown}}
 ```javascript
-$(document).foundation(); 
+$(document).foundation();
 ```
 {{/markdown}}
 

--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -113,14 +113,14 @@
           if (this.settings.focus_on_invalid) {
             els[i].focus();
           }
-          form.trigger('invalid').trigger('invalid.fndtn.abide');
+          form.trigger('invalid.fndtn.abide');
           this.S(els[i]).closest('form').attr(this.invalid_attr, '');
           return false;
         }
       }
 
       if (submit_event || is_ajax) {
-        form.trigger('valid').trigger('valid.fndtn.abide');
+        form.trigger('valid.fndtn.abide');
       }
 
       form.removeAttr(this.invalid_attr);

--- a/js/foundation/foundation.alert.js
+++ b/js/foundation/foundation.alert.js
@@ -26,12 +26,12 @@
         if (Modernizr.csstransitions) {
           alertBox.addClass('alert-close');
           alertBox.on('transitionend webkitTransitionEnd oTransitionEnd', function (e) {
-            S(this).trigger('close').trigger('close.fndtn.alert').remove();
+            S(this).trigger('close.fndtn.alert').remove();
             settings.callback();
           });
         } else {
           alertBox.fadeOut(300, function () {
-            S(this).trigger('close').trigger('close.fndtn.alert').remove();
+            S(this).trigger('close.fndtn.alert').remove();
             settings.callback();
           });
         }

--- a/js/foundation/foundation.clearing.js
+++ b/js/foundation/foundation.clearing.js
@@ -302,7 +302,7 @@
         this.go(clearing, 'prev');
       }
       if (e.which === ESC_KEY) {
-        this.S('a.clearing-close').trigger('click').trigger('click.fndtn.clearing');
+        this.S('a.clearing-close').trigger('click.fndtn.clearing');
       }
     },
 
@@ -447,7 +447,7 @@
 
       if (target.length) {
         this.S('img', target)
-          .trigger('click', [current, target]).trigger('click.fndtn.clearing', [current, target])
+          .trigger('click.fndtn.clearing', [current, target])
           .trigger('change.fndtn.clearing');
       }
     },

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -143,7 +143,7 @@
             .removeClass(self.settings.active_class)
             .removeData('target');
 
-          self.S(this).trigger('closed').trigger('closed.fndtn.dropdown', [dropdown]);
+          self.S(this).trigger('closed.fndtn.dropdown', [dropdown]);
         }
       });
       dropdown.removeClass('f-open-' + this.attr_name(true));
@@ -161,7 +161,7 @@
         .css(dropdown
         .addClass(this.settings.active_class), target);
       dropdown.prev('[' + this.attr_name() + ']').addClass(this.settings.active_class);
-      dropdown.data('target', target.get(0)).trigger('opened').trigger('opened.fndtn.dropdown', [dropdown, target]);
+      dropdown.data('target', target.get(0)).trigger('opened.fndtn.dropdown', [dropdown, target]);
       dropdown.attr('aria-hidden', 'false');
       target.attr('aria-expanded', 'true');
       dropdown.focus();

--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -35,7 +35,7 @@
       }
       var firstTopOffset = vals.first().offset().top;
       settings.before_height_change();
-      equalizer.trigger('before-height-change').trigger('before-height-change.fndth.equalizer');
+      equalizer.trigger('before-height-change.fndth.equalizer');
       vals.height('inherit');
       vals.each(function () {
         var el = $(this);
@@ -60,7 +60,7 @@
         vals.css('height', min);
       }
       settings.after_height_change();
-      equalizer.trigger('after-height-change').trigger('after-height-change.fndtn.equalizer');
+      equalizer.trigger('after-height-change.fndtn.equalizer');
     },
 
     reflow : function () {

--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -131,7 +131,7 @@
           if (passed) {
             this.settings.directives[passed
               .scenario[1]].call(this, passed.el, passed.scenario[0], (function (passed) {
-                if (arguments[0] instanceof Array) { 
+                if (arguments[0] instanceof Array) {
                   var args = arguments[0];
                 } else {
                   var args = Array.prototype.slice.call(arguments, 0);
@@ -241,7 +241,7 @@
         this.object($(this['cached_' + type][i]));
       }
 
-      return $(window).trigger('resize').trigger('resize.fndtn.interchange');
+      return $(window).trigger('resize.fndtn.interchange');
     },
 
     convert_directive : function (directive) {

--- a/js/foundation/foundation.offcanvas.js
+++ b/js/foundation/foundation.offcanvas.js
@@ -111,13 +111,13 @@
 
     show : function (class_name, $off_canvas) {
       $off_canvas = $off_canvas || this.get_wrapper();
-      $off_canvas.trigger('open').trigger('open.fndtn.offcanvas');
+      $off_canvas.trigger('open.fndtn.offcanvas');
       $off_canvas.addClass(class_name);
     },
 
     hide : function (class_name, $off_canvas) {
       $off_canvas = $off_canvas || this.get_wrapper();
-      $off_canvas.trigger('close').trigger('close.fndtn.offcanvas');
+      $off_canvas.trigger('close.fndtn.offcanvas');
       $off_canvas.removeClass(class_name);
     },
 

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -170,7 +170,7 @@
         modal.attr('tabindex','0').attr('aria-hidden','false');
 
         this.key_up_on(modal);    // PATCH #3: turning on key up capture only when a reveal window is open
-        
+
         // Prevent namespace event from triggering twice
         modal.on('open.fndtn.reveal', function(e) {
           if (e.namespace !== 'fndtn.reveal') return;
@@ -251,13 +251,13 @@
 
         this.locked = true;
         this.key_up_off(modal);   // PATCH #3: turning on key up capture only when a reveal window is open
-        modal.trigger('close').trigger('close.fndtn.reveal');
-        
+        modal.trigger('close.fndtn.reveal');
+
         if ((settings.multiple_opened && open_modals.length === 1) || !settings.multiple_opened || modal.length > 1) {
           self.toggle_bg(modal, false);
           self.to_front(modal);
         }
-        
+
         if (settings.multiple_opened) {
           self.hide(modal, settings.css.close, settings);
           self.to_front($($.makeArray(open_modals).reverse()[1]));
@@ -327,7 +327,7 @@
               .css(css)
               .animate(end_css, settings.animation_speed, 'linear', function () {
                 context.locked = false;
-                el.trigger('opened').trigger('opened.fndtn.reveal');
+                el.trigger('opened.fndtn.reveal');
               })
               .addClass('open');
           }, settings.animation_speed / 2);
@@ -342,13 +342,13 @@
               .css(css)
               .animate(end_css, settings.animation_speed, 'linear', function () {
                 context.locked = false;
-                el.trigger('opened').trigger('opened.fndtn.reveal');
+                el.trigger('opened.fndtn.reveal');
               })
               .addClass('open');
           }, settings.animation_speed / 2);
         }
 
-        return el.css(css).show().css({opacity : 1}).addClass('open').trigger('opened').trigger('opened.fndtn.reveal');
+        return el.css(css).show().css({opacity : 1}).addClass('open').trigger('opened.fndtn.reveal');
       }
 
       var settings = this.settings;
@@ -362,11 +362,11 @@
 
       return el.show();
     },
-    
+
     to_back : function(el) {
       el.addClass('toback');
     },
-    
+
     to_front : function(el) {
       el.removeClass('toback');
     },
@@ -392,7 +392,7 @@
             return el
               .animate(end_css, settings.animation_speed, 'linear', function () {
                 context.locked = false;
-                el.css(css).trigger('closed').trigger('closed.fndtn.reveal');
+                el.css(css).trigger('closed.fndtn.reveal');
               })
               .removeClass('open');
           }, settings.animation_speed / 2);
@@ -405,13 +405,13 @@
             return el
               .animate(end_css, settings.animation_speed, 'linear', function () {
                 context.locked = false;
-                el.css(css).trigger('closed').trigger('closed.fndtn.reveal');
+                el.css(css).trigger('closed.fndtn.reveal');
               })
               .removeClass('open');
           }, settings.animation_speed / 2);
         }
 
-        return el.hide().css(css).removeClass('open').trigger('closed').trigger('closed.fndtn.reveal');
+        return el.hide().css(css).removeClass('open').trigger('closed.fndtn.reveal');
       }
 
       var settings = this.settings;

--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -139,7 +139,7 @@
         $handle.siblings('.range-slider-active-segment').css('width', progress_bar_length + '%');
       }
 
-      $handle_parent.attr(this.attr_name(), value).trigger('change').trigger('change.fndtn.slider');
+      $handle_parent.attr(this.attr_name(), value).trigger('change.fndtn.slider');
 
       $hidden_inputs.val(value);
       if (settings.trigger_input_change) {

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -66,7 +66,7 @@
       var smallMatch = matchMedia(Foundation.media_queries.small).matches;
       var medMatch   = matchMedia(Foundation.media_queries.medium).matches;
       var lrgMatch   = matchMedia(Foundation.media_queries.large).matches;
-      
+
        if (sticky && settings.sticky_on === 'all') {
           return true;
        }
@@ -84,7 +84,7 @@
        if (sticky && navigator.userAgent.match(/(iPad|iPhone|iPod)/g)) {
         return true;
        }
-       
+
        return false;
     },
 
@@ -249,7 +249,7 @@
 
       S(window).off('.topbar').on('resize.fndtn.topbar', self.throttle(function () {
           self.resize.call(self);
-      }, 50)).trigger('resize').trigger('resize.fndtn.topbar').load(function () {
+      }, 50)).trigger('resize.fndtn.topbar').load(function () {
           // Ensure that the offset is calculated after all of the pages resources have loaded
           S(this).trigger('resize.fndtn.topbar');
       });

--- a/spec/abide/abide.js
+++ b/spec/abide/abide.js
@@ -27,10 +27,8 @@ describe('abide:', function() {
     it('should trigger correct events for all required fields', function() {
       $(document).foundation();
 
-      var settings = Foundation.libs.abide.settings;
-
-      spyOnEvent('form', 'invalid');
-      spyOnEvent('form', 'valid');
+      spyOnEvent('form', 'invalid.fndtn.abide');
+      spyOnEvent('form', 'valid.fndtn.abide');
 
       spyOnEvent('input[name="user_name"]', 'invalid');
       spyOnEvent('input[name="user_name"]', 'valid');
@@ -40,11 +38,11 @@ describe('abide:', function() {
 
       $('form').submit();
 
-      expect('valid').not.toHaveBeenTriggeredOn('form');
+      expect('valid.fndtn.abide').not.toHaveBeenTriggeredOn('form');
       expect('valid').not.toHaveBeenTriggeredOn('input[name="user_name"]');
-      expect('valid').not.toHaveBeenTriggeredOn('input[name="user_email"]');      
+      expect('valid').not.toHaveBeenTriggeredOn('input[name="user_email"]');
 
-      expect('invalid').toHaveBeenTriggeredOn('form');
+      expect('invalid.fndtn.abide').toHaveBeenTriggeredOn('form');
       expect('invalid').toHaveBeenTriggeredOn('input[name="user_name"]');
       expect('invalid').toHaveBeenTriggeredOn('input[name="user_email"]');
     });
@@ -67,8 +65,8 @@ describe('abide:', function() {
     it('should pass validation when all fields are filled out correctly', function() {
       $(document).foundation();
 
-      spyOnEvent('form', 'invalid');
-      spyOnEvent('form', 'valid');
+      spyOnEvent('form', 'invalid.fndtn.abide');
+      spyOnEvent('form', 'valid.fndtn.abide');
 
       spyOnEvent('input[name="user_name"]', 'invalid');
       spyOnEvent('input[name="user_name"]', 'valid');
@@ -81,11 +79,11 @@ describe('abide:', function() {
 
       $('form').submit();
 
-      expect('valid').toHaveBeenTriggeredOn('form');
+      expect('valid.fndtn.abide').toHaveBeenTriggeredOn('form');
       expect('valid').toHaveBeenTriggeredOn('input[name="user_name"]');
-      expect('valid').toHaveBeenTriggeredOn('input[name="user_email"]');      
+      expect('valid').toHaveBeenTriggeredOn('input[name="user_email"]');
 
-      expect('invalid').not.toHaveBeenTriggeredOn('form');
+      expect('invalid.fndtn.abide').not.toHaveBeenTriggeredOn('form');
       expect('invalid').not.toHaveBeenTriggeredOn('input[name="user_name"]');
       expect('invalid').not.toHaveBeenTriggeredOn('input[name="user_email"]');
     });
@@ -146,12 +144,12 @@ describe('abide:', function() {
 
       $('input[name="user_password_confirmation"]').val("foobarbaz");
       // now they're equal
-      spyOnEvent('form', 'invalid');
-      spyOnEvent('form', 'valid');
+      spyOnEvent('form', 'invalid.fndtn.abide');
+      spyOnEvent('form', 'valid.fndtn.abide');
 
       $('form').submit();
 
-      expect('valid').toHaveBeenTriggeredOn('form');
+      expect('valid.fndtn.abide').toHaveBeenTriggeredOn('form');
       expect($('input[name="user_password"]')).not.toHaveAttr('data-invalid');
       expect($('input[name="user_password_confirmation"]')).not.toHaveAttr('data-invalid');
     });
@@ -189,12 +187,12 @@ describe('abide:', function() {
 
       // valid now
       $('input[name="user_end_num"]').val("12");
-      spyOnEvent('form', 'invalid');
-      spyOnEvent('form', 'valid');
+      spyOnEvent('form', 'invalid.fndtn.abide');
+      spyOnEvent('form', 'valid.fndtn.abide');
 
       $('form').submit();
 
-      expect('valid').toHaveBeenTriggeredOn('form');
+      expect('valid.fndtn.abide').toHaveBeenTriggeredOn('form');
       expect($('input[name="user_start_num"]')).not.toHaveAttr('data-invalid');
       expect($('input[name="user_end_num"]')).not.toHaveAttr('data-invalid');
     });


### PR DESCRIPTION
Fully remove non-namespaced JS events. I didn't really know what to say in the docs' deprecation notices. Let me know if you'd like to change the wording.

I noticed only abide has tests regarding events. I didn't want to add tests for that in this PR, but might add tests separately.

And an open question: is this necessary? https://github.com/zurb/foundation/blob/624c2e35facc1d5b98bc3cacf8d4ef936f427678/js/foundation/foundation.reveal.js#L179 Maybe the check for namespace in fefc24c03b64438835f2859d18c248b9a723484e can be removed as well.

closes #5330
