### PR TITLE
Add $info-color to possible background colors for topbar buttons

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -336,6 +336,7 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
           &.button.success { @include button-style($bg:$success-color); }
           &.button.alert { @include button-style($bg:$alert-color); }
           &.button.warning { @include button-style($bg:$warning-color); }
+          &.button.info { @include button-style($bg:$info-color); }
         }
 
         > button {
@@ -348,6 +349,7 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
           &.success { @include button-style($bg:$success-color); }
           &.alert { @include button-style($bg:$alert-color); }
           &.warning { @include button-style($bg:$warning-color); }
+          &.info { @include button-style($bg:$info-color); }
         }
 
         // Apply the hover link color when it has that class


### PR DESCRIPTION
There isn't an obious reason for this class to be excluded so I'm assuming it's desired.
