### PR TITLE
Clarify documentation for off-canvas menu

### DIFF
--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -26,7 +26,7 @@ To start, create two wrappers to house the page. These are necessary to prevent 
 </body>
 ```
 
-Inside these wrapper, create an off-canvas menu with the class `.off-canvas` and the attribute `data-off-canvas`. The menu also needs a positioning class, which can be `.position-left` or `.position-right`. Lastly, make sure the off-canvas has a unique ID so it can be targeted.
+Inside these wrappers, create an off-canvas menu with the class `.off-canvas` and the attribute `data-off-canvas`. The menu also needs a positioning class, which can be `.position-left` or `.position-right`, and an attribute set for the position, `data-position="left"` or `data-position="right"`. Last, make sure the off-canvas has a unique ID so it can be targeted.
 
 Along with the menu, the main content of your page will be housed in its own container with the class `.off-canvas-content` and attribute `data-off-canvas-content`.
 

--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -28,7 +28,7 @@ To start, create two wrappers to house the page. These are necessary to prevent 
 
 Inside these wrappers, create an off-canvas menu with the class `.off-canvas` and the attribute `data-off-canvas`. The menu also needs a positioning class, which can be `.position-left` or `.position-right`, and an attribute set for the position, `data-position="left"` or `data-position="right"`. Last, make sure the off-canvas has a unique ID so it can be targeted.
 
-Along with the menu, the main content of your page will be housed in its own container with the class `.off-canvas-content` and attribute `data-off-canvas-content`.
+Along with the menu, the main content of your page will be housed in its own container with the class `.off-canvas-content` and attribute `data-off-canvas-content`. (This may be confusing, since the css namespacing means you will be putting your actual page content under a class of "off-canvas-content".)
 
 ```html
 <body>


### PR DESCRIPTION
I ran into two confusing issues transitioning my off-canvas menu to Foundation 6.

The first is just that the `data-position` attribute was used in some examples but not documented (first commit) — see http://foundation.zurb.com/forum/posts/39294-right-off-canvas-not-working for an example of someone else who ran into the same doc issue.

The second issue is that it was confusing that the _page content_ is contained in a class of `.off-canvas-content`. The first time I was adding my classes, I thought the content I wanted to display off-canvas would go in `.off-canvas-content`. Right? It makes sense if you start thinking of `.off-canvas` as a namespacing prefix, so you have [prefix]-content and [prefix]-wrap. Tried to clarify that for future users in the second commit, but you may have suggestions for better copy?

Thanks for all your work on Foundation 6!
