### PR TITLE
Accordion data-content attribute (#6923)

### DIFF
--- a/doc/includes/accordion/examples_accordion_basic.html
+++ b/doc/includes/accordion/examples_accordion_basic.html
@@ -43,3 +43,26 @@
     </div>
   </dd>
 </dl>
+
+<!-- You can also use data-content instead of href to point to the content of the accordion -->
+
+<ul class="accordion" data-accordion>
+  <li class="accordion-navigation">
+    <a href="#" data-content="panel3a">Accordion 1</a>
+    <div id="panel3a" class="content active">
+      Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    </div>
+  </li>
+  <li class="accordion-navigation">
+    <a href="#" data-content="panel3b">Accordion 2</a>
+    <div id="panel3b" class="content">
+      Panel 2. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    </div>
+  </li>
+  <li class="accordion-navigation">
+    <a href="#" data-content="panel3c">Accordion 3</a>
+    <div id="panel3c" class="content">
+      Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    </div>
+  </li>
+</ul>

--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -29,7 +29,8 @@
         var accordion = S(this).closest('[' + self.attr_name() + ']'),
             groupSelector = self.attr_name() + '=' + accordion.attr(self.attr_name()),
             settings = accordion.data(self.attr_name(true) + '-init') || self.settings,
-            target = S('#' + this.href.split('#')[1]),
+            contentAttr = S(this).context.attributes['data-content'],
+            target = S('#' + (contentAttr ? contentAttr.value : this.href.split('#')[1])),
             aunts = $('> dd, > li', accordion),
             siblings = aunts.children('.' + settings.content_class),
             active_content = siblings.filter('.' + settings.active_class);

--- a/spec/accordion/basic.html
+++ b/spec/accordion/basic.html
@@ -1,6 +1,6 @@
 <dl class="accordion" data-accordion>
   <dd class="accordion-navigation">
-    <a href="#panel1">Accordion 1</a>
+    <a href="#" data-content="panel1">Accordion 1</a>
     <div id="panel1" class="content active">
       <dl class="tabs" data-tab>
         <dd class="active"><a href="#panel2-1">Tab 1</a></dd>
@@ -31,7 +31,7 @@
     </div>
   </dd>
   <dd class="accordion-navigation">
-    <a href="#panel3">Accordion 3</a>
+    <a href="#panel3" data-content="panel3">Accordion 3</a>
     <div id="panel3" class="content">
       Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </div>

--- a/spec/accordion/grid.html
+++ b/spec/accordion/grid.html
@@ -2,7 +2,7 @@
   <li>
     <dl class="accordion" data-accordion="myAccordionGroup">
       <dd class="accordion-navigation">
-        <a href="#panel1c">Accordion 1</a>
+        <a href="#" data-content="panel1c">Accordion 1</a>
         <div id="panel1c" class="content">
           Panel 1. Lorem ipsum dolor
         </div>
@@ -14,7 +14,7 @@
         </div>
       </dd>
       <dd class="accordion-navigation">
-        <a href="#panel3c">Accordion 3</a>
+        <a href="#panel3c" data-content="panel3c">Accordion 3</a>
         <div id="panel3c" class="content">
           Panel 3. Lorem ipsum dolor
         </div>
@@ -24,7 +24,7 @@
   <li>
     <dl class="accordion" data-accordion="myAccordionGroup">
       <dd class="accordion-navigation">
-        <a href="#panel4c">Accordion 4</a>
+        <a href="#" data-content="panel4c">Accordion 4</a>
         <div id="panel4c" class="content">
           Panel 4. Lorem ipsum dolor
         </div>
@@ -36,7 +36,7 @@
         </div>
       </dd>
       <dd class="accordion-navigation">
-        <a href="#panel6c">Accordion 6</a>
+        <a href="#panel6c" data-content="panel6c">Accordion 6</a>
         <div id="panel6c" class="content">
           Panel 6. Lorem ipsum dolor
         </div>

--- a/spec/accordion/multiexpand.html
+++ b/spec/accordion/multiexpand.html
@@ -1,6 +1,6 @@
 <dl class="accordion" data-accordion>
   <dd class="accordion-navigation">
-    <a href="#panel1">Accordion 1</a>
+    <a href="#" data-content="panel1">Accordion 1</a>
     <div id="panel1" class="content">
       Panel 1. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </div>
@@ -12,7 +12,7 @@
     </div>
   </dd>
   <dd class="accordion-navigation">
-    <a href="#panel3">Accordion 3</a>
+    <a href="#panel3" data-content="panel3">Accordion 3</a>
     <div id="panel3" class="content">
       Panel 3. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     </div>


### PR DESCRIPTION
For better support of single-page frameworks I proposed using the aria-controls attribute to select the content element in an accordion with ticket #6923.

While implementing I decided that it would be better to use a data- attribute so that the solution is more in line with the existing attributes that are used by foundation.

With this change, the data-content attribute can be used to point to the content of the accordion. For backwards compatibility I have also left the existing href option intact. They can be used interchangeably.

I adjusted the unit tests to use both the href option, the new data-content option and both at the same time.

I adjusted the documentation to also show that this option is available.
