### PR TITLE
Media object flexbox fixes

### DIFF
--- a/scss/components/_media-object.scss
+++ b/scss/components/_media-object.scss
@@ -32,7 +32,7 @@ $mediaobject-image-width-stacked: 100% !default;
 /// @param {Number} $padding [$mediaobject-section-padding] - Padding between sections.
 @mixin media-object-section($padding: $mediaobject-section-padding) {
   @if $global-flexbox {
-    flex: 0 0 auto;
+    flex: 0 1 auto;
   }
   @else {
     display: table-cell;
@@ -80,7 +80,9 @@ $mediaobject-image-width-stacked: 100% !default;
 
     @if $global-flexbox {
       &.stack-for-#{$-zf-zero-breakpoint} {
-        flex-wrap: wrap;
+        @include breakpoint($-zf-zero-breakpoint only) {
+          flex-wrap: wrap;
+        }
       }
     }
 


### PR DESCRIPTION
Update `media-object-section` flex property, and wrap `stack-for-small` in zero breakpoint so it doesn't get applied to all breakpoints.

Closes #8738 and #8739
