### PR TITLE
Add active_class to initially opened accordion-navigation

### DIFF
--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -74,7 +74,7 @@
           settings = accordion.data(self.attr_name(true) + '-init') || self.settings;
 
       aunts.children('a').attr('aria-expanded','false');
-      aunts.has('.' + settings.content_class + '.' + settings.active_class).children('a').attr('aria-expanded','true');
+      aunts.has('.' + settings.content_class + '.' + settings.active_class).addClass(settings.active_class).children('a').attr('aria-expanded','true');
 
       if (settings.multi_expand) {
         $instance.attr('aria-multiselectable','true');


### PR DESCRIPTION
An active_class is added to .accordion-navigation items when the user clicks on an accordion, but is not added to the initially active accordion.

The active_class should be added both initially and after a user opens an accordion to allow for consistent styling of active accordions.
