### PR TITLE
.menu-icon & buttons elements

### DIFF
--- a/docs/pages/top-bar.md
+++ b/docs/pages/top-bar.md
@@ -63,7 +63,7 @@ In the below example, we've combined the above pattern with the Responsive Toggl
 <div class="top-bar">
   <div class="top-bar-title">
     <span data-responsive-toggle="responsive-menu" data-hide-for="medium">
-      <span class="menu-icon dark" data-toggle></span>
+      <button class="menu-icon dark" type="button" data-toggle></button>
     </span>
     <strong>Site Title</strong>
   </div>

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -187,6 +187,7 @@ $-zf-flex-classes-imported: false;
 
   // Reset <button> styles created by most browsers
   button {
+    @include disable-mouse-outline;
     -webkit-appearance: none;
     -moz-appearance: none;
     background: transparent;


### PR DESCRIPTION
This PR fixes the Top Bar documentation, recommending `<button>` instead of `<span>` for a `.menu-icon`. It also applies the `disable-mouse-outline()` mixin to default button elements—so they don't need the `.button` class in order to make use of [What Input?](https://github.com/ten1seven/what-input).

https://github.com/zurb/foundation-sites/issues/8204#issuecomment-193515849
