### PR TITLE
Responsive gutters

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -277,6 +277,32 @@ In order to work around browsers' different rounding behaviors, Foundation will 
 
 ---
 
+### Responsive Gutters
+
+<div class="warning callout">
+  <p>Responsive gutters were added in <strong>Foundation 6.1.0</strong>. As of this version, it's still possible to use static gutters, or you can upgrade your project to responsive gutters. In Foundation 6.2.0, static gutters will be removed entirely in favor of responsive gutters. Refer to the <a href="https://github.com/zurb/foundation-sites/releases/tag/v6.1.0">Version 6.1.0 changelog</a> for more details on the upgrade process.</p>
+</div>
+
+The grid *gutter*&mdash;the space between two columns in a row, and the space between the edge of a grid and the edge of the page&mdash;is responsive, and becomes wider on larger screens.
+
+Breakpoint | Gutter Size
+-----------|------------
+`small`    | 20px
+`medium`   | 30px
+
+If you're using the Sass version of Foundation, you can change these defaults by editing the `$grid-column-responsive-gutter` variable:
+
+```scss
+$grid-column-responsive-gutter: (
+  small: 20px,
+  medium: 30px,
+);
+```
+
+To add more gutter definitions, add new lines to the map. The breakpoint names used here must match a breakpoint name in your project's `$breakpoints` map.
+
+---
+
 ### Collapse/Uncollapse Rows
 
 The `.collapse` class lets you remove column gutters (padding).

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -33,10 +33,20 @@
 
     // Nesting
     & & {
-      @include grid-row($behavior: nest, $cf: false);
+      @if $grid-column-gutter == null {
+        @each $breakpoint, $gutter in $grid-column-responsive-gutter {
+          @include breakpoint($breakpoint) {
+            @include grid-row-nest($gutter);
+          }
+        }
+      }
+      @else {
+        @include grid-row-nest($grid-column-gutter);
+      }
 
       &.#{$collapse} {
-        @include grid-row($behavior: nest collapse, $cf: false);
+        margin-left: 0;
+        margin-right: 0;
       }
     }
 
@@ -48,7 +58,7 @@
 
   // Column
   .#{$column} {
-    @include grid-col($gutter: null);
+    @include grid-col;
 
     @if $grid-column-align-edge {
       &.#{$end} {
@@ -57,12 +67,14 @@
     }
 
     // Responsive gutters
-    @each $breakpoint, $gutter in $grid-column-responsive-gutter {
-      $padding: rem-calc($gutter) / 2;
-      
-      @include breakpoint($breakpoint) {
-        padding-left: $padding;
-        padding-right: $padding;
+    @if $grid-column-gutter == null {
+      @each $breakpoint, $gutter in $grid-column-responsive-gutter {
+        $padding: rem-calc($gutter) / 2;
+        
+        @include breakpoint($breakpoint) {
+          padding-left: $padding;
+          padding-right: $padding;
+        }
       }
     }
   }
@@ -120,7 +132,12 @@
     }
 
     &.#{$-zf-size}-#{$uncollapse} {
-      $gutter: -zf-get-bp-val($grid-column-responsive-gutter, $-zf-size);
+      @if $grid-column-gutter {
+        $gutter: $grid-column-gutter;
+      }
+      @else {
+        $gutter: -zf-get-bp-val($grid-column-responsive-gutter, $-zf-size);
+      }
       > .#{$column} { @include grid-col-uncollapse($gutter); }
     }
 

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -48,11 +48,21 @@
 
   // Column
   .#{$column} {
-    @include grid-col;
+    @include grid-col($gutter: null);
 
     @if $grid-column-align-edge {
       &.#{$end} {
         @include grid-col-end;
+      }
+    }
+
+    // Responsive gutters
+    @each $breakpoint, $gutter in $grid-column-responsive-gutter {
+      $padding: rem-calc($gutter) / 2;
+      
+      @include breakpoint($breakpoint) {
+        padding-left: $padding;
+        padding-right: $padding;
       }
     }
   }
