### PR TITLE
Fix top bar bug when having scrolltop=false and sticky top bar

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -134,7 +134,7 @@
           }
         }
       } else {
-        if (self.is_sticky(topbar, topbar.parent(), settings)) {
+        if (self.is_sticky(topbar, topbar.parent(), settings) && topbar.parent().offset().top==0) {
           topbar.parent().addClass('fixed');
         }
 


### PR DESCRIPTION
Context :
- scrolltop option disabled
- sticky topbar
- topbar not positionned on the top of the page (ex: under a header, 100px from the top)

Bug : on small resolution, when clicking on the menu, the topbar is fixed top the top (class "fixed") and move to the top of the page instead of keeping its original position.

Resolution: The fixed class should not be enabled if the user don't scroll enough to have the top bar positionned at the top of the page.
