### PR TITLE
[6.2] Flexbox utilities

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -11,7 +11,10 @@
 @import 'foundation';
 @import 'motion-ui';
 
+$-zf-flex-classes-imported: true;
+
 @include foundation-everything;
+@include foundation-flex-classes;
 @include motion-ui-transitions;
 
 @import 'foundation-docs';

--- a/docs/pages/flex-classes.md
+++ b/docs/pages/flex-classes.md
@@ -1,0 +1,7 @@
+---
+title: Flexbox Classes
+description: These common helper classes can be used with any flexbox-enabled component.
+sass:
+  - scss/components/_flex.scss
+  - scss/util/_flex.scss
+---

--- a/docs/pages/flex-classes.md
+++ b/docs/pages/flex-classes.md
@@ -1,7 +1,0 @@
----
-title: Flexbox Classes
-description: These common helper classes can be used with any flexbox-enabled component.
-sass:
-  - scss/components/_flex.scss
-  - scss/util/_flex.scss
----

--- a/docs/pages/flex-grid.md
+++ b/docs/pages/flex-grid.md
@@ -16,14 +16,15 @@ The flex grid is only supported in Chrome, Firefox, Safari 6+, IE10+, iOS 7+, an
 
 ## Importing
 
-If you're using the CSS version of Foundation, you'll need to generate a [custom download](http://foundation.zurb.com/sites/download/#customizeFoundation) that replaces the float grid with the flex grid.
+If you're using the CSS version of Foundation, you can generate a <a href="https://foundation.zurb.com/sites/download">custom download of Foundation</a> with flexbox mode enabled.
 
-If you're using the Sass version of Foundation, remove the CSS export for the float grid, and replace it with the CSS export for the flex grid.
+If you're using the Sass version of Foundation, you can enable a framework-wide flexbox mode, and add exports for the flex grid and flexbox helper classes. [Learn more about enabling flexbox mode.](flexbox.html#enabling-flexbox-mode)
 
 ```scss
 @import 'foundation';
 
 // @include foundation-grid;
+@include foundation-flex-classes;
 @include foundation-flex-grid;
 ```
 

--- a/docs/pages/flex-grid.md
+++ b/docs/pages/flex-grid.md
@@ -214,13 +214,17 @@ Applying a vertical alignment class to the flex row will affect every column dir
 
 ---
 
-The same alignment classes can also be applied to individual columns.
+Similar alignment classes can also be applied to individual columns, which use the format `.align-self-*` instead of `.align-*`.
+
+<div class="warning callout">
+  <p>In Foundation 6.2, we introduced the <code>.align-self-&ast;</code> classes, which replace the old method of using <code>.align-&ast;</code> classes on columns. The old classes will be removed completely in Foundation 6.3.</p>
+</div>
 
 ```html_example
 <div class="row">
-  <div class="column align-bottom">Align bottom</div>
-  <div class="column align-middle">Align middle</div>
-  <div class="column align-top">Align top. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non harum laborum cum voluptate vel, eius adipisci similique dignissimos nobis at excepturi incidunt fugit molestiae quaerat, consequuntur porro temporibus. Nisi, ex?</div>
+  <div class="column align-self-bottom">Align bottom</div>
+  <div class="column align-self-middle">Align middle</div>
+  <div class="column align-self-top">Align top. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non harum laborum cum voluptate vel, eius adipisci similique dignissimos nobis at excepturi incidunt fugit molestiae quaerat, consequuntur porro temporibus. Nisi, ex?</div>
 </div>
 ```
 

--- a/docs/pages/flex-grid.md
+++ b/docs/pages/flex-grid.md
@@ -10,7 +10,7 @@ The flex grid works very similarly to the standard float grid, but includes a nu
 
 ## Browser support
 
-The flex grid is only supported in Chrome, Firefox, Safari 6+, IE10+, iOS 7+, and Android 4+. Flexbox is supported in Android 2, but not reliably enough for use with this grid. ([View flexbox browser support.](http://caniuse.com/#feat=flexbox)) We recommend only using the flex grid on projects that can live with purely cutting-edge browser support.
+The flex grid is only supported in Chrome, Firefox, Safari 6+, IE10+, iOS 7+, and Android 4.4+. Flexbox is supported in Android 2, but not reliably enough for use with this grid. ([View flexbox browser support.](http://caniuse.com/#feat=flexbox)) We recommend only using the flex grid on projects that can live with purely cutting-edge browser support.
 
 ---
 

--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -1,0 +1,193 @@
+---
+title: Flexbox
+description: For browsers with cutting-edge support, some of Foundation's key components can be converted to flexbox.
+sass:
+  - scss/components/_flex.scss
+  - scss/util/_flex.scss
+---
+
+Foundation components use a combination of floats, vertical alignment, table cells, and various other CSS hacks to get layouts looking right. These days, there's a better way... if you have the browser support!
+
+Enabling **flexbox mode** replaces those hacks with flexbox properties, streamlining how layouts are made, and making sizing and alignment of elements much easier.
+
+Flexbox mode is only supported these browsers:
+
+- The latest Chrome and Firefox
+- Safari 6+
+- IE 10+
+- iOS 7+
+- Android 4.4+
+
+---
+
+## Enabling Flexbox Mode
+
+If you're using the CSS version of Foundation, you can generate a <a href="https://foundation.zurb.com/sites/download">custom download of Foundation</a> with flexbox mode enabled.
+
+If you're using the Sass version, open your settings file and set `$global-flexbox` to `true`.
+
+You'll also need to replace the default float grid with the flex grid, which is actually a separate component. To do this, remove the `@include` for the float grid and replace it with the one for the flex grid.
+
+```scss
+// @include foundation-grid-classes;
+@include foundation-flex-grid;
+```
+
+Lastly, you'll also may want to add the include for the flexbox helper classes.
+
+```scss
+@include foundation-flex-classes;
+```
+
+---
+
+## Supported Components
+
+Besides the flex grid, these components have flexbox modes:
+
+- [Button group](button-group.html)
+- [Input group](forms.html#inline-labels-and-buttons)
+- [Menu](menu.html)
+- [Top bar](top-bar.html)
+- [Media object](media-object.html)
+- [Title bar](title-bar.html)
+
+In general, all of the components work exactly the same. However, a few of them require slight changes to CSS classes used to work properly. Refer to the documentation for each to find out what's different.
+
+---
+
+## Helper Classes
+
+Flexbox makes horizontal and vertical alignment painless, through the CSS properties [`align-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items), [`align-self`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self), and [`justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content)`. Foundation includes a handful of classes for these properties, which work with any flexbox-enabled component.
+
+To understand how these classes work, you need to understand the parent-child relationship created with flexbox. An element with `display: flex` is a *flex parent*, and can horizontally or vertically align its children. All immediate children of the flex parent are *flex children*. A flex child can vertically align itself.
+
+Here's a basic example: when using the grid, a row is a flex parent, and a column is a flex child.
+
+```html
+<div class="row">
+  <div class="column"></div>
+  <div class="column"></div>
+  <div class="column"></div>
+</div>
+```
+
+---
+
+### Horizontal Alignment
+
+Horizontal alignment classes are applied to flex parents. Left alignment is the default, but you can use one of these classes to change this:
+
+- `.align-right`
+- `.align-center`
+- `.align-justify`
+- `.align-spaced`
+
+<div class="docs-code-live">
+  <div class="text-center">
+    <div class="row">
+      <div class="column small-4">Aligned to</div>
+      <div class="column small-4">the left</div>
+    </div>
+    <div class="row align-right">
+      <div class="column small-4">Aligned to</div>
+      <div class="column small-4">the right</div>
+    </div>
+    <div class="row align-center">
+      <div class="column small-4">Aligned to</div>
+      <div class="column small-4">the center</div>
+    </div>
+    <div class="row align-justify">
+      <div class="column small-4">Aligned to</div>
+      <div class="column small-4">the edges</div>
+    </div>
+    <div class="row align-spaced">
+      <div class="column small-4">Aligned to</div>
+      <div class="column small-4">the space around</div>
+    </div>
+  </div>
+</div>
+
+You might be wondering what the difference between `.align-justify` and `.align-spaced` is. A justified grid (`justify-content: space-between`) evenly distributes the space *between* each column. The first and last columns pin to the edge of the grid.
+
+A spaced grid (`justify-content: space-around`) evenly distributes the space *around* each column. This means there will always be space to the left of the first column, and to the right of the last column.
+
+The horizontal alignment classes are shorthands for the `justify-content` CSS property. [Learn more about `justify-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+
+---
+
+### Vertical Alignment
+
+Vertical alignment can be applied to a flex parent&mdash;which will align all the children automatically&mdash;or to a flex child, which will align only that element.
+
+Top alignment is the default. To set parent alignment, use these classes:
+
+- `.align-middle`
+- `.align-bottom`
+- `.align-stretch`
+
+<div class="primary callout">
+  <p>Note that with vertical alignment, we use the term "middle" for the midpoint, while with horizontal alignment, we use the term "center". Otherwise, we'd have two CSS classes with the same name, but different functionality.</p>
+</div>
+
+```html_example
+<div class="row align-middle">
+  <div class="columns">I'm in the middle!</div>
+  <div class="columns">I am as well, but I have so much text I take up more space! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quis facere ducimus earum minus, inventore, ratione doloremque deserunt neque perspiciatis accusamus explicabo soluta, quod provident distinctio aliquam omnis? Labore, ullam possimus.</div>
+</div>
+```
+
+```html_example
+<div class="row align-stretch">
+  <div class="columns">These colums have the same height.</div>
+  <div class="columns">That's right, equal-height columns are possible with Flexbox too! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatum, tempora. Impedit eius officia possimus laudantium? Molestiae eaque, sapiente atque doloremque placeat! In sint, fugiat saepe sunt dolore tempore amet cupiditate.</div>
+</div>
+```
+
+---
+
+To align an individual child, use the below classes. They use the same alignment terms as the parent-level classes, but the classes start with `.align-self-` instead of `.align-`.
+
+- `.align-self-top`
+- `.align-self-middle`
+- `.align-self-bottom`
+- `.align-self-stretch`
+
+```html_example
+<div class="row">
+  <div class="column align-self-bottom">Align bottom</div>
+  <div class="column align-self-middle">Align middle</div>
+  <div class="column align-self-top">Align top. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non harum laborum cum voluptate vel, eius adipisci similique dignissimos nobis at excepturi incidunt fugit molestiae quaerat, consequuntur porro temporibus. Nisi, ex?</div>
+</div>
+```
+
+---
+
+## Helper Mixins
+
+If you're using the Sass version of Foundation, you can access the above helpers as mixins as well.
+
+For parent-level alignment, use `flex-align()`. You can pass in a horizontal alignment (`$x`), vertical alignment (`$y`), or both.
+
+```scss
+.container {
+  @include flex-align($x: center, $y: stretch);
+}
+```
+
+For child-level alignment, use `flex-align-self()`. You can pass in any horizontal alignment.
+
+```scss
+.sidebar {
+  @include flex-align-self(bottom);
+}
+```
+
+Interested in building your own flexbox-ey component? Use the `flex()` mixin to get started.
+
+```scss
+.flexish-thang {
+  @include flex;
+  @include flex-align(center, middle);
+}
+```

--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -33,7 +33,7 @@ You'll also need to replace the default float grid with the flex grid, which is 
 @include foundation-flex-grid;
 ```
 
-Lastly, you'll also may want to add the include for the flexbox helper classes.
+Lastly, you'll also want to add the include for the flexbox helper classes.
 
 ```scss
 @include foundation-flex-classes;

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -70,7 +70,7 @@ Get to know the pieces of Foundation.
         <li><a href="forms.html">Forms</a></li>
         <li><a href="visibility.html">Visibility Classes</a></li>
         <li><a href="float-classes.html">Float Classes</a></li>
-        <li><a href="flex-classes.html">Flex Classes</a></li>
+        <li><a href="flex-classes.html">Flexbox</a></li>
       </ul>
     </section>
 

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -70,6 +70,7 @@ Get to know the pieces of Foundation.
         <li><a href="forms.html">Forms</a></li>
         <li><a href="visibility.html">Visibility Classes</a></li>
         <li><a href="float-classes.html">Float Classes</a></li>
+        <li><a href="flex-classes.html">Flex Classes</a></li>
       </ul>
     </section>
 

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -14,6 +14,7 @@
   <li class="docs-menu-title">General</li>
   <li{{#ifpage 'global'}} class="current"{{/ifpage}}><a href="global.html">Global Styles</a></li>
   <li{{#ifpage 'rtl'}} class="current"{{/ifpage}}><a href="rtl.html">Right-to-Left Support</a></li>
+  <li{{#ifpage 'flex-classes'}} class="current"{{/ifpage}}><a href="flex-classes.html">Flexbox</a></li>
   <li{{#ifpage 'sass'}} class="current"{{/ifpage}}><a href="sass.html">Sass</a></li>
   <li{{#ifpage 'javascript'}} class="current"{{/ifpage}}><a href="javascript.html">JavaScript</a></li>
   <li{{#ifpage 'javascript-utilities'}} class="current"{{/ifpage}}><a href="javascript-utilities.html">JavaScript Utilities</a></li>
@@ -23,7 +24,6 @@
   <li{{#ifpage 'forms'}} class="current"{{/ifpage}}><a href="forms.html">Forms</a></li>
   <li{{#ifpage 'visibility'}} class="current"{{/ifpage}}><a href="visibility.html">Visibility Classes</a></li>
   <li{{#ifpage 'float-classes'}} class="current"{{/ifpage}}><a href="float-classes.html">Float Classes</a></li>
-  <li{{#ifpage 'flex-classes'}} class="current"{{/ifpage}}><a href="flex-classes.html">Flex Classes</a></li>
 
   <li class="docs-menu-title">Typography</li>
   <li{{#ifpage 'typography-base'}} class="current"{{/ifpage}}><a href="typography-base.html">Base Styles</a></li>

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -23,6 +23,7 @@
   <li{{#ifpage 'forms'}} class="current"{{/ifpage}}><a href="forms.html">Forms</a></li>
   <li{{#ifpage 'visibility'}} class="current"{{/ifpage}}><a href="visibility.html">Visibility Classes</a></li>
   <li{{#ifpage 'float-classes'}} class="current"{{/ifpage}}><a href="float-classes.html">Float Classes</a></li>
+  <li{{#ifpage 'flex-classes'}} class="current"{{/ifpage}}><a href="flex-classes.html">Flex Classes</a></li>
 
   <li class="docs-menu-title">Typography</li>
   <li{{#ifpage 'typography-base'}} class="current"{{/ifpage}}><a href="typography-base.html">Base Styles</a></li>

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -106,6 +106,7 @@ $alert-color: map-get($foundation-palette, alert);
 
 // Remove this in 6.3
 $-zf-menu-icon-imported: false;
+$-zf-flex-classes-imported: false;
 
 @mixin foundation-global-styles {
   @include -zf-normalize;

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -18,4 +18,13 @@
       @include flex-align-self($y: $vdir);
     }
   }
+
+  // Source ordering
+  @include -zf-each-breakpoint {
+    @for $i from 1 through 6 {
+      .#{$-zf-size} {
+        @include flex-order($i);
+      }
+    }
+  }
 }

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -1,13 +1,21 @@
-// Horizontal alignment using justify-content
-@each $hdir, $prop in map-remove($-zf-flex-justify, left) {
-  .row.align-#{$hdir} {
-    @include flex-align($x: $hdir);
-  }
-}
+@mixin foundation-flex-classes {
+  $-zf-flex-classes-imported: true;
 
-// Vertical alignment using align-items and align-self
-@each $vdir, $prop in $-zf-flex-align {
-  .align-#{$vdir} {
-    @include flex-align($y: $vdir);
+  // Horizontal alignment using justify-content
+  @each $hdir, $prop in map-remove($-zf-flex-justify, left) {
+    .align-#{$hdir} {
+      @include flex-align($x: $hdir);
+    }
+  }
+
+  // Vertical alignment using align-items and align-self
+  @each $vdir, $prop in $-zf-flex-align {
+    .align-#{$vdir} {
+      @include flex-align($y: $vdir);
+    }
+
+    .align-self-#{$vdir} {
+      @include flex-align-self($y: $vdir);
+    }
   }
 }

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -1,0 +1,13 @@
+// Horizontal alignment using justify-content
+@each $hdir, $prop in map-remove($-zf-flex-justify, left) {
+  .row.align-#{$hdir} {
+    @include flex-align($x: $hdir);
+  }
+}
+
+// Vertical alignment using align-items and align-self
+@each $vdir, $prop in $-zf-flex-align {
+  .align-#{$vdir} {
+    @include flex-align($y: $vdir);
+  }
+}

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -1,5 +1,5 @@
 @mixin foundation-flex-classes {
-  $-zf-flex-classes-imported: true;
+  $-zf-flex-classes-imported: true !global;
 
   // Horizontal alignment using justify-content
   @each $hdir, $prop in map-remove($-zf-flex-justify, left) {

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -28,6 +28,7 @@
 @import 'components/drilldown';
 @import 'components/dropdown-menu';
 @import 'components/dropdown';
+@import 'components/flex';
 @import 'components/flex-video';
 @import 'components/label';
 @import 'components/media-object';
@@ -54,6 +55,7 @@
     @include foundation-grid;
   }
   @else {
+    @include foundation-flex-classes;
     @include foundation-flex-grid;
   }
   @include foundation-typography;

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -50,6 +50,8 @@
 @import 'components/tooltip';
 
 @mixin foundation-everything($flex: false) {
+  $global-flexbox: $flex !global;
+
   @include foundation-global-styles;
   @if not $flex {
     @include foundation-grid;

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -6,21 +6,6 @@
 /// @group flex-grid
 ////
 
-$-zf-flex-justify: (
-  'left': flex-start,
-  'right': flex-end,
-  'center': center,
-  'justify': space-between,
-  'spaced': space-around,
-);
-
-$-zf-flex-align: (
-  'top': flex-start,
-  'bottom': flex-end,
-  'middle': center,
-  'stretch': stretch,
-);
-
 /// Creates a container for a flex grid row.
 ///
 /// @param {Keyword|List} $behavior [null]
@@ -126,42 +111,14 @@ $-zf-flex-align: (
 /// @param {Keyword} $x [null] - Horizontal alignment to use. Can be `left`, `right`, `center`, `justify`, or `spaced`. Or, set it to `null` (the default) to not set horizontal alignment.
 /// @param {Keyword} $y [null] - Vertical alignment to use. Can be `top`, `bottom`, `middle`, or `stretch`. Or, set it to `null` (the default) to not set vertical alignment.
 @mixin flex-grid-row-align($x: null, $y: null) {
-  @if $x {
-    @if map-has-key($-zf-flex-justify, $x) {
-      $x: map-get($-zf-flex-justify, $x);
-    }
-    @else {
-      @warn 'flex-grid-row-align(): #{$x} is not a valid value for horizontal alignment. Use left, right, center, justify, or spaced.'
-    }
-  }
-
-  @if $y {
-    @if map-has-key($-zf-flex-align, $y) {
-      $y: map-get($-zf-flex-align, $y);
-    }
-    @else {
-      @warn 'flex-grid-row-align(): #{$y} is not a valid value for vertical alignment. Use top, bottom, middle, or stretch.'
-    }
-  }
-
-  justify-content: $x;
-  align-items: $y;
+  @include flex-align($x, $y);
 }
 
 /// Vertically align a single column within a flex row. Apply this mixin to a flex column.
 ///
 /// @param {Keyword} $y [null] - Vertical alignment to use. Can be `top`, `bottom`, `middle`, or `stretch`. Or, set it to `null` (the default) to not set vertical alignment.
 @mixin flex-grid-column-align($y: null) {
-  @if $y {
-    @if map-has-key($-zf-flex-align, $y) {
-      $y: map-get($-zf-flex-align, $y);
-    }
-    @else {
-      @warn 'flex-grid-column-align(): #{$y} is not a valid value for alignment. Use top, bottom, middle, or stretch.'
-    }
-  }
-
-  align-self: $y;
+  @include flex-align-self($y);
 }
 
 @mixin foundation-flex-grid {
@@ -256,19 +213,8 @@ $-zf-flex-align: (
     flex: flex-grid-column(shrink);
   }
 
-  // Horizontal alignment using justify-content
-  @each $hdir, $prop in map-remove($-zf-flex-justify, left) {
-    .row.align-#{$hdir} {
-      @include flex-grid-row-align($x: $hdir);
-    }
-  }
-
   // Vertical alignment using align-items and align-self
   @each $vdir, $prop in $-zf-flex-align {
-    .row.align-#{$vdir} {
-      @include flex-grid-row-align($y: $vdir);
-    }
-
     .column.align-#{$vdir} {
       @include flex-grid-column-align($vdir);
     }

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -231,7 +231,7 @@
 
   // Remove this in 6.3
   @if not $-zf-flex-classes-imported {
-    @warn 'In Foundation 6.2, a new component mixin was added called "foundation-flex-classes". Add "@import foundation-flex-classes" to the main Sass file of your project to remove this warning.';
+    @warn 'In Foundation 6.2, a new component mixin was added called "foundation-flex-classes". Add "@import foundation-flex-classes" to the main Sass file of your project, above "@import foundation-flex-grid", to remove this warning.';
     @include foundation-flex-classes;
   }
 }

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -103,7 +103,8 @@
 /// Changes the source order of a flex grid column. Columns with lower numbers appear first in the layout.
 /// @param {Number} $order [0] - Order number to apply.
 @mixin flex-grid-order($order: 0) {
-  order: $order;
+  @warn 'This mixin is being replaced by flex-order(). flex-grid-order() will be removed in Foundation 6.3.';
+  @include flex-order($order);
 }
 
 /// Horizontally or vertically aligns the columns within a flex row. Apply this mixin to a flex row.
@@ -111,6 +112,7 @@
 /// @param {Keyword} $x [null] - Horizontal alignment to use. Can be `left`, `right`, `center`, `justify`, or `spaced`. Or, set it to `null` (the default) to not set horizontal alignment.
 /// @param {Keyword} $y [null] - Vertical alignment to use. Can be `top`, `bottom`, `middle`, or `stretch`. Or, set it to `null` (the default) to not set vertical alignment.
 @mixin flex-grid-row-align($x: null, $y: null) {
+  @warn 'This mixin is being replaced by flex-align(). flex-grid-row-align() will be removed in Foundation 6.3.';
   @include flex-align($x, $y);
 }
 
@@ -118,6 +120,7 @@
 ///
 /// @param {Keyword} $y [null] - Vertical alignment to use. Can be `top`, `bottom`, `middle`, or `stretch`. Or, set it to `null` (the default) to not set vertical alignment.
 @mixin flex-grid-column-align($y: null) {
+  @warn 'This mixin is being replaced by flex-align-self(). flex-grid-column-align() will be removed in Foundation 6.3.';
   @include flex-align-self($y);
 }
 
@@ -166,7 +169,7 @@
     @for $i from 1 through 6 {
       // Source ordering
       .#{$-zf-size}-order-#{$i} {
-        @include flex-grid-order($i);
+        @include flex-order($i);
       }
     }
 
@@ -217,7 +220,7 @@
   // Remove these in 6.3
   @each $vdir, $prop in $-zf-flex-align {
     .column.align-#{$vdir} {
-      @include flex-grid-column-align($vdir);
+      @include flex-align-self($vdir);
     }
   }
 

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -214,6 +214,7 @@
   }
 
   // Vertical alignment using align-items and align-self
+  // Remove these in 6.3
   @each $vdir, $prop in $-zf-flex-align {
     .column.align-#{$vdir} {
       @include flex-grid-column-align($vdir);
@@ -223,5 +224,11 @@
   .columns {
     // scss-lint:disable PlaceholderInExtend
     @extend .column;
+  }
+
+  // Remove this in 6.3
+  @if not $-zf-flex-classes-imported {
+    @warn 'In Foundation 6.2, a new component mixin was added called "foundation-flex-classes". Add "@import foundation-flex-classes" to the main Sass file of your project to remove this warning.';
+    @include foundation-flex-classes;
   }
 }

--- a/scss/util/_flex.scss
+++ b/scss/util/_flex.scss
@@ -1,0 +1,62 @@
+$-zf-flex-justify: (
+  'left': flex-start,
+  'right': flex-end,
+  'center': center,
+  'justify': space-between,
+  'spaced': space-around,
+);
+
+$-zf-flex-align: (
+  'top': flex-start,
+  'bottom': flex-end,
+  'middle': center,
+  'stretch': stretch,
+);
+
+/// Enables flexbox by adding `display: flex` to the element.
+@mixin flex {
+  display: flex;
+}
+
+/// Horizontally or vertically aligns the items within a flex container.
+///
+/// @param {Keyword} $x [null] - Horizontal alignment to use. Can be `left`, `right`, `center`, `justify`, or `spaced`. Or, set it to `null` (the default) to not set horizontal alignment.
+/// @param {Keyword} $y [null] - Vertical alignment to use. Can be `top`, `bottom`, `middle`, or `stretch`. Or, set it to `null` (the default) to not set vertical alignment.
+@mixin flex-align($x: null, $y: null) {
+  @if $x {
+    @if map-has-key($-zf-flex-justify, $x) {
+      $x: map-get($-zf-flex-justify, $x);
+    }
+    @else {
+      @warn 'flex-grid-row-align(): #{$x} is not a valid value for horizontal alignment. Use left, right, center, justify, or spaced.'
+    }
+  }
+
+  @if $y {
+    @if map-has-key($-zf-flex-align, $y) {
+      $y: map-get($-zf-flex-align, $y);
+    }
+    @else {
+      @warn 'flex-grid-row-align(): #{$y} is not a valid value for vertical alignment. Use top, bottom, middle, or stretch.'
+    }
+  }
+
+  justify-content: $x;
+  align-items: $y;
+}
+
+/// Vertically align a single column within a flex row. Apply this mixin to a flex column.
+///
+/// @param {Keyword} $y [null] - Vertical alignment to use. Can be `top`, `bottom`, `middle`, or `stretch`. Or, set it to `null` (the default) to not set vertical alignment.
+@mixin flex-align-self($y: null) {
+  @if $y {
+    @if map-has-key($-zf-flex-align, $y) {
+      $y: map-get($-zf-flex-align, $y);
+    }
+    @else {
+      @warn 'flex-grid-column-align(): #{$y} is not a valid value for alignment. Use top, bottom, middle, or stretch.'
+    }
+  }
+
+  align-self: $y;
+}

--- a/scss/util/_flex.scss
+++ b/scss/util/_flex.scss
@@ -60,3 +60,9 @@ $-zf-flex-align: (
 
   align-self: $y;
 }
+
+/// Changes the source order of a flex child. Children with lower numbers appear first in the layout.
+/// @param {Number} $order [0] - Order number to apply.
+@mixin flex-order($order: 0) {
+  order: $order;
+}

--- a/scss/util/_util.scss
+++ b/scss/util/_util.scss
@@ -2,14 +2,10 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
-// Utilities
 @import 'unit';
 @import 'value';
 @import 'color';
 @import 'selector';
-
-// Libraries
+@import 'flex';
 @import 'breakpoint';
-
-// Mixins
 @import 'mixins';


### PR DESCRIPTION
A big push for 6.2 will be flexbox modes for components. With that, we're making certain helpful flexbox classes, namely the horizontal/vertical alignment ones, into generic helper classes.

These will be usable with the Flex Grid, the Foundation for Apps 2 grid (shhhh....), and any component that has flexbox support, such as menu, top bar, etc.

Along with the classes are a set of flexbox mixins called `flex()`, `flex-align()`, and `flex-align-self()`.

The goal is to take any mixin/class that can be used in multiple components, and make it generic. This includes:
- Expand/shrink behavior
- Alignment
- Source ordering

Still a work in progress!
