### PR TITLE
[tooltip.js] New option allowHtml

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -39,9 +39,15 @@ class Tooltip {
     this.options.tipText = this.options.tipText || this.$element.attr('title');
     this.template = this.options.template ? $(this.options.template) : this._buildTemplate(elemId);
 
-    this.template.appendTo(document.body)
+    if (this.options.allowHtml) {
+      this.template.appendTo(document.body)
+        .html(this.options.tipText)
+        .hide();
+    } else {
+      this.template.appendTo(document.body)
         .text(this.options.tipText)
         .hide();
+    }
 
     this.$element.attr({
       'title': '',
@@ -425,7 +431,14 @@ Tooltip.defaults = {
    * @option
    * @example 12
    */
-  hOffset: 12
+  hOffset: 12,
+    /**
+   * Allow HTML in tooltip. Warning: If you are loading user-generated content into tooltips,
+   * allowing HTML may open yourself up to XSS attacks.
+   * @option
+   * @example false
+   */
+  allowHtml: false
 };
 
 /**


### PR DESCRIPTION
Ref pr #8075 Add new option allowHtml (default false) to allow HTML in tooltip.
@gakimball @kball comments pls.
