### PR TITLE
Reveal: fix positioning of dialog when animation is turned off

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -337,8 +337,9 @@
           }, settings.animation_speed / 2);
         }
 
+        css.top = $(window).scrollTop() + el.data('css-top') + 'px';
+
         if (animData.fade) {
-          css.top = $(window).scrollTop() + el.data('css-top') + 'px';
           var end_css = {opacity: 1};
 
           return setTimeout(function () {


### PR DESCRIPTION
If Reveal's `animation` setting is set to `none` then the dialog was always being positioned from the top of the page, not accounting for any vertical scrolling.  This fixes it.
