### PR TITLE
Fix mixup between show-for-print and print-only visibility classes

### DIFF
--- a/doc/includes/sidebar.html
+++ b/doc/includes/sidebar.html
@@ -5,7 +5,7 @@
     <input tabindex="1" id="autocomplete" type="search" placeholder="Search Docs: e.g. forms">
   </form>
 
-  <a href="/develop/download.html" class="download button expand">Download Foundation</a>
+  <a href="http://foundation.zurb.com/sites/download.html" class="download button expand">Download Foundation</a>
 
   <nav>
     <ul class="side-nav">
@@ -99,9 +99,9 @@
 
       <li class="divider"></li>
       <li class="heading">Older Docs</li>
-      <li><a href="/docs/v/4.3.2/" data-search="">Foundation 4</a></li>
-      <li><a href="/docs/v/3.2.5/" data-search="">Foundation 3</a></li>
-      <li><a href="/docs/v/2.2.1/" data-search="">Foundation 2</a></li>
+      <li><a href="http://foundation.zurb.com/sites/docs/v/4.3.2/index.html" data-search="">Foundation 4</a></li>
+      <li><a href="http://foundation.zurb.com/sites/docs/v/3.2.5/" data-search="">Foundation 3</a></li>
+      <li><a href="http://foundation.zurb.com/sites/docs/v/2.2.1/" data-search="">Foundation 2</a></li>
 
     </ul>
   </nav>

--- a/doc/includes/topbar.html
+++ b/doc/includes/topbar.html
@@ -51,7 +51,7 @@
       </li>
       <li class="divider"></li>
       <li>
-        <a href="{{relative absolute 'dist/upload.html'}}" class="">Upload</a>
+        <a href="http://foundation.zurb.com/upload.html" class="">Upload</a>
       </li>
       <li class="divider"></li>
       <li class="has-dropdown">

--- a/doc/includes/topbar.html
+++ b/doc/includes/topbar.html
@@ -43,40 +43,39 @@
           <li><a  class="spaced-list-item" href="http://foundation.zurb.com/emails.html">Foundation for Emails</a></li>
           <li class="spaced-divider"><hr></li>
           <li><a href="http://foundation.zurb.com/templates.html">HTML Templates</a></li>
-          <li><a href="http://foundation.zurb.com/develop/resources.html">Resources</a></li>
-          <li><a href="http://foundation.zurb.com/sites/building-blocks.html">Building Blocks</a></li>
+          <li><a href="http://foundation.zurb.com/sites/resources.html">Resources</a></li>
+          <li><a href="http://foundation.zurb.com/develop/building-blocks.html">Building Blocks</a></li>
           <li><a href="http://foundation.zurb.com/develop/contribute.html">Contribute</a></li>  
           
         </ul>
+      </li>
+      <li class="divider"></li>
+      <li>
+        <a href="{{relative absolute 'dist/upload.html'}}" class="">Upload</a>
       </li>
       <li class="divider"></li>
       <li class="has-dropdown">
         <a href="http://foundation.zurb.com/support/support.html" class="">Support</a>
         <ul class="dropdown">
           <li><a href="http://foundation.zurb.com/support/support.html">Support Channels</a></li>
+          <li><a href="http://foundation.zurb.com/support/premium-support.html">Premium Channels</a></li>
           <li><a href="http://foundation.zurb.com/forum">Foundation Forum</a></li>
           <li><a href="http://foundation.zurb.com/support/faq.html">FAQs</a></li>
         </ul>
       </li>
       <li class="divider"></li>
       <li class="has-dropdown">
-        <a href="{{relative absolute 'dist/business/services.html'}}" class="">Business</a>
+        <a href="http://foundation.zurb.com/sites/docs/v/5.5.3/">Docs</a>
         <ul class="dropdown">
-          <li><a href="{{relative absolute 'dist/business/services.html'}}">Services</a></li>
-          <li><a href="http://foundation.zurb.com/learn/certification.html">Certification</a></li>
-          <li><a href="{{relative absolute 'dist/business/business-support.html'}}">Business Support</a></li>
-          <li><a href="{{relative absolute 'dist/business/engineering-studios.html'}}">Engineering Studios</a></li>
-          <li><a href="{{relative absolute 'dist/business/training.html'}}">Business Training</a></li>
-          <li><a href="{{relative absolute 'dist/business/design-apps.html'}}">Design Apps</a></li>
+          <li><a href="http://foundation.zurb.com/sites/docs/v/5.5.3/">F5 Sites Docs</a></li>
+          <li><a href="http://foundation.zurb.com/sites/docs">F6 Sites Docs</a></li>
+          <li><a href="http://zurb.com/ink/docs.php">Emails Docs</a></li>
+          <li><a href="http://foundation.zurb.com/apps/docs">Apps Docs</a></li>
         </ul>
       </li>
       <li class="divider"></li>
