### PR TITLE
remove left and right borders from hr

### DIFF
--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -335,8 +335,10 @@ $abbr-underline: 1px dotted $black !default;
   hr {
     max-width: $hr-width;
     height: 0;
+    border-right: 0;
     border-top: 0;
     border-bottom: $hr-border;
+    border-left: 0;
     margin: $hr-margin;
     clear: both;
   }


### PR DESCRIPTION
Fixes #7151, so browsers don't render a black dot at the left edge of `hr` tags (or a grey dot at the right edge). 
