### PR TITLE
fixing links so that they direct to the correct page

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -56,15 +56,15 @@ Get to know the pieces of Foundation.
     <strong>Media Queries</strong>
     <p>Working with Foundation's breakpoints.</p>
   </a></div>
-  <div class="column"><a href="media-queries.html">
+  <div class="column"><a href="flexbox.html">
     <strong>Flexbox Mode</strong>
     <p>Supercharge your CSS with flexbox.</p>
   </a></div>
-  <div class="column"><a href="media-queries.html">
+  <div class="column"><a href="compatibility.html">
     <strong>Compatibility</strong>
     <p>What browsers does Foundation work with?</p>
   </a></div>
-  <div class="column"><a href="media-queries.html">
+  <div class="column"><a href="kitchen-sink.html">
     <strong>Kitchen Sink</strong>
     <p>Every component on one page.</p>
   </a></div>


### PR DESCRIPTION
Multiple links were erroneously pointing to media-queries.html, updated them to link to the correct pages.
