### PR TITLE
Error in documentation

### DIFF
--- a/docs/pages/progress-bar.md
+++ b/docs/pages/progress-bar.md
@@ -82,7 +82,7 @@ As an alternative to our custom progress bar style, you can also opt to use the 
 If you're using the Sass version of Foundation, add this line to your main Sass file to export the `<progress>` CSS:
 
 ```scss
-@import foundation-progress-element;
+@include foundation-progress-element;
 ```
 
 The `<progress>` element can be styled with the same coloring classes: `.secondary`, `.success`, `.warning`, and `.alert`.

--- a/docs/pages/progress-bar.md
+++ b/docs/pages/progress-bar.md
@@ -103,7 +103,7 @@ For the *extra* adventurous developers out there, we also provide styles for the
 If you're using the Sass version of Foundation, add this line to your main Sass file to export the `<meter>` CSS:
 
 ```scss
-@import foundation-meter-element;
+@include foundation-meter-element;
 ```
 
 The meter automatically colors itself based on the current values, and the defined low, medium, and high ranges. [Learn more about the mechanics of `<meter>` values.](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms/The_native_form_widgets#Meters_and_progress_bars)


### PR DESCRIPTION
There was a slight error in the docs regarding the native progress bar usage with sass. Simply replaced @import by @include

Native element sass usage: @import replaced by @include, which it should be
