### PR TITLE
Text inputs function with modifier (for classes and pseudo-classes)

### DIFF
--- a/scss/util/_selector.scss
+++ b/scss/util/_selector.scss
@@ -9,7 +9,8 @@
 /// Generates a selector with every text input type. You can also filter the list to only output a subset of those selectors.
 ///
 /// @param {List|Keyword} $types [()] - A list of text input types to use. Leave blank to use all of them.
-@function text-inputs($types: ()) {
+/// @param {Keyword} $modifier [''] - A modifier to be applied to each text input type (e.g. a class or a pseudo-class). Leave blank to ignore.
+@function text-inputs($types: (), $modifier: '') {
   $return: ();
 
   $all-types:
@@ -33,7 +34,7 @@
   }
 
   @each $type in $types {
-    $return: append($return, unquote('[type=\'#{$type}\']'), comma);
+    $return: append($return, unquote('[type=\'#{$type}\']#{$modifier}'), comma);
   }
 
   @return $return;

--- a/test/sass/_selector.scss
+++ b/test/sass/_selector.scss
@@ -14,4 +14,14 @@
 	    'Creates a selector out of a list of text input types');
 	}
 
+	@include test('Selector (with modifiers) [function]') {
+	  $test: #{text-inputs(text password, $modifier: ':focus')};
+	  $expect: "[type='text']:focus, [type='password']:focus";
+
+	  //@debug $test;
+
+	  @include assert-equal($test, $expect,
+	    'Creates a selector out of a list of text input types with a modifier');
+	}
+
 }


### PR DESCRIPTION
Permit to define a class or a pseudo-class for text inputs generated through the text-inputs sass function.
