### PR TITLE
[#8300] Fix for Tooltips remaining open despite option data-click-ope…

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -237,23 +237,22 @@ class Tooltip {
     var $template = this.template;
     var isFocus = false;
 
-    if (!this.options.disableHover) {
-
-      this.$element
-      .on('mouseenter.zf.tooltip', function(e) {
-        if (!_this.isActive) {
-          _this.timeout = setTimeout(function() {
-            _this.show();
-          }, _this.options.hoverDelay);
-        }
-      })
-      .on('mouseleave.zf.tooltip', function(e) {
-        clearTimeout(_this.timeout);
-        if (!isFocus || (!_this.isClick && _this.options.clickOpen)) {
-          _this.hide();
-        }
-      });
-    }
+    this.$element
+    .on('mouseenter.zf.tooltip', function(e) {
+      if (!_this.isActive && !_this.options.disableHover) {
+        _this.timeout = setTimeout(function() {
+          _this.show();
+        }, _this.options.hoverDelay);
+      }
+    })
+    .on('mouseleave.zf.tooltip', function(e) {
+      clearTimeout(_this.timeout);
+      if (!isFocus || (!_this.isClick && _this.options.clickOpen)) {
+        _this.hide();
+      } else if(!_this.options.clickOpen) {
+        _this.hide();
+      }
+    });
 
     if (this.options.clickOpen) {
       this.$element.on('mousedown.zf.tooltip', function(e) {
@@ -403,7 +402,7 @@ Tooltip.defaults = {
   tipText: '',
   touchCloseText: 'Tap to close.',
   /**
-   * Allows the tooltip to remain open if triggered with a click or touch event.
+   * Allows the tooltip to remain open if triggered with a click event.
    * @option
    * @example true
    */


### PR DESCRIPTION
Before submitting a pull request, make sure it's targeting the right branch:
- For documentation fixes, use `master`.
- For bug fixes, use `develop`.
- For new features, use the branch for the next minor version, which will be formatted `v6.x`.

If you're fixing a JavaScript issue, it would help to create a new test case under the folder `test/visual/` that recreates the issue and show's that it's been fixed. Run `npm test` to compile the testing folder.

Happy coding! :)

…n is set to false.
