### PR TITLE
Add checkbox-group validation

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -83,11 +83,6 @@ class Abide {
     var isGood = true;
 
     switch ($el[0].type) {
-      case 'checkbox':
-        isGood = $el[0].checked;
-        break;
-      case 'radio':
-        break;
       case 'select':
       case 'select-one':
       case 'select-multiple':
@@ -196,14 +191,13 @@ class Abide {
 
     switch ($el[0].type) {
       case 'radio':
-//        validated = this.validateRadio($el.attr('name'));
-//        break;
+        validated = this.validateRadio($el.attr('name'));
+        break;
 
       case 'checkbox':
-        var $group = $el.parent().closest('.'+$el[0].type+'-group');
+        var $group = $el.parent().closest('.checkbox-group');
         if ($group.length) {
-          var minRequired = ($el[0].type === 'radio') ? 1
-            : $group.attr('data-min-required') ? $group.attr('data-min-required') : 1;
+          var minRequired = $group.attr('data-min-required') ? $group.attr('data-min-required') : 1;
           if ($group.find(':checked').length >= minRequired) validated = true;
           $elError = $group;
         } else {

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -83,6 +83,11 @@ class Abide {
     var isGood = true;
 
     switch ($el[0].type) {
+      case 'checkbox':
+        isGood = $el[0].checked;
+        break;
+      case 'radio':
+        break;
       case 'select':
       case 'select-one':
       case 'select-multiple':
@@ -186,15 +191,24 @@ class Abide {
         validated = false,
         customValidator = true,
         validator = $el.attr('data-validator'),
-        equalTo = true;
+        equalTo = true,
+        $elError = $el;
 
     switch ($el[0].type) {
       case 'radio':
-        validated = this.validateRadio($el.attr('name'));
-        break;
+//        validated = this.validateRadio($el.attr('name'));
+//        break;
 
       case 'checkbox':
-        validated = clearRequire;
+        var $group = $el.parent().closest('.'+$el[0].type+'-group');
+        if ($group.length) {
+          var minRequired = ($el[0].type === 'radio') ? 1
+            : $group.attr('data-min-required') ? $group.attr('data-min-required') : 1;
+          if ($group.find(':checked').length >= minRequired) validated = true;
+          $elError = $group;
+        } else {
+          validated = clearRequire;
+        }
         break;
 
       case 'select':
@@ -219,7 +233,7 @@ class Abide {
     var goodToGo = [clearRequire, validated, customValidator, equalTo].indexOf(false) === -1;
     var message = (goodToGo ? 'valid' : 'invalid') + '.zf.abide';
 
-    this[goodToGo ? 'removeErrorClasses' : 'addErrorClasses']($el);
+    this[goodToGo ? 'removeErrorClasses' : 'addErrorClasses']($elError);
 
     /**
      * Fires when the input is done checking for validation. Event trigger is either `valid.zf.abide` or `invalid.zf.abide`


### PR DESCRIPTION
Propose adding checkbox group for required validation. Wrap the icheckbox fields in container with class `checkbox-group` with`data-min-required="n"` attribute. `data-min-required` is default to 1. In field `required` attribute check is still supported.

Example for checkbox-group required validation

```

<div class="row">
  <div class="medium-4 column">
    <label for "hobby-group">Select two or more hobbies</label>
  </div>
  <div id="hobby-group" class="medium-8 column checkbox-group" data-min-required="2">
    <input name="hobby" type="checkbox" value="reading">Reading
    <input name="hobby" type="checkbox" value="writing">Writing
    <input name="hobby" type="checkbox" value="music">Music
    <input name="hobby" type="checkbox" value="sport">Sport
    <br />
    <div class="form-error">At lease two hobbies must be selected</div>
  </div>
</div>
```

If no checkbox-group is found, required check on checkbox field still holds.

Please provide feedback and comments.
