### PR TITLE
Fixes for django-compressor compressing foundation.

### DIFF
--- a/scss/components/_media-object.scss
+++ b/scss/components/_media-object.scss
@@ -27,7 +27,6 @@ $mediaobject-image-width-stacked: 100% !default;
 /// Adds styles for sections within a media object.
 /// @param {Number} $padding [$mediaobject-section-padding] - Padding between sections.
 @mixin media-object-section($padding: $mediaobject-section-padding) {
-  $selector: &;
   display: table-cell;
   vertical-align: top;
 
@@ -35,7 +34,7 @@ $mediaobject-image-width-stacked: 100% !default;
     padding-#{$global-right}: $padding;
   }
 
-  &:last-child:not(+ $selector:first-child) {
+  &:last-child:not(+ &:first-child) {
     padding-#{$global-left}: $padding;
   }
 }

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -112,7 +112,7 @@
 @mixin background-triangle($color: $black) {
   $rgb: 'rgb(#{red($color)}, #{green($color)}, #{blue($color)})';
 
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='32' height='24' viewBox='0 0 32 24'><polygon points='0,0 32,0 16,24' style='fill: #{$rgb}'></polygon></svg>");
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="32" height="24" viewBox="0 0 32 24"><polygon points="0,0 32,0 16,24" style="fill: #{$rgb}"></polygon></svg>');
 
   @media screen and (min-width:0\0) {
     @if lightness($color) < 50% {


### PR DESCRIPTION
Running the latest version of django compressor/sass ruby.

scss/components/_media-object.scss
    Breaks when trying to compress the file becauses of $selector.
scss/util/_mixins.scss
    Compiles but corrupts css output making screen unusable.

Not sure why this is happening since it supports ruby sass 3.4+. Any ideas?
