### PR TITLE
[V5] throttle scroll handler for performance gain

### DIFF
--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -16,7 +16,8 @@
       is_hover : true,
       scrolltop : true, // jump to top when sticky nav menu toggle is clicked
       sticky_on : 'all',
-      dropdown_autoclose: true
+      dropdown_autoclose: true,
+      scroll_throttle: 300
     },
 
     init : function (section, method, options) {
@@ -430,9 +431,9 @@
     sticky : function () {
       var self = this;
 
-      this.S(window).on('scroll', function () {
+      this.S(window).on('scroll', self.throttle( function () {
         self.update_sticky_positioning();
-      });
+      }, self.settings.scroll_throttle));
     },
 
     update_sticky_positioning : function () {


### PR DESCRIPTION
While profiling our Zurb 5 implementation, we noticed a slight bottle neck using a "sticky" top bar.  The user would sometimes experience a "stutter" or "glitch" while scrolling.  Users with lower end devices would experience the issue more often.

The problem: `update_sticky_positioning` is called a lot.  Too much.

The solution: `throttle` the `scroll` handler when calling `update_sticky_positioning`

I introduced a new `setting` named `scroll_throttle` with a default value of 300 milliseconds.  Throughout our test cycles the value works well.

Profiler before:

![before](https://cloud.githubusercontent.com/assets/156634/15751986/2d2c124c-28ba-11e6-8ecb-c781ea6fa410.PNG)

Profiler after:

![after](https://cloud.githubusercontent.com/assets/156634/15751989/30daf980-28ba-11e6-9328-f189d395c489.PNG)
