### PR TITLE
Update _top-bar.scss

### DIFF
--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -435,8 +435,6 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
         top: 0;
         z-index: 99;
         #{$default-float}: 100%;
-        
-        background: $topbar-dropdown-bg;
 
         li {
           height: auto;
@@ -632,6 +630,7 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
         }
 
         .dropdown {
+          background: $topbar-dropdown-bg;
           #{$default-float}: 0;
           min-width: 100%;
           top: auto;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -329,7 +329,6 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
       }
 
       ul li {
-        background: $topbar-dropdown-bg;
 
         > a {
           color: $topbar-link-color;
@@ -436,6 +435,8 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
         top: 0;
         z-index: 99;
         #{$default-float}: 100%;
+        
+        background: $topbar-dropdown-bg;
 
         li {
           height: auto;

--- a/scss/foundation/components/_top-bar.scss
+++ b/scss/foundation/components/_top-bar.scss
@@ -633,7 +633,6 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
 
         .dropdown {
           #{$default-float}: 0;
-          background: transparent;
           min-width: 100%;
           top: auto;
 


### PR DESCRIPTION
Fixed a minor bug which resulted in '$topbar-dropdown-bg' being applied as the background to every top-bar-section list-item Also, the variable wasn't even being used to set the background of the dropdown menu; so I simply moved it down.
