### PR TITLE
Changed "Github" to "GitHub"

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 			<p>Once you've exhausted the fun in this document, you should check out:</p>
 			<ul class="disc">
 				<li><a href="http://foundation.zurb.com/docs">Foundation Documentation</a><br />Everything you need to know about using the framework.</li>
-				<li><a href="http://github.com/zurb/foundation">Foundation on Github</a><br />Latest code, issue reports, feature requests and more.</li>
+				<li><a href="http://github.com/zurb/foundation">Foundation on GitHub</a><br />Latest code, issue reports, feature requests and more.</li>
 				<li><a href="http://twitter.com/foundationzurb">@foundationzurb</a><br />Ping us on Twitter if you have questions. If you build something with this we'd love to see it (and send you a totally boss sticker).</li>
 			</ul>
 		</div>


### PR DESCRIPTION
Changed the spelling of GitHub to reflect its proper name.
