### PR TITLE
[RFR] Updated accessibility guidelines for label and badge

### DIFF
--- a/docs/pages/badge.md
+++ b/docs/pages/badge.md
@@ -6,10 +6,25 @@ sass: scss/components/_badge.scss
 
 ## Basics
 
-Add the `.badge` class to an element to create a badge.
+Add the `.badge` class to an element to create a badge. In the below example, we're using `<span>`, but any tag will work fine.
 
 ```html_example
 <span class="badge">1</span>
+```
+
+<br>
+
+A badge will typically be describing another element on the page. To bind the two elements together, give the badge a unique ID, and reference that ID in an `aria-describedby` attribute on the main element.
+
+```html
+<h1 aria-describedby="messageCount">Unread Messages</h1>
+<span class="badge" id="messageCount">1<span>
+```
+
+Finally, the content itself might need more context for users that use screen readers. You can add extra text inside the badge using the `.show-for-sr` class.
+
+```html
+<span class="badge" id="messageCount">1 <span class="show-for-sr">unread message</span></span>
 ```
 
 ---

--- a/docs/pages/label.md
+++ b/docs/pages/label.md
@@ -21,6 +21,14 @@ A label will typically be describing another element on the page. To bind the tw
 <span class="label" id="emailLabel">High Priority<span>
 ```
 
+If an element is described by multiple labels, place multiple IDs inside of `aria-describedby`.
+
+```html
+<p aria-describedby="emailLabel1 emailLabel2">Re: re: re: you won't believe what's in this email!</p>
+<span class="label" id="emailLabel">High Priority<span>
+<span class="label" id="emailLabe2">Unread<span>
+```
+
 ---
 
 ## Coloring

--- a/docs/pages/label.md
+++ b/docs/pages/label.md
@@ -6,10 +6,19 @@ sass: scss/components/_label.scss
 
 ## Basics
 
-Add the `.label` class to an element to create a label.
+Add the `.label` class to an element to create a label. In the below example, we're using `<span>`, but any tag will work fine.
 
 ```html_example
 <span class="label">Default Label</span>
+```
+
+<br>
+
+A label will typically be describing another element on the page. To bind the two elements together, give the label a unique ID, and reference that ID in an `aria-describedby` attribute on the main element.
+
+```html
+<p aria-describedby="emailLabel">Re: re: re: you won't believe what's in this email!</p>
+<span class="label" id="emailLabel">High Priority<span>
 ```
 
 ---


### PR DESCRIPTION
The label and badge components shipped without concrete accessibility guidelines, so this pull request updates them.

**Label:**
- Add an ID to any label.
- Add `aria-describedby` by to the thing the label describes.
- If an element has multiple labels, reference them all in `aria-describedby`.

**Badge:**
- Add an ID to any badge.
- Add `aria-describedby` to the thing the badge describes.
- Use `.show-for-sr` to give a badge's content more context (e.g., "1 unread message" if the badge only says "1" inside).
