### PR TITLE
Fixed the joyride bottom and left arrows

### DIFF
--- a/scss/foundation/components/_joyride.scss
+++ b/scss/foundation/components/_joyride.scss
@@ -95,9 +95,9 @@ $joyride-screenfill: rgba(0,0,0,0.5) !default;
           top: -($joyride-tip-nub-size*2);
         }
         &.bottom {
+          border-color: $joyride-tip-bg !important;
           border-bottom-color: transparent !important;
           border-bottom-style: solid;
-          border-color: $joyride-tip-bg !important;
           border-#{$default-float}-color: transparent !important;
           border-#{$opposite-direction}-color: transparent !important;
           bottom: -($joyride-tip-nub-size*2);
@@ -190,8 +190,8 @@ $joyride-screenfill: rgba(0,0,0,0.5) !default;
       .joyride-tip-guide { width: $joyride-tip-default-width; #{$default-float}: inherit;
         .joyride-nub {
           &.bottom {
-            border-bottom-color: transparent !important;
             border-color: $joyride-tip-bg !important;
+            border-bottom-color: transparent !important;
             border-#{$default-float}-color: transparent !important;
             border-#{$opposite-direction}-color: transparent !important;
             bottom: -($joyride-tip-nub-size*2);
@@ -205,8 +205,8 @@ $joyride-screenfill: rgba(0,0,0,0.5) !default;
             top: $joyride-tip-position-offset;
           }
           &.left {
-            border-bottom-color: transparent !important;
             border-color: $joyride-tip-bg !important;
+            border-bottom-color: transparent !important;
             border-left-color: transparent !important;
             border-top-color: transparent !important;
             left: -($joyride-tip-nub-size*2);


### PR DESCRIPTION
The rule <code>border-color</code> should come before <code>border-color-[top|right|bottom|left]</code>
The "bottom" issue has been mentioned here #6472 .
