### PR TITLE
Added and optional background parameter to the reveal-overlay() mixin

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -40,7 +40,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
 
 /// Adds styles for a modal overlay.
 /// @param {Color} $background [$reveal-overlay-background] - Background color of the overlay.
-@mixin reveal-overlay {
+@mixin reveal-overlay($background: $reveal-overlay-background) {
   display: none;
   position: fixed;
   top: 0;
@@ -48,7 +48,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   left: 0;
   right: 0;
   z-index: $reveal-zindex;
-  background-color: $reveal-overlay-background;
+  background-color: $background;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
As per the documentation, `@mixin reveal-overlay` should accept an optional `background-color` value to override `$reveal-overlay-background`
