### PR TITLE
Issue #7156 - fix $topbar-link-color variable

### DIFF
--- a/scss/components/_top-bar.scss
+++ b/scss/components/_top-bar.scss
@@ -29,6 +29,11 @@ $topbar-input-width: 200px !default;
 
   &, ul {
     background-color: $topbar-background;
+
+    & li > a {
+      color: $topbar-link-color;
+    }
+
   }
 
   input {


### PR DESCRIPTION
Changing $topbar-link-color in _settings was having no effect.
Modified _top-bar.scss similar to what version 5.0 had
