### PR TITLE
The accordion does not work with "any" element as the documentation states. Here is a fix.

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -55,7 +55,7 @@
    */
   Accordion.prototype._init = function() {
     this.$element.attr('role', 'tablist');
-    this.$tabs = this.$element.children('li');
+    this.$tabs = this.$element.children('.accordion-item');
     this.$tabs.each(function(idx, el){
 
       var $el = $(el),


### PR DESCRIPTION
The accordion does not work with "any" element as the documentation states it requires the use of ul and li. This is a quick fix to that issue.

This “li” selector assumes the use of ul and li to create an accordion however the documentation indicates any elements “should” work.

Switching to “.accordion-item” allows for the use of any element.
