### PR TITLE
Docs: Fix grunt config indentation in sass.md

### DIFF
--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -51,7 +51,7 @@ Here's an example using grunt-contrib-sass:
 grunt.initConfig({
   sass: {
     dist: {
-    options: {
+      options: {
         loadPath: ['node_modules/foundation-sites/scss']
       }
     }


### PR DESCRIPTION
Let me know if I used the wrong indentation character (it looked like spaces but the GitHub editor was treating them as soft-tabs, so I may have introduced `\t` without knowing it).
