### PR TITLE
Update foundation.reveal.js to ensure target is not undefined in open event

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -155,7 +155,7 @@
       settings = settings || this.settings;
 
 
-      if (modal.hasClass('open') && target.attr('data-reveal-id') == modal.attr('id')) {
+      if (modal.hasClass('open') && target !== undefined && target.attr('data-reveal-id') == modal.attr('id')) {
         return self.close(modal);
       }
 


### PR DESCRIPTION
Ensure open event has a target before accessing the 'data-reveal-id' attribute. I ran into target === undefined after calling $('#myModal').foundation('reveal', 'open');
