### PR TITLE
Minor update to magellan reflow docs

### DIFF
--- a/doc/pages/components/magellan.html
+++ b/doc/pages/components/magellan.html
@@ -84,7 +84,7 @@ Reflow will make Foundation check the DOM for any elements and re-apply any list
 
 {{#markdown}}
 ```javascript
-$(document).foundation('magellan', 'reflow');
+$(document).foundation('magellan-expedition', 'reflow');
 ```
 {{/markdown}}
 


### PR DESCRIPTION
In the _"Adding New Content After Page Load"_ section of the Magellan plugin, the following instruction was not working for me:

``` js
$(document).foundation('magellan', 'reflow');
```

It seems the library is called  `magellan-expedition`. This worked as expected:

``` js
$(document).foundation('magellan-expedition', 'reflow');
```

This PR updates this documentation page. Let me know if I'm missing anything.

Thank you for all the hard work you put into Foundation :+1:
