### PR TITLE
Make off canvas work no matter where you are on the page...

### DIFF
--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -72,6 +72,7 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     background: $body-background;
     transition: transform $offcanvas-transition-length $offcanvas-transition-timing;
     backface-visibility: hidden;
+    overflow-y: auto;
     z-index: 1;
     padding-bottom: 0.1px; // Prevents margin collapsing, which would reveal the box shadow of the wrapper
 

--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -50,8 +50,9 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
 
   .off-canvas-wrapper {
     width: 100%;
-    overflow-x: hidden;
+    height: 100%;
     position: relative;
+    overflow: hidden;
     backface-visibility: hidden;
     -webkit-overflow-scrolling: auto;
   }
@@ -60,13 +61,14 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
     @include clearfix;
     position: relative;
     width: 100%;
+    height: 100%;
     transition: transform $offcanvas-transition-length $offcanvas-transition-timing;
   }
 
   // Container for page content
   .off-canvas-content,
   .#{$maincontent-class} {
-    min-height: 100%;
+    height: 100%;
     background: $body-background;
     transition: transform $offcanvas-transition-length $offcanvas-transition-timing;
     backface-visibility: hidden;
@@ -98,7 +100,7 @@ $maincontent-shadow: 0 0 10px rgba($black, 0.5) !default;
   position: absolute;
   background: $offcanvas-background;
   z-index: $offcanvas-zindex;
-  max-height: 100%;
+  height: 100%;
   overflow-y: auto;
   transform: translateX(0);
 }


### PR DESCRIPTION
... and avoid having to jump to the top every time. This also now works when using a sticky menu etc.
See [this CodePen](http://codepen.io/brettsmason/pen/WxeeNO) for an example of how it works.

This could use some cross device/browser testing to confirm it works correctly.

Closes #8836 
