### PR TITLE
Add drilldown parent link option.

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -68,6 +68,9 @@ class Drilldown {
     this.$submenuAnchors.each(function(){
       var $sub = $(this);
       var $link = $sub.find('a:first');
+      if(_this.options.parentLink){
+        $link.clone().prependTo($sub.children('[data-submenu]')).wrap('<li class="is-submenu-parent-item is-submenu-item is-drilldown-submenu-item" role="menu-item"></li>');
+      }
       $link.data('savedHref', $link.attr('href')).removeAttr('href');
       $sub.children('[data-submenu]')
           .attr({
@@ -295,7 +298,7 @@ class Drilldown {
     this._hideAll();
     Foundation.Nest.Burn(this.$element, 'drilldown');
     this.$element.unwrap()
-                 .find('.js-drilldown-back').remove()
+                 .find('.js-drilldown-back, .is-submenu-parent-item').remove()
                  .end().find('.is-active, .is-closing, .is-drilldown-submenu').removeClass('is-active is-closing is-drilldown-submenu')
                  .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role')
                  .off('.zf.drilldown').end().off('zf.drilldown');
@@ -322,6 +325,12 @@ Drilldown.defaults = {
    * @example '<\div class="is-drilldown"><\/div>'
    */
   wrapper: '<div></div>',
+  /**
+   * Adds the parent link to the submenu.
+   * @option
+   * @example false
+   */
+  parentLink: false,
   /**
    * Allow the menu to return to root list on body click.
    * @option


### PR DESCRIPTION
If set to true this prepend's the parent link to the submenu.
See issue [7770](https://github.com/zurb/foundation-sites/issues/7770) and previous PR [8060](https://github.com/zurb/foundation-sites/pull/8060)
