### PR TITLE
Add new version for zurb:foundation-sites

### DIFF
--- a/.versions
+++ b/.versions
@@ -12,4 +12,4 @@ meteor@1.1.10
 promise@0.5.1
 random@1.0.5
 underscore@1.0.4
-zurb:foundation-sites@6.2.0_1
+zurb:foundation-sites@6.2.0


### PR DESCRIPTION
It had the 6.1.2 version, and we are in 6.2.0. So, I changed it.
