### PR TITLE
Search for the target tab content within existing tab content

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -210,7 +210,7 @@
   Tabs.prototype._handleTabChange = function($target){
     var $tabLink = $target.find('[role="tab"]'),
         hash = $tabLink[0].hash,
-        $targetContent = $(hash),
+        $targetContent = this.$tabContent.find(hash),
         $oldTab = this.$element.find('.' + this.options.linkClass + '.is-active')
                   .removeClass('is-active').find('[role="tab"]')
                   .attr({'aria-selected': 'false'}).attr('aria-controls');


### PR DESCRIPTION
Search for the target tab content within existing tab content instead of the global jQuery context. This makes the code more internally consistent, and resolves a unit testing issue where the Foundation Tabs element doesn't exist in the global jQuery context.
