### PR TITLE
Removing unnecessary spaces

### DIFF
--- a/doc/pages/components/equalizer.html
+++ b/doc/pages/components/equalizer.html
@@ -104,7 +104,7 @@ You can also nest "equalized" elements in other Equalizer elements. Apply the `d
 {{#markdown}}
 ```html
 <div class="row" data-equalizer="foo">
-  <div class="medium-4 columns" >
+  <div class="medium-4 columns">
     <div class="panel" data-equalizer-watch="foo">
     <h3>Parent panel</h3>
     <div class="row" data-equalizer="bar">
@@ -139,7 +139,7 @@ You can also nest "equalized" elements in other Equalizer elements. Apply the `d
   <div class="large-12 columns">
     <h4>Rendered HTML</h4>
     <div class="row" data-equalizer="foo">
-      <div class="medium-4 columns" >
+      <div class="medium-4 columns">
         <div class="panel" data-equalizer-watch="foo">
         <h3>Parent panel</h3>
         <div class="row" data-equalizer="bar">


### PR DESCRIPTION
Removing unnecessary spaces on closing bracket on a couple opening tags. Pedantic but y'know.
