### PR TITLE
Enhance keyboard util.

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -144,11 +144,11 @@ class AccordionMenu {
         },
         up: function() {
           $prevElement.attr('tabindex', -1).focus();
-          e.preventDefault();
+          return true;
         },
         down: function() {
           $nextElement.attr('tabindex', -1).focus();
-          e.preventDefault();
+          return true;
         },
         toggle: function() {
           if ($element.children('[data-submenu]').length) {
@@ -158,7 +158,10 @@ class AccordionMenu {
         closeAll: function() {
           _this.hideAll();
         },
-        handled: function() {
+        handled: function(preventDefault) {
+          if (preventDefault) {
+            e.preventDefault();
+          }
           e.stopImmediatePropagation();
         }
       });

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -155,7 +155,7 @@ class Drilldown {
             $element.parent('li').one(Foundation.transitionend($element), function(){
               $element.parent('li').find('ul li a').filter(_this.$menuItems).first().focus();
             });
-            e.preventDefault();
+            return true;
           }
         },
         previous: function() {
@@ -165,15 +165,15 @@ class Drilldown {
               $element.parent('li').parent('ul').parent('li').children('a').first().focus();
             }, 1);
           });
-          e.preventDefault();
+          return true;
         },
         up: function() {
           $prevElement.focus();
-          e.preventDefault();
+          return true;
         },
         down: function() {
           $nextElement.focus();
-          e.preventDefault();
+          return true;
         },
         close: function() {
           _this._back();
@@ -187,16 +187,18 @@ class Drilldown {
                 $element.parent('li').parent('ul').parent('li').children('a').first().focus();
               }, 1);
             });            
-            e.preventDefault();
           } else if ($element.is(_this.$submenuAnchors)) {
             _this._show($element.parent('li'));
             $element.parent('li').one(Foundation.transitionend($element), function(){
               $element.parent('li').find('ul li a').filter(_this.$menuItems).first().focus();
             });            
+          }
+          return true;
+        },
+        handled: function(preventDefault) {
+          if (preventDefault) {
             e.preventDefault();
           }
-        },
-        handled: function() {
           e.stopImmediatePropagation();
         }
       });

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -313,19 +313,19 @@ class Reveal {
         tab_forward: function() {
           if (_this.$element.find(':focus').is(_this.focusableElements.eq(-1))) { // left modal downwards, setting focus to first element
             _this.focusableElements.eq(0).focus();
-            e.preventDefault();
+            return true;
           }
           if (_this.focusableElements.length === 0) { // no focusable elements inside the modal at all, prevent tabbing in general
-            e.preventDefault();
+            return true;
           }
         },
         tab_backward: function() {
           if (_this.$element.find(':focus').is(_this.focusableElements.eq(0)) || _this.$element.is(':focus')) { // left modal upwards, setting focus to last element
             _this.focusableElements.eq(-1).focus();
-            e.preventDefault();
+            return true;
           }
           if (_this.focusableElements.length === 0) { // no focusable elements inside the modal at all, prevent tabbing in general
-            e.preventDefault();
+            return true;
           }
         },
         open: function() {
@@ -341,6 +341,11 @@ class Reveal {
           if (_this.options.closeOnEsc) {
             _this.close();
             _this.$anchor.focus();
+          }
+        },
+        handled: function(preventDefault) {
+          if (preventDefault) {
+            e.preventDefault();
           }
         }
       });

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -129,8 +129,7 @@ class Tabs {
 
     this.$tabTitles.off('keydown.zf.tabs').on('keydown.zf.tabs', function(e){
       if (e.which === 9) return;
-      e.stopPropagation();
-      e.preventDefault();
+      
 
       var $element = $(this),
         $elements = $element.parent('ul').children('li'),
@@ -163,6 +162,10 @@ class Tabs {
         next: function() {
           $nextElement.find('[role="tab"]').focus();
           _this._handleTabChange($nextElement);
+        },
+        handled: function() {
+          e.stopPropagation();
+          e.preventDefault();
         }
       });
     });

--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -66,13 +66,13 @@ var Keyboard = {
 
     fn = functions[command];
     if (fn && typeof fn === 'function') { // execute function  if exists
-      fn.apply();
+      var returnValue = fn.apply();
       if (functions.handled || typeof functions.handled === 'function') { // execute function when event was handled
-          functions.handled.apply();
+          functions.handled(returnValue);
       }
     } else {
       if (functions.unhandled || typeof functions.unhandled === 'function') { // execute function when event was not handled
-          functions.unhandled.apply();
+          functions.unhandled();
       }
     }
   },


### PR DESCRIPTION
Enhanced keyboard util by adding a parameter that is passed to the `handled` function based on the evaluation of the function that was handled.
It is now easier to only do certain actions (e.g. calling `preventDefaul()`) in the `handled` handler by letting the other function (e.g. `next`, `up`, ...) return some value, which is directly passed into `handled` as the first parameter.
I also adjusted the calls to the keyboard util for some plugins to fix issues and prevent bad behavior.

Since this rework fixes some bugs (#8535, #8569) I will target the develop branch.
