### PR TITLE
Added double-quotes to href data targets to prevent jQuery errors

### DIFF
--- a/js/foundation/foundation.tab.js
+++ b/js/foundation/foundation.tab.js
@@ -102,19 +102,19 @@
             var hash_element = S(hash);
             if (hash_element.hasClass('content') && hash_element.parent().hasClass('tabs-content')) {
               // Tab content div
-              self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href=\\' + hash + ']').parent());
+              self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href="' + hash + '"]').parent());
             } else {
               // Not the tab content div. If inside the tab content, find the
               // containing tab and toggle it as active.
               var hash_tab_container_id = hash_element.closest('.content').attr('id');
               if (hash_tab_container_id != undefined) {
-                self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href=\\#' + hash_tab_container_id + ']').parent(), hash);
+                self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href="#' + hash_tab_container_id + '"]').parent(), hash);
               }
             }
           } else {
             // Reference the default tab hashes which were initialized in the init function
             for (var ind = 0; ind < self.default_tab_hashes.length; ind++) {
-              self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href=\\' + self.default_tab_hashes[ind] + ']').parent());
+              self.toggle_active_tab($('[' + self.attr_name() + '] > * > a[href="' + self.default_tab_hashes[ind] + '"]').parent());
             }
           }
         }


### PR DESCRIPTION
Added double-quotes to href data targets on Foundation tabs to prevent errors with jQuery 1.12.3. WordPress 4.5.2 includes jQuery 1.12.3 by default so this was causing a JavaScript error when using deeplinking: true on Foundation tabs. 

Adding double-quotes around these three locations in foundation.tab.js fixes this issue.
