### PR TITLE
fix incorrect gutter padding to *-uncollapse classes

### DIFF
--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -13,9 +13,12 @@
 }
 
 /// Un-collapse the gutters on a column by re-adding the padding.
-@mixin grid-column-uncollapse() {
-  padding-left: $grid-column-gutter;
-  padding-right: $grid-column-gutter;
+///
+/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
+@mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
+  $gutter: rem-calc($gutter) / 2;
+  padding-left: $gutter;
+  padding-right: $gutter;
 }
 
 /// Shorthand for `grid-column-collapse()`.


### PR DESCRIPTION
Here is a proposed fix to issue #7452. In addition, it now accepts a $gutter parameter so that columns with non-default gutter value can make use of this mixin.
