### PR TITLE
Remove Tabindex section from Accessibility page

### DIFF
--- a/doc/pages/accessibility.html
+++ b/doc/pages/accessibility.html
@@ -23,28 +23,9 @@ Aside from accessibility features that has been built into Foundation's componen
 
 <p>The most common impairments for web users are those with problems seeing, hearing or a physical inability to use a mouse. For that reason, the site must be navigatable by keyboard. Most commonly the tab key is used to tab through the content. For a vision impaired person will have a <a href="http://en.wikipedia.org/wiki/Screen_reader">screenreader</a> installed that reads the content out loud. We used <a href="http://www.chromevox.com/">Chromevox</a> to test with. You can find a list of popular screen readers below in the resource list.</p>
 
-### Tab-index
-
-<p>Tab index lets users move forward and backward through the links and form elements on a page. But you can make anything "tabbable" with the tabindex attribute. 
-
-{{#markdown}}
-```html
-<h2 tabindex="1">…</h2>
-
-<article tabindex="2">…</article>
-
-<ul tabindex="3">…</ul>
-```
-{{/markdown}}
-
-<p>As the numbers suggest, tapping on the tab key takes users through anything with the tabindex attribute in order. In HTML5, you can use it on any element. That means you can set priorities quickly. Want to help people get past the same tedious navigation they get on every page? Use tabindex to put navigation last.</p>
-
-<p><strong>Tip:</strong> When starting out use sets of 10: tabindex="10", tabindex="20", tabindex="30". If you decide to rearrange the order — say, put the third item between the first and second — you don't have to rearrange everything. Just make it tabindex="15".</p>
-
-
 ###  How to Test a Website’s Keyboard Accessibility
 
-<p>On a desktop or laptop in Firefox, IE, Chrome, or Safari, 
+<p>On a desktop or laptop in Firefox, IE, Chrome, or Safari,
 click into the browser address bar.</p>
 
 <p>Take your hand off your mouse and use only your keyboard.
@@ -81,11 +62,11 @@ Using the Tab button, navigate until you’ve reached the link below. (You can u
 		overflow:hidden;
 	}
 
-	#skip a:focus { 
-		position:static; 
-		width:auto; 
-		height:auto; 
-	} 
+	#skip a:focus {
+		position:static;
+		width:auto;
+		height:auto;
+	}
 ```
 {{/markdown}}
  </div>


### PR DESCRIPTION
Hello all :)

I reached out via Twitter to note that on the Accessibility page there is a section that suggests the usage of tabindex="1+" to establish a tab order to a document. This is actually not such a good idea unless you really know what you are doing. @rafibomb reached back and asked if I could maybe help with this page.

I believe that entire chunk could be removed. The keyboard accessibility section leads well into how to test for keyboard accessibility as well. That is great content btw :) It is important that when exposing markup examples to the world that they are good examples. I worry young developers seeing the declaration of 1+ values on the attribute rendering their UI unusable.

Here is some further reading about this topic:
http://www.paciellogroup.com/blog/2014/08/using-the-tabindex-attribute/

Browsers and Assistive Technology work naturally with the markup order. The user can flow through the document without the assistance of tabindex if the document is marked up correctly. Skip links are the best way to allow jumps/hops for users.

I'll make another PR for a section covering CSS `outline: none;` which is a great high level topic that would fit in well with this page.

Thanks for taking the time to include a special page covering accessibility! I'd love to contribute more accessibility enhancements to the framework if needed :)
