### PR TITLE
Add missing abide features

### DIFF
--- a/dist/foundation.js
+++ b/dist/foundation.js
@@ -1728,7 +1728,23 @@ Foundation.Motion = Motion;
             valid = (from === to);
 
         return valid;
+      },
+      // rewrite equal_to to new params, equalTo probably won't work
+      equal_to: function (el, required, parent) {
+        var from_id  = el.attr('data-equal-to'),
+            from = $("#"+from_id).val(),
+            to    = el.val(),
+            valid = (from === to);
+        return valid;
+      },
+      greater_than: function (el, required, parent) {
+        var from_id  = el.attr('data-greater-than'),
+            from = $("#"+from_id).val(),
+            to    = el.val(),
+            valid = (parseInt(from) <= parseInt(to));
+        return valid;
       }
+
     }
   };
 
@@ -1794,6 +1810,10 @@ Foundation.Motion = Motion;
       case 'password':
       case 'number':
       case 'tel':
+      case 'date':
+      case 'time':
+      case 'datetime':
+      case 'color':
       case 'select-one':
         if ($el.attr('required') && !$el.val()) {
           // requirement check does not pass
@@ -1804,6 +1824,13 @@ Foundation.Motion = Motion;
         break;
       case 'checkbox':
         if ($el.attr('required') && !$el.is(':checked')) {
+          return false;
+        }
+        var group = $el.parent().closest('.checkbox-group'),
+            min = group.attr('data-min-required'),
+            counter = group.find(':checked').length;
+        if (group.attr('required') && !min) min = 1;
+        if ((group.attr('required') || min) && counter < min) {
           return false;
         } else {
           return true;
@@ -1910,6 +1937,10 @@ Foundation.Motion = Motion;
         $el[0].type === 'email' ||
         $el[0].type === 'url' ||
         $el[0].type === 'tel' ||
+        $el[0].type === 'date' ||
+        $el[0].type === 'time' ||
+        $el[0].type === 'datetime' ||
+        $el[0].type === 'color' ||
         $el[0].type === 'password' ||
         $el[0].type === 'number') {
       if (!self.requiredCheck($el) || !self.validateText($el)) {
@@ -1941,15 +1972,25 @@ Foundation.Motion = Motion;
       };
     }
     else if ($el[0].type === 'checkbox') {
+      var group = $el.parent().closest('.checkbox-group');
       if (!self.requiredCheck($el)) {
-        self.addErrorClasses($el);
+        if (group) {
+          self.addErrorClasses(group);
+        } else {
+          self.addErrorClasses($el);
+        }
         $el.trigger('invalid.fndtn.abide', $el[0]);
       }
       else {
-        self.removeErrorClasses($el);
+        if (group) {
+          self.removeErrorClasses(group);
+        } else {
+          self.removeErrorClasses($el);
+        }
         $el.trigger('valid.fndtn.abide', $el[0]);
       }
     }
+    // handle select, no validateText needed
     else if ($el[0].type === 'select-one' ||
              $el[0].type === 'select-multiple') {
       if (!self.requiredCheck($el)) {
@@ -2027,6 +2068,10 @@ Foundation.Motion = Motion;
       if ($el[0].type === 'email' ||
           $el[0].type === 'url' ||
           $el[0].type === 'tel' ||
+          $el[0].type === 'date' ||
+          $el[0].type === 'time' ||
+          $el[0].type === 'datetime' ||
+          $el[0].type === 'color' ||
           $el[0].type === 'number' ) {
         pattern = $el[0].type;
       }
@@ -2042,6 +2087,7 @@ Foundation.Motion = Motion;
     if (!validatorLib[validator]) {
       return true;
     }
+    // params uses jquery elements
     return validatorLib[validator]($el,$el.attr('required'),$el.parent());
   };
   /**

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -129,6 +129,12 @@
   Abide.prototype.requiredCheck = function($el) {
     switch ($el[0].type) {
       case 'text':
+      case 'email':
+      case 'url':
+      case 'password':
+      case 'number':
+      case 'tel':
+      case 'select-one':
         if ($el.attr('required') && !$el.val()) {
           // requirement check does not pass
           return false;
@@ -150,6 +156,15 @@
           return true;
         }
         break;
+      case 'select-multiple':
+        var value,
+            counter = $el.find(':checked').length;
+        if (counter) value = $el.val().join();
+        if ($el.attr('required') && (!counter || !value)) {
+          return false;
+        } else {
+          return true;
+        }
       default:
         if ($el.attr('required') && (!$el.val() || !$el.val().length || $el.is(':empty'))) {
           return false;
@@ -226,7 +241,17 @@
         label,
         radioGroupName;
 
-    if ($el[0].type === 'text') {
+    if ($el[0].type === 'hidden' ||
+        $el[0].type === 'submit' ||
+        $el[0].type === 'reset') {
+      return;
+    }
+    if ($el[0].type === 'text' ||
+        $el[0].type === 'email' ||
+        $el[0].type === 'url' ||
+        $el[0].type === 'tel' ||
+        $el[0].type === 'password' ||
+        $el[0].type === 'number') {
       if (!self.requiredCheck($el) || !self.validateText($el)) {
         self.addErrorClasses($el);
         $el.trigger('invalid.fndtn.abide', $el[0]);
@@ -265,6 +290,17 @@
         $el.trigger('valid.fndtn.abide', $el[0]);
       }
     }
+    else if ($el[0].type === 'select-one' ||
+             $el[0].type === 'select-multiple') {
+      if (!self.requiredCheck($el)) {
+        self.addErrorClasses($el);
+        $el.trigger('invalid.fndtn.abide', $el[0]);
+      }
+      else {
+        self.removeErrorClasses($el);
+        $el.trigger('valid.fndtn.abide', $el[0]);
+      }
+    }
     else {
       if (!self.requiredCheck($el) || !self.validateText($el)) {
         self.addErrorClasses($el);
@@ -284,6 +320,8 @@
     var self = this,
         inputs = $form.find('input'),
         inputCount = $form.find('input').length,
+        selects = $form.find('select'),
+        selectCount = $form.find('select').length,
         counter = 0;
 
     while (counter < inputCount) {
@@ -291,12 +329,20 @@
       counter++;
     }
 
+    counter = 0;
+    while (counter < selectCount) {
+      self.validateInput($(selects[counter]), $form);
+      counter++;
+    }
+
     // what are all the things that can go wrong with a form?
     if ($form.find('.form-error.is-visible').length || $form.find('.is-invalid-label').length) {
       $form.find('[data-abide-error]').css('display', 'block');
+      $form.trigger('form-invalid');
     }
     else {
       $form.find('[data-abide-error]').css('display', 'none');
+      $form.trigger('form-valid');
     }
   };
   /**
@@ -317,14 +363,26 @@
     if (inputText.length === 0) {
       return true;
     }
-    else {
-      if (inputText.match(patternLib[pattern])) {
-        return true;
-      }
-      else {
-        return false;
+    if (!pattern) {
+      if ($el[0].type === 'email' ||
+          $el[0].type === 'url' ||
+          $el[0].type === 'tel' ||
+          $el[0].type === 'number' ) {
+        pattern = $el[0].type;
       }
     }
+    if (patternLib[pattern] && !inputText.match(patternLib[pattern])) {
+      return false;
+    }
+    var validatorLib = this.options.validators,
+        validator = $($el).attr('data-abide-validator');
+    if (!validator) {
+      return true;
+    }
+    if (!validatorLib[validator]) {
+      return true;
+    }
+    return validatorLib[validator]($el,$el.attr('required'),$el.parent());
   };
   /**
    * Determines whether or a not a radio input is valid based on whether or not it is required and selected

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -68,7 +68,23 @@
             valid = (from === to);
 
         return valid;
+      },
+      // rewrite equal_to to new params, equalTo probably won't work
+      equal_to: function (el, required, parent) {
+        var from_id  = el.attr('data-equal-to'),
+            from = $("#"+from_id).val(),
+            to    = el.val(),
+            valid = (from === to);
+        return valid;
+      },
+      greater_than: function (el, required, parent) {
+        var from_id  = el.attr('data-greater-than'),
+            from = $("#"+from_id).val(),
+            to    = el.val(),
+            valid = (parseInt(from) <= parseInt(to));
+        return valid;
       }
+
     }
   };
 
@@ -134,6 +150,10 @@
       case 'password':
       case 'number':
       case 'tel':
+      case 'date':
+      case 'time':
+      case 'datetime':
+      case 'color':
       case 'select-one':
         if ($el.attr('required') && !$el.val()) {
           // requirement check does not pass
@@ -144,6 +164,13 @@
         break;
       case 'checkbox':
         if ($el.attr('required') && !$el.is(':checked')) {
+          return false;
+        }
+        var group = $el.parent().closest('.checkbox-group'),
+            min = group.attr('data-min-required'),
+            counter = group.find(':checked').length;
+        if (group.attr('required') && !min) min = 1;
+        if ((group.attr('required') || min) && counter < min) {
           return false;
         } else {
           return true;
@@ -250,6 +277,10 @@
         $el[0].type === 'email' ||
         $el[0].type === 'url' ||
         $el[0].type === 'tel' ||
+        $el[0].type === 'date' ||
+        $el[0].type === 'time' ||
+        $el[0].type === 'datetime' ||
+        $el[0].type === 'color' ||
         $el[0].type === 'password' ||
         $el[0].type === 'number') {
       if (!self.requiredCheck($el) || !self.validateText($el)) {
@@ -281,15 +312,25 @@
       };
     }
     else if ($el[0].type === 'checkbox') {
+      var group = $el.parent().closest('.checkbox-group');
       if (!self.requiredCheck($el)) {
-        self.addErrorClasses($el);
+        if (group) {
+          self.addErrorClasses(group);
+        } else {
+          self.addErrorClasses($el);
+        }
         $el.trigger('invalid.fndtn.abide', $el[0]);
       }
       else {
-        self.removeErrorClasses($el);
+        if (group) {
+          self.removeErrorClasses(group);
+        } else {
+          self.removeErrorClasses($el);
+        }
         $el.trigger('valid.fndtn.abide', $el[0]);
       }
     }
+    // handle select, no validateText needed
     else if ($el[0].type === 'select-one' ||
              $el[0].type === 'select-multiple') {
       if (!self.requiredCheck($el)) {
@@ -367,6 +408,10 @@
       if ($el[0].type === 'email' ||
           $el[0].type === 'url' ||
           $el[0].type === 'tel' ||
+          $el[0].type === 'date' ||
+          $el[0].type === 'time' ||
+          $el[0].type === 'datetime' ||
+          $el[0].type === 'color' ||
           $el[0].type === 'number' ) {
         pattern = $el[0].type;
       }
@@ -382,6 +427,7 @@
     if (!validatorLib[validator]) {
       return true;
     }
+    // params uses jquery elements
     return validatorLib[validator]($el,$el.attr('required'),$el.parent());
   };
   /**


### PR DESCRIPTION
Abide 6 is missing some features and not usable coming form F5. This is my effort to add them. The codes is tested on test cases and in my project. 

requiredCheck: Add support for email, url, password, number, tel, select-one, select-multiple, etc.

validateInput: Add support for hidden, submit, reset (do nothing), email, url, tel, password, number, select-one, select-multiple

validateForm: Add support for select fields validation. Also trigger "form-valid" or "form-invalid" events for form accordingly. Somehow, "valid.fndtn.abide" and "invalid.fndtn.abide" for form do not get picked up by form event listener. 

validateText: Add support for email, url, tel, number, date, time, datetime, color (type->pattern), more can be added easily. Add support for data-abide-validator. If pattern or validator not found in defaults, ignore or return true.

Add group: checkbox-group (parent) with data-min-checked as requiredCheck for checkbox. updated validateText and validateInput (error highlight group).

``` HTML
    <div class="checkbox-group" data-min-checked=1 required>
      <input type=checkbox>1
      <input type=checkbox>2
    </div>
```

Added sample validators equal_to and greater_than (params using jquery element)

Please review.
