### PR TITLE
Account for hOffset

### DIFF
--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -186,7 +186,7 @@ function GetOffsets(element, anchor, position, vOffset, hOffset, isOverflow) {
       break;
     default:
       return {
-        left: (Foundation.rtl() ? $anchorDims.offset.left - $eleDims.width + $anchorDims.width : $anchorDims.offset.left),
+        left: (Foundation.rtl() ? $anchorDims.offset.left - $eleDims.width + $anchorDims.width : $anchorDims.offset.left + hOffset),
         top: $anchorDims.offset.top + $anchorDims.height + vOffset
       }
   }


### PR DESCRIPTION
Currently if you set `data-h-offset` on a dropdown menu, the hoffset value is not used.
