### PR TITLE
Fix "media-object-section" mixin

### DIFF
--- a/scss/components/_media-object.scss
+++ b/scss/components/_media-object.scss
@@ -35,7 +35,7 @@ $mediaobject-image-width-stacked: 100% !default;
     padding-#{$global-right}: $padding;
   }
 
-  &:last-child:not(+ $selector:first-child) {
+  &:last-child:not(+ #{$selector}:first-child) {
     padding-#{$global-left}: $padding;
   }
 }


### PR DESCRIPTION
Fix `media-object-section` mixin in order to work when compiling with
Compass.
