### PR TITLE
Escape '#' in Magellan anchor selector

### DIFF
--- a/js/foundation/foundation.magellan.js
+++ b/js/foundation/foundation.magellan.js
@@ -32,7 +32,7 @@
 
       S(self.scope)
         .off('.magellan')
-        .on('click.fndtn.magellan', '[' + self.add_namespace('data-magellan-arrival') + '] a[href*=#]', function (e) {
+        .on('click.fndtn.magellan', '[' + self.add_namespace('data-magellan-arrival') + '] a[href*=\\#]', function (e) {
           var sameHost = ((this.hostname === location.hostname) || !this.hostname),
               samePath = self.filterPathname(location.pathname) === self.filterPathname(this.pathname),
               testHash = this.hash.replace(/(:|\.|\/)/g, '\\$1'),


### PR DESCRIPTION
Found another place where the unescaped '#' in a selector was causing issues with jQuery.
