### PR TITLE
Contain nested rows to grid

### DIFF
--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -82,7 +82,6 @@
   @if type-of($gutter) == 'number' {
     $gutter: ($-zf-zero-breakpoint: $gutter);
   }
-  max-width: none;
 
   @each $breakpoint, $value in $gutter {
     $margin: rem-calc($value) / 2 * -1;


### PR DESCRIPTION
This commit removes a single line that was recently added that results in the following style:

``` css
.row .row {
  max-width: none
}
```

The line was added in response to #8304. However, the appropriate solution would have been to add the expanded class to nested rows. Setting max-width to none introduces a break. If a nested row needs to be full width, the `expanded` class can be applied to that row; however, if nested row max-width is set to none, there's no way to contain a row to the grid inside of an expanded row.

If a row is nested inside of an expanded row, it should be contained to the grid unless the expanded class is explicitly added to the nested row. 

This fixes #8886
