### PR TITLE
Add top off-canvas

### DIFF
--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -114,3 +114,40 @@ The main content area (`.off-canvas-content`) will be padded to the left or righ
 ```
 
 <button type="button" class="button" data-docs-example-ofc>Toggle Reveal Class</button>
+
+---
+
+## Off-canvas from Any Direction
+
+In addition to left and right off-canvas menus, you can also have top or bottom off-canvases as well.
+
+```html
+<body>
+  <div class="off-canvas-wrapper">
+    <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
+      <div class="off-canvas position-top" id="offCanvasTop" data-off-canvas data-position="top"></div>
+      <div class="off-canvas position-bottom" id="offCanvasBottom" data-off-canvas data-position="bottom"></div>
+      <div class="off-canvas-content" data-off-canvas-content></div>
+    </div>
+  </div>
+</body>
+```
+
+<button class="button" type="button" data-toggle="offCanvasTop">Open Top Menu</button>
+<button class="button" type="button" data-toggle="offCanvasBottom">Open Bottom Menu</button>
+
+<div class="primary callout">
+  <p>When using the `title-bar`, the title-bar icons are still either `title-bar-left` or `title-bar-right`, but the off-canvas can be set to top or bottom.</p>
+</div>
+
+```html_example
+<div class="title-bar">
+  <div class="title-bar-left">
+    <button class="menu-icon" type="button" data-open="offCanvasTop"></button>
+    <span class="title-bar-title">Foundation title bar with vertical off-canvas</span>
+  </div>
+  <div class="title-bar-right">
+    <button class="menu-icon" type="button" data-open="offCanvasBottom"></button>
+  </div>
+</div>
+```

--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -117,16 +117,15 @@ The main content area (`.off-canvas-content`) will be padded to the left or righ
 
 ---
 
-## Off-canvas from Any Direction
+## Vertical Off-canvas
 
-In addition to left and right off-canvas menus, you can also have top or bottom off-canvases as well.
+In addition to left and right off-canvas menus, you can have vertical off-canvases as well.
 
 ```html
 <body>
   <div class="off-canvas-wrapper">
     <div class="off-canvas-wrapper-inner" data-off-canvas-wrapper>
       <div class="off-canvas position-top" id="offCanvasTop" data-off-canvas data-position="top"></div>
-      <div class="off-canvas position-bottom" id="offCanvasBottom" data-off-canvas data-position="bottom"></div>
       <div class="off-canvas-content" data-off-canvas-content></div>
     </div>
   </div>
@@ -134,20 +133,19 @@ In addition to left and right off-canvas menus, you can also have top or bottom 
 ```
 
 <button class="button" type="button" data-toggle="offCanvasTop">Open Top Menu</button>
-<button class="button" type="button" data-toggle="offCanvasBottom">Open Bottom Menu</button>
 
 <div class="primary callout">
-  <p>When using the `title-bar`, the title-bar icons are still either `title-bar-left` or `title-bar-right`, but the off-canvas can be set to top or bottom.</p>
+  <p>When using the `title-bar` with a vertical off-canvas, the title-bar icons are still either `title-bar-left` or `title-bar-right`.</p>
 </div>
 
 ```html_example
 <div class="title-bar">
   <div class="title-bar-left">
     <button class="menu-icon" type="button" data-open="offCanvasTop"></button>
-    <span class="title-bar-title">Foundation title bar with vertical off-canvas</span>
+    <span class="title-bar-title">Foundation title bar with top off-canvas</span>
   </div>
   <div class="title-bar-right">
