### PR TITLE
set full width on stack-for-small button group

### DIFF
--- a/scss/foundation/components/_button-groups.scss
+++ b/scss/foundation/components/_button-groups.scss
@@ -172,6 +172,7 @@ $button-group-border-width: 1px !default;
           @include button-group-style($orientation:horizontal);
           @media #{$small-only} {
             @include button-group-style($orientation:vertical);
+            width: 100%;
           }
         }
       }


### PR DESCRIPTION
to account if the group also has even-x specified. ticket #6555
