### PR TITLE
clarify loadPath for node-sass wrt to npm v3

### DIFF
--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -48,11 +48,13 @@ Next, add the framework files as an import path. How you do this depends on your
 Here's an example using grunt-contrib-sass:
 
 ```js
+var path = require('path');
+
 grunt.initConfig({
   sass: {
     dist: {
     options: {
-        loadPath: ['node_modules/foundation-sites/scss']
+        loadPath: [path.join(path.dirname(require.resolve('foundation-sites')), '../scss')]
       }
     }
   }


### PR DESCRIPTION
This PR updates the Foundation SASS docs to clarify `loadPath` for the grunt example.

Due to the changes npm v3 introduced regarding dependency resolution, I'm not sure we can guarantee the `foundation` module will live in the root of the `node_modules` folder.

Therefore, this update suggests using node's builtin require (https://nodejs.org/dist/latest-v4.x/docs/api/modules.html#modules_all_together) and path (https://nodejs.org/dist/latest-v4.x/docs/api/path.html) modules for determining the path to Foundation.