-    <button class="menu-icon" type="button" data-open="offCanvasBottom"></button>
+    <button class="menu-icon" type="button" data-open="offCanvasTop"></button>
   </div>
 </div>
 ```

--- a/docs/partials/off-canvi.html
+++ b/docs/partials/off-canvi.html
@@ -71,3 +71,33 @@
     <li><a href="#">Sites</a></li>
   </ul>
 </div>
+
+<div class="off-canvas position-top" id="offCanvasTop" data-off-canvas data-position="top">
+  <button class="close-button" aria-label="Close menu" type="button" data-close>
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <ul class="mobile-ofc vertical menu">
+    <li><a href="#">Off-canvas</a></li>
+    <li><a href="#">Example</a></li>
+    <li><a href="#">Vertical</a></li>
+    <li><a href="#">Menu</a></li>
+    <li><a href="#">From</a></li>
+    <li><a href="#">The</a></li>
+    <li><a href="#">Top</a></li>
+  </ul>
+</div>
+
+<div class="off-canvas position-bottom" id="offCanvasBottom" data-off-canvas data-position="bottom">
+  <button class="close-button" aria-label="Close menu" type="button" data-close>
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <ul class="mobile-ofc vertical menu">
+    <li><a href="#">Off-canvas</a></li>
+    <li><a href="#">Example</a></li>
+    <li><a href="#">Vertical</a></li>
+    <li><a href="#">Menu</a></li>
+    <li><a href="#">From</a></li>
+    <li><a href="#">The</a></li>
+    <li><a href="#">Bottom</a></li>
+  </ul>
+</div>

--- a/docs/partials/off-canvi.html
+++ b/docs/partials/off-canvi.html
@@ -3,18 +3,18 @@
     <span aria-hidden="true">&times;</span>
   </button>
   <ul class="mobile-ofc vertical menu">
-    
+
     <li>
       <a href="http://foundation.zurb.com/learn/about.html">Learn</a>
       <ul class="submenu menu vertical" data-submenu>
-        <li><a href="http://foundation.zurb.com/learn/about.html">About Foundation</a></li> 
+        <li><a href="http://foundation.zurb.com/learn/about.html">About Foundation</a></li>
         <li><a href="http://foundation.zurb.com/learn/tutorials.html">Tutorials</a></li>
         <li><a href="http://foundation.zurb.com/learn/classes.html">Classes</a></li>
         <li><a href="http://foundation.zurb.com/learn/case-studies.html">Case Studies</a></li>
-        <li><a href="http://foundation.zurb.com/learn/brands.html">Brands</a></li>  
+        <li><a href="http://foundation.zurb.com/learn/brands.html">Brands</a></li>
       </ul>
     </li>
-    
+
     <li>
       <a href="http://foundation.zurb.com/develop/getting-started.html">Develop</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -33,7 +33,7 @@
     </li>
 
     <li><a href="http://foundation.zurb.com/upload.html">Upload</a></li>
-    
+
     <li>
       <a href="http://foundation.zurb.com/support/support.html">Support</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -43,7 +43,7 @@
         <li><a href="http://foundation.zurb.com/support/faq.html">FAQs</a></li>
       </ul>
     </li>
-    
+
     <li>
       <a href="http://foundation.zurb.com/frameworks-docs.html">Docs</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -52,7 +52,7 @@
         <li><a href="http://zurb.com/ink/docs.php" target="_blank">Email Docs</a></li>
       </ul>
     </li>
-    
+
     <li><a href="http://foundation.zurb.com/develop/getting-started.html" class="button">Getting Started</a></li>
 
   </ul>
@@ -84,20 +84,5 @@
     <li><a href="#">From</a></li>
     <li><a href="#">The</a></li>
     <li><a href="#">Top</a></li>
-  </ul>
-</div>
-
-<div class="off-canvas position-bottom" id="offCanvasBottom" data-off-canvas data-position="bottom">
-  <button class="close-button" aria-label="Close menu" type="button" data-close>
-    <span aria-hidden="true">&times;</span>
-  </button>
-  <ul class="mobile-ofc vertical menu">
-    <li><a href="#">Off-canvas</a></li>
-    <li><a href="#">Example</a></li>
-    <li><a href="#">Vertical</a></li>
-    <li><a href="#">Menu</a></li>
-    <li><a href="#">From</a></li>
-    <li><a href="#">The</a></li>
-    <li><a href="#">Bottom</a></li>
   </ul>
 </div>

--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -33,7 +33,7 @@ $offcanvas-fixed-reveal: true !default;
 /// @type Color
 $offcanvas-exit-background: rgba($white, 0.25) !default;
 
-/// Height of a top or bottom off-canvas menu.
+/// Height of a vertical off-canvas menu.
 /// @type Number
 $offcanvas-vertical-size: 250px !default;
 
@@ -131,10 +131,6 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     top: -$vertical-size;
     width: 100%;
   }
-  @else if $position == bottom {
-    bottom: -$vertical-size;
-    width: 100%;
-  }
 
   // Generates an open state class that matches the width of the menu
   @at-root {
@@ -147,9 +143,6 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
       }
       @else if $position == top {
         transform: translateY($vertical-size);
-      }
-      @else if $position == bottom {
-        transform: translateY(-$vertical-size);
       }
     }
   }
@@ -182,7 +175,6 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     &.position-left   { @include off-canvas-position(left); }
     &.position-right  { @include off-canvas-position(right); }
     &.position-top    { @include off-canvas-position(top); }
-    &.position-bottom { @include off-canvas-position(bottom); }
   }
 
   // Reveal off-canvas menu on larger screens
@@ -197,12 +189,8 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
           @include off-canvas-reveal(right);
         }
 
-        .position-right.reveal-for-#{$name} {
+        .position-top.reveal-for-#{$name} {
           @include off-canvas-reveal(top);
-        }
-
-        .position-right.reveal-for-#{$name} {
-          @include off-canvas-reveal(bottom);
         }
       }
     }

--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -33,6 +33,10 @@ $offcanvas-fixed-reveal: true !default;
 /// @type Color
 $offcanvas-exit-background: rgba($white, 0.25) !default;
 
+/// Height of a top or bottom off-canvas menu.
+/// @type Number
+$offcanvas-vertical-size: 250px !default;
+
 /// CSS class used for the main content area. The off-canvas mixins use this to target the page body.
 $maincontent-class: 'off-canvas-content' !default;
 
@@ -51,6 +55,7 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
   .off-canvas-wrapper {
     width: 100%;
     overflow-x: hidden;
+    overflow-y: hidden;
     position: relative;
     backface-visibility: hidden;
     -webkit-overflow-scrolling: auto;
@@ -103,13 +108,14 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
   z-index: $offcanvas-zindex;
   max-height: 100%;
   overflow-y: auto;
-  transform: translateX(0);
+  transform: translateX(0) translateY(0);
 }
 
 @mixin off-canvas-position(
   $position: left,
   $size: $offcanvas-size,
-  $fixed: false
+  $fixed: false,
+  $vertical-size: $offcanvas-vertical-size
 ) {
   @if $position == left {
     left: -$size;
@@ -121,6 +127,14 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     top: 0;
     width: $size;
   }
+  @else if $position == top {
+    top: -$vertical-size;
+    width: 100%;
+  }
+  @else if $position == bottom {
+    bottom: -$vertical-size;
+    width: 100%;
+  }
 
   // Generates an open state class that matches the width of the menu
   @at-root {
@@ -130,6 +144,12 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
       }
       @else if $position == right {
         transform: translateX(-$size);
+      }
+      @else if $position == top {
+        transform: translateY($vertical-size);
+      }
+      @else if $position == bottom {
+        transform: translateY(-$vertical-size);
       }
     }
   }
@@ -161,6 +181,8 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
 
     &.position-left   { @include off-canvas-position(left); }
     &.position-right  { @include off-canvas-position(right); }
+    &.position-top    { @include off-canvas-position(top); }
+    &.position-bottom { @include off-canvas-position(bottom); }
   }
 
   // Reveal off-canvas menu on larger screens
@@ -173,6 +195,14 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
 
         .position-right.reveal-for-#{$name} {
           @include off-canvas-reveal(right);
+        }
+
+        .position-right.reveal-for-#{$name} {
+          @include off-canvas-reveal(top);
+        }
+
+        .position-right.reveal-for-#{$name} {
+          @include off-canvas-reveal(bottom);
         }
       }
     }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -384,6 +384,7 @@ $offcanvas-transition-length: 0.5s;
 $offcanvas-transition-timing: ease;
 $offcanvas-fixed-reveal: true;
 $offcanvas-exit-background: rgba($white, 0.25);
+$offcanvas-vertical-size: 250px;
 $maincontent-class: 'off-canvas-content';
 $maincontent-shadow: 0 0 10px rgba($black, 0.5);
 


### PR DESCRIPTION
Foundation 6 is pretty great so far. Top/bottom off-canvas is the feature I missed the most from 5.

This (re)adds top and bottom functionality to off-canvas. I've tried to keep it as minimal as possible so that it's more in line with the new svelter codebase.

Please let me know if this needs any additional work. :heart:
