### PR TITLE
Reporting on old-ish DevDependencies

### DIFF
--- a/grunt/config/devUpdate.js
+++ b/grunt/config/devUpdate.js
@@ -1,0 +1,15 @@
+module.exports = {
+       main: {
+           options: {
+               updateType: 'report', //just report outdated packages
+               reportUpdated: false, //don't report up-to-date packages
+               semver: true, //stay within semver when updating
+               packages: {
+                   devDependencies: true, //only check for devDependencies
+                   dependencies: false
+               },
+               packageJson: null, //use matchdep default findup to locate package.json
+               reportOnlyPkgs: [] //use updateType action on all packages
+           }
+       }
+   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-dev-update": "^1.4.0",
     "grunt-karma": "~0.6.2",
     "grunt-newer": "~0.7.0",
     "grunt-rsync": "~0.2.1",


### PR DESCRIPTION
Add a grunt module [grunt-dev-update](https://github.com/pgilad/grunt-dev-update) to report on, and optionally update, development dependencies.  

To run:  `grunt devUpdate`.  
Change the params in `grunt/config/devUpdate.js` to provide interactive prompts or force updates on everything.
