### PR TITLE
Fixed appearance and positioning of tooltip nubs for small devices

### DIFF
--- a/scss/foundation/components/_tooltips.scss
+++ b/scss/foundation/components/_tooltips.scss
@@ -134,9 +134,18 @@ $tooltip-max-width: 300px !default;
           right: auto;
           top: 50%;
         }
+      }
 
+      .tooltip.tip-override {
+        > .nub {
+          border-color: transparent transparent $tooltip-bg transparent;
+        }
+
+        &.tip-left>.nub,
+        &.tip-right>.nub {
+          margin-top: 0;
+        }
       }
     }
-
   }
 }


### PR DESCRIPTION
This is a fix for issue #6939. 

On small devices, all tooltips are treated as `tip-bottom` but the direction and positioning of the nubs wasn't being adjusted. 

I figured there were a couple of ways to go about fixing this. I opted for adjusting `border` and--in the case of `tip-left` and `tip-right`--the `margin-top` based on the presence of the tip-override class. 

This could also be done with a media query or potentially in the tooltip JS, so let me know if one of those options would be preferable.

Before:
![screen shot 2015-10-14 at 3 36 09 pm](https://cloud.githubusercontent.com/assets/788530/10495696/1db96840-728b-11e5-9db1-b216f6b57229.png)

After:
![screen shot 2015-10-14 at 3 49 24 pm](https://cloud.githubusercontent.com/assets/788530/10495710/2c794968-728b-11e5-9493-140cfdf2e793.png)
