### PR TITLE
Replaces `&` at the middle of the media-object rule

### DIFF
--- a/scss/components/_media-object.scss
+++ b/scss/components/_media-object.scss
@@ -27,6 +27,7 @@ $mediaobject-image-width-stacked: 100% !default;
 /// Adds styles for sections within a media object.
 /// @param {Number} $padding [$mediaobject-section-padding] - Padding between sections.
 @mixin media-object-section($padding: $mediaobject-section-padding) {
+  $selector: &;
   display: table-cell;
   vertical-align: top;
 
@@ -34,7 +35,7 @@ $mediaobject-image-width-stacked: 100% !default;
     padding-#{$global-right}: $padding;
   }
 
-  &:last-child:not(+ &:first-child) {
+  &:last-child:not(+ $selector:first-child) {
     padding-#{$global-left}: $padding;
   }
 }


### PR DESCRIPTION
As stated in Sass documentation

> & must appear at the beginning of a compound selector

So the way this mixin was written was causing invalid CSS to be generated. Assigning the selector to a variable allows it to be used anywhere in the compound selector.

This fixes #7245
