### PR TITLE
[bugfix] Abide: dont validate hidden fields

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -29,7 +29,7 @@ class Abide {
    * @private
    */
   _init() {
-    this.$inputs = this.$element.find('input, textarea, select').not('[data-abide-ignore]');
+    this.$inputs = this.$element.find('input, textarea, select');
 
     this._events();
   }
@@ -241,6 +241,11 @@ class Abide {
         customValidator = true,
         validator = $el.attr('data-validator'),
         equalTo = true;
+
+    // don't validate ignored inputs or hidden inputs
+    if ($el.is('[data-abide-ignore]') || $el.is('[type="hidden"]')) {
+      return true;
+    }
 
     switch ($el[0].type) {
       case 'radio':

--- a/test/javascript/components/abide.js
+++ b/test/javascript/components/abide.js
@@ -1,20 +1,39 @@
+/* jslint mocha: true */
+/*global describe, it, before, beforeEach, after, afterEach, $, Foundation */
+
 describe('Abide', function() {
   var plugin;
   var $html;
 
-  // afterEach(function() {
-  //   plugin.destroy();
-  //   $html.remove();
-  // });
+  afterEach(function() {
+    plugin.destroy();
+    $html.remove();
+  });
 
   describe('constructor()', function() {
-    // it('', function() {
-    //   $html = $('').appendTo('body');
-    //   plugin = new Foundation.Abide($html, {});
+    it('stores the element & plugin options', function() {
+      $html = $('<form data-abide novalidate></form>').appendTo('body');
+      plugin = new Foundation.Abide($html, {});
 
-    //   plugin.$element.should.be.an('object');
-    //   plugin.options.should.be.an('object');
-    // });
+      plugin.$element.should.be.an('object');
+      plugin.options.should.be.an('object');
+    });
+  });
+
+  describe('validateInput()', function() {
+    it('returns true for hidden inputs', function() {
+      $html = $("<form data-abide novalidate><input type='hidden' required></form>").appendTo("body");
+      plugin = new Foundation.Abide($html, {});
+
+      plugin.validateInput($html.find("input")).should.equal(true);
+    });
+
+    it('returns true for inputs with [data-abide-ignore]', function() {
+      $html = $("<form data-abide novalidate><input type='text' required data-abide-ignore></form>").appendTo("body");
+      plugin = new Foundation.Abide($html, {});
+
+      plugin.validateInput($html.find("input")).should.equal(true);
+    });
   });
 
 });

--- a/test/visual/abide/hidden_and_ignored_fields.html
+++ b/test/visual/abide/hidden_and_ignored_fields.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+  <div class="row column">
+    <h1>Abide: Hidden and Ignored Fields</h1>
+    <div class="callout">
+      <p>This form has a hidden field and a required text field.</p>
+      <p>Errors should be displayed properly.</p>
+
+      <form data-abide novalidate>
+        <input required type="text" placeholder="Required - try submitting without a value">
+        <span class='form-error'>This field is required</span>
+        <input type="hidden" value="foo">
+        <button type="submit" class="button">Submit</button>
+        <button type="reset" class="button">Reset</button>
+      </form>
+    </div>
+    <div class="callout">
+      <p>This form has a required text field and an ignored field that is ignored after page load.</p>
+      <p>The ignored field should be ignored.</p>
+      <form data-abide novalidate>
+        <div class="row column">
+          <input required type="text" placeholder="Required">
+          <span class='form-error'>This field is required</span>
+        </div>
+        <div class="row column">
+          <input required id="ignoreAfter" type="text" placeholder="Ignored">
+          <span class='form-error'>You should never see this error!</span>
+        </div>
+        <button type="submit" class="button">Submit</button>
+        <button type="reset" class="button">Reset</button>
+      </form>
+    </div>
+  </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      Foundation.Abide.defaults.patterns['customPattern'] = /^\w{4,16}$/;
+      $(document).foundation();
+      $("#ignoreAfter").attr("data-abide-ignore", true);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This addresses #8039 where hidden fields can cause error messages to be hidden, making it unclear why a form was not submitted.

It also moves the skipping of `[data-abide-ignore]` fields to validation-time such that if that property is added or changed with javascript, it will still be respected by Abide.

I welcome feedback and suggestions. Sorry I don't have time to really backfill tests for Abide.
