### PR TITLE
Corrected submenu adjustment

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -100,7 +100,9 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
       border: $dropdownmenu-border;
 
       @if (type-of($dropdownmenu-border-width) == 'number') {
-        margin-top: (-$dropdownmenu-border-width);
+        & .submenu {
+          margin-top: (-$dropdownmenu-border-width);
+        }
       }
 
       > li {


### PR DESCRIPTION
I noticed the first level submenu if a border was enabled was 1 pixel higher than needed.
This PR targets just nested submenus with the margin-top adjustment which corrects the problem.
