### PR TITLE
[Orbit] Bugfix: Remove image-loaded checking with this.naturalWidth

### DIFF
--- a/js/foundation.util.timerAndImageLoader.js
+++ b/js/foundation.util.timerAndImageLoader.js
@@ -62,9 +62,9 @@ function onImagesLoaded(images, callback){
     if (this.complete) {
       singleImageLoaded();
     }
-    else if (typeof this.naturalWidth !== 'undefined' && this.naturalWidth > 0) {
-      singleImageLoaded();
-    }
+    // else if (typeof this.naturalWidth !== 'undefined' && this.naturalWidth > 0) {
+    //   singleImageLoaded();
+    // }
     else {
       $(this).one('load', function() {
         singleImageLoaded();


### PR DESCRIPTION
When serving properly cached images, this method of checking weather an image has been loaded breaks the height calculation resulting in "thin" orbit boxes.
<br />
<br />Reloading the page and ignoring cached content (Cmd + Shift + R) everything loads as it should be, however, on subsequent normal refreshes (Cmd + R) orbit galleries "shrink".
<br />
<br />See image for details.
<br />
<br />#### Preview:
<br />![break2](https://cloud.githubusercontent.com/assets/2998029/14100148/8a78e220-f58b-11e5-856c-7f1a62539f5c.png)
<br />
<br />#### DOM:
<br />![break](https://cloud.githubusercontent.com/assets/2998029/14100084/158a0304-f58b-11e5-9b0d-13fd0b01860c.png)
<br />
