### PR TITLE
Modify Button Background to Background Color

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -113,11 +113,11 @@ $button-opacity-disabled: 0.25 !default;
     $color: $button-color;
   }
 
-  background: $background;
+  background-color: $background;
   color: $color;
 
   &:hover, &:focus {
-    background: $background-hover;
+    background-color: $background-hover;
     color: $color;
   }
 }
@@ -126,7 +126,7 @@ $button-opacity-disabled: 0.25 !default;
 @mixin button-hollow {
   &,
   &:hover, &:focus {
-    background: transparent;
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
This allows background images to be placed within a button and them not disappearing on hover.
