### PR TITLE
Last accordion's item border fixed

### DIFF
--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -49,6 +49,11 @@ $accordion-content-padding: 1rem !default;
   border: $accordion-content-border;
   border-radius: $global-radius;
   margin-#{$global-left}: 0;
+
+  // Remove the border on the last container
+  :last-child > & {
+    border-bottom-width: 0;
+  }
 }
 
 /// Adds styles for the title of an accordion item. Apply this to the link within an accordion item.
@@ -64,11 +69,6 @@ $accordion-content-padding: 1rem !default;
   &:hover,
   &:focus {
     background-color: $accordion-item-background-hover;
-  }
-
-  // Remove the border on the last title
-  :last-child > & {
-    border-bottom-width: 0;
   }
 
   @if $accordion-plusminus {


### PR DESCRIPTION
Hi,
Last accordion's border disabled on the wrong element. It should have a bottom border on the title and it shouldn't have it on contents.

Here are pictures instead of thousands of words.
**Before and wrong**
![before](https://cloud.githubusercontent.com/assets/156709/12080221/3dcc94d0-b265-11e5-9c9d-74d86c43aa67.png)
Note, there is no border on the title, and double border on contents (it's made of last item's content and whole accordion).

**After and correct**
![after](https://cloud.githubusercontent.com/assets/156709/12080220/3dcae39c-b265-11e5-9f0d-11c4b0248876.png)
Last item's content has no border.

Happy New Year!
:tada:
