### PR TITLE
Fix for #7112

### DIFF
--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -43,7 +43,7 @@
 @mixin grid-column-end() {
   // This extra specificity is required for the property to be applied
   &:last-child {
-    float: $global-left;
+    float: $global-left !important;
   }
 }
 

--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -42,8 +42,8 @@
 /// Disable the default behavior of the last column in a row aligning to the opposite edge.
 @mixin grid-column-end() {
   // This extra specificity is required for the property to be applied
-  &:last-child {
-    float: $global-left !important;
+  &:last-child:last-child {
+    float: $global-left;
   }
 }
 


### PR DESCRIPTION
Preventing grid-column-end() from being overruled by specifics of grid-column().

grid-column-end() from grid/_position.scss (lines 43-47) is being overruled by the specificity of grid-column() from grid/_column.scss (lines 70-72). Preventing this from happening by adding !important to grid-colimn-end()'s float property.
