### PR TITLE
Multiple Select Menu

### DIFF
--- a/docs/pages/forms.md
+++ b/docs/pages/forms.md
@@ -18,7 +18,7 @@ Creating a form in Foundation is designed to be easy but extremely flexible. For
 
 ---
 
-### Text Inputs
+#### Text Inputs
 
 These input types create a text field: `text`, `date`, `datetime`, `datetime-local`, `email`, `month`, `number`, `password`, `search`, `tel`, `time`, `url`, and `week`.
 
@@ -67,7 +67,7 @@ The `<textarea>` element creates a multi-line text input.
 
 ---
 
-### Select Menus
+#### Select Menus
 
 Use select menus to combine many choices into one menu.
 
@@ -82,9 +82,22 @@ Use select menus to combine many choices into one menu.
 </label>
 ```
 
+Add the `multiple` attribute to allow more than one option to be selected.
+
+```html_example
+<label>Multiple Select Menu
+  <select multiple>
+    <option value="showboat">Showboat</option>
+    <option value="redwing">Redwing</option>
+    <option value="narcho">Narcho</option>
+    <option value="hardball">Hardball</option>
+  </select>
+</label>
+```
+
 ---
 
-### Checkboxes and Radio Buttons
+#### Checkboxes and Radio Buttons
 
 Use groups of checkboxes when the user may select multiple choices from a list, and use radio buttons when the user must select just one choice.
 
@@ -109,7 +122,7 @@ Wrap a group of checkboxes or radio buttons in a `<fieldset>` element, and give 
 
 ---
 
-### Fieldset Styles
+#### Fieldset Styles
 
 To encourage their use as an accessibility tool, the `<fieldset>` element is no longer styled by default. Those styles are now contained in the `.fieldset` class.
 

--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -55,6 +55,7 @@ $select-radius: $global-radius !default;
 
   &[multiple] {
     height: auto;
+    background-image: none;
   }
 }
 


### PR DESCRIPTION
This PR styles `select` elements with the `multiple` attribute (removing the triangle) and adds "Multiple Select Menu" to the docs. 

Tho already closed, applies to https://github.com/zurb/foundation-sites/issues/4990. 

(Also makes section headings consistent in docs.)
