### PR TITLE
changed.zf.mediaquery improvements

### DIFF
--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -106,14 +106,14 @@ var MediaQuery = {
    */
   _watcher() {
     $(window).on('resize.zf.mediaquery', () => {
-      var newSize = this._getCurrentSize();
+      var newSize = this._getCurrentSize(), currentSize = this.current;
 
-      if (newSize !== this.current) {
+      if (newSize !== currentSize) {
         // Change the current media query
         this.current = newSize;
 
         // Broadcast the media query change on the window
-        $(window).trigger('changed.zf.mediaquery', [newSize, this.current]);
+        $(window).trigger('changed.zf.mediaquery', [newSize, currentSize]);
       }
     });
   }

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -109,11 +109,11 @@ var MediaQuery = {
       var newSize = this._getCurrentSize();
 
       if (newSize !== this.current) {
-        // Broadcast the media query change on the window
-        $(window).trigger('changed.zf.mediaquery', [newSize, this.current]);
-
         // Change the current media query
         this.current = newSize;
+
+        // Broadcast the media query change on the window
+        $(window).trigger('changed.zf.mediaquery', [newSize, this.current]);
       }
     });
   }


### PR DESCRIPTION
this.current = newSize; (should be set before window triggered because if something goes wrong changed.zf.mediaquery fires constantly, because current is neer set
