### PR TITLE
[Dropdown] Add back closeOnClick functionality for dropdowns.

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -69,7 +69,13 @@
      * @option
      * @example true
      */
-    autoFocus: false
+    autoFocus: false,
+    /**
+     * Allows a click on the body to close the dropdown.
+     * @option
+     * @example true
+     */
+    closeOnClick: false
   };
   /**
    * Initializes the plugin by setting/checking options and attributes, adding helper variables, and saving the anchor.
@@ -248,6 +254,25 @@
     });
   };
   /**
+   * Adds an event handler to the body to close any dropdowns on a click.
+   * @function
+   * @private
+   */
+  Dropdown.prototype._addBodyHandler = function(){
+     var $body = $(document.body).not(this.$element),
+         _this = this;
+     $body.off('click.zf.dropdown')
+          .on('click.zf.dropdown', function(e){
+            var $link = _this.$element.find(e.target);
+            if($link.length){
+              $link.triggerHandler('click.zf.dropdown', [$link]);
+              return false;
+            }
+            _this.close();
+            $body.off('click.zf.dropdown');
+          });
+  };
+  /**
    * Opens the dropdown pane, and fires a bubbling event to close other dropdowns.
    * @function
    * @fires Dropdown#closeme
@@ -266,7 +291,7 @@
     this._setPosition();
     this.$element.addClass('is-open')
         .attr({'aria-hidden': false});
-        
+
     if(this.options.autoFocus){
       var $focusable = Foundation.Keyboard.findFocusable(this.$element);
       if($focusable.length){
@@ -274,6 +299,7 @@
       }
     }
 
+    if(this.options.closeOnClick){ this._addBodyHandler(); }
 
     /**
      * Fires once the dropdown is visible.

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -263,6 +263,9 @@
          _this = this;
      $body.off('click.zf.dropdown')
           .on('click.zf.dropdown', function(e){
+            if(_this.$anchor.is(e.target) || _this.$anchor.find(e.target).length) {
+              return;
+            }
             if(_this.$element.find(e.target).length) {
               return;
             }

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -263,11 +263,8 @@
          _this = this;
      $body.off('click.zf.dropdown')
           .on('click.zf.dropdown', function(e){
-            var $parents = $(e.target).parents(),
-                isChild = $parents.filter(_this.$element[0].id).length,
-                inDom = $parents.filter('html').length;
-            if(isChild || !inDom) {
-              return true;
+            if(_this.$element.find(e.target).length) {
+              return;
             }
             _this.close();
             $body.off('click.zf.dropdown');

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -263,10 +263,12 @@
          _this = this;
      $body.off('click.zf.dropdown')
           .on('click.zf.dropdown', function(e){
-            var $link = _this.$element.find(e.target);
-            if($link.length){
-              $link.triggerHandler('click.zf.dropdown', [$link]);
-              return false;
+            var $target = $(e.target),
+                $parents = $target.parents(),
+                isChild = $parents.filter(_this.$element[0].id).length,
+                inDom = $parents.filter('html').length;
+            if(isChild || !inDom) {
+              return true;
             }
             _this.close();
             $body.off('click.zf.dropdown');

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -263,8 +263,7 @@
          _this = this;
      $body.off('click.zf.dropdown')
           .on('click.zf.dropdown', function(e){
-            var $target = $(e.target),
-                $parents = $target.parents(),
+            var $parents = $(e.target).parents(),
                 isChild = $parents.filter(_this.$element[0].id).length,
                 inDom = $parents.filter('html').length;
             if(isChild || !inDom) {

--- a/scss/components/_dropdown.scss
+++ b/scss/components/_dropdown.scss
@@ -42,7 +42,7 @@ $dropdown-sizes: (
   padding: $dropdown-padding;
   position: absolute;
   visibility: hidden;
-  width: 300px;
+  width: $dropdown-width;
   z-index: 10;
   border-radius: $dropdown-radius;
 


### PR DESCRIPTION
Use this functionality heavily on our site.
Unsure why it was excluded in 6 so I disabled by default.

Shamelessly copied this commented out code from DropdownMenu. Then retooled to fit the new flow.

Do I also have to rebuild foundation.js in this pr?
