### PR TITLE
[Abide] Closes #7304 - fix validation of required textarea

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -151,7 +151,7 @@
         }
         break;
       default:
-        if ($el.attr('required') && (!$el.val() || !$el.val().length || $el.is(':empty'))) {
+        if ($el.attr('required') && (!$el.val() || !$el.val().length)) {
           return false;
         } else {
           return true;


### PR DESCRIPTION
Closes #7304, where required <textarea> was wrongly reported as empty.
