### PR TITLE
Features for drilldown - get visible height on a hidden drilldown-men…

### DIFF
--- a/docs/pages/javascript-utilities.md
+++ b/docs/pages/javascript-utilities.md
@@ -15,6 +15,11 @@ One of the useful libraries is `Foundation.Box`, and it has a couple methods des
 ```js
 
 var dims = Foundation.Box.GetDimensions(element);
+
+// or to get dimension on an hidden element
+
+var dims = Foundation.Box.GetDimensions(element, true);
+
 ```
 Will return an object that contains the dimensions of the `element` passed. The object return looks like:
 

--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -56,14 +56,35 @@ function ImNotTouchingYou(element, parent, lrOnly, tbOnly) {
  * Uses native methods to return an object of dimension values.
  * @function
  * @param {jQuery || HTML} element - jQuery object or DOM element for which to get the dimensions. Can be any element other that document or window.
+ * @param {Boolean} element - If true, get dimensions on an hidden element.
  * @returns {Object} - nested object of integer pixel values
  * TODO - if element is window, return only those values.
  */
-function GetDimensions(elem, test){
+function GetDimensions(elem, checkHidden){
   elem = elem.length ? elem[0] : elem;
 
   if (elem === window || elem === document) {
     throw new Error("I'm sorry, Dave. I'm afraid I can't do that.");
+  }
+
+  if (checkHidden) {
+    var savedStyles = [],
+        visibleStyle = 'visibility: hidden !important; display: block !important; ',
+        hiddenParents = [],
+        parseElem = elem;
+    // Get all hidden parents and make them visible and store original style
+    do {
+      if ( !(parseElem.offsetWidth > 0 || parseElem.offsetHeight > 0 || parseElem.getClientRects().length > 0)) {
+        var computedStyle = window.getComputedStyle(parseElem);
+        if (computedStyle.getPropertyValue('display') === 'none') {
+          var thisStyle = parseElem.style.cssText;
+          savedStyles.push(thisStyle);
+          parseElem.style.cssText = thisStyle ? thisStyle + ';' + visibleStyle : visibleStyle;
+          hiddenParents.push(parseElem);
+        }
+      }
+      parseElem = parseElem.parentNode;
+    } while (parseElem && parseElem !== document.body);
   }
 
   var rect = elem.getBoundingClientRect(),
@@ -72,7 +93,7 @@ function GetDimensions(elem, test){
       winY = window.pageYOffset,
       winX = window.pageXOffset;
 
-  return {
+  var dimensions = {
     width: rect.width,
     height: rect.height,
     offset: {
@@ -95,7 +116,21 @@ function GetDimensions(elem, test){
         left: winX
       }
     }
+  };
+
+  if (checkHidden) {
+    // Restore all hidden parents to their original style
+    for (var i = 0; i < hiddenParents.length; i++) {
+      var style = savedStyles[i];
+      if (typeof style == "string" && style !=='') {
+        hiddenParents[i].style.cssText = style;
+      } else {
+        hiddenParents[i].removeAttribute("style");
+      }
+    }
   }
+  return dimensions;
+
 }
 
 /**

--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -22,14 +22,26 @@ $drilldown-arrow-color: $primary-color !default;
 /// @type Color
 $drilldown-background: $white !default;
 
+/// Enables auto width at breakpoint defined in $drilldown-auto-width-breakpoint
+/// @type Boolean
+$drilldown-auto-width: false !default;
+
+/// The breakpoint for activating the auto width
+/// @type String
+$drilldown-auto-width-breakpoint: small only !default;
+
 @mixin foundation-drilldown-menu {
   // Applied to the Menu container
   .is-drilldown {
     position: relative;
     overflow: hidden;
-
-    li {
-      display: block !important;
+    // When on small media then overwrite width
+    @if $drilldown-auto-width {
+      @media screen and #{breakpoint($drilldown-auto-width-breakpoint)} {
+        & {
+          width: auto !important;
+        }
+      }
     }
   }
 
@@ -52,6 +64,17 @@ $drilldown-background: $white !default;
 
     &.is-closing {
       transform: translateX(if($global-text-direction == ltr, 100%, -100%));
+    }
+  }
+  // Only used for calculating max height and width
+  .is-drilldown-prepare {
+    .is-drilldown-submenu {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: -1;
+      height: auto;
+      height: auto;
     }
   }
 

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -281,6 +281,8 @@ $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
 $drilldown-arrow-color: $primary-color;
 $drilldown-background: $white;
+$drilldown-auto-width: false;
+$drilldown-auto-width-breakpoint: small only;
 
 // 16. Dropdown
 // ------------


### PR DESCRIPTION
…u, also extend Foundation.Box.GetDimensions

foundation.drilldown.js - new Option showParentLink, if true then the parent button is prepended to the submenu, only if the parent href is set.

foundation.util.box.js - Extend Foundation.Box.GetDimensions to use on an hidden element

drilldown.scss
- new vars: $drilldown-auto-width and $drilldown-auto-width-breakpoint
  to set the width to auto at a specific breakpoint
- new css class .is-drilldown-prepare - is used for calculating the max height and width of the menu during preparing
