### PR TITLE
Added showAll using down() for all elements.

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -173,7 +173,15 @@ class AccordionMenu {
    * @function
    */
   hideAll() {
-    this.$element.find('[data-submenu]').slideUp(this.options.slideSpeed);
+    this.up(this.$element.find('[data-submenu]'));
+  }
+
+  /**
+   * Opens all panes of the menu.
+   * @function
+   */
+  showAll() {
+    this.down(this.$element.find('[data-submenu]'));
   }
 
   /**


### PR DESCRIPTION
Like in #8460 purposed by @crbranch the hideAll method should use the up() method.
Also showAll() could be useful.

Basically the same as #8493, but against v6.3.
