### PR TITLE
Add note to block grid documentation

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -388,7 +388,7 @@ Using these source ordering classes, you can shift columns around between our br
 
 ### Block Grids
 
-The block grid from Foundation 5 has been merged into the main grid. Add a class of the format `[size]-up-[n]` to change the size of all columns within the row.
+The block grid from Foundation 5 has been merged into the main grid. Add a class of the format `[size]-up-[n]` to change the size of all columns within the row. By default, the max number of columns you can use with block grid are 6.
 
 ```html_example
 <div class="row small-up-1 medium-up-2 large-up-4">


### PR DESCRIPTION
Add note to block grid documentation pointing out that Foundation defaults to a maximum of six columns.
