### PR TITLE
Fix for Sass precompiler does not work with abide form error class #6942

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -547,7 +547,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
 
     /* Error Handling */
 
-    #{data('abide')} {
+    (#{data('abide')}) {
       .error small.error, .error span.error, span.error, small.error {
         @include form-error-message;
       }


### PR DESCRIPTION
In libsass the attribute selector (e.g. [data-abide]) is rendered to CSS with quoted (e.g. "[data-abide]"). Wrapping the isolated interpolated value in parenthesis resolves the problem.
