### PR TITLE
Make em-calc sensitive to $rem-base

### DIFF
--- a/scss/foundation/_functions.scss
+++ b/scss/foundation/_functions.scss
@@ -135,8 +135,8 @@ $modules: () !default;
 }
 
 
-@function em-calc($values) {
-  $remValues: rem-calc($values);
+@function em-calc($values, $base-value: $rem-base) {
+  $remValues: rem-calc($values, $base-value: $rem-base);
 
   $max: length($remValues);
 


### PR DESCRIPTION
This is an update to [PR6052](https://github.com/zurb/foundation/pull/6502) and fixing [this](http://foundation.zurb.com/forum/posts/25180-update-v-550-to-552-calculates-wrong-breakpoints)
