### PR TITLE
Issue #7381 Use $maincontent-class as selector

### DIFF
--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -64,7 +64,8 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
   }
 
   // Container for page content
-  .off-canvas-content {
+  .off-canvas-content,
+  .#{$maincontent-class} {
     min-height: 100%;
     background: $body-background;
     transition: transform $offcanvas-transition-length $offcanvas-transition-timing;


### PR DESCRIPTION
The $maincontent-class variable was only used for the off-canvas-reveal sibling rule on line 150. 

Original single class selector off-canvas-content was left to prevent breaking existing implementations.
