### PR TITLE
Added documentation for orbit image mixin.

### DIFF
--- a/scss/components/_orbit.scss
+++ b/scss/components/_orbit.scss
@@ -80,6 +80,7 @@ $orbit-control-zindex: 10 !default;
   margin: 0;
 }
 
+/// Adds styles for a slide containing an image. These styles are used on the `.orbit-image` class.
 @mixin orbit-image {
   margin: 0;
   width: 100%;


### PR DESCRIPTION
Small addition to orbit rotator documentation. Added the `orbit-image` mixin to the docs as it wasn't included but fairly important if you're using images in your rotator.
