### PR TITLE
fix defaults for accordion content color

### DIFF
--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -36,7 +36,7 @@ $accordion-content-border: 1px solid $light-gray !default;
 
 /// Default text color of tab content.
 /// @type Color
-$accordion-content-color: foreground($accordion-background, $primary-color) !default;
+$accordion-content-color: foreground($accordion-content-background, $body-font-color) !default;
 
 /// Default padding for tab content.
 /// @type Number | List

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -200,7 +200,7 @@ $accordion-item-background-hover: $light-gray;
 $accordion-item-padding: 1.25rem 1rem;
 $accordion-content-background: $white;
 $accordion-content-border: 1px solid $light-gray;
-$accordion-content-color: foreground($accordion-background, $primary-color);
+$accordion-content-color: foreground($accordion-content-background, $body-font-color);
 $accordion-content-padding: 1rem;
 
 // 8. Accordion Menu
@@ -564,4 +564,3 @@ $topbar-submenu-background: $topbar-background;
 $topbar-title-spacing: 1rem;
 $topbar-input-width: 200px;
 $topbar-unstack-breakpoint: medium;
-


### PR DESCRIPTION
Accordion content colors were `$primary-color`. Changed them to match body `$body-font-color`. And changed the accordion content's `foreground()` function to use `$accordion-content-background` instead of `$accordion-background`. Now all the text isn't blue and calculates correctly for dark backgrounds. 

Closes #8708. 
