### PR TITLE
Fix space interaction with inputs in Dropdowns

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -213,7 +213,8 @@
     }
     this.$anchor.add(this.$element).on('keydown.zf.dropdown', function(e) {
 
-      var visibleFocusableElements = Foundation.Keyboard.findFocusable(_this.$element);
+      var $target = $(this),
+        visibleFocusableElements = Foundation.Keyboard.findFocusable(_this.$element);
 
       Foundation.Keyboard.handleKey(e, _this, {
         tab_forward: function() {
@@ -237,8 +238,13 @@
           }
         },
         open: function() {
-          _this.open();
-          _this.$element.attr('tabindex', -1).focus();
+          if ($target.is(_this.$anchor)) {
+            _this.open();
+            _this.$element.attr('tabindex', -1).focus();
+            e.preventDefault();
+          } else {
+            console.log($target, _this.$anchor);
+          }
         },
         close: function() {
           _this.close();

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -242,8 +242,6 @@
             _this.open();
             _this.$element.attr('tabindex', -1).focus();
             e.preventDefault();
-          } else {
-            console.log($target, _this.$anchor);
           }
         },
         close: function() {


### PR DESCRIPTION
Fixed space key causing the page to scroll when clicked within an input in a Dropdown
Fix for #7394.
