### PR TITLE
[Bugfix] Sticky : Fixes #8393. anchor object undefined when destroyin…

### DIFF
--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -355,8 +355,9 @@ class Sticky {
                    'max-width': ''
                  })
                  .off('resizeme.zf.trigger');
-
-    this.$anchor.off('change.zf.sticky');
+    if (this.$anchor && this.$anchor.length) {
+      this.$anchor.off('change.zf.sticky');
+    }
     $(window).off(this.scrollListener);
 
     if (this.wasWrapped) {


### PR DESCRIPTION
Fixed object undefined error when destroying sticky element with no anchors set.
Fixes https://github.com/zurb/foundation-sites/issues/8393
