### PR TITLE
Adding JS label to those corresponding components

### DIFF
--- a/docs/assets/scss/_navigation.scss
+++ b/docs/assets/scss/_navigation.scss
@@ -28,6 +28,13 @@
   .current a {
     background: rgba(#000, 0.05);
   }
+  .label {
+    background-color: #DDDDDD;
+    color: #777;
+    margin-left: 5px;
+    padding: 0.22222rem 0.44444rem 0.22222rem;
+    font-size: 0.61111rem;
+  }
 }
 
 .docs-menu-title {

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -32,39 +32,39 @@
   <li{{#ifpage 'button'}} class="current"{{/ifpage}}><a href="button.html">Button</a></li>
   <li{{#ifpage 'button-group'}} class="current"{{/ifpage}}><a href="button-group.html">Button Group</a></li>
   <li{{#ifpage 'close-button'}} class="current"{{/ifpage}}><a href="close-button.html">Close Button</a></li>
-  <li{{#ifpage 'slider'}} class="current"{{/ifpage}}><a href="slider.html">Slider</a></li>
+  <li{{#ifpage 'slider'}} class="current"{{/ifpage}}><a href="slider.html">Slider <span class="label">JS</span></a></li>
   <li{{#ifpage 'switch'}} class="current"{{/ifpage}}><a href="switch.html">Switch</a></li>
 
   <li class="docs-menu-title">Navigation</li>
   <li{{#ifpage 'navigation'}} class="current"{{/ifpage}}><a href="navigation.html">Overview</a></li>
   <li{{#ifpage 'menu'}} class="current"{{/ifpage}}><a href="menu.html">Menu</a></li>
-  <li{{#ifpage 'dropdown-menu'}} class="current"{{/ifpage}}><a href="dropdown-menu.html">Dropdown Menu</a></li>
-  <li{{#ifpage 'drilldown-menu'}} class="current"{{/ifpage}}><a href="drilldown-menu.html">Drilldown Menu</a></li>
-  <li{{#ifpage 'accordion-menu'}} class="current"{{/ifpage}}><a href="accordion-menu.html">Accordion Menu</a></li>
+  <li{{#ifpage 'dropdown-menu'}} class="current"{{/ifpage}}><a href="dropdown-menu.html">Dropdown Menu <span class="label">JS</span></a></li>
+  <li{{#ifpage 'drilldown-menu'}} class="current"{{/ifpage}}><a href="drilldown-menu.html">Drilldown Menu <span class="label">JS</span></a></li>
+  <li{{#ifpage 'accordion-menu'}} class="current"{{/ifpage}}><a href="accordion-menu.html">Accordion Menu <span class="label">JS</span></a></li>
   <li{{#ifpage 'top-bar'}} class="current"{{/ifpage}}><a href="top-bar.html">Top Bar</a></li>
   <li{{#ifpage 'responsive-navigation'}} class="current"{{/ifpage}}><a href="responsive-navigation.html">Responsive Navigation</a></li>
-  <li{{#ifpage 'magellan'}} class="current"{{/ifpage}}><a href="magellan.html">Magellan</a></li>
+  <li{{#ifpage 'magellan'}} class="current"{{/ifpage}}><a href="magellan.html">Magellan <span class="label">JS</span></a></li>
   <li{{#ifpage 'pagination'}} class="current"{{/ifpage}}><a href="pagination.html">Pagination</a></li>
   <li{{#ifpage 'breadcrumbs'}} class="current"{{/ifpage}}><a href="breadcrumbs.html">Breadcrumbs</a></li>
 
   <li class="docs-menu-title">Containers</li>
-  <li{{#ifpage 'accordion'}} class="current"{{/ifpage}}><a href="accordion.html">Accordion</a></li>
+  <li{{#ifpage 'accordion'}} class="current"{{/ifpage}}><a href="accordion.html">Accordion <span class="label">JS</span></a></li>
   <li{{#ifpage 'callout'}} class="current"{{/ifpage}}><a href="callout.html">Callout</a></li>
-  <li{{#ifpage 'dropdown'}} class="current"{{/ifpage}}><a href="dropdown.html">Dropdown</a></li>
+  <li{{#ifpage 'dropdown'}} class="current"{{/ifpage}}><a href="dropdown.html">Dropdown <span class="label">JS</span></a></li>
   <li{{#ifpage 'media-object'}} class="current"{{/ifpage}}><a href="media-object.html">Media Object</a></li>
-  <li{{#ifpage 'off-canvas'}} class="current"{{/ifpage}}><a href="off-canvas.html">Off-canvas</a></li>
-  <li{{#ifpage 'reveal'}} class="current"{{/ifpage}}><a href="reveal.html">Reveal <small>Modal</small></a></li>
+  <li{{#ifpage 'off-canvas'}} class="current"{{/ifpage}}><a href="off-canvas.html">Off-canvas <span class="label">JS</span></a></li>
+  <li{{#ifpage 'reveal'}} class="current"{{/ifpage}}><a href="reveal.html">Reveal <span class="label">JS</span> <small>Modal</small></a></li>
   <li{{#ifpage 'table'}} class="current"{{/ifpage}}><a href="table.html">Table</a></li>
-  <li{{#ifpage 'tabs'}} class="current"{{/ifpage}}><a href="tabs.html">Tabs</a></li>
+  <li{{#ifpage 'tabs'}} class="current"{{/ifpage}}><a href="tabs.html">Tabs <span class="label">JS</span></a></li>
 
   <li class="docs-menu-title">Media</li>
   <li{{#ifpage 'badge'}} class="current"{{/ifpage}}><a href="badge.html">Badge</a></li>
   <li{{#ifpage 'flex-video'}} class="current"{{/ifpage}}><a href="flex-video.html">Flex Video</a></li>
   <li{{#ifpage 'label'}} class="current"{{/ifpage}}><a href="label.html">Label</a></li>
-  <li{{#ifpage 'orbit'}} class="current"{{/ifpage}}><a href="orbit.html">Orbit <small>Carousel</small></a></li>
+  <li{{#ifpage 'orbit'}} class="current"{{/ifpage}}><a href="orbit.html">Orbit <span class="label">JS</span> <small>Carousel</small></a></li>
   <li{{#ifpage 'progress-bar'}} class="current"{{/ifpage}}><a href="progress-bar.html">Progress Bar</a></li>
   <li{{#ifpage 'thumbnail'}} class="current"{{/ifpage}}><a href="thumbnail.html">Thumbnail</a></li>
-  <li{{#ifpage 'tooltip'}} class="current"{{/ifpage}}><a href="tooltip.html">Tooltip</a></li>
+  <li{{#ifpage 'tooltip'}} class="current"{{/ifpage}}><a href="tooltip.html">Tooltip <span class="label">JS</span></a></li>
 
   <li class="docs-menu-title">Plugins</li>
   <li{{#ifpage 'abide'}} class="current"{{/ifpage}}><a href="abide.html">Abide <small>Form Validation</small></a></li>


### PR DESCRIPTION
In the previous docs (v5), there was a `JS` label next to each component in the navigation. This was a handy reference that I'd like to see in the v6 docs too.
