### PR TITLE
Fix flex-grid-column with nowrap child

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -96,6 +96,11 @@
     padding-right: $padding;
   }
 
+  // fixes recent Chrome version not limiting child width
+  // https://stackoverflow.com/questions/34934586/white-space-nowrap-and-flexbox-did-not-work-in-chrome
+  @if $columns == null {
+    min-width: 0;
+  }
   // max-width fixes IE 10/11 not respecting the flex-basis property
   @if $columns != null and $columns != shrink {
     max-width: grid-column($columns);


### PR DESCRIPTION
On the last version of chrome, the child of a `flex-grid-column(null)` with

``` css
white-space: nowrap;
overflow: hidden;
```

doesn't have a limited size, and the full content is showed in one line exceeding the row.

`min-width: 0;` fix this problem, probably by remembering to chrome to evaluate the column width with a `0px` content width (it's what `flex: 1 1 0px` should do).
https://stackoverflow.com/questions/34934586/white-space-nowrap-and-flexbox-did-not-work-in-chrome
