### PR TITLE
Documentation typo in description of media object components

### DIFF
--- a/scss/components/_media-object.scss
+++ b/scss/components/_media-object.scss
@@ -14,7 +14,7 @@ $mediaobject-margin-bottom: $global-margin !default;
 /// @type Number
 $mediaobject-section-padding: $global-padding !default;
 
-/// With of images within a media object, when the object is stacked vertically. Set to 'auto' to use the image's natural width.
+/// Width of images within a media object, when the object is stacked vertically. Set to 'auto' to use the image's natural width.
 /// @type Number
 $mediaobject-image-width-stacked: 100% !default;
 


### PR DESCRIPTION
Hello,

I just fixed the description of mediaobject-image-width-stacked variable.

m2c
Cecile
