### PR TITLE
Fix open inner for dropdown menu.

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -166,6 +166,7 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
 
     &.opens-inner > .is-dropdown-submenu {
       top: 100%;
+      left: auto;
     }
 
     &.opens-left > .is-dropdown-submenu {


### PR DESCRIPTION
Fixes #8298 by adding `left: auto;` to the respective CSS class when the menu should render right above the parent menu.
