### PR TITLE
[Core] Adding Plugins After Page Load Initializes Undesired Plugin On Containing Element

### DIFF
--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -158,7 +158,7 @@ var Foundation = {
       var plugin = _this._plugins[name];
 
       // Localize the search to all elements inside elem, as well as elem itself, unless elem === document
-      var $elem = $(elem).find('[data-'+name+']').addBack('*');
+      var $elem = $(elem).find('[data-'+name+']').addBack('[data-'+name+']');
 
       // For each plugin found, initialize it
       $elem.each(function() {


### PR DESCRIPTION
The documentation states that plugins can be added after page load and provides this example:

<pre>
$.ajax('assets/partials/kitten-carousel.html', function(data) {
  $('#kitten-carousel').html(data).foundation();
});
</pre>


There is a bug that will will always initialize Abide (or the first loaded plugin) on the element foundation is called on. In this example #kitten-carousel will end up having Abide initialized on it even if the data-abide was not on the element.

I have also create a pen to illustrate the bug here:
http://codepen.io/anon/pen/bEdwEX

addBack('*') appears to be the source of the problem it's always adding the containing element even if it is not of the correct type of plugin. The result is that whatever the first plugin to being processed get's initialized on the containing element.
