### PR TITLE
Add not set $breakpoint warning

### DIFF
--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -63,7 +63,7 @@ $breakpoint-classes: (small medium large) !default;
       $named: true;
     }
     @else {
-      $bp: 0;
+      @error 'Your given breakpoint "#{$val}" is not defined in your settings $breakpoints.';
     }
   }
 


### PR DESCRIPTION
add error if user want to use a breakpoint which isn't defined in $breakpoints
#8207
