### PR TITLE
Fix issue with Reveal#destroy().

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -440,6 +440,7 @@ class Reveal {
    */
   destroy() {
     if (this.options.overlay) {
+      this.$element.appendTo($('body')); // move $element outside of $overlay to prevent error unregisterPlugin()
       this.$overlay.hide().off().remove();
     }
     this.$element.hide().off();


### PR DESCRIPTION
Noticed that Reveal's `destroy()` runs into an error because the `$element` is appended to the `$overlay` and the `$overlay` is then removed before `unregisterPlugin()` gets called. Therefore `plugin.$element.data('zfPlugin')` failed because `$element` as already removed with `$overlay`.

Moved $element outside of `$overlay` to prevent error `unregisterPlugin()`.