-      <li>
-        <a href="http://foundation.zurb.com/docs" class="">Docs</a>
-      </li>
-      <li class="divider"></li>
       <li class="has-form">
-        <a href="http://foundation.zurb.com/docs" class="small button">Getting Started</a>
+        <a href="http://foundation.zurb.com/sites/getting-started.html" class="small button">Getting Started</a>
     </ul>
   </section>
 </nav>

--- a/doc/layouts/component.html
+++ b/doc/layouts/component.html
@@ -26,20 +26,13 @@
   </head>
   <body class="antialiased hide-extras">
 
-    <!-- Info Banner For Announcements or Links -->
-    <a href="http://zurb.com/article/1415/48-hour-countdown-to-foundation-6" id="notice">
-      <div class="info">
-        <h5>Countdown to Foundation 6
-        <div id="clockdiv" class="countdown">
-          <span class="timer-hour hours"></span>
-          <span class="timer-colon">:</span>
-          <span class="timer-hour minutes"></span>
-          <span class="timer-colon">:</span>
-          <span class="timer-seconds seconds"></span>
-        </div>
-        </h5>
-      </div>
-    </a>
+  <!-- Info Banner For Announcements or Links -->
+  <a href="http://zurb.com/article/1416/foundation-6-is-here" id="notice">
+    <div class="info">
+      <h5>Foundation 6 is here!</h5>
+    </div>
+  </a>
+
 
 
     <div class="marketing off-canvas-wrap" data-offcanvas>

--- a/doc/layouts/default.html
+++ b/doc/layouts/default.html
@@ -27,19 +27,12 @@
   <body class="antialiased hide-extras">
 
     <!-- Info Banner For Announcements or Links -->
-    <a href="http://zurb.com/article/1415/48-hour-countdown-to-foundation-6" id="notice">
+    <a href="http://zurb.com/article/1416/foundation-6-is-here" id="notice">
       <div class="info">
-        <h5>Countdown to Foundation 6
-        <div id="clockdiv" class="countdown">
-          <span class="timer-hour hours"></span>
-          <span class="timer-colon">:</span>
-          <span class="timer-hour minutes"></span>
-          <span class="timer-colon">:</span>
-          <span class="timer-seconds seconds"></span>
-        </div>
-        </h5>
+        <h5>Foundation 6 is here!</h5>
       </div>
     </a>
+
 
     <div class="marketing off-canvas-wrap" data-offcanvas>
       <div class="inner-wrap">

--- a/doc/layouts/kitchen.html
+++ b/doc/layouts/kitchen.html
@@ -27,20 +27,13 @@
   </head>
   <body class="antialiased hide-extras">
 
-    <!-- Info Banner For Announcements or Links -->
-  <a href="http://zurb.com/article/1415/48-hour-countdown-to-foundation-6" id="notice">
+  <!-- Info Banner For Announcements or Links -->
+  <a href="http://zurb.com/article/1416/foundation-6-is-here" id="notice">
     <div class="info">
-      <h5>Countdown to Foundation 6
-      <div id="clockdiv" class="countdown">
-        <span class="timer-hour hours"></span>
-        <span class="timer-colon">:</span>
-        <span class="timer-hour minutes"></span>
-        <span class="timer-colon">:</span>
-        <span class="timer-seconds seconds"></span>
-      </div>
-      </h5>
+      <h5>Foundation 6 is here!</h5>
     </div>
   </a>
+
 
 
     <div class="marketing off-canvas-wrap" data-offcanvas>

--- a/doc/layouts/offcanvastest.html
+++ b/doc/layouts/offcanvastest.html
@@ -27,20 +27,13 @@
   </head>
   <body class="antialiased hide-extras">
 
