### PR TITLE
Move aria label into $include-html-nav-classes conditional

### DIFF
--- a/scss/foundation/components/_breadcrumbs.scss
+++ b/scss/foundation/components/_breadcrumbs.scss
@@ -123,10 +123,9 @@ $crumb-slash: "/" !default;
         @include crumbs;
       }
     }
+    /* Accessibility - hides the forward slash */
+    [aria-label="breadcrumbs"] [aria-hidden="true"]:after {
+      content: "/";
+    }
   }
 }
-
-/* Accessibility - hides the forward slash */
-[aria-label="breadcrumbs"] [aria-hidden="true"]:after {
-  content: "/";
-  }


### PR DESCRIPTION
If $include-html-nav-classes is set to false the [aria-label="breadcrumbs"] css was still be output
