### PR TITLE
Close dropdown when a reveal modal link is clicked from inside

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -144,6 +144,12 @@
         if (typeof target.selector !== 'undefined') {
           // Find the named node; only use the first one found, since the rest of the code assumes there's only one node
           modal = self.S('#' + target.data(self.data_attr('reveal-id'))).first();
+
+          // If the modal is opened from a dropdown, close the dropdown
+          var $dropdown = target.parents('ul.f-open-dropdown');
+          if ($dropdown.length > 0) {
+              $dropdown.foundation('dropdown', 'close', $dropdown);
+          }
         } else {
           modal = self.S(this.scope);
 


### PR DESCRIPTION
I noticed that Foundation does not close a dropdown when a reveal modal link is a child of the unordered list. I figured this is a behavior most people would want, so here is some code to add it to Foundation's core.

If there's a better way to accomplish this, let me know.
