### PR TITLE
[switch] Fix missing border-radius for the paddle itself

### DIFF
--- a/scss/components/_switch.scss
+++ b/scss/components/_switch.scss
@@ -109,6 +109,7 @@ $switch-paddle-transition: all 0.25s ease-out !default;
     width: 1.5rem;
     transition: $switch-paddle-transition;
     transform: translate3d(0, 0, 0);
+    border-radius: $switch-paddle-radius;
   }
 
   // Change the visual style when the switch is active


### PR DESCRIPTION
$switch-paddle-radius was not used anywhere in the mixins.
I assume it should be used here.
