### PR TITLE
FIx reveals with multiple anchors

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -128,7 +128,6 @@
 
       this.$anchor.attr({
         'aria-controls': this.id,
-        'id': anchorId,
         'aria-haspopup': true,
         'tabindex': 0
       });


### PR DESCRIPTION
Currently if you have more than one anchor opening the same reveal, they will all be set to the id of the first anchor.  This besides creating duplicate ids will break things.
