### PR TITLE
Abide skip validation if no fields validatable

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -217,8 +217,11 @@
     // TODO: Break this up into smaller methods, getting hard to read.
     check_validation_and_apply_styles : function (el_patterns) {
       var i = el_patterns.length,
-          validations = [],
-          form = this.S(el_patterns[0][0]).closest('[data-' + this.attr_name(true) + ']'),
+          validations = [];
+      if (i == 0) {
+        return validations;
+      }
+      var form = this.S(el_patterns[0][0]).closest('[data-' + this.attr_name(true) + ']'),
           settings = form.data(this.attr_name(true) + '-init') || {};
       while (i--) {
         var el = el_patterns[i][0],

--- a/spec/abide/abide.js
+++ b/spec/abide/abide.js
@@ -24,6 +24,25 @@ describe('abide:', function() {
       expect($('input[name="user_email"]')).not.toHaveData('invalid');
     });
 
+    it('should skip validation when there are no validatable fields', function() {
+      $(document).foundation();
+
+      $('input[name="user_name"]').val('Name').hide();
+      $('input[name="user_email"]').val('user@email.com').hide();
+
+      $('form').submit();
+
+      expect('valid.fndtn.abide').not.toHaveBeenTriggeredOn('form');
+      expect('valid').not.toHaveBeenTriggeredOn('input[name="user_name"]');
+      expect('valid').not.toHaveBeenTriggeredOn('input[name="user_email"]');
+      expect('invalid.fndtn.abide').not.toHaveBeenTriggeredOn('form');
+      expect('invalid').not.toHaveBeenTriggeredOn('input[name="user_name"]');
+      expect('invalid').not.toHaveBeenTriggeredOn('input[name="user_email"]');
+
+      $('input[name="user_name"]').show();
+      $('input[name="user_email"]').show();
+    });
+
     it('should trigger correct events for all required fields', function() {
       $(document).foundation();
 


### PR DESCRIPTION
Although we originally attempted to distinguish 100% between forms that were validated and forms that were not, there is an exception case.

We have a form that dynamically hides fields after they have been loaded, when custom widgets are used to select values which must then be hidden from view (e.g. token replacement with proper names)

The issue is simply to ensure that execution continues without error in this case. Currently we see:

```
Uncaught TypeError: Cannot read property '0' of undefined    foundation.abide.js:207
```
