### PR TITLE
File name casing for foundation.util.mediaQuery.js

### DIFF
--- a/docs/pages/javascript-utilities.md
+++ b/docs/pages/javascript-utilities.md
@@ -71,7 +71,7 @@ Foundation.Keyboard.handleKey(event, this, {
 ```
 
 ## MediaQuery
-`js/foundation.util.mediaquery.js`
+`js/foundation.util.mediaQuery.js`
 
 The media query library used by Foundation has two publicly accessible functions and two properties:
 ```js


### PR DESCRIPTION
File name casing for foundation.util.mediaQuery.js
