### PR TITLE
Issue with responsive gutter

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -28,7 +28,9 @@
 
     // Collapsing
     &.#{$collapse} {
-      > .#{$column} { @include grid-col-collapse; }
+      > .#{$column} {
+        @include grid-col-collapse;
+      }
     }
 
     // Nesting
@@ -39,8 +41,7 @@
             @include grid-row-nest($gutter);
           }
         }
-      }
-      @else {
+      } @else {
         @include grid-row-nest($grid-column-gutter);
       }
 
@@ -116,7 +117,9 @@
 
     // Responsive collapsing
     .#{$-zf-size}-#{$collapse} {
-      > .#{$column} { @include grid-col-collapse; }
+      > .#{$column} {
+        @include grid-col-collapse;
+      }
 
       .#{$row} {
         margin-left: 0;
@@ -124,16 +127,30 @@
       }
     }
 
-    .#{$-zf-size}-#{$uncollapse} {
-      $gutter: null;
+    @if $grid-column-gutter {
+      $-zf-sizes: ($-zf-size);
+      $gutter: $grid-column-gutter;
+    } @else {
+      $-zf-sizes: ();
+      $-breakpoint-smaller-or-equal: true;
+      @each $-breakpoint-name in $breakpoint-classes {
+        @if $-breakpoint-smaller-or-equal {
+          $-zf-sizes: append($-zf-sizes, $-breakpoint-name);
+          @if $-breakpoint-name == $-zf-size {
+            $-breakpoint-smaller-or-equal: false;
+          }
+        }
+      }
+      $gutter: -zf-get-bp-val($grid-column-responsive-gutter, $-zf-size);
+    }
 
-      @if $grid-column-gutter {
-        $gutter: $grid-column-gutter;
-      }
-      @else {
-        $gutter: -zf-get-bp-val($grid-column-responsive-gutter, $-zf-size);
-      }
-      > .#{$column} { @include grid-col-uncollapse($gutter); }
+    $-zf-size-selector: null;
+    @each $-zf-size in $-zf-sizes {
+      $-zf-size-selector: append($-zf-size-selector, unquote('.#{$-zf-size}-#{$uncollapse}'), 'comma');
+    }
+
+    #{$-zf-size-selector} > .#{$column} {
+      @include grid-col-uncollapse($gutter);
     }
 
     // Positioning

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -28,9 +28,7 @@
 
     // Collapsing
     &.#{$collapse} {
-      > .#{$column} {
-        @include grid-col-collapse;
-      }
+      > .#{$column} { @include grid-col-collapse; }
     }
 
     // Nesting
@@ -41,7 +39,8 @@
             @include grid-row-nest($gutter);
           }
         }
-      } @else {
+      }
+      @else {
         @include grid-row-nest($grid-column-gutter);
       }
 
@@ -117,9 +116,7 @@
 
     // Responsive collapsing
     .#{$-zf-size}-#{$collapse} {
-      > .#{$column} {
-        @include grid-col-collapse;
-      }
+      > .#{$column} { @include grid-col-collapse; }
 
       .#{$row} {
         margin-left: 0;
@@ -149,11 +146,9 @@
       $-zf-size-selector: append($-zf-size-selector, unquote('.#{$-zf-size}-#{$uncollapse}'), 'comma');
     }
 
-    #{$-zf-size-selector} {
-      > .#{$column} {
+    #{$-zf-size-selector} { > .#{$column} {
         @include grid-col-uncollapse($gutter);
-      }
-    }
+      } }
 
     // Positioning
     .#{$-zf-size}-#{$center} {

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -149,8 +149,10 @@
       $-zf-size-selector: append($-zf-size-selector, unquote('.#{$-zf-size}-#{$uncollapse}'), 'comma');
     }
 
-    #{$-zf-size-selector} > .#{$column} {
-      @include grid-col-uncollapse($gutter);
+    #{$-zf-size-selector} {
+      > .#{$column} {
+        @include grid-col-uncollapse($gutter);
+      }
     }
 
     // Positioning

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -146,9 +146,11 @@
       $-zf-size-selector: append($-zf-size-selector, unquote('.#{$-zf-size}-#{$uncollapse}'), 'comma');
     }
 
-    #{$-zf-size-selector} { > .#{$column} {
+    #{$-zf-size-selector} {
+      > .#{$column} {
         @include grid-col-uncollapse($gutter);
-      } }
+      }
+    }
 
     // Positioning
     .#{$-zf-size}-#{$center} {


### PR DESCRIPTION
Case:
<img width="315" alt="screen shot 2016-01-18 at 22 00 37" src="https://cloud.githubusercontent.com/assets/9195369/12403521/9d302e52-be34-11e5-928a-ab50a7d9f833.png">

Issue:
<img width="785" alt="screen shot 2016-01-18 at 22 04 14" src="https://cloud.githubusercontent.com/assets/9195369/12403525/a2da14ee-be34-11e5-9c2c-786174d5b199.png">
-- selector for current width breakpoint is loosing with previous selector for smaller resolution

After fix:
<img width="783" alt="screen shot 2016-01-18 at 22 00 24" src="https://cloud.githubusercontent.com/assets/9195369/12403528/a82037f8-be34-11e5-98d2-13ebad0bedcc.png">
--it look like this selector is existing twice in line 1155 and 947, but those are selectors for medium and large breakpoint