-    <!-- Info Banner For Announcements or Links -->
-    <a href="http://zurb.com/article/1415/48-hour-countdown-to-foundation-6" id="notice">
-      <div class="info">
-        <h5>Foundation 6 launches in
-        <div id="clockdiv" class="countdown">
-          <span class="timer-hour hours"></span>
-          <span class="timer-colon">:</span>
-          <span class="timer-hour minutes"></span>
-          <span class="timer-colon">:</span>
-          <span class="timer-seconds seconds"></span>
-        </div>
-        </h5>
-      </div>
-    </a>
+  <!-- Info Banner For Announcements or Links -->
+  <a href="http://zurb.com/article/1416/foundation-6-is-here" id="notice">
+    <div class="info">
+      <h5>Foundation 6 is here!</h5>
+    </div>
+  </a>
+
 
     <div class="off-canvas-wrap sticky" data-offcanvas>
       <div class="inner-wrap">

--- a/doc/pages/components/visibility.html
+++ b/doc/pages/components/visibility.html
@@ -76,7 +76,7 @@ To reverse the rules defined by **hidden**, use the **visible** visibility class
 
 ## Print Visibility
 
-Foundation includes a couple of simple classes you can use to control elements printing, or not printing. Simply attach `.show-for-print` to an element to only show when printing, and `.hide-for-print` to hide something when printing.
+Foundation includes a couple of simple classes you can use to control elements printing, or not printing. Simply attach `.show-for-print` to an element to show when printing, `.print-only` for showing the element only when printing, and `.hide-for-print` to hide something when printing.
 
 Available classes:
 - `.show-for-print` , `.print-only` (Visible for printing)

--- a/doc/pages/index.html
+++ b/doc/pages/index.html
@@ -15,7 +15,7 @@ title: Getting Started
       </div>
       <div class="large-5 columns">
         <p>Millions of designers and engineers use Foundation as part of their workflows. It was the first framework to introduce the concepts of responsive design, semantics, mobile first and partials. It's also compatibile with most browsers and devices. Foundation is the professional choice for designers and engineers.</p>
-        <p><a href="http://foundation.zurb.com/business/why-foundation.html">Why choose foundation? →</a></p>
+        <p><a href="http://foundation.zurb.com/learn/why-foundation.html">Why choose foundation? →</a></p>
         <p><a href="{{relative absolute 'dist/docs/compatibility.html'}}">Foundation compatibility →</a></p>
       </div>
     </div>
@@ -182,11 +182,11 @@ title: Getting Started
         <div class="row circle-list">
           <div class="medium-4 columns">
             <h4>Components</h4>
-            <p>If you need tools to help get your project started? We have some <a href="http://foundation.zurb.com/templates.html">templates</a> we've put together, custom code snippets in our <a href="http://patterntap.com/code">Building Blocks</a>, and <a href="http://foundation.zurb.com/responsive-tables.html">responsive tables</a>. We can also help if you need <a href="http://foundation.zurb.com/icon-fonts.html">icon fonts</a> or <a href="http://foundation.zurb.com/social-icons.html">social icons</a>.</p>
+            <p>If you need tools to help get your project started? We have some <a href="http://foundation.zurb.com/templates-f5.html">templates</a> we've put together, custom code snippets in our <a href="http://patterntap.com/code">Building Blocks</a>, and <a href="http://foundation.zurb.com/responsive-tables.html">responsive tables</a>. We can also help if you need <a href="http://foundation.zurb.com/icon-fonts.html">icon fonts</a> or <a href="http://foundation.zurb.com/social-icons.html">social icons</a>.</p>
           </div>
           <div class="medium-4 columns">
             <h4>Development Tools</h4>
-            <p>The Foundation community has put together <a href="http://foundation.zurb.com/develop/resources.html">free themes</a> for WordPress, Drupal, Shopify, Jekyll, and more! Or if you're looking for <a href="http://madmimi.github.io/angular-foundation/">Angular directives for Foundation</a>, <a href="https://github.com/zurb/foundation-5-sublime-snippets">Sublime Text Snippets</a>, or <a href="http://zacksmash.github.io/foundation-5-coda-2-clips/">Clips for Coda</a> we can help you out.</p>
+            <p>The Foundation community has put together <a href="http://foundation.zurb.com/sites/resources.html">free themes</a> for WordPress, Drupal, Shopify, Jekyll, and more! Or if you're looking for <a href="http://madmimi.github.io/angular-foundation/">Angular directives for Foundation</a>, <a href="https://github.com/zurb/foundation-5-sublime-snippets"> and Sublime Text Snippets</a>to help you out.</p>
           </div>
           <div class="medium-4 columns">
             <h4>Inspiration</h4>
