### PR TITLE
Fixes [Callout] data-closable not working #7260

### DIFF
--- a/docs/pages/callout.md
+++ b/docs/pages/callout.md
@@ -93,7 +93,7 @@ Pair the callout with the [close button](close-button.html) component and `data-
 <div class="alert callout" data-closable>
   <h5>This is Important!</h5>
   <p>But when you're done reading it, click the close button in the corner to dismiss this alert.</p>
-  <button class="close-button" aria-label="Dismiss alert" type="button">
+  <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
     <span aria-hidden="true">&times;</span>
   </button>
 </div>


### PR DESCRIPTION
found this in the js files

``` js
// Elements with [data-close] will close a plugin that supports it when clicked.
// If used without a value on [data-close], the event will bubble, allowing it to close a parent component.
```

so adding data-close to the close button bubble the parent data-closeable, and this closes the box ;-)

``` js
$(document).on('close.zf.trigger', '[data-closable]', function() {
...
});
```

maybe docs should point to this too
