### PR TITLE
Fix invalid jQuery.on call which broke modal usage around jQuery ~v2.1.4

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -178,7 +178,7 @@
           if (e.namespace !== 'fndtn.reveal') return;
         });
 
-        modal.on('open.fndtn.reveal').trigger('open.fndtn.reveal');
+        modal.on('open.fndtn.reveal', false).trigger('open.fndtn.reveal');
 
         if (open_modal.length < 1) {
           this.toggle_bg(modal, true);


### PR DESCRIPTION
I ran into an issue where jQuery was returning the `window` object instead of a chainable jQuery instance in newer versions of jQuery.  Googling led to the following post that said to just downgrade to jQuery v2.1.4: http://foundation.zurb.com/forum/posts/37587-uncaught-typeerror-modalontrigger-is-not-a-function-when-using-zurb-foundation-553

Turns out the `on` method was not being passed a callback which caused the following chained method to fail.
