### PR TITLE
.column - Min-Height 1px

### DIFF
--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -61,6 +61,7 @@
 
   @include grid-column-size($columns);
   float: $global-left;
+  min-height: 1px;
   padding-left: $gutter;
   padding-right: $gutter;
 


### PR DESCRIPTION
Stops the elements from crashing due to float value. Helpful when setting up multiple columns during dev.

Also a good fall back while data-equalizer kicks in to match height.
