### PR TITLE
[6.2] increment jQuery version to ~2.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-sites",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "main": [
     "scss/foundation.scss",
     "dist/foundation.js"
@@ -25,7 +25,7 @@
     ".versions"
   ],
   "dependencies": {
-    "jquery": "~2.1.0",
+    "jquery": "~2.2.0",
     "what-input": "~1.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-sites",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "main": "dist/foundation.js",
   "description": "The most advanced responsive front-end framework in the world.",
   "author": "ZURB <foundation@zurb.com> (http://foundation.zurb.com)",
@@ -11,8 +11,8 @@
     "deploy": "gulp deploy"
   },
   "dependencies": {
-    "jquery": "^2.1.0",
-    "what-input": "^1.1.2"
+    "jquery": "~2.2.0",
+    "what-input": "~1.1.2"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -1,6 +1,6 @@
 /**
  * Foundation for Sites by ZURB
- * Version 6.1.0
+ * Version 6.2.0
  * foundation.zurb.com
  * Licensed under MIT Open Source
  */


### PR DESCRIPTION
[faster & SVG support](http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/)
bumped foundation-sites version

I'm building with this config now; let you know if there are problems if you want to wait.
