### PR TITLE
Don't prevent submitting forms with hidden inputs

### DIFF
--- a/js/foundation/foundation.abide.js
+++ b/js/foundation/foundation.abide.js
@@ -84,7 +84,7 @@
         .off('.abide')
         .on('submit.fndtn.abide', function (e) {
           var is_ajax = /ajax/i.test(self.S(this).attr(self.attr_name()));
-          return self.validate(self.S(this).find('input, textarea, select').not(":hidden, [data-abide-ignore]").get(), e, is_ajax);
+          return self.validate(self.S(this).find('input, textarea, select').not("[data-abide-ignore]").get(), e, is_ajax);
         })
         .on('validate.fndtn.abide', function (e) {
           if (settings.validate_on === 'manual') {


### PR DESCRIPTION
In my project I've dynamic forms, they can have 0 or N visible inputs. They always have one hidden input. I found a problem with submitting form where there is only a hidden input. 

Maybe you can change it?
