### PR TITLE
Remove defunct @charset-related comment

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -2,8 +2,6 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
-// Make sure the charset is set appropriately
-
 // Behold, here are all the Foundation components.
 @import 'foundation/components/grid';
 @import 'foundation/components/accordion';


### PR DESCRIPTION
The `@charset` directive that this comment referred to is no longer present.
