### PR TITLE
Issue #7405 Use hover state variable for tab-title

### DIFF
--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -106,7 +106,10 @@ $tab-content-padding: 1rem !default;
       font-size: 12px;
       color: $tab-item-color;
 
-      &:hover,
+      &:hover {
+        background: $tab-item-background-hover;
+      }
+      
       &:focus,
       &[aria-selected='true'] {
         background: $tab-background-active;


### PR DESCRIPTION
Fixes [#7405](https://github.com/zurb/foundation-sites/issues/7405) Separate the hover state from focus and aria-selected to make use of the $tab-item-background-hover variable.
