### PR TITLE
Add '!default' to $foundation-colors.

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -110,7 +110,7 @@ $foundation-colors: (
   success: $success-color,
   alert: $alert-color,
   warning: $warning-color,
-);
+) !default;
 
 @mixin foundation-global-styles {
   @include -zf-normalize;


### PR DESCRIPTION
This allows you to overwrite `$foundation-colors`.
