### PR TITLE
Added button-color-alt variable to mixin

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -99,7 +99,7 @@ $button-opacity-disabled: 0.25 !default;
   $color: $button-color
 ) {
   @if $color == auto {
-    $color: foreground($background);
+    $color: foreground($background, $button-color-alt, $button-color);
   }
 
   @if $background-hover == auto {
@@ -203,7 +203,7 @@ $button-opacity-disabled: 0.25 !default;
     @each $name, $color in $foundation-colors {
       @if $button-fill != hollow {
         &.#{$name} {
-          @include button-style($color, auto);
+          @include button-style($color, auto, auto);
         }
       }
       @else {


### PR DESCRIPTION
The alternative font color for buttons wasn't present in the button-style mixin, and the button-style constructor for alternative colors was missing the `auto` parameter to get the foreground function working.
Every button, regardless of the lightness of the background color was getting white fonts…
