### PR TITLE
Fix overlapping select arrow

### DIFF
--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -37,9 +37,10 @@ $select-radius: $global-radius !default;
   @if $select-triangle-color != transparent {
     @include background-triangle($select-triangle-color);
     background-size: 9px 6px;
-    background-position: $global-right center;
+    background-position: $global-right (-$form-spacing) center;
     background-origin: content-box;
     background-repeat: no-repeat;
+    padding-#{$global-right}: ($form-spacing * 1.5);
   }
 
   // Disabled state


### PR DESCRIPTION
Fixes the overlapping select arrow by adding additional padding to `$global-right` and changing the arrows background position accordingly.

Closes [#8685](https://github.com/zurb/foundation-sites/issues/8685)
