### PR TITLE
Issue #7468 - Allow submenu parent links

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -255,7 +255,9 @@
       });
 
       S('body').off('.topbar').on('click.fndtn.topbar', function (e) {
-        var parent = S(e.target).closest('li').closest('li.hover');
+        var parent = S(e.target).closest('li').closest('li.hover'),
+            topbar = S(e.target).closest('[' + self.attr_name() + ']'),
+            settings = topbar.data(self.attr_name(true) + '-init');
 
         if (parent.length > 0) {
           return;

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -265,7 +265,7 @@
 
         S('[' + self.attr_name() + '] li.hover').removeClass('hover');
         
-        if(!settings.is_hover){
+        if(settings && !settings.is_hover){
           S('[' + self.attr_name() + '] a.last-clicked').removeClass('last-clicked');
         }
       });

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -199,7 +199,7 @@
 
           e.stopImmediatePropagation();
 
-          if (li.hasClass('hover')) {
+          if (li.hasClass('hover') && (settings.is_hover || li.children('a').first().hasClass('last-clicked'))) {
             li
               .removeClass('hover')
               .find('li')
@@ -214,6 +214,10 @@
 
             if (target[0].nodeName === 'A' && target.parent().hasClass('has-dropdown')) {
               e.preventDefault();
+              if(!settings.is_hover){
+                topbar.find('.last-clicked').removeClass('last-clicked');
+                target.addClass('last-clicked');
+              }
             }
           }
         })
@@ -258,6 +262,10 @@
         }
 
         S('[' + self.attr_name() + '] li.hover').removeClass('hover');
+        
+        if(!settings.is_hover){
+          S('[' + self.attr_name() + '] a.last-clicked').removeClass('last-clicked');
+        }
       });
 
       // Go up a level on Click
@@ -298,7 +306,7 @@
           $(this).parents('.has-dropdown').addClass('hover');
         })
         .blur(function () {
-          $(this).parents('.has-dropdown').removeClass('hover');
+          $(this).removeClass('last-clicked').parents('.has-dropdown').removeClass('hover');
         });
     },
 


### PR DESCRIPTION
This change is intended to allow top bar elements which have the "data-options" attribute "is_hover: false" to have linked submenu parents by adding the "last-clicked" class to submenu parents the first time they are clicked and removing it from any others within that top bar element.
