### PR TITLE
Added the "plugins" folder to the Package Content section.

### DIFF
--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -154,6 +154,7 @@ Here's what comes in the package.
 - `dist/`: Compiled files.
   - `css/`: Compiled CSS files. Includes minified and unminified files.
   - `js/`: Concatenated JavaScript files. Includes minified and unminified files.
+    - `plugins/`: Standalone JavaScript plugins.
 
 ---
 


### PR DESCRIPTION
Added the `plugins/` folder to the **Package Content** section, in the **Installation** page. So the output looks like:
- `dist/`: Compiled files.
  - `css/`: Compiled CSS files. Includes minified and unminified files.
  - `js/`: Concatenated JavaScript files. Includes minified and unminified files.
    - `plugins/`: Standalone JavaScript plugins.
