### PR TITLE
Issue #7498 Remove !global flag from $grid-column-count

### DIFF
--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -29,7 +29,7 @@
   }
 
   // Restore the old column count
-  $grid-column-count: $old-grid-column-count !global;
+  $grid-column-count: $old-grid-column-count;
 }
 
 /// Creates a grid row.


### PR DESCRIPTION
Creating a custom row size using the grid-row mixin was not properly generating the correct CSS. Removing the !global flag from the $grid-column-count in the grid-context mixin seems to correct this.

Tested using following scss. The first list generates a row 17 columns wide, while the second list generates the default 12

``` css
ul.one
  @include grid-row(17)
  li
    @include grid-column(1)

ul.two
  li
    @include grid-column(1)
```
