### PR TITLE
ES6 Template Literals

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -100,7 +100,7 @@
      */
     validators: {
       equalTo: function (el, required, parent) {
-        return $('#' + el.attr('data-equalto')).val() === el.val();
+        return $(`#${el.attr('data-equalto')}`).val() === el.val();
       }
     }
   };
@@ -205,7 +205,7 @@
    * @returns {Boolean} Boolean value depends on whether or not attribute is checked or empty
    */
   Abide.prototype.findLabel = function($el) {
-    var $label = this.$element.find('label[for="' + $el[0].id + '"]');
+    var $label = this.$element.find(`label[for="${$el[0].id}"]`);
     if(!$label.length){
       return $el.closest('label');
     }
@@ -342,7 +342,7 @@
    * @returns {Boolean} Boolean value depends on whether or not at least one radio input has been selected (if it's required)
    */
   Abide.prototype.validateRadio = function(groupName){
-    var $group = this.$element.find(':radio[name="' + groupName + '"]'),
+    var $group = this.$element.find(`:radio[name="${groupName}"]`),
         counter = [],
         _this = this;
 
@@ -378,9 +378,9 @@
     var $form = this.$element,
         opts = this.options;
 
-    $('.' + opts.labelErrorClass, $form).not('small').removeClass(opts.labelErrorClass);
-    $('.' + opts.inputErrorClass, $form).not('small').removeClass(opts.inputErrorClass);
-    $(opts.formErrorSelector + '.' + opts.formErrorClass).removeClass(opts.formErrorClass);
+    $(`.${opts.labelErrorClass}`, $form).not('small').removeClass(opts.labelErrorClass);
+    $(`.${opts.inputErrorClass}`, $form).not('small').removeClass(opts.inputErrorClass);
+    $(`${opts.formErrorSelector}.${opts.formErrorClass}`).removeClass(opts.formErrorClass);
     $form.find('[data-abide-error]').css('display', 'none');
     $(':input', $form).not(':button, :submit, :reset, :hidden, [data-abide-ignore]').val('').removeAttr('data-invalid');
     /**

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -65,7 +65,7 @@
       var $el = $(el),
           $content = $el.find('[data-tab-content]'),
           id = $content[0].id || Foundation.GetYoDigits(6, 'accordion'),
-          linkId = el.id || id + '-label';
+          linkId = el.id || `${id}-label`;
 
       $el.find('a:first').attr({
         'aria-controls': id,
@@ -175,7 +175,7 @@
     // if(!firstTime){
     //   Foundation._reflow(this.$element.attr('data-accordion'));
     // }
-    $('#' + $target.attr('aria-labelledby')).attr({
+    $(`#${$target.attr('aria-labelledby')}`).attr({
       'aria-expanded': true,
       'aria-selected': true
     });
@@ -209,7 +209,7 @@
     $target.attr('aria-hidden', true)
            .parent().removeClass('is-active');
 
-    $('#' + $target.attr('aria-labelledby')).attr({
+    $(`#${$target.attr('aria-labelledby')}`).attr({
      'aria-expanded': false,
      'aria-selected': false
    });

--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -52,13 +52,13 @@ var Foundation = {
     var pluginName = name ? hyphenate(name) : functionName(plugin.constructor).toLowerCase();
     plugin.uuid = this.GetYoDigits(6, pluginName);
 
-    if(!plugin.$element.attr('data-' + pluginName)){ plugin.$element.attr('data-' + pluginName, plugin.uuid); }
+    if(!plugin.$element.attr(`data-${pluginName}`)){ plugin.$element.attr(`data-${pluginName}`, plugin.uuid); }
     if(!plugin.$element.data('zfPlugin')){ plugin.$element.data('zfPlugin', plugin); }
           /**
            * Fires when the plugin has initialized.
            * @event Plugin#init
            */
-    plugin.$element.trigger('init.zf.' + pluginName);
+    plugin.$element.trigger(`init.zf.${pluginName}`);
 
     this._uuids.push(plugin.uuid);
 
@@ -76,12 +76,12 @@ var Foundation = {
     var pluginName = hyphenate(functionName(plugin.$element.data('zfPlugin').constructor));
 
     this._uuids.splice(this._uuids.indexOf(plugin.uuid), 1);
-    plugin.$element.removeAttr('data-' + pluginName).removeData('zfPlugin')
+    plugin.$element.removeAttr(`data-${pluginName}`).removeData('zfPlugin')
           /**
            * Fires when the plugin has been destroyed.
            * @event Plugin#destroyed
            */
-          .trigger('destroyed.zf.' + pluginName);
+          .trigger(`destroyed.zf.${pluginName}`);
     for(var prop in plugin){
       plugin[prop] = null;//clean up script to prep for garbage collection.
     }
@@ -136,7 +136,7 @@ var Foundation = {
    */
   GetYoDigits: function(length, namespace){
     length = length || 6;
-    return Math.round((Math.pow(36, length + 1) - Math.random() * Math.pow(36, length))).toString(36).slice(1) + (namespace ? '-' + namespace : '');
+    return Math.round((Math.pow(36, length + 1) - Math.random() * Math.pow(36, length))).toString(36).slice(1) + (namespace ? `-${namespace}` : '');
   },
   /**
    * Initialize plugins on any elements within `elem` (and `elem` itself) that aren't already initialized.
@@ -279,7 +279,7 @@ var foundation = function(method) {
       throw new ReferenceError("We're sorry, '" + method + "' is not an available method for " + (plugClass ? functionName(plugClass) : 'this element') + '.');
     }
   }else{//error for invalid argument type
-    throw new TypeError("We're sorry, '" + type + "' is not a valid parameter. You must use a string representing the method you wish to invoke.");
+    throw new TypeError(`We're sorry, ${type} is not a valid parameter. You must use a string representing the method you wish to invoke.`);
   }
   return this;
 };

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -292,8 +292,8 @@
       max = numOfElems > max ? numOfElems : max;
     });
 
-    result.height = max * this.$menuItems[0].getBoundingClientRect().height + 'px';
-    result.width = this.$element[0].getBoundingClientRect().width + 'px';
+    result.height = `${max * this.$menuItems[0].getBoundingClientRect().height}px`;
+    result.width = `${this.$element[0].getBoundingClientRect().width}px`;
 
     return result;
   };

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -93,7 +93,7 @@
   Dropdown.prototype._init = function(){
     var $id = this.$element.attr('id');
 
-    this.$anchor = $('[data-toggle="' + $id + '"]') || $('[data-open="' + $id + '"]');
+    this.$anchor = $(`[data-toggle="${$id}"]`) || $(`[data-open="${$id}"]`);
     this.$anchor.attr({
       'aria-controls': $id,
       'data-is-focus': false,

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -139,7 +139,7 @@
 
     if(this.options.clickOpen || hasTouch){
       this.$menuItems.on('click.zf.dropdownmenu touchstart.zf.dropdownmenu', function(e){
-        var $elem = $(e.target).parentsUntil('ul', '.' + parClass),
+        var $elem = $(e.target).parentsUntil('ul', `.${parClass}`),
             hasSub = $elem.hasClass(parClass),
             hasClicked = $elem.attr('data-is-click') === 'true',
             $sub = $elem.children('.is-dropdown-submenu');
@@ -156,7 +156,7 @@
             e.preventDefault();
             e.stopImmediatePropagation();
             _this._show($elem.children('.is-dropdown-submenu'));
-            $elem.add($elem.parentsUntil(_this.$element, '.' + parClass)).attr('data-is-click', true);
+            $elem.add($elem.parentsUntil(_this.$element, `.${parClass}`)).attr('data-is-click', true);
           }
         }else{ return; }
       });
@@ -314,10 +314,10 @@
     if(!clear){
       var oldClass = this.options.alignment === 'left' ? '-right' : '-left',
           $parentLi = $sub.parent('.is-dropdown-submenu-parent');
-      $parentLi.removeClass('opens' + oldClass).addClass('opens-' + this.options.alignment);
+      $parentLi.removeClass(`opens${oldClass}`).addClass(`opens-${this.options.alignment}`);
       clear = Foundation.Box.ImNotTouchingYou($sub, null, true);
       if(!clear){
-        $parentLi.removeClass('opens-' + this.options.alignment).addClass('opens-inner');
+        $parentLi.removeClass(`opens-${this.options.alignment}`).addClass('opens-inner');
       }
       this.changed = true;
     }
@@ -363,8 +363,8 @@
       if(this.changed || $toClose.find('opens-inner').length){
         var oldClass = this.options.alignment === 'left' ? 'right' : 'left';
         $toClose.find('li.is-dropdown-submenu-parent').add($toClose)
-                .removeClass('opens-inner opens-' + this.options.alignment)
-                .addClass('opens-' + oldClass);
+                .removeClass(`opens-inner opens-${this.options.alignment}`)
+                .addClass(`opens-${oldClass}`);
         this.changed = false;
       }
       /**

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -47,7 +47,7 @@
    */
   Equalizer.prototype._init = function(){
     var eqId = this.$element.attr('data-equalizer') || '';
-    var $watched = this.$element.find('[data-equalizer-watch="' + eqId + '"]');
+    var $watched = this.$element.find(`[data-equalizer-watch="${eqId}"]`);
 
     this.$watched = $watched.length ? $watched : this.$element.find('[data-equalizer-watch]');
     this.$element.attr('data-resize', (eqId || Foundation.GetYoDigits(6, 'eq')));

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -204,7 +204,7 @@
    */
   Magellan.prototype.destroy = function(){
     this.$element.off('.zf.trigger .zf.magellan')
-        .find('.' + this.options.activeClass).removeClass(this.options.activeClass);
+        .find(`.${this.options.activeClass}`).removeClass(this.options.activeClass);
 
     if(this.options.deepLinking){
       var hash = this.$active[0].getAttribute('href');

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -304,7 +304,7 @@ OffCanvas.prototype.close = function(cb) {
   var _this = this;
 
   //  Foundation.Move(this.options.transitionTime, this.$element, function(){
-  $('[data-off-canvas-wrapper]').removeClass('is-off-canvas-open is-open-' + _this.options.position);
+  $('[data-off-canvas-wrapper]').removeClass(`is-off-canvas-open is-open-${_this.options.position}`);
   _this.$element.removeClass('is-open');
     // Foundation._reflow();
   // });

--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -149,8 +149,8 @@
   * @private
   */
   Orbit.prototype._init = function(){
-    this.$wrapper = this.$element.find('.' + this.options.containerClass);
-    this.$slides = this.$element.find('.' + this.options.slideClass);
+    this.$wrapper = this.$element.find(`.${this.options.containerClass}`);
+    this.$slides = this.$element.find(`.${this.options.slideClass}`);
     var $images = this.$element.find('img'),
     initActive = this.$slides.filter('.is-active');
 
@@ -185,7 +185,7 @@
   * @private
   */
   Orbit.prototype._loadBullets = function(){
-    this.$bullets = this.$element.find('.' + this.options.boxOfBullets).find('button');
+    this.$bullets = this.$element.find(`.${this.options.boxOfBullets}`).find('button');
   };
   /**
   * Sets a `timer` object on the orbit, and starts the counter for the next slide.
@@ -291,7 +291,7 @@
           }
 
           if(this.options.navButtons){
-            var $controls = this.$element.find('.' + this.options.nextClass + ', .' + this.options.prevClass);
+            var $controls = this.$element.find(`.${this.options.nextClass}, .${this.options.prevClass}`);
             $controls.attr('tabindex', 0)
             //also need to handle enter/return and spacebar key presses
             .on('click.zf.orbit touchend.zf.orbit', function(){
@@ -350,9 +350,9 @@
 
         if(!chosenSlide){//most of the time, this will be auto played or clicked from the navButtons.
           $newSlide = isLTR ? //if wrapping enabled, check to see if there is a `next` or `prev` sibling, if not, select the first or last slide to fill in. if wrapping not enabled, attempt to select `next` or `prev`, if there's nothing there, the function will kick out on next step. CRAZY NESTED TERNARIES!!!!!
-          (this.options.infiniteWrap ? $curSlide.next('.' + this.options.slideClass).length ? $curSlide.next('.' + this.options.slideClass) : $firstSlide : $curSlide.next('.' + this.options.slideClass))//pick next slide if moving left to right
+          (this.options.infiniteWrap ? $curSlide.next(`.${this.options.slideClass}`).length ? $curSlide.next(`.${this.options.slideClass}`) : $firstSlide : $curSlide.next(`.${this.options.slideClass}`))//pick next slide if moving left to right
           :
-          (this.options.infiniteWrap ? $curSlide.prev('.' + this.options.slideClass).length ? $curSlide.prev('.' + this.options.slideClass) : $lastSlide : $curSlide.prev('.' + this.options.slideClass));//pick prev slide if moving right to left
+          (this.options.infiniteWrap ? $curSlide.prev(`.${this.options.slideClass}`).length ? $curSlide.prev(`.${this.options.slideClass}`) : $lastSlide : $curSlide.prev(`.${this.options.slideClass}`));//pick prev slide if moving right to left
         }else{
           $newSlide = chosenSlide;
         }
@@ -365,7 +365,7 @@
 
             Foundation.Motion.animateIn(
               $newSlide.addClass('is-active').css({'position': 'absolute', 'top': 0}),
-              this.options['animInFrom' + dirIn],
+              this.options[`animInFrom${dirIn}`],
               function(){
                 $newSlide.css({'position': 'relative', 'display': 'block'})
                 .attr('aria-live', 'polite');
@@ -373,7 +373,7 @@
 
               Foundation.Motion.animateOut(
                 $curSlide.removeClass('is-active'),
-                this.options['animOutTo' + dirOut],
+                this.options[`animOutTo${dirOut}`],
                 function(){
                   $curSlide.removeAttr('aria-live');
                   if(_this.options.autoPlay && !_this.timer.isPaused){
@@ -402,7 +402,7 @@
           * @param {Number} idx - the index of the current slide.
           */
           Orbit.prototype._updateBullets = function(idx){
-            var $oldBullet = this.$element.find('.' + this.options.boxOfBullets)
+            var $oldBullet = this.$element.find(`.${this.options.boxOfBullets}`)
             .find('.is-active').removeClass('is-active').blur(),
             span = $oldBullet.find('span:last').detach(),
             $newBullet = this.$bullets.eq(idx).addClass('is-active').append(span);

--- a/js/foundation.responsiveToggle.js
+++ b/js/foundation.responsiveToggle.js
@@ -44,7 +44,7 @@ ResponsiveToggle.prototype._init = function() {
     console.error('Your tab bar needs an ID of a Menu as the value of data-tab-bar.');
   }
 
-  this.$targetMenu = $('#'+targetID);
+  this.$targetMenu = $(`#${targetID}`);
   this.$toggler = this.$element.find('[data-toggle]');
 
   this._update();

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -127,7 +127,7 @@
     this.id = this.$element.attr('id');
     this.isActive = false;
 
-    this.$anchor = $('[data-open="' + this.id + '"]').length ? $('[data-open="' + this.id + '"]') : $('[data-toggle="' + this.id + '"]');
+    this.$anchor = $(`[data-open="${this.id}"]`).length ? $(`[data-open="${this.id}"]`) : $(`[data-toggle="${this.id}"]`);
 
     if(this.$anchor.length){
       var anchorId = this.$anchor[0].id || Foundation.GetYoDigits(6, 'reveal');
@@ -158,7 +158,7 @@
     });
 
     this._events();
-    if(this.options.deepLink && window.location.hash === ( '#' + this.id)){
+    if(this.options.deepLink && window.location.hash === ( `#${this.id}`)){
       $(window).one('load.zf.reveal', this.open.bind(this));
     }
   };
@@ -213,7 +213,7 @@
       this.$overlay.off('.zf.reveal').on('click.zf.reveal', this.close.bind(this));
     }
     if(this.options.deepLink){
-      $(window).on('popstate.zf.reveal:' + this.id, this._handleState.bind(this));
+      $(window).on(`popstate.zf.reveal:${this.id}`, this._handleState.bind(this));
     }
   };
   /**
@@ -221,7 +221,7 @@
    * @private
    */
   Reveal.prototype._handleState = function(e){
-    if(window.location.hash === ( '#' + this.id) && !this.isActive){ this.open(); }
+    if(window.location.hash === ( `#${this.id}`) && !this.isActive){ this.open(); }
     else{ this.close(); }
   };
   /**
@@ -271,7 +271,7 @@
    */
   Reveal.prototype.open = function(){
     if(this.options.deepLink){
-      var hash = '#' + this.id;
+      var hash = `#${this.id}`;
 
       if(window.history.pushState){
         window.history.pushState(null, null, hash);
@@ -496,7 +496,7 @@
     }
     this.$element.hide().off();
     this.$anchor.off('.zf');
-    $(window).off('.zf.reveal:' + this.id);
+    $(window).off(`.zf.reveal:${this.id}`);
 
     Foundation.unregisterPlugin(this);
   };

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -146,7 +146,7 @@
     this.handles = this.$element.find('[data-slider-handle]');
 
     this.$handle = this.handles.eq(0);
-    this.$input = this.inputs.length ? this.inputs.eq(0) : $('#' + this.$handle.attr('aria-controls'));
+    this.$input = this.inputs.length ? this.inputs.eq(0) : $(`#${this.$handle.attr('aria-controls')}`);
     this.$fill = this.$element.find('[data-slider-fill]').css(this.options.vertical ? 'height' : 'width', 0);
 
     var isDbl = false,
@@ -165,7 +165,7 @@
     if(this.handles[1]){
       this.options.doubleSided = true;
       this.$handle2 = this.handles.eq(1);
-      this.$input2 = this.inputs.length > 1 ? this.inputs.eq(1) : $('#' + this.$handle2.attr('aria-controls'));
+      this.$input2 = this.inputs.length > 1 ? this.inputs.eq(1) : $(`#${this.$handle2.attr('aria-controls')}`);
 
       if(!this.inputs[1]){
         this.inputs = this.inputs.add(this.$input2);
@@ -249,7 +249,7 @@
       //if left handle, the math is slightly different than if it's the right handle, and the left/top property needs to be changed for the fill bar
       if(isLeftHndl){
         //left or top percentage value to apply to the fill bar.
-        css[lOrT] = movement + '%';
+        css[lOrT] = `${movement}%`;
         //calculate the new min-height/width for the fill bar.
         dim = parseFloat(this.$handle2[0].style[lOrT]) - movement + handlePct;
         //this callback is necessary to prevent errors and allow the proper placement and initialization of a 2-handled slider
@@ -263,7 +263,7 @@
         dim = movement - (isNaN(handlePos) ? this.options.initialStart : handlePos) + handlePct;
       }
       // assign the min-height/width to our css object
-      css['min-' + hOrW] = dim + '%';
+      css[`min-${hOrW}`] = `${dim}%`;
     }
 
     this.$element.one('finished.zf.animate', function(){
@@ -279,11 +279,11 @@
 
     Foundation.Move(moveTime, $hndl, function(){
       //adjusting the left/top property of the handle, based on the percentage calculated above
-      $hndl.css(lOrT, movement + '%');
+      $hndl.css(lOrT, `${movement}%`);
 
       if(!_this.options.doubleSided){
         //if single-handled, a simple method to expand the fill bar
-        _this.$fill.css(hOrW, pctOfBar * 100 + '%');
+        _this.$fill.css(hOrW, `${pctOfBar * 100}%`);
       }else{
         //otherwise, use the css object we created above
         _this.$fill.css(css);

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -114,7 +114,7 @@
     this.isStuck = false;
 
     if(this.options.anchor !== ''){
-      this.$anchor = $('#' + this.options.anchor);
+      this.$anchor = $(`#${this.options.anchor}`);
     }else{
       this._parsePoints();
     }
@@ -142,7 +142,7 @@
           pt = pts[i];
         }else{
           var place = pts[i].split(':'),
-              anchor = $('#' + place[0]);
+              anchor = $(`#${place[0]}`);
 
           pt = anchor.offset().top;
           if(place[1] && place[1].toLowerCase() === 'bottom'){
@@ -166,7 +166,7 @@
    */
   Sticky.prototype._events = function(id){
     var _this = this,
-        scrollListener = this.scrollListener = 'scroll.zf.' + id;
+        scrollListener = this.scrollListener = `scroll.zf.${id}`;
     if(this.isOn){ return; }
     if(this.canStick){
       this.isOn = true;
@@ -263,20 +263,20 @@
         notStuckTo = stickTo === 'top' ? 'bottom' : 'top',
         css = {};
 
-    css[mrgn] = this.options[mrgn] + 'em';
+    css[mrgn] = `${this.options[mrgn]}em`;
     css[stickTo] = 0;
     css[notStuckTo] = 'auto';
     css['left'] = this.$container.offset().left + parseInt(window.getComputedStyle(this.$container[0])["padding-left"], 10);
     this.isStuck = true;
-    this.$element.removeClass('is-anchored is-at-' + notStuckTo)
-                 .addClass('is-stuck is-at-' + stickTo)
+    this.$element.removeClass(`is-anchored is-at-${notStuckTo}`)
+                 .addClass(`is-stuck is-at-${stickTo}`)
                  .css(css)
                  /**
                   * Fires when the $element has become `position: fixed;`
                   * Namespaced to `top` or `bottom`.
                   * @event Sticky#stuckto
                   */
-                 .trigger('sticky.zf.stuckto:' + stickTo);
+                 .trigger(`sticky.zf.stuckto:${stickTo}`);
   };
 
   /**
@@ -308,15 +308,15 @@
 
     css['left'] = '';
     this.isStuck = false;
-    this.$element.removeClass('is-stuck is-at-' + stickTo)
-                 .addClass('is-anchored is-at-' + topOrBottom)
+    this.$element.removeClass(`is-stuck is-at-${stickTo}`)
+                 .addClass(`is-anchored is-at-${topOrBottom}`)
                  .css(css)
                  /**
                   * Fires when the $element has become anchored.
                   * Namespaced to `top` or `bottom`.
                   * @event Sticky#unstuckfrom
                   */
-                 .trigger('sticky.zf.unstuckfrom:' + topOrBottom);
+                 .trigger(`sticky.zf.unstuckfrom:${topOrBottom}`);
   };
 
   /**
@@ -340,7 +340,7 @@
     }
 
     this.$element.css({
-      'max-width': newElemWidth - pdng + 'px'
+      'max-width': `${newElemWidth - pdng}px`
     });
 
     var newContainerHeight = this.$element[0].getBoundingClientRect().height || this.containerHeight;
@@ -403,7 +403,7 @@
   Sticky.prototype.destroy = function(){
     this._removeSticky(true);
 
-    this.$element.removeClass(this.options.stickyClass + ' is-anchored is-at-top')
+    this.$element.removeClass(`${this.options.stickyClass} is-anchored is-at-top`)
                  .css({
                    height: '',
                    top: '',

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -81,16 +81,16 @@
   Tabs.prototype._init = function(){
     var _this = this;
 
-    this.$tabTitles = this.$element.find('.' + this.options.linkClass);
-    this.$tabContent = $('[data-tabs-content="' + this.$element[0].id + '"]');
+    this.$tabTitles = this.$element.find(`.${this.options.linkClass}`);
+    this.$tabContent = $(`[data-tabs-content="${this.$element[0].id}"]`);
 
     this.$tabTitles.each(function(){
       var $elem = $(this),
           $link = $elem.find('a'),
           isActive = $elem.hasClass('is-active'),
           hash = $link[0].hash.slice(1),
-          linkId = $link[0].id ? $link[0].id : hash + '-label',
-          $tabContent = $('#' + hash);
+          linkId = $link[0].id ? $link[0].id : `hash${-label}`,
+          $tabContent = $(`#${hash}`);
 
       $elem.attr({'role': 'presentation'});
 
@@ -140,7 +140,7 @@
   Tabs.prototype._addClickHandler = function(){
     var _this = this;
     this.$element.off('click.zf.tabs')
-                   .on('click.zf.tabs', '.' + this.options.linkClass, function(e){
+                   .on('click.zf.tabs', `.${this.options.linkClass}`, function(e){
                      e.preventDefault();
                      e.stopPropagation();
                      if($(this).hasClass('is-active')){
@@ -211,11 +211,11 @@
     var $tabLink = $target.find('[role="tab"]'),
         hash = $tabLink[0].hash,
         $targetContent = $(hash),
-        $oldTab = this.$element.find('.' + this.options.linkClass + '.is-active')
+        $oldTab = this.$element.find(`.${this.options.linkClass}.is-active`)
                   .removeClass('is-active').find('[role="tab"]')
                   .attr({'aria-selected': 'false'}).attr('aria-controls');
 
-    $('#'+$oldTab).removeClass('is-active').attr({'aria-hidden': 'true'});
+    $(`#${$oldTab}`).removeClass('is-active').attr({'aria-hidden': 'true'});
 
     $target.addClass('is-active');
 
@@ -247,9 +247,9 @@
     }
 
     if(idStr.indexOf('#') < 0){
-      idStr = '#' + idStr;
+      idStr = `#${idStr}`;
     }
-    var $target = this.$tabTitles.find('[href="' + idStr + '"]').parent('.' + this.options.linkClass);
+    var $target = this.$tabTitles.find(`[href="${idStr}"]`).parent(`.${this.options.linkClass}`);
 
     this._handleTabChange($target);
   };
@@ -262,7 +262,7 @@
    */
   Tabs.prototype._setHeight = function(){
     var max = 0;
-    this.$tabContent.find('.' + this.options.panelClass)
+    this.$tabContent.find(`.${this.options.panelClass}`)
                     .css('height', '')
                     .each(function(){
                       var panel = $(this),
@@ -279,7 +279,7 @@
 
                       max = temp > max ? temp : max;
                     })
-                    .css('height', max + 'px');
+                    .css('height', `${max}px`);
   };
 
   /**
@@ -287,9 +287,9 @@
    * @fires Tabs#destroyed
    */
   Tabs.prototype.destroy = function() {
-    this.$element.find('.' + this.options.linkClass)
+    this.$element.find(`.${this.options.linkClass}`)
                  .off('.zf.tabs').hide().end()
-                 .find('.' + this.options.panelClass)
+                 .find(`.${this.options.panelClass}`)
                  .hide();
     if(this.options.matchHeight){
       $(window).off('changed.zf.mediaquery');

--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -57,7 +57,7 @@
 
     // Add ARIA attributes to triggers
     var id = this.$element[0].id;
-    $('[data-open="'+id+'"], [data-close="'+id+'"], [data-toggle="'+id+'"]')
+    $(`[data-open="${id}"], [data-close="${id}"], [data-toggle="${id}"]`)
       .attr('aria-controls', id);
     // If the target is hidden, add aria-hidden
     this.$element.attr('aria-expanded', this.$element.is(':hidden') ? false : true);

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -161,7 +161,7 @@
    * @private
    */
   Tooltip.prototype._buildTemplate = function(id){
-    var templateClasses = (this.options.tooltipClass + ' ' + this.options.positionClass + ' ' + this.options.templateClasses).trim();
+    var templateClasses = (`${this.options.tooltipClass} ${this.options.positionClass} ${this.options.templateClasses}`).trim();
     var $template =  $('<div></div>').addClass(templateClasses).attr({
       'role': 'tooltip',
       'aria-hidden': true,

--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -40,9 +40,9 @@
    */
   var parseKey = function(event) {
     var key = keyCodes[event.which || event.keyCode] || String.fromCharCode(event.which).toUpperCase();
-    if (event.shiftKey) key = 'SHIFT_' + key;
-    if (event.ctrlKey) key = 'CTRL_' + key;
-    if (event.altKey) key = 'ALT_' + key;
+    if (event.shiftKey) key = `SHIFT_${key}`;
+    if (event.ctrlKey) key = `CTRL_${key}`;
+    if (event.altKey) key = `ALT_${key}`;
     return key;
   };
   Foundation.Keyboard.parseKey = parseKey;

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -63,7 +63,7 @@ var MediaQuery = {
     for (var key in namedQueries) {
       self.queries.push({
         name: key,
-        value: 'only screen and (min-width: ' + namedQueries[key] + ')'
+        value: `only screen and (min-width: ${namedQueries[key]})`
       });
     }
 
@@ -147,7 +147,7 @@ window.matchMedia || (window.matchMedia = function() {
 
     styleMedia = {
       matchMedium: function(media) {
-        var text = '@media ' + media + '{ #matchmediajs-test { width: 1px; } }';
+        var text = `@media ${media}{ #matchmediajs-test { width: 1px; } }`;
 
         // 'style.styleSheet' is used by IE <= 8 and 'style.textContent' for all other browsers
         if (style.styleSheet) {

--- a/js/foundation.util.motion.js
+++ b/js/foundation.util.motion.js
@@ -50,7 +50,7 @@ function animate(isIn, element, animation, cb) {
   // Resets transitions and removes motion-specific classes
   function reset() {
     element[0].style.transitionDuration = 0;
-    element.removeClass(initClass + ' ' + activeClass + ' ' + animation);
+    element.removeClass(`${initClass} ${activeClass} ${animation}`);
   }
 }
 

--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -5,9 +5,9 @@
       menu.attr('role', 'menubar');
       type = type || 'zf';
       var items = menu.find('li').attr({'role': 'menuitem'}),
-          subMenuClass = 'is-' + type + '-submenu',
-          subItemClass = subMenuClass + '-item',
-          hasSubClass = 'is-' + type + '-submenu-parent';
+          subMenuClass = `is-${type}-submenu`,
+          subItemClass = `${subMenuClass}-item`,
+          hasSubClass = `is-${type}-submenu-parent`;
       menu.find('a:first').attr('tabindex', 0);
       items.each(function(){
         var $item = $(this),
@@ -19,7 +19,7 @@
                  'aria-expanded': false,
                  'aria-label': $item.children('a:first').text()
                });
-          $sub.addClass('submenu ' + subMenuClass)
+          $sub.addClass(`submenu ${subMenuClass}`)
               .attr({
                 'data-submenu': '',
                 'aria-hidden': true,
@@ -27,21 +27,21 @@
               });
         }
         if($item.parent('[data-submenu]').length){
-          $item.addClass('is-submenu-item ' + subItemClass);
+          $item.addClass(`is-submenu-item ${subItemClass}`);
         }
       });
       return;
     },
     Burn: function(menu, type){
       var items = menu.find('li').removeAttr('tabindex'),
-          subMenuClass = 'is-' + type + '-submenu',
-          subItemClass = subMenuClass + '-item',
-          hasSubClass = 'is-' + type + '-submenu-parent';
+          subMenuClass = `is-${type}-submenu`,
+          subItemClass = `${subMenuClass}-item`,
+          hasSubClass = `is-${type}-submenu-parent`;
 
       // menu.find('.is-active').removeClass('is-active');
       menu.find('*')
       // menu.find('.' + subMenuClass + ', .' + subItemClass + ', .is-active, .has-submenu, .is-submenu-item, .submenu, [data-submenu]')
-          .removeClass(subMenuClass + ' ' + subItemClass + ' ' + hasSubClass + ' is-submenu-item submenu is-active')
+          .removeClass(`${subMenuClass} ${subItemClass} ${hasSubClass} is-submenu-item submenu is-active`)
           .removeAttr('data-submenu').css('display', '');
 
       // console.log(      menu.find('.' + subMenuClass + ', .' + subItemClass + ', .has-submenu, .is-submenu-item, .submenu, [data-submenu]')

--- a/js/foundation.util.timerAndImageLoader.js
+++ b/js/foundation.util.timerAndImageLoader.js
@@ -29,7 +29,7 @@
         }
         cb();
       }, remain);
-      elem.trigger('timerstart.zf.' + nameSpace);
+      elem.trigger(`timerstart.zf.${nameSpace}`);
     };
 
     this.pause = function(){
@@ -39,7 +39,7 @@
       elem.data('paused', true);
       var end = Date.now();
       remain = remain - (end - start);
-      elem.trigger('timerpaused.zf.' + nameSpace);
+      elem.trigger(`timerpaused.zf.${nameSpace}`);
     };
   };
   /**

--- a/js/foundation.util.touch.js
+++ b/js/foundation.util.touch.js
@@ -43,7 +43,7 @@
       if(dir) {
         e.preventDefault();
         onTouchEnd.call(this);
-        $(this).trigger('swipe', dir).trigger('swipe' + dir);
+        $(this).trigger('swipe', dir).trigger(`swipe${dir}`);
       }
     }
   }
@@ -70,7 +70,7 @@
   $.event.special.swipe = { setup: init };
 
   $.each(['left', 'up', 'down', 'right'], function () {
-    $.event.special['swipe' + this] = { setup: function(){
+    $.event.special[`swipe${this}`] = { setup: function(){
       $(this).on('swipe', $.noop);
     } };
   });

--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -41,8 +41,8 @@
   var MutationObserver = (function () {
     var prefixes = ['WebKit', 'Moz', 'O', 'Ms', ''];
     for (var i=0; i < prefixes.length; i++) {
-      if (prefixes[i] + 'MutationObserver' in window) {
-        return window[prefixes[i] + 'MutationObserver'];
+      if (`${prefixes[i]}MutationObserver` in window) {
+        return window[`${prefixes[i]}MutationObserver`];
       }
     }
     return false;
@@ -85,7 +85,7 @@
 
       $(window).off(listeners).on(listeners, function(e, pluginId){
         var plugin = e.namespace.split('.')[0];
-        var plugins = $('[data-' + plugin + ']').not('[data-yeti-box="' + pluginId + '"]');
+        var plugins = $(`[data-${plugin}]`).not(`[data-yeti-box="${pluginId}"]`);
 
         plugins.each(function(){
           var _this = $(this);

--- a/test/sass/_value.scss
+++ b/test/sass/_value.scss
@@ -102,19 +102,17 @@
     @include assert-equal($defaultColor, black, $defaultDescription);
   }
 
-  // TODO: Add spec for pow()
-}
-
-@include describe('Map Deep Get') {
-  @include it('gets a value from a nested map') {
+  @include test('Map Deep Get [function]') {
     $map: (
       one: (
         two: 'three',
       ),
     );
-
-    @include should(expect(map-deep-get($map, one, two)), to(be('three')));
+    $expect: 'three';
+    
+    @include assert-equal(map-deep-get($map, one, two), $expect,
+      'Gets a value from a nested map');
   }
-}
 
-// TODO: Add spec for pow()
+  // TODO: Add spec for pow()
+}


### PR DESCRIPTION
I went through all of the JavaScript files and searched for `+ '`, `+'`,  `+ "`,  `+"`, `' +`, `'+`, `" +`, and `"+` to find places where I could replace concatenation with template literals.

Be forewarned, this is my first time using ES6/Babel and I was not sure if template literals are allowed everywhere I used them. I also have not had a chance to go through every component to verify they still work after migrating to template literals.
