### PR TITLE
Adding convenience variables important when topbar breakpoint != medium-breakpoint

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -1464,6 +1464,11 @@ $include-html-global-classes: $include-html-classes;
 // Using rem-calc for the below breakpoint causes issues with top bar
 // $topbar-breakpoint: #{lower-bound($medium-range)}; // Change to 9999px for always mobile layout
 // $topbar-media-query: "#{$screen} and (min-width:#{lower-bound($topbar-breakpoint)})";
+// Adding extra parameters equivalent of the {size}-up / {size}-only parameters from _globals.scss
+// this is very helpful in casees where the topbar breakpoint is != medium-range
+// $topbar-range:   (0, $topbar-breakpoint) !default;
+// $topbar-up: $screen !default;
+// $topbar-only: "#{$screen} and (max-width: #{upper-bound($topbar-range)})" !default;
 
 // Top-bar input styles
 // $topbar-input-height: rem-calc(28);

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -78,6 +78,12 @@ $topbar-transition-speed: 300ms !default;
 $topbar-breakpoint: #{lower-bound($medium-range)} !default; // Change to 9999px for always mobile layout
 $topbar-media-query: "#{$screen} and (min-width:#{lower-bound($topbar-breakpoint)})" !default;
 
+// Adding extra parameters equivalent of the {size}-up / {size}-only parameters from _globals.scss
+// this is very helpful in casees where the topbar breakpoint is != medium-range
+$topbar-range:   (0, $topbar-breakpoint) !default;
+$topbar-up: $screen !default;
+$topbar-only: "#{$screen} and (max-width: #{upper-bound($topbar-range)})" !default;
+
 // Top-bar input styles
 $topbar-input-height: rem-calc(28) !default;
 


### PR DESCRIPTION
This new variables allow for a more convenient media queries for the topbar:

```
@media #{$topbar-only} { ...
```

and

```
@media #{$topbar-up} { ...
```

This is very useful in cases when the tobbar does not break at the same time as medium which is often the case because of the width of the navigation, depending on the number of entries.

At least on my pages the navigation breaks usually independently of the ranges because of its width.
