### PR TITLE
prevent input group buttons wrapping to multiple lines

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -46,6 +46,7 @@ $input-prefix-padding: 1rem !default;
 
   %input-group-child {
     margin: 0;
+    white-space: nowrap;
 
     @if not $global-flexbox {
       display: table-cell;


### PR DESCRIPTION
Buttons in an Input Group that have multiple words were wrapping to multiple lines unless they were an `<input>` tag (which default to `white-space:pre`). So I've added `white-space:nowrap` to prevent both `<button>` and `<a>` tags from wrapping to two lines if they are multi-word. 

Bug mentioned here: https://github.com/zurb/foundation-sites/issues/7373#issuecomment-215392389. 
