### PR TITLE
Fix off-canvas for small sites

### DIFF
--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -60,6 +60,7 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     @include clearfix;
     position: relative;
     width: 100%;
+    min-height: 100%; 
     transition: transform $offcanvas-transition-length $offcanvas-transition-timing;
   }
 


### PR DESCRIPTION
Forced height of .off-canvas-wrapper-inner to be at least 100% 
## What it fixes ?

If the content inside `.off-canvas-content` is not tall enough, and doesn't fill the window. The menu is truncated 

**before**

![](https://sc-cdn.scaleengine.net/i/85b2495177d763cf6138b55b1376e4c01.png)

**after**

![](https://sc-cdn.scaleengine.net/i/9093d0c250cbe3fb2e7b0d2e7957718e.png)
