### PR TITLE
Deep-Linking Tabs prevent back button in IE from working correctly.

### DIFF
--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -179,7 +179,7 @@
             // the user would get continually redirected to the default hash.
             var default_hash = settings.scroll_to_content ? self.default_tab_hashes[0] : 'fndtn-' + self.default_tab_hashes[0].replace('#', '');
 
-            if (hash !== default_hash) {
+            if (hash !== default_hash || window.location.hash) {
               window.location.hash = hash;
             }
           };

--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -20,16 +20,12 @@
       var self = this,
           S = this.S;
 
-	  // Store the default active tabs which will be referenced when the
-	  // location hash is absent, as in the case of navigating the tabs and
-	  // returning to the first viewing via the browser Back button.
-	  S('[' + this.attr_name() + '] > .active > a', this.scope).each(function () {
-	    self.default_tab_hashes.push(this.hash);
-	  });
-
-      // store the initial href, which is used to allow correct behaviour of the
-      // browser back button when deep linking is turned on.
-      self.entry_location = window.location.href;
+  	  // Store the default active tabs which will be referenced when the
+  	  // location hash is absent, as in the case of navigating the tabs and
+  	  // returning to the first viewing via the browser Back button.
+  	  S('[' + this.attr_name() + '] > .active > a', this.scope).each(function () {
+  	    self.default_tab_hashes.push(this.hash);
+  	  });
 
       this.bindings(method, options);
       this.handle_location_hash_change();
@@ -181,10 +177,9 @@
           go_to_hash = function(hash) {
             // This function allows correct behaviour of the browser's back button when deep linking is enabled. Without it
             // the user would get continually redirected to the default hash.
-            var is_entry_location = window.location.href === self.entry_location,
-                default_hash = settings.scroll_to_content ? self.default_tab_hashes[0] : is_entry_location ? window.location.hash :'fndtn-' + self.default_tab_hashes[0].replace('#', '')
+            var default_hash = settings.scroll_to_content ? self.default_tab_hashes[0] : 'fndtn-' + self.default_tab_hashes[0].replace('#', '');
 
-            if (!(is_entry_location && hash === default_hash)) {
+            if (hash !== default_hash) {
               window.location.hash = hash;
             }
           };


### PR DESCRIPTION
I'm using the tabs plugin in a site and was testing it with Internet Explorer when I noticed that the deep-linking tabs were "breaking" the back button in the browser (creating an infinite loop as described in the pull request I mention below).

I did some Googling and found #6118. I saw that it had been accepted and updated to the latest version of Foundation to test the fix. It worked in Chrome (and I'm assuming other non-IE browsers but did not do tests to verify), but not Internet Explorer.

I re-visited the code and simplified it (getting rid of recording the entry point because it seems that the tabs work fine without having to record the entry point). I did some final testing in IE (as well as Chrome to represent the cooler browsers) and found that it worked fine.

(I also fixed some formatting at the top of the tabs plugin)
