### PR TITLE
prevent cb() from fire multiple as move is called until animation fin…

### DIFF
--- a/js/foundation.util.motion.js
+++ b/js/foundation.util.motion.js
@@ -25,10 +25,12 @@ function Move(duration, elem, fn){
   // console.log('called');
 
   function move(ts){
-    if(!start) start = window.performance.now();
+    if(!start) {
+      start = window.performance.now();
+      fn.apply(elem);
+    }
     // console.log(start, ts);
     prog = ts - start;
-    fn.apply(elem);
 
     if(prog < duration){ anim = window.requestAnimationFrame(move, elem); }
     else{


### PR DESCRIPTION
fixes #8724 
@kball 
would you please take a look at the JS

``` js
Foundation.Move(this.options.slideSpeed, $target, function(){
      $target.slideUp(_this.options.slideSpeed, function () {
```

in the old version of Foundation.Move the `fn.apply(elem);` gets called until the anim finishes, but in the fn. `slideDown` `slideUp` is called so the slidedown and slideup gets called in a 250 duration about 11 times, so the callback specified in the slideDown/slideUp also fires 11 times

so i wrapped the fn.apply in the !start if, to only call it once the animationframe is requested.
As i don't know what `requestAnimationFrame` is about and exactly how it works i don't know if thats the right way as maybe if the animationFrame is queued the slideDown ever fires.