@@ -110,7 +120,8 @@
     }
 
     &.#{$-zf-size}-#{$uncollapse} {
-      > .#{$column} { @include grid-col-uncollapse; }
+      $gutter: -zf-get-bp-val($grid-column-responsive-gutter, $-zf-size);
+      > .#{$column} { @include grid-col-uncollapse($gutter); }
     }
 
     // Positioning

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -65,18 +65,6 @@
         @include grid-col-end;
       }
     }
-
-    // Responsive gutters
-    @if $grid-column-gutter == null {
-      @each $breakpoint, $gutter in $grid-column-responsive-gutter {
-        $padding: rem-calc($gutter) / 2;
-        
-        @include breakpoint($breakpoint) {
-          padding-left: $padding;
-          padding-right: $padding;
-        }
-      }
-    }
   }
 
   // Column row

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -60,6 +60,16 @@
   @if $gutter != null {
     $gutter: rem-calc($gutter) / 2;
   }
+  @else {
+    @each $breakpoint, $gutter in $grid-column-responsive-gutter {
+      $padding: rem-calc($gutter) / 2;
+      
+      @include breakpoint($breakpoint) {
+        padding-left: $padding;
+        padding-right: $padding;
+      }
+    }
+  }
 
   @include grid-column-size($columns);
   float: $global-left;

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -57,7 +57,7 @@
   $columns: $grid-column-count,
   $gutter: $grid-column-gutter
 ) {
-  @if $gutter {
+  @if $gutter != null {
     $gutter: rem-calc($gutter) / 2;
   }
 

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -57,7 +57,9 @@
   $columns: $grid-column-count,
   $gutter: $grid-column-gutter
 ) {
-  $gutter: rem-calc($gutter) / 2;
+  @if $gutter {
+    $gutter: rem-calc($gutter) / 2;
+  }
 
   @include grid-column-size($columns);
   float: $global-left;

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -94,6 +94,16 @@ $-zf-flex-align: (
   @if $gutter != null {
     $gutter: rem-calc($gutter) / 2;
   }
+  @else {
+    @each $breakpoint, $gutter in $grid-column-responsive-gutter {
+      $padding: rem-calc($gutter) / 2;
+      
+      @include breakpoint($breakpoint) {
+        padding-left: $padding;
+        padding-right: $padding;
+      }
+    }
+  }
 
   flex: flex-grid-column($columns);
   padding-left: $gutter;
@@ -178,18 +188,6 @@ $-zf-flex-align: (
   // Column
   %flex-column {
     @include flex-grid-column;
-
-    // Responsive gutters
-    @if $grid-column-gutter == null {
-      @each $breakpoint, $gutter in $grid-column-responsive-gutter {
-        $padding: rem-calc($gutter) / 2;
-        
-        @include breakpoint($breakpoint) {
-          padding-left: $padding;
-          padding-right: $padding;
-        }
-      }
-    }
   }
 
   .column,

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -40,19 +40,23 @@ $-zf-flex-align: (
   $margin: auto;
 
   @if map-get($behavior, nest) {
-    $margin: rem-calc($gutter) / 2 * -1;
+    @include grid-row-nest($gutter);
+
+    @if map-get($behavior, collapse) {
+      margin-left: 0;
+      margin-right: 0;
+    }
   }
   @else {
     max-width: $width;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   @if $base {
     display: flex;
     flex-flow: row wrap;
   }
-
-  margin-left: $margin;
-  margin-right: $margin;
 
   @if $columns != null {
     @include grid-context($columns, $base) {
@@ -87,7 +91,9 @@ $-zf-flex-align: (
   $columns: null,
   $gutter: $grid-column-gutter
 ) {
-  $gutter: rem-calc($gutter) / 2;
+  @if $gutter != null {
+    $gutter: rem-calc($gutter) / 2;
+  }
 
   flex: flex-grid-column($columns);
   padding-left: $gutter;
@@ -172,6 +178,18 @@ $-zf-flex-align: (
   // Column
   %flex-column {
     @include flex-grid-column;
+
+    // Responsive gutters
+    @if $grid-column-gutter == null {
+      @each $breakpoint, $gutter in $grid-column-responsive-gutter {
+        $padding: rem-calc($gutter) / 2;
+        
+        @include breakpoint($breakpoint) {
+          padding-left: $padding;
+          padding-right: $padding;
+        }
+      }
+    }
   }
 
   .column,
@@ -229,8 +247,14 @@ $-zf-flex-align: (
       > .column { @include grid-col-collapse; }
     }
 
-    .#{$-zf-size}-uncollapse {
-      > .column { @include grid-col-uncollapse; }
+    &.#{$-zf-size}-uncollapse {
+      @if $grid-column-gutter {
+        $gutter: $grid-column-gutter;
+      }
+      @else {
+        $gutter: -zf-get-bp-val($grid-column-responsive-gutter, $-zf-size);
+      }
+      > .column { @include grid-col-uncollapse($gutter); }
     }
   }
 

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -225,11 +225,11 @@ $-zf-flex-align: (
     }
 
     // Responsive collapsing
-    &.#{$-zf-size}-collapse {
+    .#{$-zf-size}-collapse {
       > .column { @include grid-col-collapse; }
     }
 
-    &.#{$-zf-size}-uncollapse {
+    .#{$-zf-size}-uncollapse {
       > .column { @include grid-col-uncollapse; }
     }
   }

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -20,6 +20,7 @@ $grid-column-gutter: null !default;
 
 /// The amount of space between columns at different screen sizes.
 /// @type Map
+/// @since 6.1.0
 $grid-column-responsive-gutter: (
   small: 20px,
   medium: 30px,

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -18,6 +18,11 @@ $grid-column-count: 12 !default;
 /// @type Number
 $grid-column-gutter: 30px !default;
 
+$grid-column-responsive-gutter: (
+  small: 20px,
+  medium: 30px,
+) !default;
+
 /// If `true`, the last column in a row will align to the opposite edge of the row.
 /// @type Boolean
 $grid-column-align-edge: true !default;

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -14,10 +14,12 @@ $grid-row-width: $global-width !default;
 /// @type Number
 $grid-column-count: 12 !default;
 
-/// The amount of space between columns.
-/// @type Number
-$grid-column-gutter: 30px !default;
+// The amount of space between columns. Remove this in 6.2.
+// @type Number
+$grid-column-gutter: null !default;
 
+/// The amount of space between columns at different screen sizes.
+/// @type Map
 $grid-column-responsive-gutter: (
   small: 20px,
   medium: 30px,

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -29,6 +29,6 @@
 
 /// Shorthand for `grid-column-uncollapse()`.
 /// @alias grid-column-uncollapse
-@mixin grid-col-uncollapse {
-  @include grid-column-uncollapse;
+@mixin grid-col-uncollapse($gutter: $grid-column-gutter) {
+  @include grid-column-uncollapse($gutter);
 }

--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -52,26 +52,46 @@
   $margin: auto;
 
   @if map-get($behavior, nest) {
-    $margin: rem-calc($gutter) / 2 * -1;
+    @include grid-row-nest($gutter);
 
     @if map-get($behavior, collapse) {
-      $margin: 0;
+      margin-left: 0;
+      margin-right: 0;
     }
   }
   @else {
     max-width: $width;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   @if $cf {
     @include clearfix;
   }
 
-  margin-left: $margin;
-  margin-right: $margin;
-
   @if $columns != null {
     @include grid-context($columns) {
       @content;
+    }
+  }
+}
+
+/// Inverts the margins of a row to nest it inside of a column.
+///
+/// @param {Map|null} $gutter [null] - Gutter value to use when inverting the margins. Set to `null` to refer to the responsive gutter settings.
+@mixin grid-row-nest($gutter: null) {
+  @if $gutter != null {
+    $margin: rem-calc($gutter) / 2 * -1;
+    margin-left: $margin;
+    margin-right: $margin;
+  }
+  @else {
+    @each $breakpoint, $value in $grid-column-responsive-gutter {
+      $margin: rem-calc($value) / 2 * -1;
+      @include breakpoint($breakpoint) {
+        margin-left: $margin;
+        margin-right: $margin;
+      }
     }
   }
 }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -85,7 +85,7 @@ $breakpoint-classes: (small medium large);
 
 $grid-row-width: $global-width;
 $grid-column-count: 12;
-$grid-column-gutter: 30px;
+$grid-column-gutter: null;
 $grid-column-align-edge: true;
 $block-grid-max: 8;
 

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -187,6 +187,43 @@ $breakpoint-classes: (small medium large) !default;
   }
 }
 
+/// Get a value for a breakpoint from a responsive config map. If the config map has the key `$value`, the exact breakpoint value is returned. If the config map does *not* have the breakpoint, the value matching the next lowest breakpoint in the config map is returned.
+/// @access private
+///
+/// @param {Map} $map - Input config map.
+/// @param {Keyword} $value - Breakpoint name to use.
+///
+/// @return {Mixed} The corresponding breakpoint value.
+@function -zf-get-bp-val($map, $value) {
+  // Check if the breakpoint name exists globally
+  @if not map-has-key($breakpoints, $value) {
+    @return null;
+  }
+  // Check if the breakpoint name exists in the local config map
+  @else if map-has-key($map, $value) {
+    // If it does, just return the value
+    @return map-get($map, $value);
+  }
+  // Otherwise, find the next lowest breakpoint and return that value
+  @else {
+    $anchor: null;
+    $found: false;
+
+    @each $key, $val in $breakpoints {
+      @if not $found {
+        @if map-has-key($map, $key) {
+          $anchor: $key;
+        }
+        @if $key == $value {
+          $found: true;
+        }
+      }
+    }
+
+    @return map-get($map, $anchor);
+  }
+}
+
 // Legacy breakpoint variables
 // These will be removed in 6.2
 $small-up: null;

--- a/test/sass/_breakpoint.scss
+++ b/test/sass/_breakpoint.scss
@@ -105,3 +105,29 @@
     @include should(expect($actual), to(be($expected)));
   }
 }
+
+@include describe('Get Breakpoint Value') {
+  $config: (
+    small: 0,
+    large: 1,
+  );
+
+  @include it('given a non-existant breakpoint name, returns null') {
+    $actual: -zf-get-bp-val($config, kittens);
+    $expected: null;
+
+    @include should(expect($actual), to(be($expected)));
+  }
+
+  @include it('given a matching breakpoint, returns the exact value') {
+    $actual: -zf-get-bp-val($config, large);
+    $expected: 1;
+
+    @include should(expect($actual), to(be($expected)));
+  }
+
+  @include it('given a nearby breakpoint, returns the next lowest value') {
+    @include should(expect(-zf-get-bp-val($config, medium)), to(be(0)));
+    @include should(expect(-zf-get-bp-val($config, xlarge)), to(be(1)));
+  }
+}


### PR DESCRIPTION
Responsive gutters will allow you to define different gutter sizes at different breakpoints. It's configured like this:

``` scss
$grid-column-responsive-gutter: (
  small: 20px,
  medium: 30px,
);
```

The default `.column` class gets new media queries for the higher-up breakpoints. The `.[size]-uncollapse` classes also take these values into account.

Work left to do:
- Make it backwards compatible with existing projects. For 6.1 it'll be an optional feature, and for 6.2 it will replace the static gutter setting entirely.
- Add it to the flex grid. That won't take long.
