### PR TITLE
Make Equalizer Responsive

### DIFF
--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -64,7 +64,7 @@ You can create an equal height container using a few data attributes. Apply the 
 
 ## Responsive Equalizer
 
-You can specify media queries for which equalizer should activate on. Apply the `data-equalizer-mq` attribute to the parent container. Set the value of the attribute to the smae media queries you're use to using in foundation. If you use an unknown media query, Equalizer will ignore the media query request. This is useful if you have set `equalize_on_stack` to `true`.
+You can specify media queries for which equalizer should activate on. Apply the `data-equalizer-mq` attribute to the parent container. Set the value of the attribute to the same media queries you are use to using in Foundation. If you use an unknown media query, Equalizer will ignore the media query request. This is particularly useful if you have set `equalize_on_stack` to `true`.
 
 <div class="row">
   <div class="large-6 columns">

--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -62,6 +62,39 @@ You can create an equal height container using a few data attributes. Apply the 
   </div>
 </div>
 
+## Responsive Equalizer
+
+You can specify media queries for which equalizer should activate on. Apply the `data-equalizer-mq` attribute to the parent container. Set the value of the attribute to the smae media queries you're use to using in foundation. If you use an unknown media query, Equalizer will ignore the media query request. This is useful if you have set `equalize_on_stack` to `true`.
+
+<div class="row">
+  <div class="large-6 columns">
+    <h4>HTML</h4>
+{{#markdown}}
+```html
+<div class="row" data-equalizer data-equalizer-mq="large-up">
+  <div class="large-6 columns panel" data-equalizer-watch>
+    ...
+  </div>
+  <div class="large-6 columns panel" data-equalizer-watch>
+    ...
+  </div>
+</div>
+```
+{{/markdown}}
+  </div>
+  <div class="large-6 columns">
+    <h4>Rendered HTML</h4>
+    <div class="row" data-equalizer data-equalizer-mq="large-up">
+      <div class="large-6 columns panel" data-equalizer-watch>
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+      </div>
+      <div class="large-6 columns panel" data-equalizer-watch>
+        <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
 ## Nested Elements
 
 You can also nest "equalized" elements in other Equalizer elements. Apply the `data-equalizer` attribute to a parent container and assign a unique name to it. Then apply the `data-equalizer-watch` attribute to each nested element with the corresponding name. The height of `data-equalizer-watch` attribute will be equal to that of the tallest element.
@@ -288,6 +321,3 @@ Reflow will make Foundation check the DOM for any elements and re-apply any list
 $(document).foundation('equalizer', 'reflow');
 ```
 {{/markdown}}
-
-
-

--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -67,28 +67,28 @@ You can create an equal height container using a few data attributes. Apply the 
 You can specify media queries for which equalizer should activate on. Apply the `data-equalizer-mq` attribute to the parent container. Set the value of the attribute to the same media queries you are use to using in Foundation. If you use an unknown media query, Equalizer will ignore the media query request. This is particularly useful if you have set `equalize_on_stack` to `true`.
 
 <div class="row">
-  <div class="large-6 columns">
+  <div class="large-12 columns">
     <h4>HTML</h4>
 {{#markdown}}
 ```html
 <div class="row" data-equalizer data-equalizer-mq="large-up">
-  <div class="large-6 columns panel" data-equalizer-watch>
+  <div class="medium-6 columns panel" data-equalizer-watch>
     ...
   </div>
-  <div class="large-6 columns panel" data-equalizer-watch>
+  <div class="medium-6 columns panel" data-equalizer-watch>
     ...
   </div>
 </div>
 ```
 {{/markdown}}
   </div>
-  <div class="large-6 columns">
+  <div class="large-12 columns">
     <h4>Rendered HTML</h4>
     <div class="row" data-equalizer data-equalizer-mq="large-up">
-      <div class="large-6 columns panel" data-equalizer-watch>
+      <div class="medium-6 columns panel" data-equalizer-watch>
         <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
       </div>
-      <div class="large-6 columns panel" data-equalizer-watch>
+      <div class="medium-6 columns panel" data-equalizer-watch>
         <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</p>
       </div>
     </div>

--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -35,11 +35,11 @@
       if (vals.length === 0) {
         return;
       }
-      
+
       settings.before_height_change();
       equalizer.trigger('before-height-change.fndth.equalizer');
       vals.height('inherit');
-      
+
       if (settings.equalize_on_stack === false) {
         firstTopOffset = vals.first().offset().top;
         vals.each(function () {
@@ -62,7 +62,7 @@
         var min = Math.min.apply(null, heights);
         vals.css('height', min);
       }
-      
+
       settings.after_height_change();
       equalizer.trigger('after-height-change.fndtn.equalizer');
     },
@@ -72,8 +72,23 @@
 
       this.S('[' + this.attr_name() + ']', this.scope).each(function () {
         var $eq_target = $(this);
+        var media_query = $eq_target.data('equalizer-mq'),
+            ignore_media_query = true;
+
+        if (media_query) {
+          media_query = 'is_' + media_query.replace(/-/g, '_');
+          if (Foundation.utils.hasOwnProperty(media_query)) {
+            ignore_media_query = false;
+          }
+        }
+
         self.image_loaded(self.S('img', this), function () {
-          self.equalize($eq_target)
+          if (ignore_media_query || Foundation.utils[media_query]()) {
+            self.equalize($eq_target)
+          } else {
+            var vals = $eq_target.find('[' + self.attr_name() + '-watch]:visible');
+            vals.css('height', 'auto');
+          }
         });
       });
     }

--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -71,8 +71,8 @@
       var self = this;
 
       this.S('[' + this.attr_name() + ']', this.scope).each(function () {
-        var $eq_target = $(this);
-        var media_query = $eq_target.data('equalizer-mq'),
+        var $eq_target = $(this),
+            media_query = $eq_target.data('equalizer-mq'),
             ignore_media_query = true;
 
         if (media_query) {


### PR DESCRIPTION
#4882 Made Reference to this

The issue comes up if you have set equalize_on_stack to true.  I opted for a solution where you set the media query on the parent, and not on a per element  basis. 

Maybe there is value in having it there for both objects, but I'm not sure that's feasible given the current implementation.  I was not looking to do a whole rewrite.

Finally, I would have liked to put the value in just the data-equalizer attribute, but Nested elements are actually using that space, so i opted for a new attribute data-equalizer-mq. If you set it to some non-existant query like `data-equalizer-mq="only-megalarge"`, the plugin will just ignore your media query request and continue as if you passed no media query.
