### PR TITLE
[Documentation] grunt-sass options should use includePath

### DIFF
--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -52,7 +52,7 @@ grunt.initConfig({
   sass: {
     dist: {
     options: {
-        loadPath: ['node_modules/foundation-sites/scss']
+        includePaths: ['node_modules/foundation-sites/scss']
       }
     }
   }


### PR DESCRIPTION
The libsass-grunt documentation does use the loadPath option, but the recommended grunt-sass library uses the correct node-sass options which uses includePath option. 

node-sass docs: https://github.com/sass/node-sass#includepaths
