### PR TITLE
Slider with dual handles: draw initial fill correctly

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -168,7 +168,7 @@ export default class Slider {
         var handlePos = parseFloat(this.$handle[0].style[lOrT]);
         //calculate the new min-height/width for the fill bar. Use isNaN to prevent false positives for numbers <= 0
         //based on the percentage of movement of the handle being manipulated, less the opposing handle's left/top position, plus the percentage w/h of the handle itself
-        dim = movement - (isNaN(handlePos) ? this.options.initialStart : handlePos) + handlePct;
+        dim = movement - (isNaN(handlePos) ? this.options.initialStart/((this.options.end-this.options.start)/100) : handlePos) + handlePct;
       }
       // assign the min-height/width to our css object
       css[`min-${hOrW}`] = `${dim}%`;


### PR DESCRIPTION
The range of the slider might be different from 100. This fix takes that to account when drawing the initial fill.
