### PR TITLE
Change no scroll default - Foundation v5

### DIFF
--- a/js/foundation/foundation.reveal.js
+++ b/js/foundation/foundation.reveal.js
@@ -19,7 +19,7 @@
       multiple_opened : false,
       bg_class : 'reveal-modal-bg',
       root_element : 'body',
-      no_scroll: true,
+      no_scroll: false,
       open : function(){},
       opened : function(){},
       close : function(){},


### PR DESCRIPTION
I like that this feature was added. However, the default value should be the same as it was prior to this change. You don't want to break people's sites by simply updating the framework.
