### PR TITLE
auto width on button inputs in topbar

### DIFF
--- a/scss/components/_top-bar.scss
+++ b/scss/components/_top-bar.scss
@@ -40,6 +40,10 @@ $topbar-input-width: 200px !default;
     width: $topbar-input-width;
     margin-#{$global-right}: 1rem;
   }
+  
+  input.button {
+    width:auto;
+  }
 }
 
 @mixin foundation-top-bar {


### PR DESCRIPTION
Inputs in the topbar use the fixed $topbar-input-width and are 200px wide by default.
That applies to button inputs as well which is probably not desirable for a search submit button, for instance.
This just excludes inputs with the button class from that rule.
