### PR TITLE
Add Browserify directive to transform single source files with Babelify

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,5 +111,8 @@
         ]
       }
     }
+  },
+  "browserify": {
+    "transform": [["babelify", { "presets": ["es2015"] }]]
   }
 }


### PR DESCRIPTION
When requiring single Foundation js components and compiling them with browserify, source files aren't transform with the Babelify transformer (see : https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed). 

Adding this directive to package.json fix this. 
