### PR TITLE
Issue #7493 Move $rem-base before utils import

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -39,13 +39,14 @@
 //  34. Tooltip
 //  35. Top Bar
 
+$global-font-size: 100%;
+$rem-base: 16px;
+
 @import 'util/util';
 
 // 1. Global
 // ---------
-
 $global-width: rem-calc(1200);
-$global-font-size: 100%;
 $global-lineheight: 1.5;
 $primary-color: #2199e8;
 $secondary-color: #777;
@@ -67,7 +68,6 @@ $global-weight-normal: normal;
 $global-weight-bold: bold;
 $global-radius: 0;
 $global-text-direction: ltr;
-$rem-base: 16px;
 
 // 2. Breakpoints
 // --------------


### PR DESCRIPTION
The $rem-base variable would never change to a custom value, since the default was being initialized prior to parsing the global overrides. Moving the variable directly before the utils import corrects this.

Now changing $global-font-size to a pixel based value such as 14px, as well as changing $rem-base: $global-font-size outputs a max-width: 85.71429rem
