### PR TITLE
[V5] IE focus dropdown jumping issue

### DIFF
--- a/js/foundation/foundation.dropdown.js
+++ b/js/foundation/foundation.dropdown.js
@@ -14,6 +14,7 @@
       is_hover : false,
       hover_timeout : 150,
       no_pip : false,
+      no_focus : false,
       opened : function () {},
       closed : function () {}
     },
@@ -165,7 +166,13 @@
       dropdown.data('target', target.get(0)).trigger('opened.fndtn.dropdown', [dropdown, target]);
       dropdown.attr('aria-hidden', 'false');
       target.attr('aria-expanded', 'true');
-      dropdown.focus();
+      
+      var settings = target.data(this.attr_name(true) + '-init') || this.settings;
+      
+      if (settings.no_focus === false) {
+        dropdown.focus();
+      }
+      
       dropdown.addClass('f-open-' + this.attr_name(true));
     },
 

--- a/js/foundation/foundation.topbar.js
+++ b/js/foundation/foundation.topbar.js
@@ -16,7 +16,8 @@
       is_hover : true,
       scrolltop : true, // jump to top when sticky nav menu toggle is clicked
       sticky_on : 'all',
-      dropdown_autoclose: true
+      dropdown_autoclose: true,
+      scroll_throttle: 300
     },
 
     init : function (section, method, options) {
@@ -430,9 +431,9 @@
     sticky : function () {
       var self = this;
 
-      this.S(window).on('scroll', function () {
+      this.S(window).on('scroll', self.throttle( function () {
         self.update_sticky_positioning();
-      });
+      }, self.settings.scroll_throttle));
     },
 
     update_sticky_positioning : function () {


### PR DESCRIPTION
IE likes to "jump" the user into position when `.focus()` is called.  We don't like this.  Notice in the video when the dropdown is at the bottom of the screen, the dropdown "jumps" up -

https://www.youtube.com/watch?v=OmuSAKOMjcQ

This seems to only be an issue with IE.  Here is a video after the fix (and behaving similar to Firefox and Chrome).  Simply set your `data-options="no_focus:true"` and then no more jumping.

https://www.youtube.com/watch?v=D5BbHLIG4cE
