### PR TITLE
Fixed the initial position of the dropdown's content

### DIFF
--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -65,7 +65,11 @@ $f-dropdown-radius: $global-radius !default;
 // $max-width - Default: $f-dropdown-max-width || 200px.
 @mixin dropdown-container($content:list, $triangle:true, $max-width:$f-dropdown-max-width) {
   display: none;
-  left: -9999px;
+  @if $text-direction == ltr {
+    left: -9999px;
+  } @else {
+    right: -9999px;
+  }
   list-style: $f-dropdown-list-style;
   margin-#{$default-float}: 0;
   position: absolute;


### PR DESCRIPTION
Hi there,
In terms of pure HTML and CSS, we know that if any element absolutely takes a position out of the normal document's width - on the same document's direction-, that will cause showing unwanted horizontal scroller.
![ltr-wrong](https://cloud.githubusercontent.com/assets/177020/7126893/1a65c89e-e246-11e4-81ca-39d6f51ded28.png)

In the dropdown component, the Foundation uses that positioning technique to hide and show the dropdown's content by positioning that content in the opposite side of the normal document's direction to avoid that horizontal scroller I mentioned previously.
![ltr](https://cloud.githubusercontent.com/assets/177020/7126343/092fb3c8-e241-11e4-879c-aa7bf1c18a15.png)

Additionally, the Foundation is smart enough to recognise the document's direction and positioning that dropdown's content on the opposite side to avoid that unwanted horizontal scroller.
<a href="https://github.com/zurb/foundation/blob/master/js/foundation/foundation.dropdown.js#L139" target="_blank"><code>.css(Foundation.rtl ? 'right' : 'left', '-99999px') </code></a>

But I've noticed that, the initial CSS of that dropdown's content contains this static CSS rule: <a  href="https://github.com/zurb/foundation/blob/master/scss/foundation/components/_dropdown.scss#L68" target="_blank"><code>left: -9999px;</code></a>, and that will only work well with the LTR documents, but with the RTL documents it will cause that unwanted horizontal scroller
![rtl](https://cloud.githubusercontent.com/assets/177020/7126652/ad5243c4-e243-11e4-8ad4-5705b97682d7.png)

Therefore, I would like to suggest this commit, which reflects the same condition that is written here
<a href="https://github.com/zurb/foundation/blob/master/js/foundation/foundation.dropdown.js#L139" target="_blank"><code>.css(Foundation.rtl ? 'right' : 'left', '-99999px') </code></a>

<b>Note:</b> You will not notice that issue if the doropdown inside any container that has <code>overflow: hidden</code>

Regards, 
