### PR TITLE
Fix for click twice to follow links #7812 #7668

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -81,6 +81,11 @@ class DropdownMenu {
             hasClicked = $elem.attr('data-is-click') === 'true',
             $sub = $elem.children('.is-dropdown-submenu');
 
+        //prevent click twice to follow link for touche enabled PC browsers.
+        if(e.type === 'click'){
+          hasClicked = true;
+        }
+
         if (hasSub) {
           if (hasClicked) {
             if (!_this.options.closeOnClick || (!_this.options.clickOpen && !hasTouch) || (_this.options.forceFollow && hasTouch)) { return; }


### PR DESCRIPTION
I've experienced same issues like #7812 #7668.
I was able to fix it by adding following code to check event was made from mouse or not.

```
//prevent click twice to follow link for touche enabled PC browsers.
if(e.type === 'click'){
  hasClicked = true;
}
```
