### PR TITLE
Add Option for Collapsing Foundation Tabs

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -109,3 +109,33 @@ Add the `.vertical` class to a tabstrip to stack tabs vertically. You can also p
   </div>
 </div>
 ```
+
+---
+
+## Collapsing Tabs
+
+Add the attribute `data-active-collapse="true"` to a tabstrip to collapse active tabs.
+
+```html_example
+<ul class="tabs" data-active-collapse="true" data-tabs id="collapsing-tabs">
+  <li class="tabs-title is-active"><a href="#panel1c" aria-selected="true">Tab 1</a></li>
+  <li class="tabs-title"><a href="#panel2c">Tab 2</a></li>
+  <li class="tabs-title"><a href="#panel3c">Tab 3</a></li>
+  <li class="tabs-title"><a href="#panel4c">Tab 4</a></li>
+</ul>
+
+<div class="tabs-content" data-tabs-content="collapsing-tabs">
+  <div class="tabs-panel is-active" id="panel1c">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+  </div>
+  <div class="tabs-panel" id="panel2c">
+    <p>Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus.</p>
+  </div>
+  <div class="tabs-panel" id="panel3c">
+    <img class="thumbnail" src="assets/img/generic/rectangle-3.jpg">
+  </div>
+  <div class="tabs-panel" id="panel4c">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+  </div>
+</div>
+```

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -112,6 +112,9 @@ class Tabs {
         e.preventDefault();
         e.stopPropagation();
         if ($(this).hasClass('is-active')) {
+          if(_this.options.activeCollapse) {
+             _this._handleCollapse($(this)); 
+          }
           return;
         }
         _this._handleTabChange($(this));
@@ -201,6 +204,32 @@ class Tabs {
      * @event Tabs#change
      */
     this.$element.trigger('change.zf.tabs', [$target]);
+  }
+  
+  /**
+   * Collapses `$targetContent` defined by `$target`.
+   * @param {jQuery} $target - Tab to collapse.
+   * @fires Tabs#collapse
+   * @function
+   */
+  _handleCollapse($target) {
+    var $tabLink = $target.find('[role="tab"]'),
+        hash = $tabLink[0].hash,
+        $targetContent = this.$tabContent.find(hash);
+        
+    $target.removeClass('is-active')
+           .find('[role="tab"]')
+           .attr({ 'aria-selected': 'false' });
+
+    $targetContent
+      .removeClass('is-active')
+      .attr({'aria-hidden': 'true'});
+
+    /**
+     * Fires when the plugin has successfully collapsed tab.
+     * @event Tabs#collapse
+     */
+    this.$element.trigger('collapse.zf.tabs', [$target]);
   }
 
   /**
@@ -299,7 +328,14 @@ Tabs.defaults = {
    * @example false
    */
   matchHeight: false,
-
+  
+  /**
+   * Allows active tabs to collapse when clicked.
+   * @option
+   * @example false
+   */
+  activeCollapse: false,
+  
   /**
    * Class applied to `li`'s in tab link list.
    * @option

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -172,33 +172,22 @@ class Tabs {
   }
 
   /**
-   * Opens the tab `$targetContent` defined by `$target`.
+   * Opens the tab `$targetContent` defined by `$target`. Collapses active tab.
    * @param {jQuery} $target - Tab to open.
    * @fires Tabs#change
    * @function
    */
   _handleTabChange($target) {
-    var $tabLink = $target.find('[role="tab"]'),
-        hash = $tabLink[0].hash,
-        $targetContent = this.$tabContent.find(hash),
-        $oldTab = this.$element.
-          find(`.${this.options.linkClass}.is-active`)
-          .removeClass('is-active')
-          .find('[role="tab"]')
-          .attr({ 'aria-selected': 'false' });
+    var $oldTab = this.$element.
+          find(`.${this.options.linkClass}.is-active`);
+  
+    //close old tab
+    this._collapseTab($oldTab);
 
-    $(`#${$oldTab.attr('aria-controls')}`)
-      .removeClass('is-active')
-      .attr({ 'aria-hidden': 'true' });
-
-    $target.addClass('is-active');
-
-    $tabLink.attr({'aria-selected': 'true'});
-
-    $targetContent
-      .addClass('is-active')
-      .attr({'aria-hidden': 'false'});
-
+    //open new tab
+    this._openTab($target);
+    
+    
     /**
      * Fires when the plugin has successfully changed tabs.
      * @event Tabs#change
@@ -213,23 +202,49 @@ class Tabs {
    * @function
    */
   _handleCollapse($target) {
-    var $tabLink = $target.find('[role="tab"]'),
-        hash = $tabLink[0].hash,
-        $targetContent = this.$tabContent.find(hash);
-        
-    $target.removeClass('is-active')
-           .find('[role="tab"]')
-           .attr({ 'aria-selected': 'false' });
-
-    $targetContent
-      .removeClass('is-active')
-      .attr({'aria-hidden': 'true'});
+    this._collapseTab($target);
 
     /**
      * Fires when the plugin has successfully collapsed tab.
      * @event Tabs#collapse
      */
     this.$element.trigger('collapse.zf.tabs', [$target]);
+  }
+  
+  /**
+   * Opens the tab `$targetContent` defined by `$target`.
+   * @param {jQuery} $target - Tab to Open.
+   * @function 
+   */
+  _openTab($target) {
+      var $tabLink = $target.find('[role="tab"]'),
+          hash = $tabLink[0].hash,
+          $targetContent = this.$tabContent.find(hash);
+
+      $target.addClass('is-active');
+
+      $tabLink.attr({'aria-selected': 'true'});
+
+      $targetContent
+        .addClass('is-active')
+        .attr({'aria-hidden': 'false'});
+  }
+  
+  /**
+   * Collapses `$targetContent` defined by `$target`.
+   * @param {jQuery} $target - Tab to Open.
+   * @function 
+   */
+  _collapseTab($target) {
+    var $target_anchor = $target
+      .removeClass('is-active')
+      .find('[role="tab"]')
+      .attr({ 'aria-selected': 'false' })
+      .blur();
+
+    $(`#${$target_anchor.attr('aria-controls')}`)
+      .removeClass('is-active')
+      .attr({ 'aria-hidden': 'true' });
   }
 
   /**

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -111,12 +111,6 @@ class Tabs {
       .on('click.zf.tabs', `.${this.options.linkClass}`, function(e){
         e.preventDefault();
         e.stopPropagation();
-        if ($(this).hasClass('is-active')) {
-          if(_this.options.activeCollapse) {
-             _this._handleCollapse($(this)); 
-          }
-          return;
-        }
         _this._handleTabChange($(this));
       });
   }
@@ -178,6 +172,23 @@ class Tabs {
    * @function
    */
   _handleTabChange($target) {
+    
+    /**
+     * Check for active class on target. Collapse if exists.
+     */
+    if ($target.hasClass('is-active')) {
+        if(this.options.activeCollapse) {
+            this._collapseTab($target);
+            
+           /**
+            * Fires when the zplugin has successfully collapsed tabs.
+            * @event Tabs#collapse
+            */
+            this.$element.trigger('collapse.zf.tabs', [$target]);
+        }
+        return;
+    }
+    
     var $oldTab = this.$element.
           find(`.${this.options.linkClass}.is-active`);
   
@@ -193,22 +204,6 @@ class Tabs {
      * @event Tabs#change
      */
     this.$element.trigger('change.zf.tabs', [$target]);
-  }
-  
-  /**
-   * Collapses `$targetContent` defined by `$target`.
-   * @param {jQuery} $target - Tab to collapse.
-   * @fires Tabs#collapse
-   * @function
-   */
-  _handleCollapse($target) {
-    this._collapseTab($target);
-
-    /**
-     * Fires when the plugin has successfully collapsed tab.
-     * @event Tabs#collapse
-     */
-    this.$element.trigger('collapse.zf.tabs', [$target]);
   }
   
   /**
@@ -239,8 +234,7 @@ class Tabs {
     var $target_anchor = $target
       .removeClass('is-active')
       .find('[role="tab"]')
-      .attr({ 'aria-selected': 'false' })
-      .blur();
+      .attr({ 'aria-selected': 'false' });
 
     $(`#${$target_anchor.attr('aria-controls')}`)
       .removeClass('is-active')


### PR DESCRIPTION
Collapsing tabs was a feature I needed on a current project. I end up writing custom js to do it. But I feel like collapsing tabs should be an option in any tab library. 

I'm new to contributing so if you have any feedback/questions please let me know. I tried to follow coding standards I found with brief research and following structure of existing codebase.
