### PR TITLE
Revert "Update MediaQueries to initialize if not initialized already."

### DIFF
--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -4,11 +4,6 @@
 
 // Default set of media queries
 const defaultQueries = {
-  small : 'only screen and (min-width: 0em)',
-  medium : 'only screen and (min-width: 40em)',
-  large : 'only screen and (min-width: 64em)',
-  xlarge : 'only screen and (min-width: 75em)',
-  xxlarge : 'only screen and (min-width: 90em)',
   'default' : 'only screen',
   landscape : 'only screen and (orientation: landscape)',
   portrait : 'only screen and (orientation: portrait)',
@@ -35,22 +30,13 @@ var MediaQuery = {
     var extractedStyles = $('.foundation-mq').css('font-family');
     var namedQueries;
 
-    if (extractedStyles) {
-      namedQueries = parseStyleToObject(extractedStyles);
-    } 
+    namedQueries = parseStyleToObject(extractedStyles);
 
-    for (var key in defaultQueries) {
-      if (key in namedQueries) {
-        self.queries.push({
-          name: key,
-          value: `only screen and (min-width: ${namedQueries[key]})`
-        });
-      } else {
-        self.queries.push({
-          name: key,
-          value: defaultQueries[key]
-        });
-      }
+    for (var key in namedQueries) {
+      self.queries.push({
+        name: key,
+        value: `only screen and (min-width: ${namedQueries[key]})`
+      });
     }
 
     this.current = this._getCurrentSize();
@@ -81,10 +67,6 @@ var MediaQuery = {
    * @returns {String|null} - The media query of the breakpoint, or `null` if the breakpoint doesn't exist.
    */
   get(size) {
-    if (! this.queries.length) {
-      this._init();
-    }
-
     for (var i in this.queries) {
       var query = this.queries[i];
       if (size === query.name) return query.value;


### PR DESCRIPTION
Reverts zurb/foundation-sites#8192

Unfortunately, upon testing this PR turned out to cause a number of issues related to responsiveness... in particular, it breaks _getCurrentSize(), which caused all sorts of issues.  I looked for a quick fix and didn't find one, so I'm going to revert this for now.
