### PR TITLE
Adds the parentLink option - false by default.

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -49,6 +49,12 @@
      */
     wrapper: '<div></div>',
     /**
+     * Adds the parent link to the submenu.
+     * @option
+     * @example false
+     */
+    parentLink: false,
+    /**
      * Allow the menu to return to top level menu on body click.
      * @option
      * @example false
@@ -84,6 +90,9 @@
     this.$submenuAnchors.each(function(){
       var $sub = $(this);
       var $link = $sub.find('a:first');
+      if(_this.options.parentLink){
+        $link.clone().prependTo($sub).children('[data-submenu]').wrap('<li class="is-submenu-parent-item is-submenu-item is-drilldown-submenu-item" role="menu-item"></li>');
+      }
       $link.data('savedHref', $link.attr('href')).removeAttr('href');
       $sub.children('[data-submenu]')
           .attr({
@@ -305,7 +314,7 @@
     this._hideAll();
     Foundation.Nest.Burn(this.$element, 'drilldown');
     this.$element.unwrap()
-                 .find('.js-drilldown-back').remove()
+                 .find('.js-drilldown-back, .is-submenu-parent-item').remove()
                  .end().find('.is-active, .is-closing, .is-drilldown-submenu').removeClass('is-active is-closing is-drilldown-submenu')
                  .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role')
                  .off('.zf.drilldown').end().off('zf.drilldown');

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -91,7 +91,7 @@
       var $sub = $(this);
       var $link = $sub.find('a:first');
       if(_this.options.parentLink){
-        $link.clone().prependTo($sub).children('[data-submenu]').wrap('<li class="is-submenu-parent-item is-submenu-item is-drilldown-submenu-item" role="menu-item"></li>');
+        $link.clone().prependTo($sub.children('[data-submenu]')).wrap('<li class="is-submenu-parent-item is-submenu-item is-drilldown-submenu-item" role="menu-item"></li>');
       }
       $link.data('savedHref', $link.attr('href')).removeAttr('href');
       $sub.children('[data-submenu]')


### PR DESCRIPTION
Clones the parent menu link and prepends it to the submenu if the option is set to true.
Need some input on this for the correct way to achieve this, but it works correctly in my testing.

Also ideally should it should work with the Nest library to add the classes etc that way, rather than me adding them in the drilldown.js file.

I would love to hear thoughts and improve the code so we can get this added - I really need this in order to use the menu :smile:

See issues [7770](https://github.com/zurb/foundation-sites/issues/7770) and [7993](https://github.com/zurb/foundation-sites/issues/7993)
