### PR TITLE
Reveal: Fix top positioning when no animation is used.

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -352,6 +352,11 @@
           }, settings.animation_speed / 2);
         }
 
+        if (!animData.animate) {
+          el.css('top', $(window).scrollTop() + el.data('css-top') + 'px');
+          el.css('opacity', 1);
+        }
+
         return el.css(css).show().css({opacity : 1}).addClass('open').trigger('opened.fndtn.reveal');
       }
 


### PR DESCRIPTION
As reported here http://foundation.zurb.com/forum/posts/22812-reveal-modal-bug-with-no-animation--scrolling-version-511

When using `animation: 'none'` opening the Foundation reveal modal, the modal does not adjust to the current position of the window and always appears `$reveal-position-top` from the top of the page.  

Inserting the the inline `top` CSS property is done along with animation effects.  This will add the property should no animation effect be used.
