### PR TITLE
Doc: flex-grid; fixed `align-self-top`

### DIFF
--- a/docs/pages/flex-grid.md
+++ b/docs/pages/flex-grid.md
@@ -229,7 +229,8 @@ Similar alignment classes can also be applied to individual columns, which use t
 <div class="row">
   <div class="column align-self-bottom">Align bottom</div>
   <div class="column align-self-middle">Align middle</div>
-  <div class="column align-self-top">Align top. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non harum laborum cum voluptate vel, eius adipisci similique dignissimos nobis at excepturi incidunt fugit molestiae quaerat, consequuntur porro temporibus. Nisi, ex?</div>
+  <div class="column align-self-top">Align top</div>
+  <div class="column">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non harum laborum cum voluptate vel, eius adipisci similique dignissimos nobis at excepturi incidunt fugit molestiae quaerat, consequuntur porro temporibus. Nisi, ex?</div>
 </div>
 ```
 


### PR DESCRIPTION
The `.align-self-top` example was missing individual column.  :scroll:
