### PR TITLE
[WIP] Allow to always define components in classes

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -94,6 +94,10 @@ $global-text-direction: ltr !default;
 /// @type Boolean
 $global-flexbox: false !default;
 
+/// Always define components with classes instead of tags (besides the reset).
+/// @type Boolean
+$global-namespace: false !default;
+
 @if not map-has-key($foundation-palette, primary) {
   @error 'In $foundation-palette, you must have a color named "primary".';
 }

--- a/scss/forms/_label.scss
+++ b/scss/forms/_label.scss
@@ -38,7 +38,9 @@ $form-label-line-height: 1.8 !default;
 }
 
 @mixin foundation-form-label {
-  label {
+  $name: if($global-namespace, '.label', 'label');
+
+  #{$name} {
     @include form-label;
 
     &.middle {

--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -60,7 +60,9 @@ $select-radius: $global-radius !default;
 }
 
 @mixin foundation-form-select {
-  select {
+  $name: if($global-namespace, '.select', 'select');
+
+  #{$name} {
     @include form-select;
   }
 }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -71,6 +71,7 @@ $global-weight-bold: bold;
 $global-radius: 0;
 $global-text-direction: ltr;
 $global-flexbox: false;
+$global-namespace: false;
 $print-transparent-backgrounds: true;
 
 @include add-foundation-colors;


### PR DESCRIPTION
### Purpose

Clearly separate **reset** properties from **component structural and graphics** properties. Currently, this separations is very unclear for all `foundation-forms` components

Allow to choose if Foundation must define its components into the global namespace (HTML standard tag names) or in its own classes. Currently, lot of component define their properties (no for reset) on tags, which can lead to **unwanted properties** for someone using its own components.
### Current changes

_Updated 30 April 2015, 8:00 AM_
- Add `$global-namespace {Boolean} [false]` option which when enabled, make all components be defined in classes, instead of tags.
- Use `$global-namespace` for `label` and `select`
### Why [WIP] ?

I given the direction (how components should be defined) and added the basics (`$global-namespace` setting). But my knowledge in Foundation is too limited to differentiate _reset_ from _component_ properties in `foundation-forms`.

So I hope you can bring me feedback, ideas or explanations to finish that work :)
