### PR TITLE
[Bugfix] Sticky : Set container height before positioning anchors

### DIFF
--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -47,6 +47,10 @@ class Sticky {
     this.scrollCount = this.options.checkEvery;
     this.isStuck = false;
     $(window).one('load.zf.sticky', function(){
+      //We calculate the container height to have correct values for anchor points offset calculation.
+      _this.containerHeight = _this.$element.css("display") == "none" ? 0 : _this.$element[0].getBoundingClientRect().height;
+      _this.$container.css('height', _this.containerHeight);
+      _this.elemHeight = _this.containerHeight;
       if(_this.options.anchor !== ''){
         _this.$anchor = $('#' + _this.options.anchor);
       }else{


### PR DESCRIPTION
Anchor was positioned before container height was fixed. It was incorrect when using elements with no fixed height, as anchors was offseted by 0px (container height) instead of real element height.

Fixes https://github.com/zurb/foundation-sites/issues/8396

See Test 6 in test/visual/sticky/anchors-with-callouts.html after merging 
https://github.com/zurb/foundation-sites/pull/8674
