### PR TITLE
[BUGFIX] magellan - Recognition of local anchors when base tag is active

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -32,32 +32,40 @@
 
       S(self.scope)
         .off('.magellan')
-        .on('click.fndtn.magellan', '[' + self.add_namespace('data-magellan-arrival') + '] a[href^="#"]', function (e) {
-          e.preventDefault();
-          var expedition = $(this).closest('[' + self.attr_name() + ']'),
-              settings = expedition.data('magellan-expedition-init'),
-              hash = this.hash.split('#').join(''),
-              target = $('a[name="' + hash + '"]');
+        .on('click.fndtn.magellan', '[' + self.add_namespace('data-magellan-arrival') + '] a[href*=#]', function (e) {
+          var sameHost = ((this.hostname === location.hostname) || !this.hostname),
+              samePath = self.filterPathname(location.pathname) === self.filterPathname(this.pathname),
+              testHash = this.hash.replace(/(:|\.|\/)/g, '\\$1'),
+              anchor = this;
 
-          if (target.length === 0) {
-            target = $('#' + hash);
+          if (sameHost && samePath && testHash) {
+            e.preventDefault();
+            var expedition = $(this).closest('[' + self.attr_name() + ']'),
+                settings = expedition.data('magellan-expedition-init'),
+                hash = this.hash.split('#').join(''),
+                target = $('a[name="' + hash + '"]');
 
-          }
+            if (target.length === 0) {
+              target = $('#' + hash);
 
-          // Account for expedition height if fixed position
-          var scroll_top = target.offset().top - settings.destination_threshold + 1;
-          if (settings.offset_by_height) {
-            scroll_top = scroll_top - expedition.outerHeight();
-          }
-          $('html, body').stop().animate({
-            'scrollTop' : scroll_top
-          }, settings.duration, settings.easing, function () {
-            if (history.pushState) {
-              history.pushState(null, null, '#' + hash);
-            } else {
-              location.hash = '#' + hash;
             }
-          });
+
+            // Account for expedition height if fixed position
+            var scroll_top = target.offset().top - settings.destination_threshold + 1;
+            if (settings.offset_by_height) {
+              scroll_top = scroll_top - expedition.outerHeight();
+            }
+            $('html, body').stop().animate({
+              'scrollTop' : scroll_top
+            }, settings.duration, settings.easing, function () {
+              if (history.pushState) {
+                        history.pushState(null, null, anchor.pathname + '#' + hash);
+              }
+                    else {
+                        location.hash = anchor.pathname + '#' + hash;
+                    }
+            });
+          }
         })
         .on('scroll.fndtn.magellan', self.throttle(this.check_for_arrivals.bind(this), settings.throttle_delay));
     },
@@ -188,6 +196,14 @@
     off : function () {
       this.S(this.scope).off('.magellan');
       this.S(window).off('.magellan');
+    },
+
+    filterPathname : function (pathname) {
+      pathname = pathname || '';
+      return pathname
+          .replace(/^\//,'')
+          .replace(/(?:index|default).[a-zA-Z]{3,4}$/,'')
+          .replace(/\/$/,'');
     },
 
     reflow : function () {


### PR DESCRIPTION
Problem: local anchors in links prefixed with the path of the script. 

Basically this means that &lt;a href="#"&gt; is transformed to &lt;a href="path/path/script?params#"&gt;. This is necessary if the &lt;base&gt; tag is set.

e.g created by a Content Management System.

Example:
The &lt;base&gt; tag is www.example.com/
The page Url is www.example.com/subpage/subsubpage/abc.html#hash

``` html
<div data-magellan-expedition="fixed">
  <dl class="sub-nav">
    <dd data-magellan-arrival="build"><a href="subpage/subsubpage/abc.html#build">Build with HTML</a></dd>
    <dd data-magellan-arrival="js"><a href="subpage/subsubpage/abc.html#js">Arrival 2</a></dd>
  </dl>
</div>
```

These local anchors will detected with this bugfix .
