### PR TITLE
FIXED hover_delay in tooltip

### DIFF
--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -27,6 +27,7 @@
 
     init : function (scope, method, options) {
       Foundation.inherit(this, 'random_str');
+      this.reflow();
       this.bindings(method, options);
     },
 
@@ -53,6 +54,13 @@
       return matchMedia(Foundation.media_queries['large']).matches;
     },
 
+    hover_delay: function($target, value) {
+      if (typeof value !== 'undefined') {
+        $target.data('hover_delay', Number(value));
+      }
+      return $target.data('hover_delay');
+    },
+
     events : function (instance) {
       var self = this,
           S = self.S;
@@ -71,7 +79,7 @@
           elt.timer = setTimeout(function () {
             elt.timer = null;
             self.showTip($this);
-          }.bind(elt), self.settings.hover_delay);
+          }.bind(elt), self.hover_delay($this));
         }
       }
 
@@ -343,6 +351,13 @@
       }).remove();
     },
 
-    reflow : function () {}
+    reflow : function () {
+      var self = this;
+      self.S('[' + this.attr_name() + ']').each(function () {
+        var target = $(this);
+        var settings = $.extend({}, self.settings, self.data_options(target));
+        self.hover_delay(target, settings.hover_delay);
+      });
+    }
   };
 }(jQuery, window, window.document));

--- a/spec/tooltip/basic.html
+++ b/spec/tooltip/basic.html
@@ -1,3 +1,5 @@
 <span id="tip1" data-tooltip aria-haspopup="true" class="has-tip" title="Tooltips are awesome, you should totally use them!">extended information</span>
 
 <span id="tip2" data-tooltip aria-haspopup="true" class="has-tip" title="Tooltips are awesome, you should totally use them!">extended information</span>
+
+<span id="tip-with-hoverdelay" data-tooltip class="has-tip" title="Tooltips are awesome">more info</span>

--- a/spec/tooltip/tooltip.js
+++ b/spec/tooltip/tooltip.js
@@ -39,6 +39,27 @@ describe('tooltip:', function() {
       Foundation.libs.tooltip.showTip($("#tip2"));
     
       expect($("span.tooltip[role='tooltip']").filter(":visible").length).toBe(2);  
-    });     
+    });
+
+    it('reads hover_delay from options', function() {
+      var $el = $('#tip-with-hoverdelay');
+      $el.attr('data-options', 'hover_delay:57');
+      $(document).foundation();
+
+      var delay = Foundation.libs.tooltip.hover_delay($el);
+      expect(delay).toBe(57);
+    });
+
+    it('uses hover_delay from settings if no data options provided', function() {
+      var $el = $('#tip-with-hoverdelay');
+      $(document).foundation({
+        tooltip: {
+          hover_delay: 200
+        }
+      });
+
+      var delay = Foundation.libs.tooltip.hover_delay($el);
+      expect(delay).toBe(200);
+    });
   });
 });


### PR DESCRIPTION
hover_delay was read from global settings even if a different value
was set via data-options.
1. Add hover_delay() function that gets/sets the value using $.data
2. Implemented reflow() function that sets hover_delay value for
   all tooltips from their data-option value or global settings.
3. Changed code in showTip to take current hover_delay value
   into account
4. Add 2 specs:
   - hover_delay value is read from data-options if specified
   - hover_delay value is read from global settings if no data-options
     value.
