### PR TITLE
Fix bad nesting that breaks input-number-spinners styles

### DIFF
--- a/scss/forms/_text.scss
+++ b/scss/forms/_text.scss
@@ -153,8 +153,8 @@ $input-radius: $global-radius !default;
     @if not $input-number-spinners {
       -moz-appearance: textfield;
 
-      [type='number']::-webkit-inner-spin-button,
-      [type='number']::-webkit-outer-spin-button {
+      &::-webkit-inner-spin-button,
+      &::-webkit-outer-spin-button {
         -webkit-appearance: none;
         margin: 0;
       }


### PR DESCRIPTION
The generated styles for input number spinners are wrong - there's an addition level of nesting.  This was mentioned in #8096.
