### PR TITLE
Update foundation.topbar.js

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -8,7 +8,7 @@
 
     settings : {
       index : 0,
-      start_offset : 0,
+      start_offset : false,
       sticky_class : 'sticky',
       custom_back_text : true,
       back_text : 'Back',
@@ -31,6 +31,16 @@
         var topbar = $(this),
             settings = topbar.data(self.attr_name(true) + '-init'),
             section = self.S('section, .top-bar-section', this);
+
+        // set the start_offset to the offset of the topbar to fix the initial-scroll-issue of Google Chrome
+        if (self.settings.start_offset === false) {
+            var tbOffset = topbar.offset();
+            if (typeof tbOffset === 'object' &&
+                typeof  tbOffset.top === 'number') {
+                self.settings.start_offset = tbOffset.top;
+            }
+        }
+
         topbar.data('index', 0);
         var topbarContainer = topbar.parent();
         if (topbarContainer.hasClass('fixed') || self.is_sticky(topbar, topbarContainer, settings) ) {


### PR DESCRIPTION
Fixed an issue created by the intial-scroll of Google Chrome.

**Description of the issue and the solution:**
If you scroll down your foundation-website and use the sticky-tobbar and then you reload the page on Google Chrome, Chrome will directly jump to your last scroll position.
Because `start_offset` has the default value of `0`, the script won't toggle the `sticky` and `fixed` classes. So I've set the default value of `start_offset` to `false` (still `0` in JS arithmetics) and on the initialization of the script, it searches for the current offset of the topbar and sets it to the `start_offset` variable, if the `start_offset` equals to false.
