### PR TITLE
Fixed the margin (separator) of the stacked button group #8444

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -109,13 +109,20 @@ $buttongroup-expand-max: 6 !default;
   #{$selector} {
     @if $global-flexbox {
       flex: 0 0 100%;
+      margin-#{$global-right}: 0; 
     }
     @else {
       width: 100%;
+      border-#{$global-right}: $buttongroup-spacing solid transparent;
     }
-
+    
     &:not(:last-child) {
-      margin-#{$global-right}: 0;
+      @if $global-flexbox {
+        margin-bottom: $buttongroup-spacing;
+      }
+      @else {
+        border-bottom: $buttongroup-spacing solid $body-background;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes the margin of the stacked button group, where the margin should be from the bottom not the right (#8444).
Current state: http://codepen.io/abdullahsalem/pen/mPWZoy
![button-group-stacked-issue-zoom-in](https://cloud.githubusercontent.com/assets/177020/13952166/fa444554-f045-11e5-929d-9d1457c5b369.png)

But it should look like this
![button-group-stacked](https://cloud.githubusercontent.com/assets/177020/13953917/6cea37b8-f04f-11e5-8ec0-7d39fbfc8818.PNG)
