### PR TITLE
Toggle aria-expanded on all offcanvas triggers

### DIFF
--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -22,6 +22,7 @@ class OffCanvas {
     this.$element = element;
     this.options = $.extend({}, OffCanvas.defaults, this.$element.data(), options);
     this.$lastTrigger = $();
+    this.$triggers = $();
 
     this._init();
     this._events();
@@ -40,7 +41,7 @@ class OffCanvas {
     this.$element.attr('aria-hidden', 'true');
 
     // Find triggers that affect this element and add aria-expanded to them
-    $(document)
+    this.$triggers = $(document)
       .find('[data-open="'+id+'"], [data-close="'+id+'"], [data-toggle="'+id+'"]')
       .attr('aria-expanded', 'false')
       .attr('aria-controls', id);
@@ -178,6 +179,8 @@ class OffCanvas {
       //   _this._stick();
       // }
     });
+
+    this.$triggers.attr('aria-expanded', 'true');
     this.$element.attr('aria-hidden', 'false')
         .trigger('opened.zf.offcanvas');
 
@@ -186,7 +189,7 @@ class OffCanvas {
     }
 
     if (trigger) {
-      this.$lastTrigger = trigger.attr('aria-expanded', 'true');
+      this.$lastTrigger = trigger;
     }
 
     if (this.options.autoFocus) {
@@ -275,7 +278,7 @@ class OffCanvas {
       this.$exiter.removeClass('is-visible');
     }
 
-    this.$lastTrigger.attr('aria-expanded', 'false');
+    this.$triggers.attr('aria-expanded', 'false');
     if (this.options.trapFocus) {
       $('[data-off-canvas-content]').removeAttr('tabindex');
     }


### PR DESCRIPTION
If multiple elements are triggers for an off-canvas element, they all receive `aria-expanded="false"` when initialized, but only the actioned trigger is updated when the menu is opened.  This causes screen readers to read the wrong state of additional triggers.
