### PR TITLE
Add static grid gutters #8508

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -134,9 +134,7 @@
     }
 
     .#{$-zf-size}-#{$uncollapse} {
-      $gutter_value: -zf-get-bp-val($grid-column-gutter, $-zf-size);
-
-      > .#{$column} { @include grid-col-uncollapse($gutter_value); }
+      > .#{$column} { @include grid-col-gutter($-zf-size); }
     }
 
     // Positioning

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -12,6 +12,7 @@
   $row: 'row',
   $column: 'column',
   $column-row: 'column-row',
+  $gutter: 'gutter',
   $push: 'push',
   $pull: 'pull',
   $center: 'centered',
@@ -50,6 +51,15 @@
       .#{$row} {
         margin-left: auto;
         margin-right: auto;
+      }
+    }
+
+    // Static (unresponsive) row gutters
+    @each $breakpoint, $value in $grid-column-gutter {
+      &.#{$gutter}-#{$breakpoint} {
+        > .#{$column} {
+          @include grid-col-gutter($value);
+        }
       }
     }
   }
@@ -124,9 +134,9 @@
     }
 
     .#{$-zf-size}-#{$uncollapse} {
-      $gutter: -zf-get-bp-val($grid-column-gutter, $-zf-size);
+      $gutter_value: -zf-get-bp-val($grid-column-gutter, $-zf-size);
 
-      > .#{$column} { @include grid-col-uncollapse($gutter); }
+      > .#{$column} { @include grid-col-uncollapse($gutter_value); }
     }
 
     // Positioning

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -63,18 +63,13 @@
   // Gutters
   @if type-of($gutter) == 'map' {
     @each $breakpoint, $value in $gutter {
-      $padding: rem-calc($value) / 2;
-
       @include breakpoint($breakpoint) {
-        padding-left: $padding;
-        padding-right: $padding;
+        @include grid-col-gutter($value);
       }
     }
   }
   @else if type-of($gutter) == 'number' and strip-unit($gutter) > 0 {
-    $padding: rem-calc($gutter) / 2;
-    padding-left: $padding;
-    padding-right: $padding;
+    @include grid-col-gutter($value);
   }
 
   // Last column alignment

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -52,24 +52,17 @@
 /// Creates a grid column.
 ///
 /// @param {Mixed} $columns [$grid-column-count] - Width of the column. Refer to the `grid-column()` function to see possible values.
