### PR TITLE
Remove duplication of max-width property in row mixin

### DIFF
--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -82,10 +82,10 @@
   @if type-of($gutter) == 'number' {
     $gutter: ($-zf-zero-breakpoint: $gutter);
   }
+  max-width: none;
 
   @each $breakpoint, $value in $gutter {
     $margin: rem-calc($value) / 2 * -1;
-    max-width: none;
 
     @include breakpoint($breakpoint) {
       margin-left: $margin;


### PR DESCRIPTION
Fixes #8566 
As a result of the `max-width` property being inside the `@each` statement, the property was needlessly duplicated while compiling.
