### PR TITLE
Fixes issue when putting focus to an input outside of the modal.

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -292,9 +292,6 @@ class Reveal {
             }
           }
         });
-        if (_this.focusableElements.length === 0) { // no focusable elements inside the modal at all, prevent tabbing in general
-          e.preventDefault();
-        }
       });
     }
 
@@ -308,10 +305,16 @@ class Reveal {
             _this.focusableElements.eq(0).focus();
             e.preventDefault();
           }
+          if (_this.focusableElements.length === 0) { // no focusable elements inside the modal at all, prevent tabbing in general
+            e.preventDefault();
+          }
         },
         tab_backward: function() {
           if (_this.$element.find(':focus').is(_this.focusableElements.eq(0)) || _this.$element.is(':focus')) { // left modal upwards, setting focus to last element
             _this.focusableElements.eq(-1).focus();
+            e.preventDefault();
+          }
+          if (_this.focusableElements.length === 0) { // no focusable elements inside the modal at all, prevent tabbing in general
             e.preventDefault();
           }
         },


### PR DESCRIPTION
Fixes #8442.
It doesn't make sens to have these event handles attached to the whole document at all.

See [this pen](http://codepen.io/Owlbertz/pen/qZmyoK) using the updated version.
