### PR TITLE
Fix missing checkbox requiredCheck

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -83,6 +83,10 @@ class Abide {
     var isGood = true;
 
     switch ($el[0].type) {
+      case 'checkbox':
+        isGood = $el[0].checked;
+        break;
+
       case 'select':
       case 'select-one':
       case 'select-multiple':


### PR DESCRIPTION
requiredCheck for checkbox was removed from 6.2.1. Reinstating.

Label set/clear error highlight only for associated checkbox input, not for the entire group.
