### PR TITLE
Fix for #5810, reveal modal without animation bug

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -341,6 +341,7 @@
         var animData = getAnimationData(settings.animation);
         if (!animData.animate) {
           this.locked = false;
+          css.top = $(window).scrollTop() + el.data('css-top') + 'px';
         }
         if (animData.pop) {
           css.top = $(window).scrollTop() - el.data('offset') + 'px';


### PR DESCRIPTION
Top position was not set, when animation was disabled.
