### PR TITLE
Removes double padding from menu-text link

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -39,7 +39,7 @@ $menu-expand-max: 6 !default;
   }
 
   // Reset line height to make the height of the overall item easier to calculate
-  > li > a {
+  > li:not(.menu-text) > a {
     display: block;
     padding: $menu-item-padding;
     line-height: 1;


### PR DESCRIPTION
Adding a link to menu-text caused weird padding issues as the menu-text link was essentially getting double padding.

![screen shot 2015-11-29 at 8 56 41 pm](https://cloud.githubusercontent.com/assets/6110968/11463650/6efd0ace-96e2-11e5-9cec-e4c6f6f06325.png)
