### PR TITLE
[Abide] add .is-invalid-label to .input-group

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -159,7 +159,11 @@
     }
   };
   /**
-   * Checks whether or not a form element has the required attribute and if it's checked or not
+   * Get the first element in this order:
+   * 1. The closest parent ".input-group" class.
+   * 2. The <label> next to the element.
+   * 3. The closest parent <label>
+   *
    * @param {Object} element - jQuery object to check for required attribute
    * @returns {Boolean} Boolean value depends on whether or not attribute is checked or empty
    */

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -208,7 +208,7 @@
   Abide.prototype.addErrorClasses = function($el) {
     var self = this,
         $label = self.findLabel($el),
-        $formError = $el.next(self.options.formErrorSelector) || $el.find(self.options.formErrorSelector);
+        $formError = self.findFormError($el, self.options.formErrorSelector);
 
     // label
     if ($label) {
@@ -228,7 +228,7 @@
   Abide.prototype.removeErrorClasses = function($el) {
     var self = this,
         $label = self.findLabel($el),
-        $formError = $el.next(self.options.formErrorSelector) || $el.find(self.options.formErrorSelector);
+        $formError = self.findFormError($el, self.options.formErrorSelector);
     // label
     if ($label && $label.hasClass(self.options.labelErrorClass)) {
       $label.removeClass(self.options.labelErrorClass);

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -164,10 +164,11 @@
    * @returns {Boolean} Boolean value depends on whether or not attribute is checked or empty
    */
   Abide.prototype.findLabel = function($el) {
-    if ($el.next('label').length) {
+    if ($el.closest('.input-group').length) {
+      return $el.closest('.input-group');
+    } else if ($el.next('label').length) {
       return $el.next('label');
-    }
-    else {
+    } else if ($el.closest('label').length) {
       return $el.closest('label');
     }
   };

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -159,6 +159,31 @@
     }
   };
   /**
+   * Based on $el, get the first element with selector in this order:
+   * 1. The element next to it.
+   * 2. The element inside (is a child of) it.
+   * 3. As its sibling.
+   *
+   * @param {Object} element - jQuery object to use as reference to find the form error selector.
+   * @param {String} selector - jQuery selector to show error message when field doesn't pass validation.
+   * @returns {Object} jQuery object with the selector.
+   */
+  Abide.prototype.findFormError = function($el, selector) {
+    var formError;
+
+    formError = $el.next(selector);
+    if (formError.length) {
+        return formError;
+    }
+
+    formError = $el.find(selector);
+    if (formError.length) {
+        return formError;
+    }
+
+    return $el.parent().find(selector);
+  };
+  /**
    * Get the first element in this order:
    * 1. The closest parent ".input-group" class.
    * 2. The <label> next to the element.

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -268,20 +268,13 @@
     }
     else if ($el[0].type === 'radio') {
       radioGroupName = $el.attr('name');
-      label = $el.siblings('label');
 
       if (self.validateRadio(radioGroupName)) {
-        $(label).each(function() {
-          if ($(this).hasClass(self.options.labelErrorClass)) {
-            $(this).removeClass(self.options.labelErrorClass);
-          }
-        });
+        self.removeErrorClasses($el);
         $el.trigger('valid.fndtn.abide', $el[0]);
       }
       else {
-        $(label).each(function() {
-          $(this).addClass(self.options.labelErrorClass);
-        });
+        self.addErrorClasses($el);
         $el.trigger('invalid.fndtn.abide', $el[0]);
       };
     }


### PR DESCRIPTION
Abide currently applies the `.is-invalid-label` class only to a `<label>` element, but sometimes we have another DOM structure, like this one:

```
<div id="id-name-input-group" class="input-group">
  <label id="id-name-label" for="id-name">
    Your Name <small>(Required)</small>
  </label>
  <input required type="text" name="name" id="id-name">
  <p id="id-name-help-text" class="help-text">As it is in your documents.</p>
  <p id="id-name-error" class="form-error">Your name cannot be empty.</p>
</div>
```

In this case, the `.is-invalid-label` should be applied to `#id-name-input-group` div, instead of the `<label>` element.

It's very useful for backend generated fields, like Django, and helps us to better customize error rendering.

For compatibility, we use the `.input-group` class, already used by Foundation.

BTW, this is the recommended way to mark a field with error by both [U.S. Web Design Standards](https://playbook.cio.gov/designstandards/form-controls/#text-inputs) and [UK's Government Service Design Manual](http://govuk-elements.herokuapp.com/errors/#highlight-errors).

What do you think? Could it be accepted into Abide?
