### PR TITLE
Adding full height responsiveness to Orbit

### DIFF
--- a/doc/pages/components/orbit.html
+++ b/doc/pages/components/orbit.html
@@ -219,6 +219,11 @@ $(document).foundation({
       timer: true, // Does the slider have a timer active? Setting to false disables the timer.
       variable_height: false, // Does the slider have variable height content?
       swipe: true,
+      full_height : false, // Take all window height
+      full_height_top_offset : 0, // Add padding at top
+      full_height_bottom_offset : 0, // Add padding at bottom
+      full_height_adjust : 0, // Add or remove size
+      full_height_max : 0, // Limit the maximum size
       before_slide_change: noop, // Execute a function before the slide changes
       after_slide_change: noop // Execute a function after the slide changes
   }

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -186,13 +186,46 @@
 
     self.compute_dimensions = function () {
       var current = $(self.slides().get(idx));
-      var h = current.outerHeight();
-      if (!settings.variable_height) {
+
+      if (!settings.full_height) {
+        var h = current.outerHeight();
+        if (!settings.variable_height) {
+          self.slides().each(function(){
+            if ($(this).outerHeight() > h) { h = $(this).outerHeight(); }
+          });
+        }
+        slides_container.height(h);        
+      } else {
+        var window_height = window.innerHeight - settings.full_height_adjust;
+        var height_max = settings.full_height_max;
+        if (height_max > 0) {
+          if (window_height > height_max) {
+            window_height = height_max;    
+          }
+        }
+        var h = current.innerHeight();
+        var top_offset = settings.full_height_top_offset;
+        var bottom_offset = settings.full_height_bottom_offset;
+        var offset = top_offset + bottom_offset;
+
         self.slides().each(function(){
-          if ($(this).outerHeight() > h) { h = $(this).outerHeight(); }
+          var height = $(this).height();
+          var half_padding = ((window_height - height) - offset) / 2;
+          if (half_padding < 0) {
+            half_padding = 0;
+          }
+          $(this).context.style.paddingTop = (top_offset + half_padding) + "px";
+          $(this).context.style.paddingBottom = (bottom_offset + half_padding) + "px";
+          height = height - offset;
+          if (height > h) { h = height }
         });
+
+        if (h < window_height) {
+          slides_container.height(window_height);
+        } else {
+          slides_container.height(h);
+        }
       }
-      slides_container.height(h);
     };
 
     self.create_timer = function () {
@@ -441,6 +474,11 @@
       timer : true,
       variable_height : false,
       swipe : true,
+      full_height : false,
+      full_height_top_offset : 0,
+      full_height_bottom_offset : 0,
+      full_height_adjust : 0,
+      full_height_max : 0,
       before_slide_change : noop,
       after_slide_change : noop
     },


### PR DESCRIPTION
Orbit has some problems with responsiveness, this push solve some of that problems.
1. Allow you to set your slider to height 100%.
2. Automatically center your's sliders
3. Adjust to fit perfectly in every screen (mobile, tablet, pc)
4. Don't trim the content if it takes more than the screen size.
5. Allow you to define a maximum height to looks good even in huge screens.
6. Provide several customisation over how this height works (you can add different extra padding for top or bottom, add or remove size e.g if you need to remove the top menu height).

You can see it working at:
http://52.6.143.233
