### PR TITLE
Slider problem when decimal is 0

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -222,7 +222,7 @@
         lOrT = vert ? 'top' : 'left',
         halfOfHandle = $hndl[0].getBoundingClientRect()[hOrW] / 2,
         elemDim = this.$element[0].getBoundingClientRect()[hOrW],
-        pctOfBar = percent(location, this.options.end).toFixed(this.options.decimal),
+        pctOfBar = percent(location, this.options.end).toFixed(2),
         pxToMove = (elemDim - halfOfHandle) * pctOfBar,
         movement = (percent(pxToMove, elemDim) * 100).toFixed(this.options.decimal),
         location = location > 0 ? parseFloat(location.toFixed(this.options.decimal)) : 0,


### PR DESCRIPTION
Fixes  #7269

We don't need to use value decimal setting for slider ui positioning.