-/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
+/// @param {Mixed} $gutters [$grid-column-gutter] - Spacing between columns. Refer to the `grid-column-gutter()` function to see possible values.
 @mixin grid-column(
   $columns: $grid-column-count,
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
   @include grid-column-size($columns);
   float: $global-left;
 
   // Gutters
-  @if type-of($gutter) == 'map' {
-    @each $breakpoint, $value in $gutter {
-      @include breakpoint($breakpoint) {
-        @include grid-col-gutter($value);
-      }
-    }
-  }
-  @else if type-of($gutter) == 'number' and strip-unit($gutter) > 0 {
-    @include grid-col-gutter($value);
+  @include -zf-each-breakpoint {
+    @include grid-column-gutter($-zf-size, $gutters);
   }
 
   // Last column alignment
@@ -82,12 +75,12 @@
 
 /// Creates a grid column row. This is the equivalent of adding `.row` and `.column` to the same element.
 ///
-/// @param {Number} $gutter [$grid-column-gutter] - Width of the gutters on either side of the column row.
+/// @param {Mixed} $gutter [$grid-column-gutter] - Width of the gutters on either side of the column row. Refer to the `grid-column-gutter()` function to see possible values.
 @mixin grid-column-row(
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
   @include grid-row;
-  @include grid-column($gutter: $gutter);
+  @include grid-column($gutters: $gutters);
 
   &,
   &:last-child {
@@ -107,15 +100,15 @@
 /// @alias grid-column
 @mixin grid-col(
   $columns: $grid-column-count,
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
-  @include grid-column($columns, $gutter);
+  @include grid-column($columns, $gutters);
 }
 
 /// Shorthand for `grid-column-row()`.
 /// @alias grid-column-row
 @mixin grid-col-row(
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
-  @include grid-column-row($gutter);
+  @include grid-column-row($gutters);
 }

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -75,7 +75,7 @@
 
 /// Creates a grid column row. This is the equivalent of adding `.row` and `.column` to the same element.
 ///
-/// @param {Mixed} $gutter [$grid-column-gutter] - Width of the gutters on either side of the column row. Refer to the `grid-column-gutter()` function to see possible values.
+/// @param {Mixed} $gutters [$grid-column-gutter] - Width of the gutters on either side of the column row. Refer to the `grid-column-gutter()` function to see possible values.
 @mixin grid-column-row(
   $gutters: $grid-column-gutter
 ) {

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -246,7 +246,7 @@
     }
 
     .#{$-zf-size}-uncollapse {
-      > .column { @include grid-col-size($-zf-size); }
+      > .column { @include grid-col-gutter($-zf-size); }
     }
   }
 

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -13,18 +13,18 @@
 /// @param {Number} $width [$grid-row-width] - Maximum width of the row.
 /// @param {Number} $columns [null] - Number of columns to use for this row. If set to `null` (the default), the global column count will be used.
 /// @param {Boolean} $base [true] - Set to `false` to prevent basic styles from being output. Useful if you're calling this mixin on the same element twice, as it prevents duplicate CSS output.
-/// @param {Number} $gutter [$grid-column-gutter] - Gutter to use when inverting margins, in case the row is nested.
+/// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use when inverting margins, in case the row is nested. Responsive gutter settings by default.
 @mixin flex-grid-row(
   $behavior: null,
   $width: $grid-row-width,
   $columns: null,
   $base: true,
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
   $margin: auto;
 
   @if index($behavior, nest) != null {
-    @include grid-row-nest($gutter);
+    @include grid-row-nest($gutters);
 
     @if index($behavior, collapse) != null {
       margin-left: 0;
@@ -71,29 +71,17 @@
 /// Creates a column for a flex grid. By default, the column will stretch to the full width of its container, but this can be overridden with sizing classes, or by using the `unstack` class on the parent flex row.
 ///
 /// @param {Mixed} $columns [null] - Width of the column. Refer to the `flex-grid-column()` function to see possible values.
-/// @param {Number} $gutter [$grid-column-gutter] - Space between columns, added as a left and right padding.
+/// @param {Mixed} $gutters [$grid-column-gutter] - Spacing between columns. Refer to the `grid-column-gutter()` function to see possible values.
 @mixin flex-grid-column(
   $columns: null,
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
   // Base properties
   @include flex-grid-size($columns);
 
   // Gutters
-  @if type-of($gutter) == 'map' {
-    @each $breakpoint, $value in $gutter {
-      $padding: rem-calc($value) / 2;
-
-      @include breakpoint($breakpoint) {
-        padding-left: $padding;
-        padding-right: $padding;
-      }
-    }
-  }
-  @else if type-of($gutter) == 'number' and strip-unit($gutter) > 0 {
-    $padding: rem-calc($gutter) / 2;
-    padding-left: $padding;
-    padding-right: $padding;
+  @include -zf-each-breakpoint {
+    @include grid-column-gutter($-zf-size, $gutters);
   }
 
   // fixes recent Chrome version not limiting child width
@@ -258,9 +246,7 @@
     }
 
     .#{$-zf-size}-uncollapse {
-      $gutter: -zf-get-bp-val($grid-column-gutter, $-zf-size);
-
-      > .column { @include grid-col-uncollapse($gutter); }
+      > .column { @include grid-col-size($-zf-size); }
     }
   }
 

--- a/scss/grid/_grid.scss
+++ b/scss/grid/_grid.scss
@@ -42,13 +42,6 @@ $grid-column-responsive-gutter: null !default;
   $grid-column-gutter: $grid-column-responsive-gutter;
 }
 
-// If a single value is passed as a gutter, convert it to a map so the code knows what to do with it
-@if type-of($grid-column-gutter) == 'number' {
-  $grid-column-gutter: (
-    small: $grid-column-gutter,
-  );
-}
-
 @import 'row';
 @import 'column';
 @import 'size';

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -6,19 +6,31 @@
 /// @group grid
 ////
 
+/// Set the gutters on a column
+/// @param {Number} $gutter - Spacing between columns.
+@mixin grid-column-gutter($gutter) {
+  $padding: rem-calc($gutter) / 2;
+
+  padding-left: $padding;
+  padding-right: $padding;
+}
+
 /// Collapse the gutters on a column by removing the padding. **Note:** only use this mixin within a breakpoint. To collapse a column's gutters on all screen sizes, use the `$gutter` parameter of the `grid-column()` mixin instead.
 @mixin grid-column-collapse {
-  padding-left: 0;
-  padding-right: 0;
+  @include grid-column-gutter(0);
 }
 
 /// Un-collapse the gutters on a column by re-adding the padding.
 ///
 /// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
 @mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
-  $gutter: rem-calc($gutter) / 2;
-  padding-left: $gutter;
-  padding-right: $gutter;
+  @include grid-column-gutter($gutter);
+}
+
+/// Shorthand for `grid-column-gutter()`.
+/// @alias grid-column-gutter
+@mixin grid-col-gutter($gutter) {
+  @include grid-column-gutter($gutter);
 }
 
 /// Shorthand for `grid-column-collapse()`.

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -45,6 +45,14 @@
   @include grid-column-gutter(0);
 }
 
+/// Un-collapse the gutters on a column by re-adding the padding.
+///
+/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
+@mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
+  @warn 'This mixin is being replaced by grid-column-gutter(). grid-column-uncollapse() will be removed in Foundation 6.4.';
+  @include grid-column-gutter($gutter);
+}
+
 /// Shorthand for `grid-column-gutter()`.
 /// @alias grid-column-gutter
 @mixin grid-col-gutter($gutters) {
@@ -55,4 +63,11 @@
 /// @alias grid-column-collapse
 @mixin grid-col-collapse {
   @include grid-column-collapse;
+}
+
+/// Shorthand for `grid-column-uncollapse()`.
+/// @alias grid-column-uncollapse
+@mixin grid-col-uncollapse($gutter) {
+  @warn 'This mixin is being replaced by grid-col-gutter(). grid-col-uncollapse() will be removed in Foundation 6.4.';
+  @include grid-column-uncollapse($gutter);
 }

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -50,7 +50,7 @@
 /// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
 @mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
   @warn 'This mixin is being replaced by grid-column-gutter(). grid-column-uncollapse() will be removed in Foundation 6.4.';
-  @include grid-column-gutter($gutter);
+  @include grid-column-gutter($gutters: $gutter);
 }
 
 /// Shorthand for `grid-column-gutter()`.
