### PR TITLE
Add pointer-events: none; to unavailable pagination items

### DIFF
--- a/scss/foundation/components/_pagination.scss
+++ b/scss/foundation/components/_pagination.scss
@@ -51,6 +51,7 @@ $pagination-link-current-active-bg: $primary-color !default;
   a, button {
     cursor: $pagination-link-unavailable-cursor;
     color: $pagination-link-unavailable-font-color;
+    pointer-events: none;
   }
   &:hover a,
   & a:focus,


### PR DESCRIPTION
Adding pointer-events: none; allows modern browsers to ignore clicks on unavailable elements. 

Unavailable items look like they shouldn't be clickable, so they probably shouldn't be.
