### PR TITLE
Removed calls to deprecated jquery methods

### DIFF
--- a/js/foundation/foundation.js
+++ b/js/foundation/foundation.js
@@ -342,7 +342,7 @@
         }
       }
 
-      S(window).load(function () {
+      S(window).on('load', function () {
         S(window)
           .trigger('resize.fndtn.clearing')
           .trigger('resize.fndtn.dropdown')

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -245,7 +245,7 @@
 
       S(window).off('.topbar').on('resize.fndtn.topbar', self.throttle(function () {
           self.resize.call(self);
-      }, 50)).trigger('resize.fndtn.topbar').load(function () {
+      }, 50)).trigger('resize.fndtn.topbar').on('load', function () {
           // Ensure that the offset is calculated after all of the pages resources have loaded
           S(this).trigger('resize.fndtn.topbar');
       });


### PR DESCRIPTION
Fixes compatibility with jquery 3 (and possibly 2) Where the $.load() method has been complete removed in favor of $.on(). Current calls fail when they are sent to the ajax $.load() method.
