### PR TITLE
adds missing abide features without splitting inputs into types (code…

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -62,9 +62,9 @@
       color : /^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/
     },
     validators: {
-      equalTo: function (el, required, parent) {
-        var from  = document.getElementById(el.getAttribute(this.add_namespace('data-equalto'))).value,
-            to    = el.value,
+      equalTo: function ($el, required, parent) {
+        var from = $('#'+$el.attr('data-equalto')).val(),
+            to    = $el.val(),
             valid = (from === to);
 
         return valid;
@@ -305,13 +305,16 @@
    */
   Abide.prototype.validateText = function($el) {
     var self = this,
-        valid = false,
+        valid = true,
         patternLib = this.options.patterns,
-        inputText = $($el).val(),
+        inputText = $el.val(),
         elTypeProperty = patternLib.hasOwnProperty($el[0].type)?patternLib[$el[0].type]:false,
-        elPattern = $($el).attr('pattern'),
-        elDataPattern = $($el).data('pattern'),
-        pattern = false;
+        elPattern = $el.attr('pattern'),
+        elDataPattern = $el.attr('data-pattern'),
+        pattern = false,
+        validatorLib = this.options.validators,
+        validatorOwnProperty = $el.attr('data-abide-validator'),
+        validator = validatorLib.hasOwnProperty(validatorOwnProperty)?validatorLib[validatorOwnProperty]:false;
 
     // maybe have a different way of parsing this bc people might use type
     if (elDataPattern && elDataPattern.length > 0) {
@@ -325,16 +328,19 @@
     // if there's no value, then return true
     // since required check has already been done
     if (inputText.length === 0) {
-      return true;
+      valid = true;
     }
     else {
-      if ((pattern && inputText.match(pattern)) || !pattern) {
-        return true;
+      if ((pattern && inputText.match(pattern))) {
+        valid = true;
+      }else if(pattern){
+        valid = false;
       }
-      else {
-        return false;
+      if(typeof validator === 'function') {
+        valid = validator($el,$el.attr('required'),$el.parent());
       }
     }
+    return valid;
   };
   /**
    * Determines whether or a not a radio input is valid based on whether or not it is required and selected

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -151,7 +151,7 @@
         }
         break;
       default:
-        if ($el.attr('required') && (!$el.val() || !$el.val().length || $el.is(':empty'))) {
+        if ($el.attr('required') && (!$el.val() || !$el.val().length)) {
           return false;
         } else {
           return true;
@@ -221,8 +221,6 @@
    */
   Abide.prototype.validateInput = function($el, $form) {
     var self = this,
-        textInput = $form.find('input[type="text"]'),
-        checkInput = $form.find('input[type="checkbox"]'),
         label,
         radioGroupName;
 
@@ -282,8 +280,8 @@
    */
   Abide.prototype.validateForm = function($form) {
     var self = this,
-        inputs = $form.find('input'),
-        inputCount = $form.find('input').length,
+        inputs = $form.find('input, textarea, select'),
+        inputCount = inputs.length,
         counter = 0;
 
     while (counter < inputCount) {
@@ -297,6 +295,7 @@
     }
     else {
       $form.find('[data-abide-error]').css('display', 'none');
+      $form[0].submit();
     }
   };
   /**
@@ -309,8 +308,19 @@
         valid = false,
         patternLib = this.options.patterns,
         inputText = $($el).val(),
-        // maybe have a different way of parsing this bc people might use type
-        pattern = $($el).attr('pattern');
+        elTypeProperty = patternLib.hasOwnProperty($el[0].type)?patternLib[$el[0].type]:false,
+        elPattern = $($el).attr('pattern'),
+        elDataPattern = $($el).data('pattern'),
+        pattern = false;
+
+    // maybe have a different way of parsing this bc people might use type
+    if (elDataPattern && elDataPattern.length > 0) {
+      pattern = patternLib.hasOwnProperty(elDataPattern)?patternLib[elDataPattern]:elDataPattern;
+    }else if(elPattern && elPattern.length > 0){
+      pattern = patternLib.hasOwnProperty(elPattern)?patternLib[elPattern]:elPattern;
+    }else if (elTypeProperty) {
+      pattern = elTypeProperty;
+    }
 
     // if there's no value, then return true
     // since required check has already been done
@@ -318,7 +328,7 @@
       return true;
     }
     else {
-      if (inputText.match(patternLib[pattern])) {
+      if ((pattern && inputText.match(pattern)) || !pattern) {
         return true;
       }
       else {


### PR DESCRIPTION
… reduction)
This should fix #7424 #7406 #7357 #7345 #7304 #7230 #7228 #7226 #7209 #7196 #7127
adds support for html5 input types, selects (multi), textareas
adds support for html5 elements through patternLib
adds support for pattern and data-pattern through patternLib and own patterns

everything is tested in a testcase, for me it works without splitting the types.
For those input elements (email..) which return a el.type for example email and a pattern exists in the patternLib it will be validated with this.

what have i done?
1. fix the default case of requiredCheck because is(':emtpy') checks for innerhtml elements in inputs and there aren't
2. remove not used

``` js
textInput = $form.find('input[type="text"]'),
checkInput = $form.find('input[type="checkbox"]'),
```
1. inputcount improvement
2. submit form if valid
3. pattern support
   in html5 type overrides pattern
   in my abide i handle it like this

```
Data-pattern overrides
Pattern overrides
type
```

so you can flexible choose whatyou would like to use
even a input and for example type email, or pattern, without required, can be validated if there is something typed in.

i tested the following elements
input types and elements
    hidden
    text
    password
    color
    date
    datetime
    datetime-local
    email
    month
    number
    range
    search
    tel
    time
    url
    week
    select
    select multiple
    textarea
    radio
    checkbox
    reset
    submit

if you want to i cann paste my test html

please have a look maybe this fixes the issues without splitting the input types and bloat the code
