### PR TITLE
Include $input-placeholder-font-color variable

### DIFF
--- a/scss/foundation/_settings.scss
+++ b/scss/foundation/_settings.scss
@@ -649,6 +649,7 @@ $include-html-global-classes: $include-html-classes;
 // $input-font-family: inherit;
 // $input-font-color: rgba(0,0,0,0.75);
 // $input-font-size: rem-calc(14);
+// $input-placeholder-font-color: #cccccc;
 // $input-bg-color: $white;
 // $input-focus-bg-color: scale-color($white, $lightness: -2%);
 // $input-border-color: scale-color($white, $lightness: -20%);


### PR DESCRIPTION
The $input-placeholder-font-color: #cccccc !default; is defined in the forms.scss on line 26 and was forgotten in the settings.scss
