### PR TITLE
Read title value as text instead of HTML

### DIFF
--- a/js/foundation/foundation.tooltip.js
+++ b/js/foundation/foundation.tooltip.js
@@ -194,7 +194,7 @@
         tip_template = window[settings.tip_template];
       }
 
-      var $tip = $(tip_template(this.selector($target), $('<div></div>').html($target.attr('title')).html())),
+      var $tip = $(tip_template(this.selector($target), $('<div></div>').html($target.attr('title')).text())),
           classes = this.inheritable_classes($target);
 
       $tip.addClass(classes).appendTo(settings.append_to);


### PR DESCRIPTION
_#6956 appears abandoned by submitter and I want to get the patch in for the upcoming release, so I've replicated it here._

Using `.html()` when grabbing the `title` attribute's value allows it to be evaluated by JavaScript, a potential security loophole, as even escaped code will be evaluated in this process..
