### PR TITLE
Added mediaQuery requirement for offcanvas

### DIFF
--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -1,6 +1,7 @@
 /**
  * OffCanvas module.
  * @module foundation.offcanvas
+ * @requires foundation.util.mediaQuery
  * @requires foundation.util.triggers
  * @requires foundation.util.motion
  */

--- a/lib/util-map.json
+++ b/lib/util-map.json
@@ -32,6 +32,7 @@
     "foundation.util.motion.js"
   ],
   "offcanvas": [
+    "foundation.util.mediaQuery.js",
     "foundation.util.motion.js",
     "foundation.util.triggers.js"
   ],


### PR DESCRIPTION
`foundation-offcanvas.js` calls `Foundation.MediaQuery` and the documentation does not reflect this requirement.

I'm not sure if I should have edited this requirement somewhere else so let me know if I did something wrong.
