### PR TITLE
change default behavior of tooltips

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -40,7 +40,7 @@ class Tooltip {
     this.template = this.options.template ? $(this.options.template) : this._buildTemplate(elemId);
 
     this.template.appendTo(document.body)
-        .html(this.options.tipText)
+        .text(this.options.tipText)
         .hide();
 
     this.$element.attr({
@@ -248,28 +248,10 @@ class Tooltip {
         }
       })
       .on('mouseleave.zf.tooltip', function(e) {
-		if (_this.options.tipHoverable) {
-			_this.timeout = setTimeout(function () {
-				clearTimeout(_this.timeout);
-				if ($template.is(":hover")) {
-				  $template.on('mouseleave', function (e) {
-					 if (!isFocus || !_this.isClick && _this.options.clickOpen) {
-						_this.hide();
-					 }
-					 $template.off('mouseleave');
-				  });
-				} else {
-					if (!isFocus || !_this.isClick && _this.options.clickOpen) {
-					  _this.hide();
-					}
-				}
-			}, 200); //min required to capture
-		} else {
-			clearTimeout(_this.timeout);
-			if (!isFocus || !_this.isClick && _this.options.clickOpen) {
-			  _this.hide();
-			}
-		}
+        clearTimeout(_this.timeout);
+        if (!isFocus || (_this.isClick && !_this.options.clickOpen)) {
+          _this.hide();
+        }
       });
     }
 
@@ -449,13 +431,7 @@ Tooltip.defaults = {
    * @option
    * @example 12
    */
-  hOffset: 12,
-  /**
-	 * Should the tip remain open if hover
-	 * @option
-	 * @example false
-	 */
-	 tipHoverable: false
+  hOffset: 12
 };
 
 /**

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -40,7 +40,7 @@ class Tooltip {
     this.template = this.options.template ? $(this.options.template) : this._buildTemplate(elemId);
 
     this.template.appendTo(document.body)
-        .text(this.options.tipText)
+        .html(this.options.tipText)
         .hide();
 
     this.$element.attr({
@@ -248,10 +248,28 @@ class Tooltip {
         }
       })
       .on('mouseleave.zf.tooltip', function(e) {
-        clearTimeout(_this.timeout);
-        if (!isFocus || (_this.isClick && !_this.options.clickOpen)) {
-          _this.hide();
-        }
+		if (_this.options.tipHoverable) {
+			_this.timeout = setTimeout(function () {
+				clearTimeout(_this.timeout);
+				if ($template.is(":hover")) {
+				  $template.on('mouseleave', function (e) {
+					 if (!isFocus || !_this.isClick && _this.options.clickOpen) {
+						_this.hide();
+					 }
+					 $template.off('mouseleave');
+				  });
+				} else {
+					if (!isFocus || !_this.isClick && _this.options.clickOpen) {
+					  _this.hide();
+					}
+				}
+			}, 200); //min required to capture
+		} else {
+			clearTimeout(_this.timeout);
+			if (!isFocus || !_this.isClick && _this.options.clickOpen) {
+			  _this.hide();
+			}
+		}
       });
     }
 
@@ -259,7 +277,7 @@ class Tooltip {
       this.$element.on('mousedown.zf.tooltip', function(e) {
         e.stopImmediatePropagation();
         if (_this.isClick) {
-          _this.hide();
+          //_this.hide();
           // _this.isClick = false;
         } else {
           _this.isClick = true;
@@ -431,7 +449,13 @@ Tooltip.defaults = {
    * @option
    * @example 12
    */
-  hOffset: 12
+  hOffset: 12,
+  /**
+	 * Should the tip remain open if hover
+	 * @option
+	 * @example false
+	 */
+	 tipHoverable: false
 };
 
 /**


### PR DESCRIPTION
In reference to https://github.com/zurb/foundation-sites/issues/8697

This will change the default behavior of the tooltips to:
- mouseenter = open
- mouseleave = close
- mouseclick = stay open / no toggle
