### PR TITLE
css-triangle mixin - change keywords in documentation

### DIFF
--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -10,7 +10,7 @@
 ///
 /// @param {Number} $triangle-size - Width of the triangle.
 /// @param {Color} $triangle-color - Color of the triangle.
-/// @param {Keyword} $triangle-direction - Direction the triangle points. Can be `top`, `right`, `bottom`, or `left`.
+/// @param {Keyword} $triangle-direction - Direction the triangle points. Can be `up`, `right`, `down`, or `left`.
 @mixin css-triangle(
   $triangle-size,
   $triangle-color,

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -22,11 +22,11 @@
   height: 0;
   border: inset $triangle-size;
 
-  @if ($triangle-direction == bottom) {
+  @if ($triangle-direction == down) {
     border-color: $triangle-color transparent transparent;
     border-top-style: solid;
   }
-  @if ($triangle-direction == top) {
+  @if ($triangle-direction == up) {
     border-color: transparent transparent $triangle-color;
     border-bottom-style: solid;
   }

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -22,11 +22,11 @@
   height: 0;
   border: inset $triangle-size;
 
-  @if ($triangle-direction == down) {
+  @if ($triangle-direction == bottom) {
     border-color: $triangle-color transparent transparent;
     border-top-style: solid;
   }
-  @if ($triangle-direction == up) {
+  @if ($triangle-direction == top) {
     border-color: transparent transparent $triangle-color;
     border-bottom-style: solid;
   }


### PR DESCRIPTION
small change in documentation for css-triangle scss mixin. 'Top' and 'bottom' keywords replaced with 'up' and 'down' as they are used throughout the project.
