### PR TITLE
[tooltip.js] Add tooltip as html

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -126,7 +126,7 @@
     this.template = this.options.template ? $(this.options.template) : this._buildTemplate(elemId);
 
     this.template.appendTo(document.body)
-        .text(this.options.tipText)
+        .html(this.options.tipText)
         .hide();
 
     this.$element.attr({


### PR DESCRIPTION
Add tooltip as html rather than text, same behaviour as F5.
