### PR TITLE
Remove reflow from init

### DIFF
--- a/js/foundation/foundation.slider.js
+++ b/js/foundation/foundation.slider.js
@@ -23,7 +23,6 @@
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');
       this.bindings(method, options);
-      this.reflow();
     },
 
     events : function () {


### PR DESCRIPTION
This causes set_ui to be called twice on page load.  The other comes from the resize event fired in foundation.js.  Related https://github.com/zurb/foundation/issues/6606
