### PR TITLE
tabs:destroy fixed; reponsiveToggle:destroy

### DIFF
--- a/js/foundation.responsiveToggle.js
+++ b/js/foundation.responsiveToggle.js
@@ -51,7 +51,9 @@ class ResponsiveToggle {
   _events() {
     var _this = this;
 
-    $(window).on('changed.zf.mediaquery', this._update.bind(this));
+    this._updateMqHandler = this._update.bind(this);
+    
+    $(window).on('changed.zf.mediaquery', this._updateMqHandler);
 
     this.$toggler.on('click.zf.responsiveToggle', this.toggleMenu.bind(this));
   }
@@ -80,7 +82,7 @@ class ResponsiveToggle {
    * @function
    * @fires ResponsiveToggle#toggled
    */
-  toggleMenu() {
+  toggleMenu() {   
     if (!Foundation.MediaQuery.atLeast(this.options.hideFor)) {
       this.$targetMenu.toggle(0);
 
@@ -93,7 +95,12 @@ class ResponsiveToggle {
   };
 
   destroy() {
-    //TODO this...
+    this.$element.off('.zf.responsiveToggle');
+    this.$toggler.off('.zf.responsiveToggle');
+    
+    $(window).off('changed.zf.mediaquery', this._updateMqHandler);
+    
+    Foundation.unregisterPlugin(this);
   }
 }
 

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -93,9 +93,12 @@ class Tabs {
   _events() {
     this._addKeyHandler();
     this._addClickHandler();
-
+    this._setHeightMqHandler = null;
+    
     if (this.options.matchHeight) {
-      $(window).on('changed.zf.mediaquery', this._setHeight.bind(this));
+      this._setHeightMqHandler = this._setHeight.bind(this);
+      
+      $(window).on('changed.zf.mediaquery', this._setHeightMqHandler);
     }
   }
 
@@ -271,7 +274,9 @@ class Tabs {
       .hide();
 
     if (this.options.matchHeight) {
-      $(window).off('changed.zf.mediaquery');
+      if (this._setHeightMqHandler != null) {
+         $(window).off('changed.zf.mediaquery', this._setHeightMqHandler);
+      }
     }
 
     Foundation.unregisterPlugin(this);

--- a/test/javascript/util/core.js
+++ b/test/javascript/util/core.js
@@ -63,6 +63,8 @@ describe('Foundation core', function() {
     it('can append a namespace to the number', function() {
       var id = Foundation.GetYoDigits(6, 'plugin');
 
+      id.should.be.a('string');
+      id.should.have.lengthOf(6 + '-plugin'.length);
       id.should.contain('-plugin');
     });
   });


### PR DESCRIPTION
foundation.tabs::destroy() fixed to unbind itself from global $(window).on('changed.zf.mediaquery'), rather than unbinding everyone.

Implemented foundation.responsiveToggle::destroy().

Added a couple of asserts to core.js test.
