### PR TITLE
Fix for #8792

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -24,7 +24,7 @@ var LINT_PATHS = [
 var COMPATIBILITY = [
   'last 2 versions',
   'ie >= 9',
-  'and_chr >= 2.3'
+  'Android >= 2.3'
 ];
 
 // Compiles Sass files into CSS


### PR DESCRIPTION
I guess this is a misunderstanding about android browser versions
To target Android Webview (Android 2.3) another syntax is needed than for Android Chrome which it was until now.
