### PR TITLE
Fixes reveal modal multiple_opened ordering issues

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -267,8 +267,24 @@
         }
 
         if (settings.multiple_opened) {
+          var isCurrent = modal.is(':not(.toback)');
           self.hide(modal, settings.css.close, settings);
-          openModals.pop();
+          if(isCurrent) {
+            // remove the last modal since it is now closed
+            openModals.pop();
+          } else {
+            // if this isn't the current modal, then find it in the array and remove it
+            openModals = $.grep(openModals, function(elt) {
+              var isThis = elt[0]===modal[0];
+              if(isThis) {
+                // since it's not currently in the front, put it in the front now that it is hidden
+                // so that if it's re-opened, it won't be .toback
+                self.to_front(modal);
+              }
+              return !isThis;
+            });
+          }
+          // finally, show the next modal in the stack, if there is one
           if(openModals.length>0) {
             self.to_front(openModals[openModals.length - 1]);
           }

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -190,7 +190,7 @@
           };
         }
 
-        function openModal() {
+        var openModal = function() {
           if(open_modal.length > 0) {
             if(settings.multiple_opened) {
               self.to_back(open_modal);
@@ -205,7 +205,7 @@
           }
 
           self.show(modal, settings.css.open);
-        }
+        };
 
         if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
           openModal();

--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -1,6 +1,8 @@
 ;(function ($, window, document, undefined) {
   'use strict';
 
+  var openModals = [];
+
   Foundation.libs.reveal = {
     name : 'reveal',
 
@@ -188,16 +190,25 @@
           };
         }
 
-        if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
-          if (open_modal.length > 0) {
-            if (settings.multiple_opened) {
+        function openModal() {
+          if(open_modal.length > 0) {
+            if(settings.multiple_opened) {
               self.to_back(open_modal);
             } else {
               self.hide(open_modal, settings.css.close);
             }
           }
 
-          this.show(modal, settings.css.open);
+          // bl: add the open_modal that isn't already in the background to the openModals array
+          if(settings.multiple_opened) {
+            openModals.push(modal);
+          }
+
+          self.show(modal, settings.css.open);
+        }
+
+        if (typeof ajax_settings === 'undefined' || !ajax_settings.url) {
+          openModal();
         } else {
           var old_success = typeof ajax_settings.success !== 'undefined' ? ajax_settings.success : null;
           $.extend(ajax_settings, {
@@ -218,14 +229,7 @@
               self.S(modal).foundation('section', 'reflow');
               self.S(modal).children().foundation();
 
-              if (open_modal.length > 0) {
-                if (settings.multiple_opened) {
-                  self.to_back(open_modal);
-                } else {
-                  self.hide(open_modal, settings.css.close);
-                }
-              }
-              self.show(modal, settings.css.open);
+              openModal();
             }
           });
 
@@ -264,7 +268,10 @@
 
         if (settings.multiple_opened) {
           self.hide(modal, settings.css.close, settings);
-          self.to_front($($.makeArray(open_modals).reverse()[1]));
+          openModals.pop();
+          if(openModals.length>0) {
+            self.to_front(openModals[openModals.length - 1]);
+          }
         } else {
           self.hide(open_modals, settings.css.close, settings);
         }


### PR DESCRIPTION
Fixing issue with order of modal popups being opened/closed when it doesn't match up with the DOM. Need to maintain a primitive window manager / stack so that the proper modal is opened after closing subsequent modals.

Refer: https://github.com/zurb/foundation/issues/6690