@@ -195,7 +195,7 @@ title: Getting Started
         </div>
       </div>
     </div>
-    <p class="bottom-link"><a href="http://foundation.zurb.com/develop/tools.html">See the full list of resources our community have put together. →</a></p>
+    <p class="bottom-link"><a href="http://foundation.zurb.com/sites/resources.html">See the full list of resources our community have put together. →</a></p>
   </div>
 </div>
 
@@ -231,7 +231,7 @@ title: Getting Started
     <img src="{{assets}}/img/images/support-business-gs.svg">
     <h4>Business Support</h4>
     <p>Foundation Business Support is here to keep you projects moving along smoothly. Whether it's a complex problem or a simple fix we have a solution for your business.</p>
-    <p><a href="http://foundation.zurb.com/business/services.html">Foundation Business Support →</a></p>
+    <p><a href="http://foundation.zurb.com/support/premium-support.html">Foundation Business Support →</a></p>
   </div>
 </div>
 

--- a/doc/pages/sass.html
+++ b/doc/pages/sass.html
@@ -92,6 +92,10 @@ How to Install
   <div class="small-12 path-container columns">
     <h3>How to Install the CLI</h3>
     <h3 class="subheader">Using the CLI to install Foundation 5 only takes two easy commands. You only have to install the CLI once. Don't want to read? <a href="http://foundation.zurb.com/learn/video-started-with-foundation.html">Check out this video we made to help you out.</a></h3>
+    <div class="callout panel" style="font-family: Helvetica">
+      <p>With the release of Foundation 6, we created a new CLI that supports all three Foundation frameworks. However, it does not create new Foundation 5 projects.</p>
+      <p>If you still need to create new Foundation 5 projects, stick with the old CLI, the install instructions for which are below. If you're ready to move to Foundation 6, head over to the <a href="http://foundation.zurb.com/sites/docs/installation.html">installation docs</a> for Foundation 6 and the new CLI.</p>
+    </div>
     <div class="path-item"> 
       <div class="circlenumber">
         <h3>1</h3>

--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -194,7 +194,7 @@
         tip_template = window[settings.tip_template];
       }
 
-      var $tip = $(tip_template(this.selector($target), $('<div></div>').html($target.attr('title')).html())),
+      var $tip = $(tip_template(this.selector($target), $('<div></div>').html($target.attr('title')).text())),
           classes = this.inheritable_classes($target);
 
       $tip.addClass(classes).appendTo(settings.append_to);

--- a/package.json
+++ b/package.json
@@ -48,10 +48,5 @@
     "handlebars-helper-rel",
     "handlebars-helper-slugify"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/zurb/foundation/blob/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }

--- a/scss/foundation/components/_switches.scss
+++ b/scss/foundation/components/_switches.scss
@@ -97,7 +97,7 @@ $switch-active-color: $primary-color !default;
 
     -webkit-transition: left $transition-speed $transition-ease;
     -moz-transition: left $transition-speed $transition-ease;
-    -o-transition: translate3d(0,0,0);
+    -o-transition: left $transition-speed $transition-ease;
     transition: left $transition-speed $transition-ease;
 
     -webkit-transform: translate3d(0,0,0);

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -405,8 +405,7 @@ $visibility-breakpoint-queries:
 
   /* Print visibility */
   @if $include-print-styles {
-    .print-only,
-    .show-for-print { display: none !important; }
+    .print-only { display: none !important; }
     @media print {
       .print-only,
       .show-for-print { display: block !important; }


### PR DESCRIPTION
In foundation 5.5.X the semantics of the `show-for-print` visibility class changed. Before attaching that to an element wouldn't hide it when displaying the document on the screen but would force the element to be visible when printing. In 5.5.X the element is forcibly hidden for screens. The `print-only` class serves that purpose. This pull request restores the previous functionality.

This is related to https://github.com/cz848/foundation/pull/1 (523a434), https://github.com/zurb/foundation/issues/6445 and https://github.com/zurb/foundation/issues/3837 where, IMHO, those two classes, `show-for-print` and `print-only` are confused.
