### PR TITLE
[6.2] Native element support

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -13,6 +13,8 @@
 
 @include foundation-everything;
 @include foundation-range-input;
+@include foundation-progress-element;
+@include foundation-meter-element;
 @include motion-ui-transitions;
 
 @import 'foundation-docs';

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -12,6 +12,7 @@
 @import 'motion-ui';
 
 @include foundation-everything;
+@include foundation-range-input;
 @include motion-ui-transitions;
 
 @import 'foundation-docs';

--- a/docs/pages/progress-bar.md
+++ b/docs/pages/progress-bar.md
@@ -35,8 +35,12 @@ Add a `width` CSS property to the inner meter to fill the progress bar.
 A progress bar can be styled with the `.success`, `.warning`, and `.alert` colors.
 
 ```html_example
-<div class="success progress" role="progressbar" tabindex="0" aria-valuenow="25" aria-valuemin="0" aria-valuetext="25 percent" aria-valuemax="100">
+<div class="secondary progress" role="progressbar" tabindex="0" aria-valuenow="25" aria-valuemin="0" aria-valuetext="25 percent" aria-valuemax="100">
   <div class="progress-meter" style="width: 25%"></div>
+</div>
+
+<div class="success progress">
+  <div class="progress-meter" style="width: 50%"></div>
 </div>
 
 <div class="warning progress">
@@ -60,4 +64,49 @@ You can add text inside the meter of a progress bar. Make sure the text you use 
     <p class="progress-meter-text">25%</p>
   </span>
 </div>
+```
+
+---
+
+## Native Progress
+
+As an alternative to our custom progress bar style, you can also opt to use the native `<progress>` element. It provides a more succinct way to create progress bars, but it's not supported in IE9, and some other older browsers. [View `<progress>` element support.](http://caniuse.com/#feat=progress)
+
+```html_example
+<progress max="100" value="75"></progress>
+```
+
+If you're using the Sass version of Foundation, add this line to your main Sass file to export the `<progress>` CSS:
+
+```scss
+@import foundation-progress-element;
+```
+
+The `<progress>` element can be styled with the same coloring classes: `.secondary`, `.success`, `.warning`, and `.alert`.
+
+```html_example
+<progress class="secondary" max="100" value="75"></progress>
+<progress class="success" max="100" value="75"></progress>
+<progress class="warning" max="100" value="75"></progress>
+<progress class="alert" max="100" value="75"></progress>
+```
+
+---
+
+## Native Meter
+
+For the *extra* adventurous developers out there, we also provide styles for the `<meter>` element. What's the difference? `<progress>` represents a value that changes over time, like storage capacity. `<meter>` represents a value that fluctates around some optimum value. It also has *no* support in Internet Explorer, Mobile Safari, or Android 2. [View `<meter>` element support.](http://caniuse.com/#search=meter)
+
+If you're using the Sass version of Foundation, add this line to your main Sass file to export the `<meter>` CSS:
+
+```scss
+@import foundation-progress-element;
+```
+
+The meter automatically colors itself based on the current values, and the defined low, medium, and high ranges. [Learn more about the mechanics of `<meter>` values.](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms/The_native_form_widgets#Meters_and_progress_bars)
+
+```html_example
+<meter value="30" min="0" low="33" medium="66" optimum="100" max="100"></meter>
+<meter value="50" min="0" low="33" medium="66" optimum="100" max="100"></meter>
+<meter value="100" min="0" low="33" medium="66" optimum="100" max="100"></meter>
 ```

--- a/docs/pages/progress-bar.md
+++ b/docs/pages/progress-bar.md
@@ -103,13 +103,13 @@ For the *extra* adventurous developers out there, we also provide styles for the
 If you're using the Sass version of Foundation, add this line to your main Sass file to export the `<meter>` CSS:
 
 ```scss
-@import foundation-progress-element;
+@import foundation-meter-element;
 ```
 
 The meter automatically colors itself based on the current values, and the defined low, medium, and high ranges. [Learn more about the mechanics of `<meter>` values.](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms/The_native_form_widgets#Meters_and_progress_bars)
 
 ```html_example
-<meter value="30" min="0" low="33" medium="66" optimum="100" max="100"></meter>
-<meter value="50" min="0" low="33" medium="66" optimum="100" max="100"></meter>
-<meter value="100" min="0" low="33" medium="66" optimum="100" max="100"></meter>
+<meter value="30" min="0" low="33" high="66" optimum="100" max="100"></meter>
+<meter value="50" min="0" low="33" high="66" optimum="100" max="100"></meter>
+<meter value="100" min="0" low="33" high="66" optimum="100" max="100"></meter>
 ```

--- a/docs/pages/progress-bar.md
+++ b/docs/pages/progress-bar.md
@@ -1,7 +1,10 @@
 ---
 title: Progress Bar
 description: Show your progress. A simple way to add progress bars to your layouts. You only need two HTML elements to make them and they're easy to customize.
-sass: scss/components/_progress-bar.scss
+sass:
+  - scss/components/_progress-bar.scss
+  - scss/forms/_progress.scss
+  - scss/forms/_meter.scss
 ---
 
 ## Basics

--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -80,3 +80,27 @@ Wait, you want a visible input AND a slider? You're crazy, but ok. Change the va
   <input type="number" id="sliderOutput1">
 </div>
 ```
+
+---
+
+## Native Range Slider
+
+In Foundation 6.2, we introduced styles for `<input type="range">`, the native HTML element for range sliders. It's not supported in every browser, namely IE9 and some older mobile browsers. [View browser support for the range input type.](http://caniuse.com/#feat=input-range)
+
+```html_example
+<input type="range" min="1" max="100" step="1">
+```
+
+If you're using the Sass version of Foundation, add this line to your main Sass file:
+
+```scss
+@include foundation-range-input;
+```
+
+It's possible to use both the JavaScript slider and the native slider in the same codebase, as the CSS selectors used don't overlap. Here's what's different about the native slider:
+
+- Less markup: just write `<input type="range">` and you're good.
+- No JavaScript is needed, which guarantees it runs faster in most browsers.
+- To disable the slider, add `disabled` as an attribute, instead of a class.
+- No support for vertical orientation.
+- No support for two handles.

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -26,8 +26,8 @@ $foundation-palette: (
   primary: #2199e8,
   secondary: #777,
   success: #3adb76,
-  alert: #ffae00,
-  warning: #ec5840,
+  warning: #ffae00,
+  alert: #ec5840,
 ) !default;
 
 /// Color used for light gray UI items.

--- a/scss/components/_progress-bar.scss
+++ b/scss/components/_progress-bar.scss
@@ -2,30 +2,6 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
-////
-/// @group progress-bar
-////
-
-/// Height of a progress bar.
-/// @type Number
-$progress-height: 1rem !default;
-
-/// Background color of a progress bar.
-/// @type Color
-$progress-background: $medium-gray !default;
-
-/// Bottom margin of a progress bar.
-/// @type Number
-$progress-margin-bottom: $global-margin !default;
-
-/// Default color of a progress bar's meter.
-/// @type Color
-$progress-meter-background: $primary-color !default;
-
-/// Default radius of a progress bar.
-/// @type Number
-$progress-radius: $global-radius !default;
-
 /// Adds styles for a progress bar container.
 @mixin progress-container {
   background-color: $progress-background;

--- a/scss/components/_slider.scss
+++ b/scss/components/_slider.scss
@@ -9,43 +9,11 @@
 /// @group slider
 ////
 
-/// Default height of the slider.
-/// @type Number
-$slider-height: 0.5rem !default;
-
-/// Default slider width of a vertical slider.
+/// Default slider width of a vertical slider. (Doesn't apply to the native slider.)
 /// @type Number
 $slider-width-vertical: $slider-height !default;
 
-/// Default background color of the slider's track.
-/// @type Color
-$slider-background: $light-gray !default;
-
-/// Default color of the active fill color of the slider.
-/// @type Color
-$slider-fill-background: $medium-gray !default;
-
-/// Default height of the handle of the slider.
-/// @type Number
-$slider-handle-height: 1.4rem !default;
-
-/// Default width of the handle of the slider.
-/// @type Number
-$slider-handle-width: 1.4rem !default;
-
-/// Default color of the handle for the slider.
-/// @type Color
-$slider-handle-background: $primary-color !default;
-
-/// Default fade amount of a disabled slider.
-/// @type Number
-$slider-opacity-disabled: 0.25 !default;
-
-/// Default radius for slider.
-/// @type Number
-$slider-radius: $global-radius !default;
-
-/// Transition properties to apply to the slider handle and fill.
+/// Transition properties to apply to the slider handle and fill. (Doesn't apply to the native slider.)
 /// @type Transition
 $slider-transition: all 0.2s ease-in-out !default;
 

--- a/scss/forms/_forms.scss
+++ b/scss/forms/_forms.scss
@@ -18,6 +18,7 @@ $form-spacing: rem-calc(16) !default;
   'input-group',
   'fieldset',
   'select',
+  'range',
   'error';
 
 @mixin foundation-forms {

--- a/scss/forms/_forms.scss
+++ b/scss/forms/_forms.scss
@@ -19,6 +19,8 @@ $form-spacing: rem-calc(16) !default;
   'fieldset',
   'select',
   'range',
+  'progress',
+  'meter',
   'error';
 
 @mixin foundation-forms {

--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -1,8 +1,33 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group meter
+////
+
+/// Height of a `<meter>` element.
+/// @type Length
 $meter-height: $progress-height !default;
+
+/// Border radius of a `<meter>` element.
+/// @type Length
 $meter-radius: $progress-radius !default;
+
+/// Background color of a `<meter>` element.
+/// @type Color
 $meter-background: $progress-background !default;
+
+/// Meter fill for an optimal value in a `<meter>` element.
+/// @type Color
 $meter-fill-good: $success-color !default;
+
+/// Meter fill for an average value in a `<meter>` element.
+/// @type Color
 $meter-fill-medium: $warning-color !default;
+
+/// Meter fill for a suboptimal value in a `<meter>` element.
+/// @type Color
 $meter-fill-bad: $alert-color !default;
 
 @mixin foundation-meter-element {
@@ -51,7 +76,7 @@ $meter-fill-bad: $alert-color !default;
       @if has-value($meter-radius) {
         border-radius: $meter-radius;
       }
-    }
+    }d
 
     &::-webkit-meter-even-less-good-value {
       background: $meter-fill-bad;

--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -1,0 +1,87 @@
+$meter-height: $progress-height !default;
+$meter-radius: $progress-radius !default;
+$meter-background: $progress-background !default;
+$meter-fill-good: $success-color !default;
+$meter-fill-medium: $warning-color !default;
+$meter-fill-bad: $alert-color !default;
+
+@mixin foundation-meter-element {
+  meter {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    display: block;
+    width: 100%;
+    height: $meter-height;
+    margin-bottom: 1rem;
+
+    @if has-value($meter-radius) {
+      border-radius: $meter-radius;
+    }
+
+    // For Firefox
+    background: $meter-background;
+    border: 0;
+
+    // Chrome/Safari
+    &::-webkit-meter-bar {
+      background: $meter-background;
+
+      @if has-value($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    &::-webkit-meter-inner-element {
+      @if has-value($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    &::-webkit-meter-optimum-value {
+      background: $meter-fill-good;
+
+      @if has-value($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    &::-webkit-meter-suboptimum-value {
+      background: $meter-fill-medium;
+
+      @if has-value($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    &::-webkit-meter-even-less-good-value {
+      background: $meter-fill-bad;
+
+      @if has-value($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    // Firefox
+    background: $meter-background;
+
+    &::-moz-meter-bar {
+      background: $primary-color;
+
+      @if has-value($meter-radius) {
+        border-radius: $meter-radius;
+      }
+    }
+
+    &:-moz-meter-optimum::-moz-meter-bar {
+      background: $meter-fill-good;
+    }
+
+    &:-moz-meter-sub-optimum::-moz-meter-bar {
+      background: $meter-fill-medium;
+    }
+
+    &:-moz-meter-sub-sub-optimum::-moz-meter-bar {
+      background: $meter-fill-bad;
+    }
+  }
+}

--- a/scss/forms/_progress.scss
+++ b/scss/forms/_progress.scss
@@ -1,0 +1,82 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group progress-bar
+////
+
+/// Height of a progress bar.
+/// @type Number
+$progress-height: 1rem !default;
+
+/// Background color of a progress bar.
+/// @type Color
+$progress-background: $medium-gray !default;
+
+/// Bottom margin of a progress bar.
+/// @type Number
+$progress-margin-bottom: $global-margin !default;
+
+/// Default color of a progress bar's meter.
+/// @type Color
+$progress-meter-background: $primary-color !default;
+
+/// Default radius of a progress bar.
+/// @type Number
+$progress-radius: $global-radius !default;
+
+@mixin foundation-progress-element {
+  progress {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    display: block;
+    width: 100%;
+    height: $progress-height;
+    margin-bottom: $progress-margin-bottom;
+
+    @if hasvalue($progress-radius) {
+      border-radius: $progress-radius;
+    }
+
+    // For Firefox
+    background: $progress-background;
+    border: 0;
+
+    &::-webkit-progress-bar {
+      background: $progress-background;
+
+      @if hasvalue($progress-radius) {
+        border-radius: $progress-radius;
+      }
+    }
+
+    &::-webkit-progress-value {
+      background: $progress-meter-background;
+
+      @if hasvalue($progress-radius) {
+        border-radius: $progress-radius;
+      }
+    }
+
+    &::-moz-progress-bar {
+      background: $progress-meter-background;
+
+      @if hasvalue($progress-radius) {
+        border-radius: $progress-radius;
+      }
+    }
+
+    @each $name, $color in $foundation-palette {
+      &.#{$name} {
+        &::-webkit-progress-value {
+          background: $color;
+        }
+
+        &::-moz-progress-bar {
+          background: $color;
+        }
+      }
+    }
+  }
+}

--- a/scss/forms/_range.scss
+++ b/scss/forms/_range.scss
@@ -84,12 +84,14 @@ $slider-radius: $global-radius !default;
         border-radius: $slider-radius;
       }
     }
+
     // Firefox
     &::-moz-range-track {
       -moz-appearance: none;
       height: $slider-height;
       background: #ccc;
     }
+    
     &::-moz-range-thumb {
       -moz-appearance: none;
       background: $slider-thumb-color;

--- a/scss/forms/_range.scss
+++ b/scss/forms/_range.scss
@@ -1,0 +1,143 @@
+/// Default height of the slider.
+/// @type Number
+$slider-height: 0.5rem !default;
+
+/// Default background color of the slider's track.
+/// @type Color
+$slider-background: $light-gray !default;
+
+/// Default color of the active fill color of the slider.
+/// @type Color
+$slider-fill-background: $medium-gray !default;
+
+/// Default height of the handle of the slider.
+/// @type Number
+$slider-handle-height: 1.4rem !default;
+
+/// Default width of the handle of the slider.
+/// @type Number
+$slider-handle-width: 1.4rem !default;
+
+/// Default color of the handle for the slider.
+/// @type Color
+$slider-handle-background: $primary-color !default;
+
+/// Default fade amount of a disabled slider.
+/// @type Number
+$slider-opacity-disabled: 0.25 !default;
+
+/// Default radius for slider.
+/// @type Number
+$slider-radius: $global-radius !default;
+
+@mixin foundation-range-input {
+  input[type="range"] {
+    $slider-background: $light-gray;
+    $slider-height: 0.5rem;
+    $slider-radius: 0px;
+    $slider-thumb-height: 1.4rem;
+    $slider-thumb-width: 1.4rem;
+    $slider-thumb-color: $primary-color;
+    $slider-opacity-disabled: 0.25;
+    $slider-fill-background: $medium-gray;
+
+    $margin: ($slider-thumb-height - $slider-height) / 2;
+
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    display: block;
+    width: 100%;
+    height: auto;
+    cursor: pointer;
+    margin-top: $margin;
+    margin-bottom: $margin;
+    border: 0;
+    line-height: 1;
+    margin-bottom: $global-margin;
+
+    @if has-value($slider-radius) {
+      border-radius: $slider-radius;
+    }
+
+    &:focus {
+      outline: 0;
+    }
+
+    &[disabled] {
+      opacity: $slider-opacity-disabled;
+    }
+
+    // Chrome/Safari
+    &::-webkit-slider-runnable-track {
+      height: $slider-height;
+      background: $slider-background;
+    }
+
+    &::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      background: $slider-thumb-color;
+      width: $slider-thumb-width;
+      height: $slider-thumb-height;
+      margin-top: -$margin;
+
+      @if has-value($slider-radius) {
+        border-radius: $slider-radius;
+      }
+    }
+    // Firefox
+    &::-moz-range-track {
+      -moz-appearance: none;
+      height: $slider-height;
+      background: #ccc;
+    }
+    &::-moz-range-thumb {
+      -moz-appearance: none;
+      background: $slider-thumb-color;
+      width: $slider-thumb-width;
+      height: $slider-thumb-height;
+      margin-top: -$margin;
+
+      @if has-value($slider-radius) {
+        border-radius: $slider-radius;
+      }
+    }
+
+    // Internet Explorer
+    &::-ms-track {
+      height: $slider-height;
+      background: $slider-background;
+      color: transparent;
+      border: 0;
+      overflow: visible;
+      border-top: $margin solid $body-background;
+      border-bottom: $margin solid $body-background;
+    }
+
+    &::-ms-thumb {
+      background: $slider-thumb-color;
+      width: $slider-thumb-width;
+      height: $slider-thumb-height;
+      border: 0;
+
+      @if has-value($slider-radius) {
+        border-radius: $slider-radius;
+      }
+    }
+
+    &::-ms-fill-lower {
+      background: $slider-fill-background;
+    }
+
+    &::-ms-fill-upper {
+      background: $slider-background;
+    }
+
+    @at-root {
+      output {
+        line-height: $slider-thumb-height;
+        vertical-align: middle;
+        margin-left: 0.5em;
+      }
+    }
+  }
+}

--- a/scss/forms/_range.scss
+++ b/scss/forms/_range.scss
@@ -1,3 +1,11 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group slider
+////
+
 /// Default height of the slider.
 /// @type Number
 $slider-height: 0.5rem !default;


### PR DESCRIPTION
For 6.2, we're adding support for these native controls:
- `<input type="range">`
- `<progress>`
- `<meter>`

They'll all be optional, and include their own CSS exports separate from our custom implementations.
