### PR TITLE
Fix SASS depreciation warning

### DIFF
--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -22,7 +22,7 @@
   // more often than not this will be correct, just one time round the loop it won't so set in scope here
   $lower-bound: -zf-bp-to-em($lower-bound-size) - (1/16);
   // test actual lower-bound-size, if 0 set it to 0em
-  @if $lower-bound-size == 0 {
+  @if strip-unit($lower-bound-size) == 0 {
     $lower-bound: -zf-bp-to-em($lower-bound-size);
   }
 


### PR DESCRIPTION
SASS is generatng the following depreciation warning:

DEPRECATION WARNING on line 25 of
/foundation/components/_visibility.scss:
The result of `0px == 0` will be `false` in future releases of Sass.
Unitless numbers will no longer be equal to the same numbers with units.

This PR fixes the issue
