### PR TITLE
Fix incorrect vertical alignment Sass comment

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -176,7 +176,7 @@
     }
   }
 
-  // Horizontal alignment using align-items and align-self
+  // Vertical alignment using align-items and align-self
   @each $vdir, $prop in (
     'top': flex-start,
     'bottom': flex-end,


### PR DESCRIPTION
Comment incorrectly labels vertical alignment section in flex grid as horizontal.
