### PR TITLE
Issue #7555 - align submenu of dd menu below parent if no room to right

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -103,7 +103,7 @@ $dropdownmenu-border: 1px solid $medium-gray !default;
 
     .is-dropdown-submenu-parent.opens-left .submenu {
       left: auto;
-      right: 100%;
+      right: 0;
     }
 
     &.align-right {


### PR DESCRIPTION
Issue #7555 Changing the right css property to 0 will position submenu below parent menu item.
