### PR TITLE
Add flex-grid size modifier

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -77,7 +77,7 @@
   $gutter: $grid-column-gutter
 ) {
   // Base properties
-  flex: flex-grid-column($columns);
+  @include flex-grid-size($columns);
 
   // Gutters
   @if type-of($gutter) == 'map' {
@@ -94,11 +94,6 @@
     $padding: rem-calc($gutter) / 2;
     padding-left: $padding;
     padding-right: $padding;
-  }
-
-  // max-width fixes IE 10/11 not respecting the flex-basis property
-  @if $columns != null and $columns != shrink {
-    max-width: grid-column($columns);
   }
 }
 
@@ -117,6 +112,17 @@
 
     flex: 0 0 $pct;
     max-width: $pct;
+  }
+}
+
+/// Changes the width flex grid column.
+/// @param {Mixed} $columns [null] - Width of the column. Refer to the `flex-grid-column()` function to see possible values.
+@mixin flex-grid-size($columns: null) {
+  flex: flex-grid-column($columns);
+
+  // max-width fixes IE 10/11 not respecting the flex-basis property
+  @if $columns != null and $columns != shrink {
+    max-width: grid-column($columns);
   }
 }
 


### PR DESCRIPTION
Add `flex-grid-size` to modify the size of a flex-grid column. It allows to define responsive behaviors in a semantic Scss.

For exemple:

``` scss
.layout {
  @include flex-grid-row;

  // Mobile: menu above the content
  &__col-menu { @include flex-grid-column(12); }
  &__col-content { @include flex-grid-column(12); }

  // Desktop: menu on the left of the content
  @include breakpoint(medium) {
    &__col-menu { @include flex-grid-size(4); }
    &__col-content { @include flex-grid-size(8); }
  }
}
```

I think that many other changes (on grids and other components) can be done to make Foundation fully compatible with a semantic Scss, and I can work on it later if you think it's necessary. But for now I just need this feature ;)

ncoden
