### PR TITLE
add specificity for .expanded.row .[size]-collapse.row

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -116,7 +116,8 @@
     .#{$-zf-size}-#{$collapse} {
       > .#{$column} { @include grid-col-collapse; }
 
-      .#{$row} {
+      .#{$row},
+      .#{$expanded}.#{$row} &.#{$row} {
         margin-left: 0;
         margin-right: 0;
       }


### PR DESCRIPTION
Fixes #8533. 

The `.expanded` class had more specificity than the `.[size]-collapse` classes, so they weren't getting the zero side margins and were spilling past the edges. So I added an explicit selector for responsive collapsed rows that are within expanded rows. 
