### PR TITLE
Fix: shrink wider than 100%

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -237,6 +237,7 @@ $-zf-flex-align: (
   // Sizing (shrink)
   .shrink {
     flex: flex-grid-column(shrink);
+    max-width: 100%;
   }
 
   // Horizontal alignment using justify-content


### PR DESCRIPTION
If the objects inside a div with .shrink class are wider than the browser on iOS devices, the responsive layout got broken.
With a max-with of 100% this bug is getting fixed.
