### PR TITLE
[Bugfix] Drilldown - Cleaning attached events correctly on destroy() …

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -315,8 +315,10 @@ class Drilldown {
     this.$element.unwrap()
                  .find('.js-drilldown-back, .is-submenu-parent-item').remove()
                  .end().find('.is-active, .is-closing, .is-drilldown-submenu').removeClass('is-active is-closing is-drilldown-submenu')
-                 .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role')
-                 .off('.zf.drilldown').end().off('zf.drilldown');
+                 .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role');
+    this.$submenuAnchors.each(function() {
+      $(this).off('.zf.drilldown');
+    });
     this.$element.find('a').each(function(){
       var $link = $(this);
       if($link.data('savedHref')){


### PR DESCRIPTION
(Reopen of https://github.com/zurb/foundation-sites/pull/8550 with a clean history, as asked)

Having a responsive drilldown/dropdown clickable only menu configured like this :
`data-responsive-menu="drilldown medium-dropdown" data-click-open="true" data-disable-hover="true"`
If you load the page (dropdown mode), then resize to small to get your drilldown, then go back to medium/large to get back your dropdown the event handler for drilldown is still registered in handlerQueue.handlers[0] while the dropdown one is in handlerQueue.handlers[1], thus the drilldown handler catch the request (first array item...) and the dropdown handler never got it...
In this specific case you can't click your dropdown menu anymore after resizing (click event is still registered to the destroyed drilldown menu...). This bug didn't appeared in dropdown hover mode because drilldown is click only mode, and then events does not "collide".

This patch try to unregister every event handlers attached to submenuAnchors on Drilldown, the same way as it is constructed in _prepareMenu in place of the
`.off('.zf.drilldown').end().off('zf.drilldown')`
which seems to be inconsistent.
