### PR TITLE
Fix the 'aria-expanded' in multi-buttons scenario

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -138,8 +138,8 @@
 
     close : function (dropdown) {
       var self = this;
-      dropdown.each(function () {
-        var original_target = $('[' + self.attr_name() + '=' + dropdown[0].id + ']') || $('aria-controls=' + dropdown[0].id + ']');
+      dropdown.each(function (idx) {
+        var original_target = $('[' + self.attr_name() + '=' + dropdown[idx].id + ']') || $('aria-controls=' + dropdown[idx].id + ']');
         original_target.attr('aria-expanded', 'false');
         if (self.S(this).hasClass(self.settings.active_class)) {
           self.S(this)


### PR DESCRIPTION
Hi there,
I have noticed that if you have many dropdown's buttons on the page, then you follow the below scenario, you will notice that the <code>aria-expanded</code> attribute of that clicked button <b>will not be updated!</b>. 
Now lets assume that we have 3 <code><button></code>s, then:
1- Click on the button (2), and on this step, the button's <code>aria-expanded</code> will be <code>true</code>
2- After that, <b>click out</b> the button (2), and here you will notice that the button's <code>aria-expanded</code> is still <code>true</code> instead of be changed to <code>false</code>.

<b>Note:</b>
You will not figure out that issue in the following cases:
- If you have only one dropdown's button.
- If you click again on the same button to close the dropdown.
