### PR TITLE
Fix rule for block grid.

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -106,7 +106,7 @@
 
       // Block grid
       @for $i from 1 through $block-grid-max {
-        .#{$size}-up-#{$i} {
+        .#{$size}-up-#{$i} > {
           @include grid-layout($i);
         }
       }


### PR DESCRIPTION
Fix rule for block grid.
In this example you can see http://codepen.io/anon/pen/obvdaN that grid inside block grid doesn't work correctly. It's apply size from block grid instead from grid definition.   
