### PR TITLE
Moved max-width of shrunken column.

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -60,6 +60,7 @@
 
   @if $columns == shrink {
     $flex: 0 0 auto;
+    max-width: 100%;
   }
   @else if $columns != null {
     $flex: 0 0 grid-column($columns);
@@ -262,7 +263,6 @@
   // Sizing (shrink)
   .shrink {
     flex: flex-grid-column(shrink);
-    max-width: 100%;
   }
 
   // Vertical alignment using align-items and align-self


### PR DESCRIPTION
I've asked for feedback on Forums:

http://foundation.zurb.com/forum/posts/43843-flex-column-shrink-max-width-issue

Didn't hear anything back so made the pull request. To have the class work differently to the mixin in such a big way is annoying. Also, as described in my forum post, if you have a shrunken column and the content (image for example) is larger than the screen width, a scrollbar will appear, which is obviously not responsive friendly.
