### PR TITLE
Tab active color can be set

### DIFF
--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -114,6 +114,7 @@ $tab-content-padding: 1rem !default;
       &:focus,
       &[aria-selected='true'] {
         background: $tab-background-active;
+        color: $tab-item-color-active;
       }
     }
   }

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -26,6 +26,10 @@ $tab-border: $light-gray !default;
 /// @type Color
 $tab-item-color: foreground($tab-background, $primary-color) !default;
 
+/// Default text color for active items in a Menu.
+/// @type Color
+$tab-item-color-active: foreground($tab-background, $primary-color) !default;
+
 /// Default background color on hover for items in a Menu.
 $tab-item-background-hover: $white !default;
 

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -28,7 +28,7 @@ $tab-item-color: foreground($tab-background, $primary-color) !default;
 
 /// Default text color for active items in a Menu.
 /// @type Color
-$tab-item-color-active: foreground($tab-background, $primary-color) !default;
+$tab-item-color-active: $tab-item-color !default;
 
 /// Default background color on hover for items in a Menu.
 $tab-item-background-hover: $white !default;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -490,7 +490,7 @@ $tab-background: $white;
 $tab-background-active: $light-gray;
 $tab-border: $light-gray;
 $tab-item-color: foreground($tab-background, $primary-color);
-$tab-item-color-active: foreground($tab-background, $primary-color);
+$tab-item-color-active: $tab-item-color;
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -490,6 +490,7 @@ $tab-background: $white;
 $tab-background-active: $light-gray;
 $tab-border: $light-gray;
 $tab-item-color: foreground($tab-background, $primary-color);
+$tab-item-color-active: foreground($tab-background, $primary-color);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;


### PR DESCRIPTION
I wanted to be able to change the color of an active tabs and there was no settings for that. 

```
/// Default text color for active items in a Menu.
/// @type Color
$tab-item-color-active: $tab-item-color !default;
```

I set the value as `$tab-item-color` to make it backward compatible

If I forgot to change some files please tell me
