### PR TITLE
[Dropdown] Dropdown-font-size variable not used in mixin

### DIFF
--- a/scss/components/_dropdown.scss
+++ b/scss/components/_dropdown.scss
@@ -38,13 +38,14 @@ $dropdown-sizes: (
 @mixin dropdown-container {
   background-color: $body-background;
   border: $dropdown-border;
+  border-radius: $dropdown-radius;
   display: block;
+  font-size: $dropdown-font-size;
   padding: $dropdown-padding;
   position: absolute;
   visibility: hidden;
   width: $dropdown-width;
   z-index: 10;
-  border-radius: $dropdown-radius;
 
   &.is-open {
     visibility: visible;


### PR DESCRIPTION
The sass variable `$dropdown-font-size` is not used in the mixin used to create the dropdown-container CSS.
