### PR TITLE
Making '$span-border' param in 'split-button' mixin actually change the border

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -1184,6 +1184,7 @@ $include-html-global-classes: $include-html-classes;
 // We use these to control different shared styles for Split Buttons
 // $split-button-function-factor: 10%;
 // $split-button-pip-color: $white;
+// $split-button-span-border-color: rgba(255,255,255,0.5);
 // $split-button-pip-color-alt: $oil;
 // $split-button-active-bg-tint: rgba(0,0,0,0.1);
 

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -61,7 +61,7 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
 //
 // $padding - Type of padding to apply. Default: medium. Options: tiny, small, medium, large.
 // $pip-color - Color of the triangle. Default: $split-button-pip-color.
-// $span-border - Border color of button divider. Default: $primary-color.
+// $span-border - Border color of button divider. Default: $split-button-span-border-color.
 // $base-style - Apply base style to split button. Default: true.
 @mixin split-button(
   $padding:medium,

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -102,7 +102,7 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
   // Control the border color for the span area of the split button
   @if $span-border {
     span {
-      border-#{$default-float}-color: $split-button-span-border-color;
+      border-#{$default-float}-color: $span-border;
     }
   }
 

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -22,6 +22,7 @@ $split-button-function-factor: 10% !default;
 $split-button-pip-color: $white !default;
 $split-button-pip-color-alt: $oil !default;
 $split-button-active-bg-tint: rgba(0,0,0,0.1) !default;
+$split-button-span-border-color: rgba(255,255,255,0.5) !default;
 
 // We use these to control tiny split buttons
 $split-button-padding-tny: $button-pip-tny * 10 !default;
@@ -65,7 +66,7 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
 @mixin split-button(
   $padding:medium,
   $pip-color:$split-button-pip-color, 
-  $span-border:$primary-color, 
+  $span-border:$split-button-span-border-color, 
   $base-style:true) {
 
   // With this, we can control whether or not the base styles come through.
@@ -101,7 +102,7 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
   // Control the border color for the span area of the split button
   @if $span-border {
     span {
-      border-#{$default-float}-color: rgba(255,255,255,0.5);
+      border-#{$default-float}-color: $split-button-span-border-color;
     }
   }
 


### PR DESCRIPTION
Currently, $span-border in the split button mixin is documented as accepting a color to use as the divider however any truthy value sets the border color to rgba(255,255,255,.5)

This PR adds a default $split-button-span-border-color and sets the split button border color to whatever is passed into the mixin.
