### PR TITLE
Add some love to breakpoints

### DIFF
--- a/doc/pages/media-queries.html
+++ b/doc/pages/media-queries.html
@@ -8,7 +8,7 @@ title: Media Queries
 
 <h3>Basic</h3>
 
-Media queries are built using ems in Foundation.
+Media queries are built using rems in Foundation.
 
 <h4>CSS</h4>
 
@@ -46,12 +46,18 @@ Media queries can be easily customized by changing the variable values in `_sett
 <h4>SCSS</h4>
 
 ```scss
+// Here we define the upper breakpoint for each media size
+$small-breakpoint:  rem-calc(640)  !default;
+$medium-breakpoint: rem-calc(1024) !default;
+$large-breakpoint:  rem-calc(1440) !default;
+$xlarge-breakpoint: rem-calc(1920) !default;
+
 // Here we define the lower and upper bounds for each media size
-$small-range: (0em, 40em); /* 0, 640px */
-$medium-range: (40.063em, 64em); /* 641px, 1024px */
-$large-range: (64.063em, 90em); /* 1025px, 1440px */
-$xlarge-range: (90.063em, 120em); /* 1441px, 1920px */
-$xxlarge-range: (120.063em); /* 1921px */
+$small-range:   (0, $small-breakpoint) !default; /* 0, 640px */
+$medium-range:  ($small-breakpoint  + rem-calc(1), $medium-breakpoint) !default; /* 641px, 1024px */
+$large-range:   ($medium-breakpoint + rem-calc(1), $large-breakpoint)  !default; /* 1025px, 1440px */
+$xlarge-range:  ($large-breakpoint  + rem-calc(1), $xlarge-breakpoint) !default; /* 1441px, 1920px */
+$xxlarge-range: ($xlarge-breakpoint + rem-calc(1), rem-calc(99999999)) !default; /* 1921px, ... */
 
 // Media Queries
 $screen: "only screen" !default;

--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -151,11 +151,16 @@ $include-html-global-classes: $include-html-classes;
 // d. Media Query Ranges
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
-// $small-range: (0em, 40em);
-// $medium-range: (40.0625em, 64em);
-// $large-range: (64.0625em, 90em);
-// $xlarge-range: (90.0625em, 120em);
-// $xxlarge-range: (120.0625em, 99999999em);
+// $small-breakpoint:  rem-calc(640);
+// $medium-breakpoint: rem-calc(1024);
+// $large-breakpoint:  rem-calc(1440);
+// $xlarge-breakpoint: rem-calc(1920);
+
+// $small-range:   (0, $small-breakpoint);
+// $medium-range:  ($small-breakpoint  + rem-calc(1), $medium-breakpoint);
+// $large-range:   ($medium-breakpoint + rem-calc(1), $large-breakpoint);
+// $xlarge-range:  ($large-breakpoint  + rem-calc(1), $xlarge-breakpoint);
+// $xxlarge-range: ($xlarge-breakpoint + rem-calc(1), rem-calc(99999999));
 
 // $screen: "only screen";
 

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -296,11 +296,17 @@ $include-html-global-classes: $include-html-classes !default;
 $column-gutter: rem-calc(30) !default;
 
 // Media Query Ranges
-$small-range: (0, 40em) !default;
-$medium-range: (40.0625em, 64em) !default;
-$large-range: (64.0625em, 90em) !default;
-$xlarge-range: (90.0625em, 120em) !default;
-$xxlarge-range: (120.0625em, 99999999em) !default;
+
+$small-breakpoint:  rem-calc(640)  !default;
+$medium-breakpoint: rem-calc(1024) !default;
+$large-breakpoint:  rem-calc(1440) !default;
+$xlarge-breakpoint: rem-calc(1920) !default;
+
+$small-range:   (0, $small-breakpoint) !default;
+$medium-range:  ($small-breakpoint  + rem-calc(1), $medium-breakpoint) !default;
+$large-range:   ($medium-breakpoint + rem-calc(1), $large-breakpoint)  !default;
+$xlarge-range:  ($large-breakpoint  + rem-calc(1), $xlarge-breakpoint) !default;
+$xxlarge-range: ($xlarge-breakpoint + rem-calc(1), rem-calc(99999999)) !default;
 
 
 $screen: "only screen" !default;


### PR DESCRIPTION
1. Add breakpoints for media queries, which are a) easier to change and can b) be used as variables elsewhere.
2. Make them `rem`-compatible and more consistent with foundation. This also makes them more meaningful, i.e. `rem-calc(1024)` is easier than `64em`
