### PR TITLE
Feature: added .alert, .warning and .success colors to switch input

### DIFF
--- a/docs/pages/switch.md
+++ b/docs/pages/switch.md
@@ -29,6 +29,37 @@ Give the `<input>` a unique ID and point the `<label>` to it with the `for` attr
 
 ---
 
+## Coloring
+
+Switch paddle can be colored, using the .success`, `.warning` or `.alert` classes.
+
+```html_example
+<div class="switch">
+  <input class="switch-input" id="exampleColorSwitch1" type="checkbox" name="exampleColorSwitch1">
+  <label class="switch-paddle success" for="exampleColorSwitch1">
+    <span class="show-for-sr">Pat the cat</span>
+  </label>
+</div>
+
+<div class="switch">
+  <input class="switch-input" id="exampleColorSwitch2" type="checkbox" name="exampleColorSwitch2">
+  <label class="switch-paddle warning" for="exampleColorSwitch2">
+    <span class="show-for-sr">Disable the cat</span>
+  </label>
+</div>
+
+<div class="switch">
+  <input class="switch-input" id="exampleColorSwitch3" type="checkbox" name="exampleColorSwitch3">
+  <label class="switch-paddle alert" for="exampleColorSwitch3">
+    <span class="show-for-sr">Delete cat food?</span>
+  </label>
+</div>
+```
+
+Alternatively, in your css, use following selector: `input:checked~.switch-paddle.yourclass`, where `yourclass` is a class name of your choice.
+
+---
+
 ## Radio Switch
 
 You can also use `<input type="radio">` instead of `checkbox` to create a series of options.

--- a/scss/components/_switch.scss
+++ b/scss/components/_switch.scss
@@ -14,6 +14,18 @@ $switch-background: $medium-gray !default;
 /// @type Color
 $switch-background-active: $primary-color !default;
 
+/// Background active color of a switch - semantic success
+/// @type Color
+$switch-background-active-success: $success-color !default;
+
+/// Background active color of a switch - semantic warning
+/// @type Color
+$switch-background-active-warning: $warning-color !default;
+
+/// Background active color of a switch - semantic alert
+/// @type Color
+$switch-background-active-alert: $alert-color !default;
+
 /// Height of a switch, with no class applied.
 /// @type Number
 $switch-height: 2rem !default;
@@ -115,6 +127,16 @@ $switch-paddle-transition: all 0.25s ease-out !default;
   // Change the visual style when the switch is active
   input:checked ~ & {
     background: $switch-background-active;
+
+    &.success {
+      background: $switch-background-active-success;
+    }
+    &.warning {
+      background: $switch-background-active-warning;
+    }
+    &.alert {
+      background: $switch-background-active-alert;
+    }
 
     &::after {
       #{$global-left}: 2.25rem;


### PR DESCRIPTION
|  |  |
| --- | --- |
| **Type** | Feature |
| **Fixes issues** | n/a |
| **Documentation** | updated |
| **BC Break** | no |

In our internal intranet, we have a shipping dispatch form built with Foundation.

In there, we have various checkboxes that update ERPs / suppliers interfaces / databases / etc. I wanted to bring one of those checkboxes to users attention when checked (since default is off, and when on, it does a lot of things _behind the scenes_).
Intuitively, I tried adding "warning" class to the checkbox label.... and nothing happened.

This fixes the "issue", if you agree that this might/should be part of standard.

Currently I'm using following in my app.scss tu spplement the feature:

``` scss
input:checked~.switch-paddle.alert { background: $alert-color; }
input:checked~.switch-paddle.warning { background: $warning-color; }
input:checked~.switch-paddle.success { background: $success-color; }
```

Let me know if this makes sense / you would want to somehow update this.

Thanks!
Pavel
