### PR TITLE
Remove Border in Full Screen

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -109,6 +109,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   min-height: 100vh;
   max-width: none;
   margin-left: 0;
+  border: none;
 }
 
 @mixin foundation-reveal {


### PR DESCRIPTION
Not needed in full screen. CSS targets fullscreen only.

Test case - black background, border is visible.
