### PR TITLE
Update foundation.drilldown.js

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -63,7 +63,7 @@
   Drilldown.prototype._init = function(){
     this.$submenuAnchors = this.$element.find('li.has-submenu');
     this.$submenus = this.$submenuAnchors.children('[data-submenu]');
-    this.$menuItems = this.$element.find('li:visible').not('.js-drilldown-back').attr('role', 'menuitem');
+    this.$menuItems = this.$element.find('li').not('.js-drilldown-back').attr('role', 'menuitem');
 
     this._prepareMenu();
 


### PR DESCRIPTION
If I use one of the visibility classes (http://foundation.zurb.com/sites/docs/visibility.html) to conditionally hide the drilldown, then _getMaxDims() throws an exception during initialization on line 295 when dereferencing the empy this.$menuItems array. That prevent other javascript on the page from executing. This change ensures the array is not empty in such cases, providing of course there are actually li elements in the DOM.
