### PR TITLE
Typo in 6.2 new foundation-menu-icon inclusion

### DIFF
--- a/scss/components/_title-bar.scss
+++ b/scss/components/_title-bar.scss
@@ -85,7 +85,7 @@ $titlebar-icon-spacing: 0.25rem !default;
 
   // Remove this in 6.3
   @if not $-zf-menu-icon-imported {
-    @warn 'In Foundation 6.2, a new component mixin was added called "foundation-menu-icon". Add "@import foundation-menu-icon" to the main Sass file of your project to remove this warning.';
+    @warn 'In Foundation 6.2, a new component mixin was added called "foundation-menu-icon". Add "@include foundation-menu-icon" to the main Sass file of your project to remove this warning.';
     @include foundation-menu-icon;
   }
 


### PR DESCRIPTION
Typo in 6.1 -> 6.2 migration message for the new `$foundation-menu-icon` component.

In the rc1 ([scss/components/_title-bar.scss](https://github.com/zurb/foundation-sites/blob/6.2-dev/scss/components/_title-bar.scss#L88)), foundation 6.2 state to 

> Add "@import foundation-menu-icon" to the main Sass file ...

actually one must be 

> Add "@include  foundation-menu-icon" to the main Sass file ...
