### PR TITLE
dropdown performance boost

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -275,23 +275,25 @@
         //lets see if the panel will be off the screen
         //get the actual width of the page and store it
         var actualBodyWidth;
+        var windowWidth = window.innerWidth;
+        
         if (document.getElementsByClassName('row')[0]) {
           actualBodyWidth = document.getElementsByClassName('row')[0].clientWidth;
         } else {
-          actualBodyWidth = window.innerWidth;
+          actualBodyWidth = windowWidth;
         }
 
-        var actualMarginWidth = (window.innerWidth - actualBodyWidth) / 2;
+        var actualMarginWidth = (windowWidth - actualBodyWidth) / 2;
         var actualBoundary = actualBodyWidth;
 
         if (!this.hasClass('mega') && !s.ignore_repositioning) {
-		  var outerWidth = this.outerWidth();
-		  var o_left = t.offset().left;
+          var outerWidth = this.outerWidth();
+          var o_left = t.offset().left;
 		  
           //miss top
           if (t.offset().top <= this.outerHeight()) {
             p.missTop = true;
-            actualBoundary = window.innerWidth - actualMarginWidth;
+            actualBoundary = windowWidth - actualMarginWidth;
             p.leftRightFlag = true;
           }
 

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -285,6 +285,9 @@
         var actualBoundary = actualBodyWidth;
 
         if (!this.hasClass('mega') && !s.ignore_repositioning) {
+		  var outerWidth = this.outerWidth();
+		  var o_left = t.offset().left;
+		  
           //miss top
           if (t.offset().top <= this.outerHeight()) {
             p.missTop = true;
@@ -293,13 +296,13 @@
           }
 
           //miss right
-          if (t.offset().left + this.outerWidth() > t.offset().left + actualMarginWidth && t.offset().left - actualMarginWidth > this.outerWidth()) {
+          if (o_left + outerWidth > o_left + actualMarginWidth && o_left - actualMarginWidth > outerWidth) {
             p.missRight = true;
             p.missLeft = false;
           }
 
           //miss left
-          if (t.offset().left - this.outerWidth() <= 0) {
+          if (o_left - outerWidth <= 0) {
             p.missLeft = true;
             p.missRight = false;
           }


### PR DESCRIPTION
timing went from ~65 milliseconds down to ~45 milliseconds for a long
list of items

An example: http://www.barenecessities.com/Bras_catalog_nxs,31.htm

Mobile view... the Size dropdown is now 20 milliseconds faster on desktop (even better on mobile).
