### PR TITLE
topbar feature - set a diffrent background color of all submenus

### DIFF
--- a/scss/components/_top-bar.scss
+++ b/scss/components/_top-bar.scss
@@ -14,6 +14,10 @@ $topbar-padding: 0.5rem !default;
 /// @type Color
 $topbar-background: $light-gray !default;
 
+/// Background color submenus within the top bar. Usefull if $topbar-background is transparent.
+/// @type Color
+$topbar-submenu-background: $topbar-background !default;
+
 /// Spacing for the top bar title.
 /// @type Number
 $topbar-title-spacing: 1rem !default;
@@ -39,6 +43,13 @@ $topbar-input-width: 200px !default;
   &,
   ul {
     background-color: $topbar-background;
+  }
+
+  // check if $topbar-background is differnt from $topbar-background-submenu
+  @if ($topbar-background != $topbar-submenu-background) {
+    ul ul {
+      background-color: $topbar-submenu-background;
+    }
   }
 
   input {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -544,6 +544,7 @@ $tooltip-radius: $global-radius;
 
 $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
+$topbar-submenu-background: $topbar-background;
 $topbar-title-spacing: 1rem;
 $topbar-input-width: 200px;
 


### PR DESCRIPTION
New option to set a different background-color for the submenus of a menu in the topbar.
For example if the topbar-background is transparent.
new var $topbar-background-submenu
