### PR TITLE
Partially fixes #8325

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -228,6 +228,9 @@ $menu-icon-spacing: 0.25rem !default;
     @include menu-base;
     @include menu-icons;
 
+    // Orientation
+    @include menu-direction(horizontal);
+
     // Even-width
     &.expanded {
       @include menu-expand;
@@ -236,9 +239,6 @@ $menu-icon-spacing: 0.25rem !default;
         width: 100%;
       }
     }
-
-    // Orientation
-    @include menu-direction(horizontal);
 
     &.vertical {
       @include menu-direction(vertical);
@@ -249,6 +249,15 @@ $menu-icon-spacing: 0.25rem !default;
         @include breakpoint($size) {
           &.#{$size}-horizontal {
             @include menu-direction(horizontal);
+
+            // Even-width
+            &.expanded {
+              @include menu-expand;
+
+              > li:first-child:last-child {
+                width: 100%;
+              }
+            }
           }
 
           &.#{$size}-vertical {

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -83,6 +83,10 @@ $menu-icon-spacing: 0.25rem !default;
     display: table;
     table-layout: fixed;
   }
+
+  > li:first-child:last-child {
+    width: 100%;
+  }
 }
 
 /// Sets the direction of a Menu.
@@ -234,10 +238,6 @@ $menu-icon-spacing: 0.25rem !default;
     // Even-width
     &.expanded {
       @include menu-expand;
-
-      > li:first-child:last-child {
-        width: 100%;
-      }
     }
 
     &.vertical {
@@ -253,10 +253,6 @@ $menu-icon-spacing: 0.25rem !default;
             // Even-width
             &.expanded {
               @include menu-expand;
-
-              > li:first-child:last-child {
-                width: 100%;
-              }
             }
           }
 

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -228,6 +228,15 @@ $menu-icon-spacing: 0.25rem !default;
     @include menu-base;
     @include menu-icons;
 
+    // Even-width
+    &.expanded {
+      @include menu-expand;
+
+      > li:first-child:last-child {
+        width: 100%;
+      }
+    }
+
     // Orientation
     @include menu-direction(horizontal);
 
@@ -265,15 +274,6 @@ $menu-icon-spacing: 0.25rem !default;
         > li {
           float: $global-right;
         }
-      }
-    }
-
-    // Even-width
-    &.expanded {
-      @include menu-expand;
-
-      > li:first-child:last-child {
-        width: 100%;
       }
     }
 


### PR DESCRIPTION
`.expanded` was overwriting the vertical styles. Not sure if the other part of #8325 can be fixed without deeper changes.
