### PR TITLE
Add radio-group and checkbox-group validation

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -166,7 +166,6 @@
         isGood = $el[0].checked;
         break;
       case 'radio':
-//        isGood = $el[0].checked;
         break;
 
       case 'select':

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -262,8 +262,8 @@
     switch ($el[0].type) {
 
       case 'radio':
-      case 'checkbox':
 //        validated = this.validateRadio($el.attr('name'));
+      case 'checkbox':
         var group = $el.parent().closest('.'+$el[0].type+'-group');
         if (group.length) {
           validated = group.attr('required') ? group.find(':checked').length > 0 : true;

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -256,8 +256,8 @@
         validated = false,
         customValidator = true,
         validator = $el.attr('data-validator'),
-        equalTo = true,
-        elError = $el;
+        elError = $el,
+        equalTo = true;
 
     switch ($el[0].type) {
 

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -163,8 +163,10 @@
     switch ($el[0].type) {
 
       case 'checkbox':
-      case 'radio':
         isGood = $el[0].checked;
+        break;
+      case 'radio':
+//        isGood = $el[0].checked;
         break;
 
       case 'select':
@@ -255,16 +257,21 @@
         validated = false,
         customValidator = true,
         validator = $el.attr('data-validator'),
-        equalTo = true;
+        equalTo = true,
+        elError = $el;
 
     switch ($el[0].type) {
 
       case 'radio':
-        validated = this.validateRadio($el.attr('name'));
-        break;
-
       case 'checkbox':
-        validated = clearRequire;
+//        validated = this.validateRadio($el.attr('name'));
+        var group = $el.parent().closest('.'+$el[0].type+'-group');
+        if (group.length) {
+          validated = group.attr('required') ? group.find(':checked').length > 0 : true;
+          elError = group;
+        } else {
+          validated = clearRequire;
+        }
         break;
 
       case 'select':
@@ -283,7 +290,7 @@
     var goodToGo = [clearRequire, validated, customValidator, equalTo].indexOf(false) === -1,
         message = (goodToGo ? 'valid' : 'invalid') + '.zf.abide';
 
-    this[goodToGo ? 'removeErrorClasses' : 'addErrorClasses']($el);
+    this[goodToGo ? 'removeErrorClasses' : 'addErrorClasses'](elError);
 
     /**
      * Fires when the input is done checking for validation. Event trigger is either `valid.zf.abide` or `invalid.zf.abide`


### PR DESCRIPTION
Required attribute for input radio does not make much sense. Proposed .radio-group wrapper container for radio require check. Function validateRadio is no longer needed.

```
<label for="pokemonRadio">Pick one pokemon</label>
<div id="pokemonRadio" class="radio-group" required>
  <input type="radio" name="pokemon" value="red">Red
  <input type="radio" name="pokemon" value="blue">Blue
  <input type="radio" name="pokemon" value="yellow">Yellow
</div>
<div class="form-error">Please pick one pokemon</div>
```

Similarly for checkbox, (though retain required check for individual checkbox input, probably not much use either ).

```
<label for="pokemonCheckbox">Pick at least one pokemon</label>
<div id="pokemonCheckbox" class="checkbox-group" required>
  <input type="checkbox" name="pokemon" value="red">Red
  <input type="checkbox" name="pokemon" value="blue">Blue
  <input type="checkbox" name="pokemon" value="yellow">Yellow
</div>
<div class="form-error">Please select at lease one pokemon</div>
```
