### PR TITLE
Fix markdown syntax-highlighting at javascript-utilities doc page.

### DIFF
--- a/doc/pages/javascript-utilities.html
+++ b/doc/pages/javascript-utilities.html
@@ -254,6 +254,7 @@ Foundation.utils.is_xlarge_up();
 // XXLarge queries
 Foundation.utils.is_xxlarge_only();
 Foundation.utils.is_xxlarge_up();
+```
 {{/markdown}}
 
 <div class="row">


### PR DESCRIPTION
Today we have a markdown syntax-hightlighting problem at [javascript-utilities](http://foundation.zurb.com/docs/javascript-utilities.html). <br />
![captura de tela 2015-03-11 as 4 17 56 pm](https://cloud.githubusercontent.com/assets/2065325/6604877/7f50e820-c80a-11e4-876f-5d9d0657ba35.png)

I've just closed the tag.
