### PR TITLE
Fix grid-context mixin

### DIFF
--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -18,7 +18,7 @@
   $root: false
 ) {
   // Store the current column count so it can be re-set later
-  $old-grid-column-count: $columns;
+  $old-grid-column-count: $grid-column-count;
   $grid-column-count: $columns !global;
 
   @if $root {


### PR DESCRIPTION
Store the correct value in $old-grid-column-count so it can be restored later.

As it was, everytime the grid-context mixin was called, the global value of $grid-column-count would change to the value of the $columns parameter.
