### PR TITLE
Fix Reveal in Foundation v5 with jQuery 2.2

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -187,7 +187,7 @@
           if (e.namespace !== 'fndtn.reveal') return;
         });
 
-        modal.on('open.fndtn.reveal').trigger('open.fndtn.reveal');
+        modal.trigger('open.fndtn.reveal');
 
 
         if (open_modal.length < 1) {


### PR DESCRIPTION
This removes the invalid call to `.on`. It was working before, but a change in jQuery (https://github.com/jquery/jquery/commit/04a29696e5b176ac66401120e433d52425222f0f) changed the return value of `.on` when called with just a string.
