### PR TITLE
Added title text for orbit for better accessibility

### DIFF
--- a/doc/pages/components/orbit.html
+++ b/doc/pages/components/orbit.html
@@ -220,7 +220,9 @@ $(document).foundation({
       variable_height: false, // Does the slider have variable height content?
       swipe: true,
       before_slide_change: noop, // Execute a function before the slide changes
-      after_slide_change: noop // Execute a function after the slide changes
+      after_slide_change: noop, // Execute a function after the slide changes
+      prev_text: 'Previous slide', // (Title) text for arrow to previous slide
+      next_text: 'Next slide' // (Title) text for arrow to next slide
   }
 });
 ```

--- a/js/foundation/foundation.orbit.js
+++ b/js/foundation/foundation.orbit.js
@@ -54,8 +54,8 @@
       }
 
       if (settings.navigation_arrows) {
-        container.append($('<a href="#"><span></span></a>').addClass(settings.prev_class));
-        container.append($('<a href="#"><span></span></a>').addClass(settings.next_class));
+        container.append($('<a href="#" title="'+settings.prev_text+'"><span></span></a>').addClass(settings.prev_class).append('<span class="visuallyhidden">'+settings.prev_text+'</span>'));
+        container.append($('<a href="#" title="'+settings.next_text+'"><span></span></a>').addClass(settings.next_class).append('<span class="visuallyhidden">'+settings.next_text+'</span>'));
       }
 
       if (settings.timer) {
@@ -442,7 +442,9 @@
       variable_height : false,
       swipe : true,
       before_slide_change : noop,
-      after_slide_change : noop
+      after_slide_change : noop,
+      prev_text: 'Previous slide',
+      next_text: 'Next slide'
     },
 
     init : function (scope, method, options) {


### PR DESCRIPTION
The Orbit initializing now takes two additional parameters allowing to set the text for the arrows that control the slider.
(I am not quite sure if this is considered bad practice to have English fallback strings?)
