### PR TITLE
Remove duplicate $global-margin in _settings.scss

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -63,7 +63,6 @@ $body-antialiased: true;
 $text-direction: ltr;
 $global-margin: 1rem;
 $global-padding: 1rem;
-$global-margin: 1rem;
 $global-weight-normal: normal;
 $global-weight-bold: bold;
 $global-radius: 0;


### PR DESCRIPTION
Noticed a duplicate $global-margin in settings on one of my recent projects.
