### PR TITLE
Removed braces from $.ajax call example

### DIFF
--- a/docs/pages/reveal.md
+++ b/docs/pages/reveal.md
@@ -182,7 +182,7 @@ To use AJAX to load your modal content, use the code snippet below.
 ```js
 var $modal = $('#modal');
 
-$.ajax({'/url'})
+$.ajax('/url')
   .done(function(resp){
     $modal.html(resp.html).foundation('open');
 });


### PR DESCRIPTION
jQuery wants an url string or/plus a config object with a set of key/value pairs
