### PR TITLE
fix block scope issue. without this, node-sass@3.7.0+ and node 6 break

### DIFF
--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -84,14 +84,14 @@ $base-line-height: 1.5 !default;
 // $delay - Default: null (0s)
 @mixin transition($property:all, $speed:300ms, $ease:ease-out, $delay:null) {
   $transition: none;
-  $_property: none;
-  $_speed: none;
-  $_ease: none;
-  $_delay: none;
 
   @if length($property) > 1 {
 
     @each $transition_list in $property {
+      $_property: all;
+      $_speed: $speed;
+      $_ease: $ease;
+      $_delay: $delay;
 
       @for $i from 1 through length($transition_list) {
 

--- a/scss/foundation/components/_global.scss
+++ b/scss/foundation/components/_global.scss
@@ -84,6 +84,10 @@ $base-line-height: 1.5 !default;
 // $delay - Default: null (0s)
 @mixin transition($property:all, $speed:300ms, $ease:ease-out, $delay:null) {
   $transition: none;
+  $_property: none;
+  $_speed: none;
+  $_ease: none;
+  $_delay: none;
 
   @if length($property) > 1 {
 


### PR DESCRIPTION
PROBLEM
The latest version of node-sass (v3.7.0) implements the SASS spec more accurately which in this case affects how block scope is handled.  node-sass@3.7.0 is the only version that supports node 6.  

In the transition mixin, the temp vars in the loop are getting block scoped inside the loop causing a sass compile error like this:

```
{ Error: Undefined variable: "$-property".
    at options.error (/src/web-app/node_modules/gulp-sass/node_modules/node-sass/lib/index.js:271:32)
  formatted: 'Error: Undefined variable: "$-property".\n        on line 126 of node_modules/foundation-sites/scss/foundation/components/_global.scss\n>>         $transition: $_property $_speed $_ease $_delay;\n   ---------------------^\n',
  message: 'Undefined variable: "$-property".',
  column: 22,
  line: 126,
  file: '/Users/tommy/src/web/cbw/node_modules/foundation-sites/scss/foundation/components/_global.scss',
  status: 1 }
```

SOLUTION
Declare locally scoped vars at the top of the mixin so they are available throughout the life of the mixin.

MERGING HELP
I need help with merging this.  Ideally, this should be a patch version to 5.5.3 and only make this change.  My work was done like this:

```
git checkout v5.5.3
git checkout -b 5.5_transition_fix
```

If you'll accept, this should be pushed as 5.5.4 b/c it does not change any interfaces.  I looked at targeting the V5 branch, but that has a bunch of breaking API changes in it (like re-naming transition() to single-transition() b/c some people use Compass).  

Please let me know if you have any questions.
