### PR TITLE
Add (flex-)grid-row size modifier

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -45,7 +45,7 @@
 
     // Expanded (full-width) row
     &.#{$expanded} {
-      max-width: none;
+      @include grid-row-size(expand);
 
       .#{$row} {
         margin-left: auto;

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -10,13 +10,13 @@
 ///
 /// @param {Keyword|List} $behavior [null]
 ///   Modifications to the default grid styles. `nest` indicates the row will be placed inside another row. `collapse` indicates that the columns inside this row will not have padding. `nest collapse` combines both behaviors.
-/// @param {Number} $width [$grid-row-width] - Maximum width of the row.
+/// @param {Keyword|Number} $size [$grid-row-width] Maximum size of the row. Set to `expand` to make the row taking the full width.
 /// @param {Number} $columns [null] - Number of columns to use for this row. If set to `null` (the default), the global column count will be used.
 /// @param {Boolean} $base [true] - Set to `false` to prevent basic styles from being output. Useful if you're calling this mixin on the same element twice, as it prevents duplicate CSS output.
 /// @param {Number} $gutter [$grid-column-gutter] - Gutter to use when inverting margins, in case the row is nested.
 @mixin flex-grid-row(
   $behavior: null,
-  $width: $grid-row-width,
+  $size: $grid-row-width,
   $columns: null,
   $base: true,
   $gutter: $grid-column-gutter
@@ -32,7 +32,7 @@
     }
   }
   @else {
-    max-width: $width;
+    @include grid-row-size($size);
     margin-left: auto;
     margin-right: auto;
   }
@@ -172,7 +172,7 @@
 
     // Expanded row
     &.expanded {
-      max-width: none;
+      @include grid-row-size(expand);
     }
 
     &.collapse {

--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -38,13 +38,13 @@
 /// @param {Number} $columns [null] - Column count for this row. `null` will use the default column count.
 /// @param {Keywords} $behavior [null]
 ///   Modifications to the default grid styles. `nest` indicates the row will be placed inside another row. `collapse` indicates that the columns inside this row will not have padding. `nest collapse` combines both behaviors.
-/// @param {Number} $width [$grid-row-width] - Maximum width of the row.
+/// @param {Keyword|Number} $size [$grid-row-width] Maximum size of the row. Set to `expand` to make the row taking the full width.
 /// @param {Boolean} $cf [true] - Whether or not to include a clearfix.
 /// @param {Number} $gutter [$grid-column-gutter] - Gutter to use when inverting margins, in case the row is nested.
 @mixin grid-row(
   $columns: null,
   $behavior: null,
-  $width: $grid-row-width,
+  $size: $grid-row-width,
   $cf: true,
   $gutter: $grid-column-gutter
 ) {
@@ -59,7 +59,7 @@
     }
   }
   @else {
-    max-width: $width;
+    @include grid-row-size($size);
     margin-left: auto;
     margin-right: auto;
   }
@@ -92,4 +92,15 @@
       margin-right: $margin;
     }
   }
+}
+
+/// Set a grid row size
+///
+/// @param {Keyword|Number} $size [$grid-row-width] Maximum size of the row. Set to `expand` to make the row taking the full width.
+@mixin grid-row-size($size: $grid-row-width) {
+  @if $size == expand {
+    $size: none;
+  }
+
+  max-width: $size;
 }


### PR DESCRIPTION
Add a `grid-row` and `flex-grid-row` width modifier

``` scss
@mixin grid-row-width($width)
// Set a grid row width

// $width : [$grid-row-width] Maximum width of the row. Set to `expand`
//          to make the row taking the full width.
```

Examples with a semantic sass:

``` scss
.my-row {
  @include grid-row($width: 900px);
  // Or
  @include grid-row($width: expand);
}
```

``` scss
.my-row {
  @include grid-row;

  @include breakpoint(medium) {
    @include grid-row-width(expand);
  }
}
```

**Note**
There is lot of similar work to do in `grid` and `flex-grid`. As said in https://github.com/zurb/foundation-sites/pull/8528 :

> Anyway, all the "groups of properties" of a component (i.e. size, align, color, or specific behavior like collapse, expand...) should have their own `@mixin`, to allow a component customization in responsive/semantic cases

So if you searched what to do to improve foundation, you know what to do ;) !
