### PR TITLE
Set $block-grid-default-spacing to !default

### DIFF
--- a/scss/foundation/components/_block-grid.scss
+++ b/scss/foundation/components/_block-grid.scss
@@ -16,7 +16,7 @@ $block-grid-default-spacing: rem-calc(20) !default;
 
 $align-block-grid-to-grid: false !default;
 @if $align-block-grid-to-grid {
-  $block-grid-default-spacing: $column-gutter;
+  $block-grid-default-spacing: $column-gutter !default;
 }
 
 // Enables media queries for block-grid classes. Set to false if writing semantic HTML.


### PR DESCRIPTION
This setting was not being overridden in settings.scss because it's missing the !default.
