### PR TITLE
Only apply $topbar-dropdown-bg to dropdown li's

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -314,7 +314,6 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
       }
 
       ul li {
-        background: $topbar-dropdown-bg;
         > a {
           display: block;
           width: 100%;
@@ -415,7 +414,8 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
         li {
           width: 100%;
           height: auto;
-
+          background: $topbar-dropdown-bg;
+          
           a {
             font-weight: $topbar-dropdown-link-weight;
             padding: 8px $topbar-link-padding;


### PR DESCRIPTION
Otherwise the property is applied to all topbar list items, rather than specifically to dropdown list items as the variable name describes.  I'm not familiar enough to know if this is a clean solution but I hope that it illustrates the problem.
