### PR TITLE
Settings for .has-tip

### DIFF
--- a/docs/pages/tooltip.md
+++ b/docs/pages/tooltip.md
@@ -7,7 +7,7 @@ js: js/foundation.tooltip.js
 
 
 ## Basic Tooltip
-By default, a tooltip appears below the the definition on hover.
+By default, a tooltip appears below the defined term on hover.
 
 ```html_example
 <p>
@@ -18,7 +18,7 @@ The <span data-tooltip aria-haspopup="true" class="has-tip" data-disable-hover='
 ---
 
 ## Tooltip Top
-To get a tip-top top tooltip (lol), just add the class <code>top</code> the <code>span</code> tag.
+To get a tip-top top tooltip (lol), just add the class `.top` the `<span>` element.
 
 ```html_example
 <p>

--- a/scss/components/_tooltip.scss
+++ b/scss/components/_tooltip.scss
@@ -6,6 +6,14 @@
 /// @group tooltip
 ////
 
+/// Default font weight of the defined term.
+/// @type Keyword | Number
+$has-tip-font-weight: $global-weight-bold !default;
+
+/// Default border bottom of the defined term.
+/// @type List
+$has-tip-border-bottom: dotted 1px $dark-gray !default;
+
 /// Default color of the tooltip background.
 /// @type Color
 $tooltip-background-color: $black !default;
@@ -39,8 +47,8 @@ $tooltip-pip-offset: 1.25rem !default;
 $tooltip-radius: $global-radius !default;
 
 @mixin has-tip {
-  border-bottom: dotted 1px $dark-gray;
-  font-weight: bold;
+  border-bottom: $has-tip-border-bottom;
+  font-weight: $has-tip-font-weight;
   position: relative;
   display: inline-block;
   cursor: help;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -528,6 +528,8 @@ $titlebar-icon-spacing: 0.25rem;
 // 34. Tooltip
 // -----------
 
+$has-tip-border-bottom: dotted 1px $dark-gray;
+$has-tip-font-weight: $global-weight-bold;
 $tooltip-background-color: $black;
 $tooltip-color: $white;
 $tooltip-padding: 0.75rem;
@@ -544,4 +546,3 @@ $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
 $topbar-link-color: $primary-color;
 $topbar-input-width: 200px;
-


### PR DESCRIPTION
This PR add `_settings.scss` variables for `.has-tip` so the defined term can be styled. 
Also fixes typos in docs, along with some clarification. 

Closes #7798. 
