### PR TITLE
[Bugfix] Sticky - sticky-container should be 0px height when children…

### DIFF
--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -195,7 +195,8 @@ class Sticky {
    * @private
    */
   _setSticky() {
-    var stickTo = this.options.stickTo,
+    var _this = this,
+        stickTo = this.options.stickTo,
         mrgn = stickTo === 'top' ? 'marginTop' : 'marginBottom',
         notStuckTo = stickTo === 'top' ? 'bottom' : 'top',
         css = {};
@@ -214,6 +215,9 @@ class Sticky {
                   * @event Sticky#stuckto
                   */
                  .trigger(`sticky.zf.stuckto:${stickTo}`);
+    this.$element.on("transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd", function() {
+      _this._setSizes();
+    });
   }
 
   /**

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -281,6 +281,9 @@ class Sticky {
     });
 
     var newContainerHeight = this.$element[0].getBoundingClientRect().height || this.containerHeight;
+    if (this.$element.css("display") == "none") {
+      newContainerHeight = 0;
+    }
     this.containerHeight = newContainerHeight;
     this.$container.css({
       height: newContainerHeight


### PR DESCRIPTION
When you have a responsive menu ("drilldown medium-dropdown" for example) and you put the dropdown in sticky mode, if you resize the window to small size to get the drilldown appears, the height of the sticky container will remains as before and you'll have a blank div between your menu and content.

See a codepen here :
[https://codepen.io/gehasia/pen/JXMZJB](https://codepen.io/gehasia/pen/JXMZJB)
Just resize from medium to small and you'll se the sticky container, in red, remaining in the small size, pushing the content...

The height of the sticky-container is calculated depending on his children "sticky" element height. When using the responsive menu, if we resize the window until the drilldown breakpoint, the "sticky" dropdown will stay at the same height, but will pass in display="none". The proposal patch just test if the sticky element is displayed or not, and, in the last case, set the height of the sticky-container to 0...
