### PR TITLE
adds support for equalizeByRow - Responsive Equalizer

### DIFF
--- a/docs/pages/equalizer.md
+++ b/docs/pages/equalizer.md
@@ -79,3 +79,146 @@ In the below example, the first set of Equalizer elements have the value `foo`, 
     </div>
   </div>
 </div>
+
+## Responsive Equalizer - equalize row by row
+
+Equalizer works the Elements row by row, so every data-equalizer-watch on one row has the highest height from the row.
+Usefull for Rows that should be the Same height on every breakpoint because it works responsive
+
+<div class="callout success">
+  <strong>Works great with Block-Grid</strong>
+</div>
+
+<div class="callout primary">
+  <strong>Under the Hood</strong><br>
+  Equalizer splits the data-equalizer-watch elements into groups by checking the offset().top position and then sets the max height to each element in a row<br>
+  But be aware on what you set the data-equalizer-watch, if the offset().top position is different, maybe of a text changes ahead of, it's a new row
+  <br>
+  todo:<br>
+  test with data-equalize-on
+  test with nested id if fires right
+</div>
+
+<div class="row small-up-1 medium-up-2 large-up-4" data-equalizer data-equalize-by-row="true">
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="//placehold.it/180x200" class="thumbnail" alt="">
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="//placehold.it/180x180" class="thumbnail" alt="">
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="//placehold.it/180x400" class="thumbnail" alt="">
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="//placehold.it/180x200" class="thumbnail" alt="">
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="//placehold.it/180x180" class="thumbnail" alt="">
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="//placehold.it/180x400" class="thumbnail" alt="">
+    </div>
+  </div>
+</div>
+
+Also see this Example, resize the Browser to see what happens
+
+<div class="row" data-equalizer data-equalize-by-row="true">
+  <div class="small-12 medium-6 large-4 columns">
+    <div class="callout clearfix">
+      <div data-equalizer-watch>
+        <h5>Login</h5>
+        <p>Login Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sunt magni quia unde laboriosam tempore et quibusdam. Quibusdam maxime sit atque!</p>
+      </div>
+      <a href="#" class="button success expanded">Login</a> </div>
+  </div>
+  <div class="small-12 medium-6 large-4 columns">
+    <div class="callout clearfix">
+      <div data-equalizer-watch>
+        <h5>Create Account</h5>
+        <p>You can create an account here Lorem ipsum dolor sit amet, consectetur adipisicing elit. Doloribus, assumenda, molestiae. Laboriosam et exercitationem, veniam odit, dicta illum corporis, placeat voluptates fuga, expedita distinctio quae magnam temporibus porro quas eius.</p>
+      </div>
+      <a href="#" class="button expanded">Create account</a> </div>
+  </div>
+  <div class="small-12 medium-12 large-4 columns">
+    <div class="callout clearfix">
+      <div data-equalizer-watch>
+        <h5>Social Login</h5>
+        <p>Social Networks Login Text</p>
+      </div>
+      <a href="#" class="button hollow expanded">Login</a> </div>
+  </div>
+</div>

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -182,7 +182,7 @@
       groups[group].push([this.$watched[i],this.$watched[i].offsetHeight]);
     }
 
