### PR TITLE
Eyeglass: add `eyeglass-module` keyword and avoid exporting anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,13 +83,15 @@
     "email": "foundation@zurb.com"
   },
   "keywords": [
+    "eyeglass-module",
     "handlebars-helper-rel",
     "handlebars-helper-slugify"
   ],
   "eyeglass": {
     "name": "foundation",
     "sassDir": "scss",
-    "needs": "^0.8.0"
+    "needs": "^0.8.0",
+    "exports": false
   },
   "jspm": {
     "format": "global",


### PR DESCRIPTION
Hey folks, here's my (simplified) use case.

The dependency tree looks like:

```
$ npm ls

import-foundation-importer@1.0.0 ~/import-foundation-importer
+-- eyeglass@0.8.3
+-- import-foundation@1.0.0 (git://github.com/jsdotcr/import-foundation.git#3db2bc107f4176669bdc131fb67a5d799ecca561)
  `-- foundation-sites@6.2.0
```

In real life [import-foundation](https://github.com/jsDotCr/import-foundation) is a design system and it works with foundation-site, while [import-foundation-importer](https://github.com/jsDotCr/import-foundation-importer) is a project relying on such design system (it may or may not use foundation directly, but it's not relevant here).
They all work with eyeglass to handle SASS dependencies.

Trying to compile import-foundation-importer's SCSS files (using `npm test` script), I get the following error:

```
$ npm test

> import-foundation-importer@1.0.0 test ~/import-foundation-importer
> node index.js

error { [Error: Error: Could not import foundation from any of the following locations:
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.scss
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.sass
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.css
  ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.scss
  ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.sass
  ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.css
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.scss
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.sass
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.css
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.scss
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.sass
  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.css]
  formatted: 'Error: Error: Could not import foundation from any of the following locations:\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.scss\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.sass\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.css\n         ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.scss\n         ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.sass\n         ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.css\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.scss\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.sass\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.css\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.scss\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.sass\n         ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.css\n        on line 1 of node_modules/import-foundation/styles/index.scss\n>> @import \'foundation\';\n   --------^\n',
  message: 'Error: Could not import foundation from any of the following locations:\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.scss\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.sass\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation.css\n  ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.scss\n  ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.sass\n  ~/import-foundation-importer/node_modules/import-foundation/styles/_foundation.css\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.scss\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.sass\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/index.css\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.scss\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.sass\n  ~/import-foundation-importer/node_modules/import-foundation/styles/foundation/_index.css',
  column: 9,
  line: 1,
  file: '~/import-foundation-importer/node_modules/import-foundation/styles/index.scss',
  status: 1 }
```

This is unfortunately due to how eyeglass discovers modules, because it requires having `eyeglass-module` as a package keyword. Just setting that won't work either, though:

```
$ npm test

> import-foundation-importer@1.0.0 test /Users/rcurcio/workspace/import-foundation-importer
> node index.js

/Users/rcurcio/workspace/import-foundation-importer/node_modules/foundation-sites/dist/foundation.js:386
}(jQuery);
  ^

ReferenceError: jQuery is not defined
```

And that's because it requires the file defined as the package.json's main value, if no `eyeglass.exports` property is defined.

[eyeglass-fix branch](jsdotcr/import-foundation-importer#eyeglass-fix), which uses this PR, fixes both issues.
Would you folks be fine with this change?

Cheers :heart: 
