### PR TITLE
Remove trailing commas for IE8 and lower support

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -53,7 +53,7 @@
      * @option
      * @example false
      */
-    closeOnClick: false,
+    closeOnClick: false
     // holdOpen: false
   };
   /**

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -168,7 +168,7 @@
     if(($eleDims.width >= $eleDims.windowDims.width) || (!this.counter && !Foundation.Box.ImNotTouchingYou(this.$element))){
       this.$element.offset(Foundation.Box.GetOffsets(this.$element, this.$anchor, 'center bottom', this.options.vOffset, this.options.hOffset, true)).css({
         'width': $eleDims.windowDims.width - (this.options.hOffset * 2),
-        'height': 'auto',
+        'height': 'auto'
       });
       this.classChanged = true;
       return false;

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -235,14 +235,14 @@
               down: nextSibling,
               up: prevSibling,
               next: openSub,
-              previous: closeSub,
+              previous: closeSub
             });
           } else { // right aligned
             $.extend(functions, {
               down: nextSibling,
               up: prevSibling,
               next: closeSub,
-              previous: openSub,
+              previous: openSub
             });
           }
         } else { // horizontal menu
@@ -250,7 +250,7 @@
             next: nextSibling,
             previous: prevSibling,
             down: openSub,
-            up: closeSub,
+            up: closeSub
           });
         }
       } else { // not tabs -> one sub

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -26,7 +26,7 @@
       'ARROW_RIGHT': 'next',
       'ARROW_UP': 'previous',
       'ARROW_DOWN': 'next',
-      'ARROW_LEFT': 'previous',
+      'ARROW_LEFT': 'previous'
       // 'TAB': 'next',
       // 'SHIFT_TAB': 'previous'
     });

--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -151,7 +151,7 @@
       case 'reveal full':
         return {
           left: $eleDims.windowDims.offset.left,
-          top: $eleDims.windowDims.offset.top,
+          top: $eleDims.windowDims.offset.top
         };
         break;
       default:


### PR DESCRIPTION
Removed a couple of trailing commas as a result of [Google's closure-compiler](https://github.com/google/closure-compiler) complaining:

```
> java -jar /usr/local/lib/compiler.jar --js_output_file=out.js *
foundation.drilldown.js:56: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
    closeOnClick: false,
                       ^

foundation.dropdown.js:171: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
        'height': 'auto',
                        ^

foundation.dropdownMenu.js:238: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
              previous: closeSub,
                                ^

foundation.dropdownMenu.js:245: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
              previous: openSub,
                               ^

foundation.dropdownMenu.js:253: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
            up: closeSub,
                        ^

foundation.tabs.js:29: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
      'ARROW_LEFT': 'previous',
                              ^

foundation.util.box.js:154: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
          top: $eleDims.windowDims.offset.top,
                                             ^

7 error(s), 0 warning(s)
```

A fair amount of warnings are spat out, also. Might be worth taking a look. BTW the `--language_in=ECMASCRIPT5` option to closure-compiler is useful to ignore these problems.
