### PR TITLE
+ interchange src path each

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -49,7 +49,8 @@
           // });
 
           if (el !== null && /IMG/.test(el[0].nodeName)) {
-            var orig_path = el[0].src;
+            var orig_path = $.each(el, function(){this.src = path;});
+            // var orig_path = el[0].src;
 
             if (new RegExp(path, 'i').test(orig_path)) {
               return;


### PR DESCRIPTION
I have changed line 52 og thd interchnage plugin to resolve the issue of slick slider and last element problem.

Now every slide is rendered with data interchange.

PLEASE accept the pull request.

 var orig_path = $.each(el, function(){this.src = path;});
// var orig_path = el[0].src;
