### PR TITLE
[Abide] Closes #7531 - Validate <textarea> and <select> on form submit.

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -282,8 +282,8 @@
    */
   Abide.prototype.validateForm = function($form) {
     var self = this,
-        inputs = $form.find('input'),
-        inputCount = $form.find('input').length,
+        inputs = $form.find('input, select, textarea'),
+        inputCount = inputs.length,
         counter = 0;
 
     while (counter < inputCount) {


### PR DESCRIPTION
Fix the problem of not validating <textarea> and <select> with `required` attribute, when the form is submitted.
