### PR TITLE
Fix to include query arguments to magellan nav links.

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -59,11 +59,10 @@
               'scrollTop' : scroll_top
             }, settings.duration, settings.easing, function () {
               if (history.pushState) {
-                        history.pushState(null, null, anchor.pathname + '#' + hash);
+                history.pushState(null, null, anchor.pathname + anchor.search + '#' + hash);
+              } else {
+                location.hash = anchor.pathname + anchor.search + '#' + hash;
               }
-                    else {
-                        location.hash = anchor.pathname + '#' + hash;
-                    }
             });
           }
         })


### PR DESCRIPTION
The animation bound to `click.fndtn.magellan` sends the user to a URL lacking the query string arguments. The URL generation was missing the `anchor.search` component.

Before, when viewing a page, e.g.:

```
http://example.com/report.php?survey_id=6
```

Clicking a magellan nav link would scroll and the URL location would change to:

```
http://example.com/report.php#location-3
```

Adding the `anchor.search` component to the URL correctly shows the full URL including query args:

```
http://example.com/report.php?survey_id=6#location-3
```

(I also fixed some JS formatting.)
