### PR TITLE
Fixes #7449 [Magellan] Last menu element active on load if body has no margin

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -93,7 +93,7 @@
         html = document.documentElement;
 
     this.points = [];
-    this.winHeight = Math.round(Math.max(window.innerHeight, document.body.clientHeight));
+    this.winHeight = Math.round(Math.max(window.innerHeight, html.clientHeight));
     this.docHeight = Math.round(Math.max(body.scrollHeight, body.offsetHeight, html.clientHeight, html.scrollHeight, html.offsetHeight));
 
     this.$targets.each(function(){


### PR DESCRIPTION
Uses `document.documentElement.clientHeight` to calculate viewport height instead of `document.body.clientHeight`. See http://jsfiddle.net/tzdcx/1/ for differences between the two.
