### PR TITLE
Clarified language: "instead" to "inside"

### DIFF
--- a/docs/pages/breadcrumbs.md
+++ b/docs/pages/breadcrumbs.md
@@ -4,7 +4,7 @@ description: Breadcrumbs come in handy to show a navigation trail for users clic
 sass: scss/components/_breadcrumbs.scss
 ---
 
-To make a set of breadcrumb links, just add the class `.breadcrumbs` to a `<ul>`, and then add links instead of `<li>` elements.
+To make a set of breadcrumb links, just add the class `.breadcrumbs` to a `<ul>`, and then add links inside of the `<li>` elements.
 
 The current page doesn't require a link or a class, but you should add some explanatory text for AT that indicates which item is the current page.
 


### PR DESCRIPTION
Changed to better describe the appropriate action that needs to be taken by the user. You don't place links "instead" of list items, but rather, "inside" of them.
