### PR TITLE
don't skip 'small down' value for breakpoint

### DIFF
--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -73,8 +73,8 @@ $breakpoint-classes: (small medium large) !default;
     $bp-max: -zf-bp-to-em($bp-max) - (1/16);
   }
 
-  // Skip media query creation if the input is "0 up" or "0 down"
-  @if $bp > 0em or $dir == 'only' {
+  // Skip media query creation if the input is "0 up"
+  @if $bp > 0 or $dir == 'only' or $dir == 'down' {
     // `only` ranges use the format `(min-width: n) and (max-width: n)`
     @if $dir == 'only' {
       @if $named == true {
@@ -101,11 +101,14 @@ $breakpoint-classes: (small medium large) !default;
         $max: $bp;
       }
 
-      $str: $str + '(max-width: #{$max})';
+      // Skip media query creation if input value is exactly "0 down" but don't "small down"
+      @if $named or $bp > 0 {
+        $str: $str + '(max-width: #{$max})';
+      }
     }
 
     // `up` ranges use the format `(min-width: n)`
-    @else if $bp > 0em {
+    @else if $bp > 0 {
       $str: $str + '(min-width: #{$bp})';
     }
   }

--- a/test/sass/_breakpoint.scss
+++ b/test/sass/_breakpoint.scss
@@ -24,10 +24,15 @@
   }
 
   @include it('creates a down range out of a named breakpoint') {
-    $actual: breakpoint(medium down);
-    $expected: '(max-width: 63.9375em)';
+    $actual_medium: breakpoint(medium down);
+    $expected_medium: '(max-width: 63.9375em)';
 
-    @include should(expect($actual), to(be($expected)));
+    @include should(expect($actual_medium), to(be($expected_medium)));
+
+    $actual_small: breakpoint(small down);
+    $expected_small: '(max-width: 39.9375em)';
+
+    @include should(expect($actual_small), to(be($expected_small)));
   }
 
   @include it('creates a down range out of a pixel, rem or em value') {
@@ -41,7 +46,6 @@
   @include it('returns an empty string for the values zero down or zero up') {
     $expected: '';
 
-    @include should(expect(breakpoint(small down)), to(be($expected)));
     @include should(expect(breakpoint(small up)), to(be($expected)));
     @include should(expect(breakpoint(0 down)), to(be($expected)));
     @include should(expect(breakpoint(0 up)), to(be($expected)));


### PR DESCRIPTION
- sass tests
- revert to comparison with unitless 0

releated to: #7587 

With this, breakpoint(small down) will transpile to media query css, but breakpoint(0 down) will be skipped. I also took liberty to modify sass tests.
