### PR TITLE
s.no_pip vs. self.settings.no_pip

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -331,7 +331,7 @@
           p.left = p.left - thisOuterWidth + tOuterWidth;
         }
 
-        if (!self.settings.no_pip && tOuterWidth < thisOuterWidth || self.small() || this.hasClass(s.mega_menu)) {
+        if (!s.no_pip && tOuterWidth < thisOuterWidth || self.small() || this.hasClass(s.mega_menu)) {
           self.adjust_pip(this, t, s, p);
         }
 
@@ -354,7 +354,7 @@
           p.left = p.left - thisOuterWidth + tOuterWidth;
         }
 
-        if (!self.settings.no_pip && tOuterWidth < thisOuterWidth || self.small() || this.hasClass(s.mega_menu)) {
+        if (!s.no_pip && tOuterWidth < thisOuterWidth || self.small() || this.hasClass(s.mega_menu)) {
           self.adjust_pip(this, t, s, p);
         }
 


### PR DESCRIPTION
https://github.com/zurb/foundation-sites/commit/48aa4843c51f7a95a31ff59db146c55bb5f68b03

We would like this change in our project. However, `!s.no_pip` was accidentally over written. In both `top:` and `bottom:` it should be `!s.no_pip` and **not** `!self.settings.no_pip`.
