### PR TITLE
Add class to block-grid <li> to specify block size

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -72,6 +72,11 @@ $block-grid-media-queries: true !default;
         @include block-grid-aligned($per-row, $spacing);
       }
     }
+    @for $i from 1 through $per-row {
+      .block-#{($i)} {
+        width: (100%*$i)/$per-row;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
In a block-grid, add class="block-X" to a <li> to specify how many blocks the element should take up.

For example:
This is a block-grid:
[X] [X] [X] 
[X] [X] [X]

Changing the first <li> to <li class="block-2"> will give this:
[--X--] [X]
[X] [X] [X] 
[X]