-    for (var i = 0; i < groups.length; i++) {
+    for (var i = 0, len = groups.length; i < len; i++) {
       var heights = $(groups[i]).map(function () { return this[1]}).get();
       var max         = Math.max.apply(null, heights);
       groups[i].push(max);
@@ -220,20 +220,15 @@
    * @fires Equalizer#postEqualized
    */
   Equalizer.prototype.applyHeightByRow = function(groups){
-    var max;
     /**
      * Fires before the heights are applied
      */
     this.$element.trigger('preEqualized.zf.Equalizer');
-    for (var i = 0; i < groups.length ; i++) {
-      var groupsILength = groups[i].length;
+    for (var i = 0, len = groups.length; i < len ; i++) {
+      var groupsILength = groups[i].length,
           max = groups[i][groupsILength - 1];
-      //max height excluded
       if (groupsILength<=2) {
-        //stacked set to auto
-        for (var j = 0; j < groupsILength ; j++) {
-          $(groups[i][j][0]).css({'height':'auto'});
-        }
+        $(groups[i][0][0]).css({'height':'auto'});
         continue;
       };
       /**
@@ -241,7 +236,7 @@
         * @event Equalizer#preEqualizedRow
         */
       this.$element.trigger('preEqualizedRow.zf.Equalizer');
-      for (var j = 0; j < groupsILength ; j++) {
+      for (var j = 0, lenJ = (groupsILength-1); j < lenJ ; j++) {
         $(groups[i][j][0]).css({'height':max});
       }
       /**

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -28,6 +28,12 @@
      */
     equalizeOnStack: true,
     /**
+     * Enable height equalization row by row.
+     * @option
+     * @example false
+     */
+    equalizeByRow: false,
+    /**
      * String representing the minimum breakpoint size the plugin should equalize heights on.
      * @option
      * @example 'medium'
@@ -125,7 +131,11 @@
         return false;
       }
     }
-    this.getHeights(this.applyHeight.bind(this));
+    if (this.options.equalizeByRow) {
+      this.getHeightsByRow(this.applyHeightByRow.bind(this));
+    }else{
+      this.getHeights(this.applyHeight.bind(this));
+    }
   };
   /**
    * Manually determines if the first 2 elements are *NOT* stacked.
@@ -148,6 +158,38 @@
     cb(heights);
   };
   /**
+   * Finds the outer heights of children contained within an Equalizer parent and returns them in an array
+   * @param {Function} cb - A non-optional callback to return the heights array to.
+   * @returns {Array} groups - An array of heights of children within Equalizer container grouped by row with element,height and max as last child
+   */
+  Equalizer.prototype.getHeightsByRow = function(cb) {
+    var eqGroup = this.$watched,
+        firstTopOffset = this.$watched.first().offset().top,
+        lastElTopOffset = firstTopOffset,
+        groups = [],
+        group = 0;
+    //group by Row
+    groups[group] = [];
+    for(var i = 0, len = this.$watched.length; i < len; i++){
+      this.$watched[i].style.height = 'auto';
+      //maybe could use this.$watched[i].offsetTop
+      var elOffsetTop = $(this.$watched[i]).offset().top;
+      if (elOffsetTop!=lastElTopOffset) {
+        group++;
+        groups[group] = [];
+        lastElTopOffset=elOffsetTop;
+      };
+      groups[group].push([this.$watched[i],this.$watched[i].offsetHeight]);
+    }
+
+    for (var i = 0; i < groups.length; i++) {
+      var heights = $(groups[i]).map(function () { return this[1]}).get();
+      var max         = Math.max.apply(null, heights);
+      groups[i].push(max);
+    }
+    cb(groups);
+  };
+  /**
    * Changes the CSS height property of each child in an Equalizer parent to match the tallest
    * @param {array} heights - An array of heights of children within Equalizer container
    * @fires Equalizer#preEqualized
@@ -166,6 +208,50 @@
     /**
      * Fires when the heights have been applied
      * @event Equalizer#postEqualized
+     */
+     this.$element.trigger('postEqualized.zf.Equalizer');
+  };
+  /**
+   * Changes the CSS height property of each child in an Equalizer parent to match the tallest by row
+   * @param {array} groups - An array of heights of children within Equalizer container grouped by row with element,height and max as last child
+   * @fires Equalizer#preEqualized
+   * @fires Equalizer#preEqualizedRow
+   * @fires Equalizer#postEqualizedRow
+   * @fires Equalizer#postEqualized
+   */
+  Equalizer.prototype.applyHeightByRow = function(groups){
+    var max;
+    /**
+     * Fires before the heights are applied
+     */
+    this.$element.trigger('preEqualized.zf.Equalizer');
+    for (var i = 0; i < groups.length ; i++) {
+      var groupsILength = groups[i].length;
+          max = groups[i][groupsILength - 1];
+      //max height excluded
+      if (groupsILength<=2) {
+        //stacked set to auto
+        for (var j = 0; j < groupsILength ; j++) {
+          $(groups[i][j][0]).css({'height':'auto'});
+        }
+        continue;
+      };
+      /**
+        * Fires before the heights per row are applied
+        * @event Equalizer#preEqualizedRow
+        */
+      this.$element.trigger('preEqualizedRow.zf.Equalizer');
+      for (var j = 0; j < groupsILength ; j++) {
+        $(groups[i][j][0]).css({'height':max});
+      }
+      /**
+        * Fires when the heights per row have been applied
+        * @event Equalizer#postEqualizedRow
+        */
+      this.$element.trigger('postEqualizedRow.zf.Equalizer');
+    }
+    /**
+     * Fires when the heights have been applied
      */
      this.$element.trigger('postEqualized.zf.Equalizer');
   };

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -163,9 +163,7 @@
    * @returns {Array} groups - An array of heights of children within Equalizer container grouped by row with element,height and max as last child
    */
   Equalizer.prototype.getHeightsByRow = function(cb) {
-    var eqGroup = this.$watched,
-        firstTopOffset = this.$watched.first().offset().top,
-        lastElTopOffset = firstTopOffset,
+    var lastElTopOffset = this.$watched.first().offset().top,
         groups = [],
         group = 0;
     //group by Row


### PR DESCRIPTION
Responsive Equalizer
a very helpful feature for example for Block Grid or Elements that are stack on mobile but should be equalized on medium or large, but medium ist different rows to large

i make a commit with doc examples to show the features
