### PR TITLE
Include $body-font-family as a default

### DIFF
--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -228,6 +228,11 @@ $keystroke-radius: $global-radius !default;
 $abbr-underline: 1px dotted $black !default;
 
 @mixin foundation-typography-base {
+  // Default body font
+  body {
+    font-family: $body-font-family;
+  }
+  
   // Typography resets
   div,
   dl,


### PR DESCRIPTION
Currently, $body-font-family is not included in output css. This is because $body-font-family is not referenced anywhere except for $header-font-family. Even <p> would not be styled with $body-font-family

By adding a body tag, we are defaulting to $body-font-family but this can be overriden by any other selector, including headers (as it will be more specific)
