### PR TITLE
Fix mixup between show-for-print and print-only visibility classes

### DIFF
--- a/doc/pages/components/visibility.html
+++ b/doc/pages/components/visibility.html
@@ -76,7 +76,7 @@ To reverse the rules defined by **hidden**, use the **visible** visibility class
 
 ## Print Visibility
 
-Foundation includes a couple of simple classes you can use to control elements printing, or not printing. Simply attach `.show-for-print` to an element to only show when printing, and `.hide-for-print` to hide something when printing.
+Foundation includes a couple of simple classes you can use to control elements printing, or not printing. Simply attach `.show-for-print` to an element to show when printing, `.print-only` for showing the element only when printing, and `.hide-for-print` to hide something when printing.
 
 Available classes:
 - `.show-for-print` , `.print-only` (Visible for printing)

--- a/scss/foundation/components/_visibility.scss
+++ b/scss/foundation/components/_visibility.scss
@@ -405,8 +405,7 @@ $visibility-breakpoint-queries:
 
   /* Print visibility */
   @if $include-print-styles {
-    .print-only,
-    .show-for-print { display: none !important; }
+    .print-only { display: none !important; }
     @media print {
       .print-only,
       .show-for-print { display: block !important; }


### PR DESCRIPTION
This PR replaces #6997

In foundation 5.5.X the semantics of the `show-for-print` visibility class changed. Before attaching that to an element wouldn't hide it when displaying the document on the screen but would force the element to be visible when printing. In 5.5.X the element is forcibly hidden for screens. The `print-only` class serves that purpose. This pull request restores the previous functionality.

This is related to https://github.com/cz848/foundation/pull/1 (523a434), https://github.com/zurb/foundation/issues/6445 and https://github.com/zurb/foundation/issues/3837 where, IMHO, those two classes, `show-for-print` and `print-only` are confused.
