### PR TITLE
fix form select focus background

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -135,7 +135,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
   }
   // Basic focus styles
   &:focus {
-    background: $input-focus-bg-color;
+    background-color: $input-focus-bg-color;
     border-color: $input-focus-border-color;
     outline: none;
   }


### PR DESCRIPTION
When focusing a <select> box in a form, the dropdown arrow is wiped out because its set by background-url.  Not sure if this is intended, but it makes it very difficult to _not_ wipe out the arrow if you do decide you want it.  Changing background to background-color fixes this.
