### PR TITLE
Rework Button Group to not use borders

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -99,7 +99,7 @@ $buttongroup-expand-max: 6 !default;
     @include button-group;
 
     // Sizes
-    @each $size, $value in $button-sizes {
+    @each $size, $value in map-remove($button-sizes, default) {
       &.#{$size} #{$buttongroup-child-selector} { font-size: $value; }
     }
 

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -12,7 +12,7 @@ $buttongroup-margin: 1rem !default;
 
 /// Margin between buttons in a button group.
 /// @type Border
-$buttongroup-spacing: 1px !default;
+$buttongroup-spacing: 10px !default;
 
 /// Selector for the buttons inside a button group.
 /// @type String
@@ -29,15 +29,17 @@ $buttongroup-expand-max: 6 !default;
 ) {
   @include clearfix;
   margin-bottom: $buttongroup-margin;
-  font-size: map-get($button-sizes, default);
+  font-size: 0;
+  &.tiny #{$child-selector}     { font-size: map-get($button-sizes, tiny); }
+  &.small #{$child-selector}    { font-size: map-get($button-sizes, small); }
+  &.large #{$child-selector}    { font-size: map-get($button-sizes, large); }
 
   #{$child-selector} {
-    float: #{$global-left};
     margin: 0;
-    font-size: inherit;
+    font-size: map-get($button-sizes, default);
 
     &:not(:last-child) {
-      border-#{$global-right}: $buttongroup-spacing solid $body-background;
+      margin-right: $buttongroup-spacing;
     }
   }
 }
@@ -52,18 +54,18 @@ $buttongroup-expand-max: 6 !default;
     @warn 'button-group-expand(): the $count property is no longer needed. This parameter will be removed in Foundation 6.2.';
   }
 
-  display: table;
-  table-layout: fixed;
-  width: 100%;
-
-  &::before,
-  &::after {
-    display: none;
-  }
+  margin-right: -$buttongroup-spacing;
 
   #{$selector} {
-    display: table-cell;
-    float: none;
+    @for $i from 2 through $buttongroup-expand-max {
+      &:first-child:nth-last-child(#{$i}) {
+        &, &:first-child:nth-last-child(#{$i}) ~ #{$selector} {
+          display: inline-block;
+          width: calc( #{percentage(1/$i)} - #{$buttongroup-spacing} );
+          margin-right: $buttongroup-spacing;
+        }
+      }
+    }
   }
 }
 
@@ -76,7 +78,7 @@ $buttongroup-expand-max: 6 !default;
     width: 100%;
 
     &:not(:last-child) {
-      border-#{$global-right}: $buttongroup-spacing solid;
+      margin-right: $buttongroup-spacing;
     }
   }
 }
@@ -90,7 +92,7 @@ $buttongroup-expand-max: 6 !default;
     width: auto;
 
     &:not(:last-child) {
-      border-#{$global-right}: $buttongroup-spacing solid $body-background;
+      margin-right: $buttongroup-spacing;
     }
   }
 }
@@ -99,10 +101,7 @@ $buttongroup-expand-max: 6 !default;
   .button-group {
     @include button-group;
 
-    // Sizes
-    &.tiny     { font-size: map-get($button-sizes, tiny); }
-    &.small    { font-size: map-get($button-sizes, small); }
-    &.large    { font-size: map-get($button-sizes, large); }
+    // Even-width Group
     &.expanded { @include button-group-expand; }
 
     // Colors
@@ -137,7 +136,7 @@ $buttongroup-expand-max: 6 !default;
 
         #{$buttongroup-child-selector} {
           display: block;
-          border-right: 0;
+          margin-right: 0;
         }
       }
     }

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -12,7 +12,7 @@ $buttongroup-margin: 1rem !default;
 
 /// Margin between buttons in a button group.
 /// @type Border
-$buttongroup-spacing: 10px !default;
+$buttongroup-spacing: 1px !default;
 
 /// Selector for the buttons inside a button group.
 /// @type String

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -30,9 +30,6 @@ $buttongroup-expand-max: 6 !default;
   @include clearfix;
   margin-bottom: $buttongroup-margin;
   font-size: 0;
-  &.tiny #{$child-selector}     { font-size: map-get($button-sizes, tiny); }
-  &.small #{$child-selector}    { font-size: map-get($button-sizes, small); }
-  &.large #{$child-selector}    { font-size: map-get($button-sizes, large); }
 
   #{$child-selector} {
     margin: 0;
@@ -100,6 +97,11 @@ $buttongroup-expand-max: 6 !default;
 @mixin foundation-button-group {
   .button-group {
     @include button-group;
+
+    // Sizes
+    @each $size, $value in $button-sizes {
+      &.#{$size} #{$buttongroup-child-selector} { font-size: $value; }
+    }
 
     // Even-width Group
     &.expanded { @include button-group-expand; }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -194,10 +194,9 @@ $button-opacity-disabled: 0.25 !default;
     @include button;
 
     // Sizes
-    &.tiny     { font-size: map-get($button-sizes, tiny); }
-    &.small    { font-size: map-get($button-sizes, small); }
-    &.large    { font-size: map-get($button-sizes, large); }
-    &.expanded { @include button-expand; }
+    @each $size, $value in map-remove($button-sizes, default) {
+      &.#{$size} { font-size: $value; }
+    }
 
     // Colors
     @each $name, $color in $foundation-colors {

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -197,6 +197,7 @@ $button-opacity-disabled: 0.25 !default;
     @each $size, $value in map-remove($button-sizes, default) {
       &.#{$size} { font-size: $value; }
     }
+    &.expanded { @include button-expand; }
 
     // Colors
     @each $name, $color in $foundation-colors {


### PR DESCRIPTION
This PR implements margin for the space between buttons, instead of faking it with borders. It also nixes the use of table display & floats, instead using `inline-block`. 

Let me know if you have feedback. 

Woot!
-Andy

Related issues: #7665, #7844 
