### PR TITLE
Update What Input to v2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
   ],
   "dependencies": {
     "jquery": "~2.2.0",
-    "what-input": "~1.1.2"
+    "what-input": "~2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "jquery": "^2.2.0",
-    "what-input": "^1.1.2"
+    "what-input": "^2.0.0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Resolves issue with AMD wrapper causing error when compiled to ES2015
with Babel. Addresses issue #8273 
