### PR TITLE
Features for drilldown - get visible height on a hidden drilldown-menu

### DIFF
--- a/docs/pages/javascript-utilities.md
+++ b/docs/pages/javascript-utilities.md
@@ -15,6 +15,11 @@ One of the useful libraries is `Foundation.Box`, and it has a couple methods des
 ```js
 
 var dims = Foundation.Box.GetDimensions(element);
+
+// or to get dimension on an hidden element
+
+var dims = Foundation.Box.GetDimensions(element, true);
+
 ```
 Will return an object that contains the dimensions of the `element` passed. The object return looks like:
 

--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -22,11 +22,27 @@ $drilldown-arrow-color: $primary-color !default;
 /// @type Color
 $drilldown-background: $white !default;
 
+/// Enables auto width at breakpoint defined in $drilldown-auto-width-breakpoint
+/// @type Boolean
+$drilldown-auto-width: false !default;
+
+/// The breakpoint for activating the auto width
+/// @type String
+$drilldown-auto-width-breakpoint: small only !default;
+
 @mixin foundation-drilldown-menu {
   // Applied to the Menu container
   .is-drilldown {
     position: relative;
     overflow: hidden;
+    // When on small media then overwrite width
+    @if $drilldown-auto-width {
+      @media screen and #{breakpoint($drilldown-auto-width-breakpoint)} {
+        & {
+          width: auto !important;
+        }
+      }
+    }
   }
 
   // Applied to nested <ul>s
@@ -48,6 +64,17 @@ $drilldown-background: $white !default;
 
     &.is-closing {
       transform: translateX(if($global-text-direction == ltr, 100%, -100%));
+    }
+  }
+  // Only used for calculating max height and width
+  .is-drilldown-prepare {
+    .is-drilldown-submenu {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: -1;
+      height: auto;
+      height: auto;
     }
   }
 

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -281,6 +281,8 @@ $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
 $drilldown-arrow-color: $primary-color;
 $drilldown-background: $white;
+$drilldown-auto-width: false;
+$drilldown-auto-width-breakpoint: small only;
 
 // 16. Dropdown
 // ------------


### PR DESCRIPTION
also extend Foundation.Box.GetDimensions

foundation.drilldown.js - new Option showParentLink, if true then the parent button is prepended to the submenu, only if the parent href is set.

foundation.util.box.js - Extend Foundation.Box.GetDimensions to use on an hidden element

drilldown.scss
- new vars: $drilldown-auto-width and $drilldown-auto-width-breakpoint
  to set the width to auto at a specific breakpoint
- new css class .is-drilldown-prepare - is used for calculating the max height and width of the menu during preparing
