### PR TITLE
Allows Equalizer to act on hidden elements.

### DIFF
--- a/js/foundation/foundation.equalizer.js
+++ b/js/foundation/foundation.equalizer.js
@@ -28,7 +28,7 @@
     equalize : function (equalizer) {
       var isStacked = false,
           group = equalizer.data('equalizer'),
-          vals = group ? equalizer.find('['+this.attr_name()+'-watch="'+group+'"]:visible') : equalizer.find('['+this.attr_name()+'-watch]:visible'),
+          vals = group ? equalizer.find('['+this.attr_name()+'-watch="'+group+'"]') : equalizer.find('['+this.attr_name()+'-watch]'),
           settings = equalizer.data(this.attr_name(true)+'-init'),
           firstTopOffset;
 


### PR DESCRIPTION
There are cases where it's useful to allow Equalizer to act on nodes that are hidden. Use case would be Equalizer inside of a Reveal Modal. If you are forced to trigger the reflow after the element becomes visible, the result is jerky and jarring. 

If Equalizer reflow can be triggered before an element becomes visible, the transition is smoother.
