### PR TITLE
Abide: Change target parm on element level trigger to jQuery 

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -291,7 +291,7 @@
      * @event Abide#valid
      * @event Abide#invalid
      */
-    $el.trigger(message, $el[0]);
+    $el.trigger(message, [$el]);
 
     return goodToGo;
   };


### PR DESCRIPTION
Abide plugin: validateInput

Change param to jquery selector to standardize across plugins. DOM element already accessible via event.target
