### PR TITLE
adding decimal place to breakpoints/ranges in both _globals.scss and _se...

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -152,10 +152,10 @@ $include-html-global-classes: $include-html-classes;
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // $small-range: (0em, 40em);
-// $medium-range: (40.063em, 64em);
-// $large-range: (64.063em, 90em);
-// $xlarge-range: (90.063em, 120em);
-// $xxlarge-range: (120.063em, 99999999em);
+// $medium-range: (40.0625em, 64em);
+// $large-range: (64.0625em, 90em);
+// $xlarge-range: (90.0625em, 120em);
+// $xxlarge-range: (120.0625em, 99999999em);
 
 // $screen: "only screen";
 

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -297,10 +297,10 @@ $column-gutter: rem-calc(30) !default;
 
 // Media Query Ranges
 $small-range: (0, 40em) !default;
-$medium-range: (40.063em, 64em) !default;
-$large-range: (64.063em, 90em) !default;
-$xlarge-range: (90.063em, 120em) !default;
-$xxlarge-range: (120.063em, 99999999em) !default;
+$medium-range: (40.0625em, 64em) !default;
+$large-range: (64.0625em, 90em) !default;
+$xlarge-range: (90.0625em, 120em) !default;
+$xxlarge-range: (120.0625em, 99999999em) !default;
 
 
 $screen: "only screen" !default;


### PR DESCRIPTION
...ttings.scss as '.063' ends up leaving a tailing .008 in the calculation, and Chrome rounds up (meaning the 641 med range won't kick in until 642, large won't kick in until 1026, etc; this creates some really messed up displays right at the breakpoints as of right now
