### PR TITLE
Adding Right Click support to dropdowns

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -35,19 +35,15 @@
                
           var settings = S(this).data(self.attr_name(true) + '-init') || self.settings;
           
-          if(settings.is_right_click === true && e.type === "contextmenu")
-            e.preventDefault();
-          
-          if((settings.is_right_click === true && e.type !== "contextmenu") || 
-              (!settings.is_right_click === true && e.type === "contextmenu"))
-            return;
        
           if (!settings.is_hover || Modernizr.touch || settings.is_right_click) {
             e.preventDefault();
             if (S(this).parent('[data-reveal-id]').length) {
               e.stopPropagation();
             }
-            self.toggle($(this));
+			
+          if((settings.is_right_click && e.type === "contextmenu") || (!settings.is_right_click && e.type !== "contextmenu"))
+                  self.toggle($(this));
           }
         })
         .on('mouseenter.fndtn.dropdown', '[' + this.attr_name() + '], [' + this.attr_name() + '-content]', function (e) {

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -18,7 +18,6 @@
       opened : function () {},
       closed : function () {}
     },
-
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');
 

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -18,9 +18,6 @@
       opened : function () {},
       closed : function () {}
     },
-    
-    timer : null,
-    timeout : 500,
 
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -35,7 +35,7 @@
                
           var settings = S(this).data(self.attr_name(true) + '-init') || self.settings;
           
-          if(settings.is_right_click && e.type === "contextmenu")
+          if(settings.is_right_click === true && e.type === "contextmenu")
             e.preventDefault();
           
           if((settings.is_right_click && e.type !== "contextmenu") || 

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -12,11 +12,15 @@
       mega_class : 'mega',
       align : 'bottom',
       is_hover : false,
+      is_right_click: false,
       hover_timeout : 150,
       no_pip : false,
       opened : function () {},
       closed : function () {}
     },
+    
+    timer : null,
+    timeout : 500,
 
     init : function (scope, method, options) {
       Foundation.inherit(this, 'throttle');
@@ -30,10 +34,19 @@
           S = self.S;
 
       S(this.scope)
-        .off('.dropdown')
-        .on('click.fndtn.dropdown', '[' + this.attr_name() + ']', function (e) {
+        .off('.dropdown')      
+        .on('click.fndtn.dropdown, contextmenu.fndtn.dropdown', '[' + this.attr_name() + ']', function (e) {  
+               
           var settings = S(this).data(self.attr_name(true) + '-init') || self.settings;
-          if (!settings.is_hover || Modernizr.touch) {
+          
+          if(settings.is_right_click && e.type === "contextmenu")
+            e.preventDefault();
+          
+          if((settings.is_right_click && e.type !== "contextmenu") || 
+              (!settings.is_right_click && e.type === "contextmenu"))
+            return;
+       
+          if (!settings.is_hover || Modernizr.touch || settings.is_right_click) {
             e.preventDefault();
             if (S(this).parent('[data-reveal-id]').length) {
               e.stopPropagation();

--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -38,8 +38,8 @@
           if(settings.is_right_click === true && e.type === "contextmenu")
             e.preventDefault();
           
-          if((settings.is_right_click && e.type !== "contextmenu") || 
-              (!settings.is_right_click && e.type === "contextmenu"))
+          if((settings.is_right_click === true && e.type !== "contextmenu") || 
+              (!settings.is_right_click === true && e.type === "contextmenu"))
             return;
        
           if (!settings.is_hover || Modernizr.touch || settings.is_right_click) {


### PR DESCRIPTION
As you can see I have added an option **_is_right_click**_. If the user enable this option the dropdown menu will show up when the user right-clicks on the item ( or touch and press for about 1 second ).

Of course on Safari web browser the user should set the CSS rule `-webkit-touch-callout: none;` to avoid Safari open its own menu.

I tested this code on Google Chrome 46 (and its mobile emulator) and Internet Explorer 11.