@@ -67,7 +67,7 @@
 
 /// Shorthand for `grid-column-uncollapse()`.
 /// @alias grid-column-uncollapse
-@mixin grid-col-uncollapse($gutter) {
+@mixin grid-col-uncollapse($gutter: $grid-column-gutter) {
   @warn 'This mixin is being replaced by grid-col-gutter(). grid-col-uncollapse() will be removed in Foundation 6.4.';
   @include grid-column-uncollapse($gutter);
 }

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -6,9 +6,34 @@
 /// @group grid
 ////
 
+/// Get a gutter size for a given breakpoint
+/// @param {Keyword} $breakpoint [small] - Breakpoint name.
+/// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use. Responsive gutter settings by default.
+///
+/// @returns {Number} Gutter size.
+@function grid-column-gutter(
+  $breakpoint: $-zf-zero-breakpoint,
+  $gutters: $grid-column-gutter
+) {
+  // If gutter is single value, return it
+  @if type-of($gutters) == 'number' {
+    @return $gutters;
+  }
+
+  // Else, return the corresponding responsive value
+  @return -zf-get-bp-val($gutters, $breakpoint);
+}
+
 /// Set the gutters on a column
-/// @param {Number} $gutter - Spacing between columns.
-@mixin grid-column-gutter($gutter) {
+/// @param {Number|Keyword} $gutters [small] - Spacing between columns or breakpoint name.
+/// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use. Responsive gutter settings by default.
+@mixin grid-column-gutter(
+  $gutter: $-zf-zero-breakpoint,
+  $gutters: $grid-column-gutter
+) {
+  @if type-of($gutter) == 'string' {
+    $gutter: grid-column-gutter($gutter, $gutters);
+  }
   $padding: rem-calc($gutter) / 2;
 
   padding-left: $padding;
@@ -20,27 +45,14 @@
   @include grid-column-gutter(0);
 }
 
-/// Un-collapse the gutters on a column by re-adding the padding.
-///
-/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
-@mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
-  @include grid-column-gutter($gutter);
-}
-
 /// Shorthand for `grid-column-gutter()`.
 /// @alias grid-column-gutter
-@mixin grid-col-gutter($gutter) {
-  @include grid-column-gutter($gutter);
+@mixin grid-col-gutter($gutters) {
+  @include grid-column-gutter($gutters);
 }
 
 /// Shorthand for `grid-column-collapse()`.
 /// @alias grid-column-collapse
 @mixin grid-col-collapse {
   @include grid-column-collapse;
-}
-
-/// Shorthand for `grid-column-uncollapse()`.
-/// @alias grid-column-uncollapse
-@mixin grid-col-uncollapse($gutter: $grid-column-gutter) {
-  @include grid-column-uncollapse($gutter);
 }

--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -40,18 +40,18 @@
 ///   Modifications to the default grid styles. `nest` indicates the row will be placed inside another row. `collapse` indicates that the columns inside this row will not have padding. `nest collapse` combines both behaviors.
 /// @param {Number} $width [$grid-row-width] - Maximum width of the row.
 /// @param {Boolean} $cf [true] - Whether or not to include a clearfix.
-/// @param {Number} $gutter [$grid-column-gutter] - Gutter to use when inverting margins, in case the row is nested.
+/// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use when inverting margins. Responsive gutter settings by default.
 @mixin grid-row(
   $columns: null,
   $behavior: null,
   $width: $grid-row-width,
   $cf: true,
-  $gutter: $grid-column-gutter
+  $gutters: $grid-column-gutter
 ) {
   $margin: auto;
 
   @if index($behavior, nest) != null {
-    @include grid-row-nest($gutter);
+    @include grid-row-nest($gutters);
 
     @if index($behavior, collapse) != null {
       margin-left: 0;
@@ -77,19 +77,14 @@
 
 /// Inverts the margins of a row to nest it inside of a column.
 ///
-/// @param {Map|null} $gutter [null] - Gutter value to use when inverting the margins. Set to `null` to refer to the responsive gutter settings.
-@mixin grid-row-nest($gutter: $grid-column-gutter) {
-  @if type-of($gutter) == 'number' {
-    $gutter: ($-zf-zero-breakpoint: $gutter);
-  }
+/// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use when inverting margins. Responsive gutter settings by default.
+@mixin grid-row-nest($gutters: $grid-column-gutter) {
   max-width: none;
 
-  @each $breakpoint, $value in $gutter {
-    $margin: rem-calc($value) / 2 * -1;
+  @include -zf-each-breakpoint {
+    $margin: rem-calc(grid-column-gutter($-zf-size, $gutters)) / 2 * -1;
 
-    @include breakpoint($breakpoint) {
-      margin-left: $margin;
-      margin-right: $margin;
-    }
+    margin-left: $margin;
+    margin-right: $margin;
   }
 }


### PR DESCRIPTION
**Add static (unresponsive) grid gutters**
See: https://github.com/zurb/foundation-sites/issues/8508
Use: `.gutter-{size}` class on a row

Example:

``` html
<div class="row gutter-small"> <!-- Gutters always have a "small" width -->
  <div class="large-6 columns">...</div>
  <div class="large-6 columns">...</div>
  ...
</div>
```

**Standardize grid gutters functions, mixins and arguments.**

Adds/Removes:
- Add `@function grid-column-gutter( {breakpoint} )`: Get a gutter size for a given breakpoint.
- Add `@mixin grid-column-size( {px or breakpoint} )`: Set the gutters on a column.
- Depreciate `@mixin grid-column-uncollapse`. Use `grid-column-gutter` instead.
- Use these new features in all `(flex-)grid` mixin & functions. Use `@function grid-column-gutter` instead of modifying `$grid-column-gutter` to support its possible single value.

Other changes:
- Argument naming: use `$gutter` for a single size, and `$gutters` for a size map.
- Fix `$gutter` (now `$gutters`) argument descriptions.

_Required for the previous feature.
Anyway, all the "groups of properties" of a component (i.e. `size`, `align`, `color`, or specific behavior like `collapse`, `expand`...) should have their own `@mixin`, to allow a component customization in responsive/semantic cases_
