### PR TITLE
Fix 'dd a active' for tabs

### DIFF
--- a/scss/foundation/components/_tabs.scss
+++ b/scss/foundation/components/_tabs.scss
@@ -52,7 +52,7 @@ $tabs-vertical-navigation-margin-bottom: 1.25rem !default;
           }
         }
 
-        &.active a {
+        &.active > a {
           background-color: $tabs-navigation-active-bg-color;
           color: $tabs-navigation-active-font-color;
         }


### PR DESCRIPTION
Why in tag 'a' (line 42) you are using '>' but in line 55 you are not?
