### PR TITLE
Update sass.md

### DIFF
--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -52,7 +52,7 @@ grunt.initConfig({
   sass: {
     dist: {
     options: {
-        includePaths: ['node_modules/foundation-sites/scss']
+        loadPath: ['node_modules/foundation-sites/scss']
       }
     }
   }


### PR DESCRIPTION
changed includePaths to loadPath as grunt-contrib-sass does not support "includePaths".
