### PR TITLE
Media query utils are required

### DIFF
--- a/docs/pages/javascript.md
+++ b/docs/pages/javascript.md
@@ -12,10 +12,11 @@ Once you have the files, add links to jQuery and Foundation as `<script>` tags a
 ```html
 <script src="js/jquery.min.js"></script>
 <script src="js/foundation.min.js"></script>
+<script src="js/foundation.util.mediaQuery.js"></script>
 ```
 
 <div class="callout warning">
-  <p>Make sure Foundation loads <em>after</em> jQuery.</p>
+  <p>Make sure Foundation loads <em>after</em> jQuery, and make sure to include the media query utils.</p>
 </div>
 
 ### File Structure


### PR DESCRIPTION
A minor update to the docs at http://foundation.zurb.com/sites/docs/javascript.html, to make sure that people know that `foundation.util.mediaQuery.js` is required.

My feeling is that if it really is required, then it should be in core. Having this in the docs will save others wasting time debugging jscript errors!

Without `foundation.util.mediaQuery.js` included I get this error in Chrome:

```
Uncaught TypeError: Cannot read property '_init' of undefined
  foundation @ foundation.core.js:254
  (anonymous function) @ (index):273
```
