### PR TITLE
Parameter $pip-color provided more than once in call to mixin split-button

### DIFF
--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -67,8 +67,6 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
   $padding:medium,
   $pip-color:$split-button-pip-color,
   $span-border:$primary-color,
-  $pip-color:$split-button-pip-color, 
-  $span-border:$split-button-span-border-color, 
   $base-style:true) {
 
   // With this, we can control whether or not the base styles come through.

--- a/scss/foundation/components/_split-buttons.scss
+++ b/scss/foundation/components/_split-buttons.scss
@@ -65,8 +65,8 @@ $split-button-pip-default-float-lrg: rem-calc(-6) !default;
 // $base-style - Apply base style to split button. Default: true.
 @mixin split-button(
   $padding:medium,
-  $pip-color:$split-button-pip-color,
-  $span-border:$primary-color,
+  $pip-color:$split-button-pip-color, 
+  $span-border:$split-button-span-border-color, 
   $base-style:true) {
 
   // With this, we can control whether or not the base styles come through.


### PR DESCRIPTION
Fix for this error:

```
error: parameter $pip-color provided more than once in call to mixin split-button
```
