### PR TITLE
Fixed issue with Reveal modal being rendered below the backdrop on iOS

### DIFF
--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -53,7 +53,7 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     overflow-x: hidden;
     position: relative;
     backface-visibility: hidden;
-    -webkit-overflow-scrolling: touch;
+    -webkit-overflow-scrolling: auto;
   }
 
   .off-canvas-wrapper-inner {


### PR DESCRIPTION
Fixes #7380, as well as #7280, #7281.
See example here http://codepen.io/Owlbertz/pen/eJOQVv.
