### PR TITLE
Fix tooltip nub on small screen

### DIFF
--- a/scss/foundation/components/_tooltips.scss
+++ b/scss/foundation/components/_tooltips.scss
@@ -66,8 +66,8 @@ $tooltip-max-width: 300px !default;
       #{$default-float}: 50%;
 
       > .nub {
-        border-color: transparent transparent $tooltip-bg transparent;
         border: solid $tooltip-pip-size;
+        border-color: transparent transparent $tooltip-bg transparent;
         display: block;
         height: 0;
         pointer-events: none;


### PR DESCRIPTION
On narrow screen toolip nub wasn't triangle but white square. One css rule override another.
