### PR TITLE
Add parentLink option to drilldown

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -49,6 +49,12 @@
      */
     wrapper: '<div></div>',
     /**
+     * Adds the parent link to the submenu.
+     * @option
+     * @example false
+     */
+    parentLink: false,
+    /**
      * Allow the menu to return to root list on body click.
      * @option
      * @example false
@@ -84,6 +90,9 @@
     this.$submenuAnchors.each(function(){
       var $sub = $(this);
       var $link = $sub.find('a:first');
+      if(_this.options.parentLink){
+        $link.clone().prependTo($sub.children('[data-submenu]')).wrap('<li class="is-submenu-parent-item is-submenu-item is-drilldown-submenu-item" role="menu-item"></li>');
+      }
       $link.data('savedHref', $link.attr('href')).removeAttr('href');
       $sub.children('[data-submenu]')
           .attr({
@@ -305,7 +314,7 @@
     this._hideAll();
     Foundation.Nest.Burn(this.$element, 'drilldown');
     this.$element.unwrap()
-                 .find('.js-drilldown-back').remove()
+                 .find('.js-drilldown-back, .is-submenu-parent-item').remove()
                  .end().find('.is-active, .is-closing, .is-drilldown-submenu').removeClass('is-active is-closing is-drilldown-submenu')
                  .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role')
                  .off('.zf.drilldown').end().off('zf.drilldown');


### PR DESCRIPTION
Add parentLink option to drilldowns (false by default).
This prepends the parent link to the submenu.
