### PR TITLE
Issue #7441 Enable non-list elements in Accordions

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -55,7 +55,10 @@
    */
   Accordion.prototype._init = function() {
     this.$element.attr('role', 'tablist');
-    this.$tabs = this.$element.children('.accordion-item');
+    this.$tabs = this.$element.children('li');
+    if (this.$tabs.length == 0) {
+      this.$tabs = this.$element.children('[data-accordion-item]');
+    }
     this.$tabs.each(function(idx, el){
 
       var $el = $(el),

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -55,7 +55,7 @@
    */
   Accordion.prototype._init = function() {
     this.$element.attr('role', 'tablist');
-    this.$tabs = this.$element.children('li');
+    this.$tabs = this.$element.children('.accordion-item');
     this.$tabs.each(function(idx, el){
 
       var $el = $(el),


### PR DESCRIPTION
Fixes [#7441](https://github.com/zurb/foundation-sites/issues/7441) Instead of selecting an `li` element, I set the selector to `accordion-item`. I tested using nested div elements instead of a list and it worked correctly.
