### PR TITLE
pass column class along to grid-layout()

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -110,7 +110,7 @@
     // Block grid
     @for $i from 1 through $block-grid-max {
       .#{$-zf-size}-up-#{$i} {
-        @include grid-layout($i);
+        @include grid-layout($i, ".#{$column}");
       }
     }
 


### PR DESCRIPTION
This fixes an issue where overriding grid class names via the `foundation-grid()` mixin params weren't passed along to `grid-layout()` which meant that it always used the default `column` class.
