### PR TITLE
Differentiate Tab Example Content

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -24,7 +24,7 @@ The tab content container has the class `.tabs-content`, while each section has 
     <p>Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus.</p>
   </div>
   <div class="tabs-panel" id="panel2">
-    <p>Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus.</p>
+    <p>Suspendisse dictum feugiat nisl ut dapibus.  Vivamus hendrerit arcu sed erat molestie vehicula. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor.  Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor.</p>
   </div>
 </div>
 ```


### PR DESCRIPTION
The tab bodies in the horizontal tab demo had the same contents, potentially causing a copy/paste user to think that the example code does not work.
