### PR TITLE
added a-tag class qualifier ":not(.follow)" to allow accordion a-tags to refere…

### DIFF
--- a/js/foundation/foundation.accordion.js
+++ b/js/foundation/foundation.accordion.js
@@ -25,7 +25,7 @@
 
       S(this.scope)
       .off('.fndtn.accordion')
-      .on('click.fndtn.accordion', '[' + this.attr_name() + '] > dd > a, [' + this.attr_name() + '] > li > a', function (e) {
+      .on('click.fndtn.accordion', '[' + this.attr_name() + '] > dd > a:not(.follow), [' + this.attr_name() + '] > li > a:not(.follow)', function (e) {
         var accordion = S(this).closest('[' + self.attr_name() + ']'),
             groupSelector = self.attr_name() + '=' + accordion.attr(self.attr_name()),
             settings = accordion.data(self.attr_name(true) + '-init') || self.settings,


### PR DESCRIPTION
This is a new feature. In a zurb accordion, the a-tags are completely co-opted to open and close the accordion. It is desirable to have a-tags that actually point somewhere without getting turned into accordion opener-closers.

This change allows the use of the class "follow" within an accordion a-tag to bypass the accordion javascript open-close and instead point to a URL.

For example, in many file-manager applications, the little icon to the left of a directory will be used to open and close the directory, but clicking on the directory name will point and move the file-manager to the directory itself.

To see this new feature in action, see the left side navigation menu bar at [alphabent.com](https://www.alphabent.com)
