### PR TITLE
fix float if last-column is true

### DIFF
--- a/scss/foundation/components/_grid.scss
+++ b/scss/foundation/components/_grid.scss
@@ -128,7 +128,7 @@ $last-child-float: $opposite-direction !default;
   @if $push { #{$default-float}: grid-calc($push, $total-columns); #{$opposite-direction}: auto; }
   @if $pull { #{$opposite-direction}: grid-calc($pull, $total-columns); #{$default-float}: auto; }
 
-  @if $float {
+  @if $float and $last-column == false {
     @if $float == left or $float == true { float: $default-float; }
     @else if $float == right { float: $opposite-direction; }
     @else { float: none; }


### PR DESCRIPTION
If you write something like:

```
@include grid-column($columns: 4, $last-column: true)
```

you will have this CSS:

```
.main__header-btns {
  padding-left: 0.9375rem;
  padding-right: 0.9375rem;
  width: 33.33333%;
  float: right;
  float: left; }
```

where last float is wrong. Solution for fix this is one of both to set `$float` as `false` by default or don't add some `float` if `$last-column` was defined as `true`.

Now I have correct CSS:

```
.main__header-btns {
  padding-left: 0.9375rem;
  padding-right: 0.9375rem;
  width: 33.33333%;
  float: right; }
```
