### PR TITLE
Fixes #7229 - limit block grid columns to only immediate child column

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -14,7 +14,7 @@
   $n,
   $selector: '.column'
 ) {
-  #{$selector} {
+  & > #{$selector} {
     width: percentage(1/$n);
     float: $global-left;
 


### PR DESCRIPTION
Let's limit block grid columns to only immediate child columns so we could use normal grid inside it.
