### PR TITLE
Fix inline-list margin issue caused by re-ordering of css properties

### DIFF
--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -33,7 +33,8 @@ $inline-list-children-display: block !default;
 // We use this mixin to create inline lists
 @mixin inline-list {
   list-style: none;
-  margin: $inline-list-top-margin auto $inline-list-bottom-margin auto;
+  margin-top: $inline-list-top-margin;
+  margin-bottom: $inline-list-bottom-margin;
   margin-#{$default-float}: $inline-list-default-float-margin;
   margin-#{$opposite-direction}: $inline-list-opposite-margin;
   overflow: $inline-list-overflow;

--- a/scss/foundation/components/_inline-lists.scss
+++ b/scss/foundation/components/_inline-lists.scss
@@ -33,9 +33,9 @@ $inline-list-children-display: block !default;
 // We use this mixin to create inline lists
 @mixin inline-list {
   list-style: none;
+  margin: $inline-list-top-margin auto $inline-list-bottom-margin auto;
   margin-#{$default-float}: $inline-list-default-float-margin;
   margin-#{$opposite-direction}: $inline-list-opposite-margin;
-  margin: $inline-list-top-margin auto $inline-list-bottom-margin auto;
   overflow: $inline-list-overflow;
   padding: $inline-list-padding;
 


### PR DESCRIPTION
The commit https://github.com/zurb/foundation/commit/c65a8e9e1f422b48ce7be9665292e848b188c293 alphabetically sorting a lot of .scss properties has caused some issues.

This is fine when all properties are unique but this has broken the margins on `.inline-list.scss` as the margin properties are deliberately declared twice, with one overwriting the other, in this case the order matters and changing it has broken the margins.

This is especially apparent if you're using a css minification tool.
