### PR TITLE
error input focus background fix

### DIFF
--- a/scss/foundation/components/_forms.scss
+++ b/scss/foundation/components/_forms.scss
@@ -293,7 +293,7 @@ $select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
 
   // Go back to normal on focus
   &:focus {
-    background: $input-focus-bg-color;
+    background-color: $input-focus-bg-color;
     border-color: $input-focus-border-color;
   }
 }


### PR DESCRIPTION
Similar to pull request #6943, this is another instance of `background` that should probably be `background-color`
