### PR TITLE
Removing duplicate -ms-transform translate attribute

### DIFF
--- a/scss/foundation/components/_offcanvas.scss
+++ b/scss/foundation/components/_offcanvas.scss
@@ -95,7 +95,6 @@ $menu-slide: "transform 500ms ease" !default;
   -webkit-transform: translate3d($tx, $ty, $tz);
      -moz-transform: translate3d($tx, $ty, $tz);
       -ms-transform: translate($tx, $ty);
-      -ms-transform: translate3d($tx, $ty, $tz);
        -o-transform: translate3d($tx, $ty, $tz);
           transform: translate3d($tx, $ty, $tz)
 }


### PR DESCRIPTION
Duplicate properties cause a lot of problems, especially with css minification tools. 

Removing the `-ms-transform: translate3d($tx, $ty, $tz);` line keeps IE support for IE9 and up with the 2d transform, and stops the 3d transform overwriting the 2d one and breaking the offcanvas menu on IE9 when CSS is minified.

Tested in IE9 to IE11
