### PR TITLE
[Button Group] Remove font-size: inherit; from button group

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -34,7 +34,6 @@ $buttongroup-expand-max: 6 !default;
   #{$child-selector} {
     float: #{$global-left};
     margin: 0;
-    font-size: inherit;
 
     &:not(:last-child) {
       border-#{$global-right}: $buttongroup-spacing solid $body-background;


### PR DESCRIPTION
In my sites, the font-size: inherit conflicts with the button sizes (tiny, small, large). Ends up overwriting tiny with the default button font size. Without inherit, the sizes seem correct.

Here is a reduced test-case using the JSDeliver CDN CSS: http://codepen.io/ksherman/details/ZQLgPo/
