### PR TITLE
slider: add support for changing by clicking on the slider without having started to drag from the handle

### DIFF
--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -53,6 +53,22 @@
           }
         })
         .on('mouseup.fndtn.slider touchend.fndtn.slider pointerup.fndtn.slider', function (e) {
+          if(!self.cache.active) {
+            // if the user has just clicked into the slider without starting to drag the handle
+            var slider = $(e.target).attr('role') === 'slider' ? $(e.target) : $(e.target).closest('.range-slider').find("[role='slider']");
+            if (slider.length) {
+              self.set_active_slider(slider);
+              if ($.data(self.cache.active[0], 'settings').vertical) {
+                var scroll_offset = 0;
+                if (!e.pageY) {
+                  scroll_offset = window.scrollY;
+                }
+                self.calculate_position(self.cache.active, self.get_cursor_position(e, 'y') + scroll_offset);
+              } else {
+                self.calculate_position(self.cache.active, self.get_cursor_position(e, 'x'));
+              }
+            }
+          }
           self.remove_active_slider();
         })
         .on('change.fndtn.slider', function (e) {


### PR DESCRIPTION
The idea is that in many other implementation of a slider, it's possible to directly click/tap on a target value to change the slider, rather than to grab the handle first, which can be a bit annoying. There's a bit of almost-duplicate code compared to the mousemove event handler, but it seemed overkill to create another function before get_cursor_position for this.
