### PR TITLE
Make custom drilldown backButton markup working

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -98,8 +98,8 @@
           $back = $menu.find('.js-drilldown-back');
       if(!$back.length){
         $menu.prepend(_this.options.backButton);
-        _this._back($menu);
       }
+      _this._back($menu);
     });
     if(!this.$element.parent().hasClass('is-drilldown')){
       this.$wrapper = $(this.options.wrapper).addClass('is-drilldown').css(this._getMaxDims());


### PR DESCRIPTION
The drilldown back event currently works only with the default markup. The reason is it's currently triggered only when a custom markup doesn't exist. Fix by detaching _this._back($menu) from the existing condition.

See http://foundation.zurb.com/forum/posts/36661-bug-in-custom-drilldown-backbutton-markup
