### PR TITLE
Sticky Experiment: staticHeight option added

### DIFF
--- a/docs/assets/partials/sticky-nav.html
+++ b/docs/assets/partials/sticky-nav.html
@@ -32,7 +32,7 @@
 </head>
 <body>
   <div data-sticky-container>
-    <div class="title-bar" data-sticky data-options="marginTop:0;">
+    <div class="title-bar" data-sticky data-static-height="false" data-options="marginTop:0;">
       <div class="title-bar-left">
 
         <span class="title-bar-title">Sticky Navigation</span>

--- a/docs/pages/sticky.md
+++ b/docs/pages/sticky.md
@@ -65,22 +65,25 @@ You can also use two anchors, if you please. Using `data-top-anchor="idOfSomethi
 
 <div class="row">
   <div class="columns small-12">
-    <div class="columns small-6" id="example2">
+    <div class="columns small-6">
       <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+      <p id="example2">
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
       <p id="foo">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        The image to the right will lose stickiness when it hits the top of this paragraph element.
       </p>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
     </div>
     <div class="columns small-6 right" data-sticky-container>
-      <div class="sticky" data-sticky data-top-anchor="example2:top" data-btm-anchor="foo" data-stick-to="bottom">
+      <div class="sticky" data-sticky data-top-anchor="example2:top" data-btm-anchor="foo:bottom">
         <img class="thumbnail" src="assets/img/generic/rectangle-5.jpg">
       </div>
     </div>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ gulp.task('serve', ['build'], function(){
 // Watch files for changes
 gulp.task('watch', function() {
   gulp.watch('docs/**/*', ['docs', browser.reload]);
-  gulp.watch(['docs/layout/*.html', 'docs/partials/*.html'], ['docs:all', browser.reload]);
+  gulp.watch(['docs/layout/*.html', 'docs/partials/*.html', 'docs/assets/partials/*.html'], ['docs:all', browser.reload]);
   gulp.watch('scss/**/*', ['sass', browser.reload]);
   gulp.watch(['docs/assets/scss/**/*', 'foundation-docs/scss/**/*'], ['sass:docs', browser.reload]);
   gulp.watch('js/**/*', ['javascript:foundation', browser.reload]);

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -42,8 +42,11 @@ class Sticky {
     this.$container.addClass(this.options.containerClass);
 
     this.$element.addClass(this.options.stickyClass)
-                 .attr({'data-resize': id});
+                 .attr({
+                        'data-resize': id
+                      });
 
+    this.staticHeight = this.options.staticHeight;
     this.scrollCount = this.options.checkEvery;
     this.isStuck = false;
     $(window).one('load.zf.sticky', function(){
@@ -215,9 +218,9 @@ class Sticky {
                   * @event Sticky#stuckto
                   */
                  .trigger(`sticky.zf.stuckto:${stickTo}`);
-    this.$element.on("transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd", function() {
-      _this._setSizes();
-    });
+    // this.$element.on("transitionend webkitTransitionEnd oTransitionEnd otransitionend MSTransitionEnd", function() {
+    //   _this._setSizes();
+    // });
   }
 
   /**
@@ -235,10 +238,10 @@ class Sticky {
         anchorPt = (this.points ? this.points[1] - this.points[0] : this.anchorHeight) - this.elemHeight,
         mrgn = stickToTop ? 'marginTop' : 'marginBottom',
         notStuckTo = stickToTop ? 'bottom' : 'top',
-        topOrBottom = isTop ? 'top' : 'bottom';
-
-    css[mrgn] = 0;
-
+        topOrBottom = isTop ? 'top' : 'bottom',
+        preserveHeight = this.elemHeight,
+        staticHeight = this.staticHeight;
+    
     if ((isTop && !stickToTop) || (stickToTop && !isTop)) {
       css[stickTo] = anchorPt;
       css[notStuckTo] = 0;
@@ -247,7 +250,14 @@ class Sticky {
       css[notStuckTo] = anchorPt;
     }
 
+    if (staticHeight) {
+      css['height'] = preserveHeight;
+    }
+
     css['left'] = '';
+    
+    console.log(staticHeight);
+    
     this.isStuck = false;
     this.$element.removeClass(`is-stuck is-at-${stickTo}`)
                  .addClass(`is-anchored is-at-${topOrBottom}`)
@@ -437,7 +447,13 @@ Sticky.defaults = {
    * @option
    * @example 50
    */
-  checkEvery: -1
+  checkEvery: -1,
+  /**
+   * If the element you are stickying has height: auto when not sticky, 
+   * @option
+   * @example true
+   */
+  staticHeight: true
 };
 
 /**

--- a/test/javascript/components/sticky.js
+++ b/test/javascript/components/sticky.js
@@ -2,19 +2,26 @@ describe('Sticky', function() {
 	var plugin;
 	var $html;
 
-	// afterEach(function() {
-	// 	plugin.destroy();
-	// 	$html.remove();
-	// });
+	afterEach(function() {
+		plugin.destroy();
+		$html.remove();
+	});
 
 	describe('constructor()', function() {
-		// it('', function() {
-		// 	$html = $('').appendTo('body');
-		// 	plugin = new Foundation.Sticky($html, {});
+		it('stores the element and plugin options', function() {
+			$html = $(`
+				<div class="columns small-6 right" data-sticky-container>
+  					<div class="sticky" data-sticky data-margin-top="0">
+    					<p>I'm sticky</p>
+  					</div>
+				</div>
+				`).appendTo('body');
 
-		// 	plugin.$element.should.be.an('object');
-		// 	plugin.options.should.be.an('object');
-		// });
+			plugin = new Foundation.Sticky($html, {});
+
+			plugin.$element.should.be.an('object');
+			plugin.options.should.be.an('object');
+		});
 	});
 
 });

--- a/test/visual/sticky/anchors-with-callouts.html
+++ b/test/visual/sticky/anchors-with-callouts.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+  <meta charset="UTF-8">
+  <title>Foundation for Sites Testing</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+  <link href="../assets/css/foundation.css" rel="stylesheet" />
+  <style>
+    .foo {
+      height: 30rem;
+    }
+
+    .foo h1 {
+      display: inline-block;
+      float: right;
+    }
+
+    .foo:nth-child(odd) {
+      background-color: lightgreen;
+      color: white;
+    }
+
+    .foo:nth-child(even) {
+      background-color: lightblue;
+      color: white;
+    }
+
+  </style>
+
+</head>
+<body>
+  
+  <div class="row">
+
+    <div class="small-12 medium-2 columns">
+      <div class="container" data-sticky-container>
+        <div class="callout sticky" data-sticky data-margin-top="0" data-anchor="foo1">
+          <h5>Test 1</h5>
+          <p>I should stick to the top and bottom of #foo1. I'm not a child of any #foo's.</p>
+          <a href="http://foundation.zurb.com/sites/docs/stick.html" class="small button">Go to Sticky Docs</a>          
+        </div>
+      </div>
+    </div>
+    
+    <div class="small-12 medium-7 columns">
+      <div id="foo1" class="foo">
+        <h1>#foo1</h1>
+      </div>
+      <div id="foo2" class="foo">
+        <h1>#foo2</h1>
+        <div class="container" data-sticky-container>
+          <div class="callout sticky" data-sticky data-margin-top="0" data-anchor="foo2">
+            <h5>Test 2</h5>
+            <p>I should stick to the top and bottom of #foo2.<br/>I'm also a child of #foo2</p>
+            <a href="http://foundation.zurb.com/sites/docs/stick.html" class="small button">Go to Sticky Docs</a>          
+          </div>
+        </div>
+      </div>
+      <div id="foo3" class="foo">
+        <h1>#foo3</h1>
+
+      </div>
+      <div id="foo4" class="foo">
+        <h1>#foo4</h1>
+        <div class="container" data-sticky-container>
+          <div class="callout sticky" data-sticky data-margin-top="0" data-top-anchor="foo4" data-btm-anchor="foo6">
+            <h5>Test 4</h5>
+            <p>I should stick to the top of #foo4 and the bottom of #foo5.<br/>I'm a child of #foo4</p>
+            <a href="http://foundation.zurb.com/sites/docs/stick.html" class="small button">Go to Sticky Docs</a>          
+          </div>
+        </div>
+      </div>
+      <div id="foo5" class="foo">
+        <h1>#foo5</h1>
+      </div>
+      <div id="foo6" class="foo">
+        <h1>#foo6</h1>
+      </div>
+      <div id="foo7" class="foo">
+        <h1>#foo7</h1>
+      </div>
+      <div id="foo8" class="foo">
+        <h1>#foo8</h1>
+      </div>
+    </div>
+
+    <div class="small-12 medium-3 columns">
+      <div class="container" data-sticky-container>
+        <div class="callout sticky" data-sticky data-margin-top="0" data-anchor="foo3">
+          <h5>Test 3</h5>
+          <p>I should stick to the top and bottom of #foo3.<br/>I'm not the child of any of you #foo's.<br/>When I'm not feeling stuck I jump to the top because I'm not a child of the top anchor</p>
+          <a href="http://foundation.zurb.com/sites/docs/stick.html" class="small button">Go to Sticky Docs</a>          
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="../assets/js/vendor.js"></script>
+  <script src="../assets/js/foundation.js"></script>
+  <script>
+    $(document).foundation();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Added a `staticHeight` option to Sticky which defaults to `true`. If the sticky element has a height that will change between sticky states, set this to false. Otherwise, the default plugin setting of `true` will get the height of the element before sticky is removed, and set the element to that height after sticky is removed. This is so when `position` is changed to `absolute` when it "unsticks" the container doesn't lose it's height.

Resolves: #8435 

@gehasia please check out what I have done when you get a chance.
