### PR TITLE
Corrected margin rule for .sub-nav

### DIFF
--- a/scss/foundation/components/_sub-nav.scss
+++ b/scss/foundation/components/_sub-nav.scss
@@ -61,7 +61,7 @@ $sub-nav-item-divider-margin: rem-calc(12) !default;
   display: block;
   width: auto;
   overflow: hidden;
-  margin-bottom: $sub-nav-list-margin;
+  margin: $sub-nav-list-margin;
   padding-top: $sub-nav-list-padding-top;
 
   dt {


### PR DESCRIPTION
Margins list was assigned to "margin-bottom" rule instead of general "margin".
