### PR TITLE
Global font size and rem/em calculation

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -7,6 +7,7 @@
 //
 // Feel free to submit pull requests to foundation-docs like you would Foundation itself!
 
+@import 'settings/settings';
 @import 'foundation';
 @import 'motion-ui';
 

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -118,8 +118,7 @@ $foundation-colors: (
     font-family: '#{-zf-bp-serialize($breakpoints)}';
   }
 
-  html,
-  body {
+  html {
     font-size: $global-font-size;
     box-sizing: border-box;
   }

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -6,13 +6,13 @@
 /// @group global
 ////
 
-/// Global width of your site. Used by the grid to determine row width.
-/// @type Number
-$global-width: rem-calc(1200) !default;
-
 /// Font size attribute applied to `<html>` and `<body>`. We use 100% by default so the value is inherited from the user's browser settings.
 /// @type Number
 $global-font-size: 100% !default;
+
+/// Global width of your site. Used by the grid to determine row width.
+/// @type Number
+$global-width: rem-calc(1200) !default;
 
 /// Default line height for all type. `$global-lineheight` is 24px while `$global-font-size` is 16px
 /// @type Number

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -44,8 +44,8 @@
 // 1. Global
 // ---------
 
-$global-width: rem-calc(1200);
 $global-font-size: 100%;
+$global-width: rem-calc(1200);
 $global-lineheight: 1.5;
 $primary-color: #2199e8;
 $secondary-color: #777;
@@ -67,7 +67,6 @@ $global-weight-normal: normal;
 $global-weight-bold: bold;
 $global-radius: 0;
 $global-text-direction: ltr;
-$rem-base: 16px;
 
 // 2. Breakpoints
 // --------------
@@ -303,7 +302,6 @@ $dropdownmenu-border: 1px solid $medium-gray;
 // 18. Flex Video
 // --------------
 
-$flexvideo-padding-top: rem-calc(25);
 $flexvideo-margin-bottom: rem-calc(16);
 $flexvideo-ratio: 4 by 3;
 $flexvideo-ratio-widescreen: 16 by 9;

--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -52,7 +52,7 @@ $global-font-size: 100% !default;
 @function -zf-bp-to-em($value) {
   // Pixel and unitless values are converted to rems
   @if unit($value) == 'px' or unitless($value) {
-    $value: rem-calc($value);
+    $value: rem-calc($value, $base: 16px);
   }
 
   // Then the value is converted to ems

--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -22,19 +22,22 @@ $global-font-size: 100% !default;
 /// Converts one or more pixel values into matching rem values.
 ///
 /// @param {Number|List} $values - One or more values to convert. Be sure to separate them with spaces and not commas. If you need to convert a comma-separated list, wrap the list in parentheses.
-/// @param {Number} $base [null] - The base value to use when calculating the `rem`. If you're using Foundation out of the box, this is 16px.
+/// @param {Number} $base [null] - The base value to use when calculating the `rem`. If you're using Foundation out of the box, this is 16px. If this parameter is `null`, the function will reference the `$base-font-size` variable as the base.
 ///
 /// @returns {List} A list of converted values.
 @function rem-calc($values, $base: null) {
   $rem-values: ();
   $count: length($values);
 
+  // If no base is defined, defer to the global font size
   @if $base == null {
     $base: $global-font-size;
   }
 
+  // If the base font size is a %, then multiply it by 16px
+  // This is because 100% font size = 16px in most all browsers
   @if unit($base) == '%' {
-    $base: 16px;
+    $base: ($base / 100%) * 16px;
   }
 
   @if $count == 1 {

--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -6,12 +6,9 @@
 /// @group functions
 ////
 
-// scss-lint:disable ZeroUnit
+$global-font-size: 100% !default;
 
-/// Defines the base font size of the page, which is the value `1rem` is equal to.
-/// @type Number
-/// @group global
-$rem-base: 16px !default;
+// scss-lint:disable ZeroUnit
 
 /// Removes the unit (e.g. px, em, rem) from a value, returning the number only.
 ///
@@ -25,15 +22,19 @@ $rem-base: 16px !default;
 /// Converts one or more pixel values into matching rem values.
 ///
 /// @param {Number|List} $values - One or more values to convert. Be sure to separate them with spaces and not commas. If you need to convert a comma-separated list, wrap the list in parentheses.
-/// @param {Number} $base [$rem-base] - The base value to use when calculating the `rem`. If you're using Foundation out of the box, this is 16px.
+/// @param {Number} $base [null] - The base value to use when calculating the `rem`. If you're using Foundation out of the box, this is 16px.
 ///
 /// @returns {List} A list of converted values.
-@function rem-calc($values, $base: $rem-base) {
+@function rem-calc($values, $base: null) {
   $rem-values: ();
   $count: length($values);
 
   @if $base == null {
-    $base: $rem-base;
+    $base: $global-font-size;
+  }
+
+  @if unit($base) == '%' {
+    $base: 16px;
   }
 
   @if $count == 1 {
@@ -58,14 +59,14 @@ $rem-base: 16px !default;
   @return strip-unit($value) * 1em;
 }
 
-/// Converts a pixel value to matching rem value. *Any* value passed, regardless of unit, is assumed to be a pixel value. By default, the base pixel value used to calculate the rem value is taken from the `$rem-base` variable.
+/// Converts a pixel value to matching rem value. *Any* value passed, regardless of unit, is assumed to be a pixel value. By default, the base pixel value used to calculate the rem value is taken from the `$global-font-size` variable.
 /// @access private
 ///
 /// @param {Number} $value - Pixel value to convert.
-/// @param {Number} $base [$rem-base] - Base for pixel conversion.
+/// @param {Number} $base [null] - Base for pixel conversion.
 ///
 /// @returns {Number} A number in rems, calculated based on the given value and the base pixel value. rem values are passed through as is.
-@function -zf-to-rem($value, $base: $rem-base) {
+@function -zf-to-rem($value, $base: null) {
   // Calculate rem if units for $value is not rem
   @if (unit($value) != 'rem') {
     $value: strip-unit($value) / strip-unit($base) * 1rem;


### PR DESCRIPTION
This pull request addresses #7021, #7500, and others. With these changes, the base font size can be shifted up or down without affecting any `rem` or `em` based lengths, such as the `.row` width, or the widths of breakpoints.

Here are the changes:
- Removed `$rem-base`.
- `rem-calc()` references `$base-font-size` for rem calculation.
- `-zf-bp-to-em()` always uses a 16px base when calculating breakpoint widths.

Still need to figure out what migration process would be necessary.
