### PR TITLE
Fixed plugin 'double dip' in foundation.reflow.fn

### DIFF
--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -168,7 +168,7 @@ var Foundation = {
         var $el = $(this),
             opts = {};
         // Don't double-dip on plugins
-        if ($el.attr('zf-plugin')) {
+        if ($el.data('zf-plugin')) {
           console.warn("Tried to initialize "+name+" on an element that already has a Foundation plugin.");
           return;
         }


### PR DESCRIPTION
Checking for “double dip” on plugins should use the jQuery ‘data’
instead of ‘attr’ since ‘zf-plugin’ is set as a jQuery data key when
the instance of the plugin on the element is created.
