### PR TITLE
Interchange Fix - Add additional check on el

### DIFF
--- a/js/foundation/foundation.interchange.js
+++ b/js/foundation/foundation.interchange.js
@@ -48,7 +48,7 @@
           //   console.log($(this).html(), a, b, c);
           // });
 
-          if (el !== null && /IMG/.test(el[0].nodeName)) {
+          if (el !== null && el.length > 0 && /IMG/.test(el[0].nodeName)) {
             var orig_path = $.each(el, function(){this.src = path;});
             // var orig_path = el[0].src;
 


### PR DESCRIPTION
Fixes a "Cannot read property 'nodeName' of undefined" error that people
seem to run into now and again.

I don't know what I did to get in a situation to get this error,
interchange works in other places on the same site fine, but adding this
little extra check fixed one usage that threw it.

Even if it was "my fault" somehow probably never a bad idea to check
what really matters here.
