### PR TITLE
fixes closeOnClick

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -116,8 +116,9 @@ class Drilldown {
       _this._show($elem.parent('li'));
 
       if(_this.options.closeOnClick){
-        var $body = $('body').not(_this.$wrapper);
+        var $body = $('body');
         $body.off('.zf.drilldown').on('click.zf.drilldown', function(e){
+          if (e.target === _this.$element[0] || $.contains(_this.$element[0], e.target)) { return; }
           e.preventDefault();
           _this._hideAll();
           $body.off('.zf.drilldown');


### PR DESCRIPTION
var $body = $('body').not(_this.$wrapper);
not ignores clicks on links in the drilldown menu
fixes links with no sub and closeOnClick true doesn't fire
