### PR TITLE
add scss var for input font weight

### DIFF
--- a/scss/forms/_text.scss
+++ b/scss/forms/_text.scss
@@ -22,6 +22,10 @@ $input-font-family: inherit !default;
 /// @type Number
 $input-font-size: rem-calc(16) !default;
 
+/// Font weight of text inputs.
+/// @type Keyword
+$input-font-weight: $global-weight-normal !default;
+
 /// Background color of text inputs.
 /// @type Color
 $input-background: $white !default;
@@ -79,6 +83,7 @@ $input-radius: $global-radius !default;
 
   font-family: $input-font-family;
   font-size: $input-font-size;
+  font-weight: $input-font-weight;
   color: $input-color;
   background-color: $input-background;
   box-shadow: $input-shadow;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -346,6 +346,7 @@ $input-color: $black;
 $input-placeholder-color: $medium-gray;
 $input-font-family: inherit;
 $input-font-size: rem-calc(16);
+$input-font-weight: $global-weight-normal;
 $input-background: $white;
 $input-background-focus: $white;
 $input-background-disabled: $light-gray;


### PR DESCRIPTION
Closes #8283. 

This PR sets an explicit font weight for inputs to prevent cascade if an `input` is inside a `label` and `$form-label-font-weight` is bold. 
