### PR TITLE
Fixing tooltip placement for screen sizes larger than medium

### DIFF
--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -233,8 +233,11 @@
     },
 
     small : function () {
-      return matchMedia(Foundation.media_queries.small).matches &&
-        !matchMedia(Foundation.media_queries.medium).matches;
+      return matchMedia(Foundation.media_queries.small).matches
+         && !matchMedia(Foundation.media_queries.medium).matches
+         && !matchMedia(Foundation.media_queries.large).matches
+         && !matchMedia(Foundation.media_queries.xlarge).matches
+         && !matchMedia(Foundation.media_queries.xxlarge).matches;
     },
 
     inheritable_classes : function ($target) {


### PR DESCRIPTION
When the screen size was larger than medium, the "small" function in foundation.tooltips was returning true causing all tooltips to be placed at 12.5em left margin from the page.
