### PR TITLE
Move the dropdown radius to the right place

### DIFF
--- a/scss/foundation/components/_dropdown.scss
+++ b/scss/foundation/components/_dropdown.scss
@@ -215,8 +215,6 @@ $f-dropdown-radius: $global-radius !default;
   &:hover,
   &:focus { background: $f-dropdown-list-hover-bg; }
 
-  &.radius { @include radius($f-dropdown-radius); }
-
   a {
     display: block;
     padding: $f-dropdown-list-padding;
@@ -248,6 +246,9 @@ $f-dropdown-radius: $global-radius !default;
 
       // You can also put custom content in these dropdowns
       &.content { @include dropdown-container(content, $triangle:false); }
+
+      // Radius of Dropdown
+      &.radius { @include radius($f-dropdown-radius); }
 
       // Sizes
       &.tiny    { max-width: 200px; }


### PR DESCRIPTION
Hi, Because the dropdown-style mixin will be included in li selector so the radius class will apply to this, so I move radius class to the parent of li, I think it is the right place.
