### PR TITLE
Fixes bug where the ".end" class is overridden

### DIFF
--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -67,7 +67,7 @@
   padding-left: $gutter;
   padding-right: $gutter;
 
-  &:last-child:not(:first-child) {
+  &:last-child:not(:first-child):not(.end) {
     float: $global-right;
   }
 }


### PR DESCRIPTION
The `.end` class is currently being overridden by `.columns:last-child:not(:first-child)` as shown by the following:
https://jsfiddle.net/anik786/qy45s94e/embedded/result/

The fixed version is as so:
https://jsfiddle.net/anik786/gc58hhcg/1/embedded/result/
