### PR TITLE
Enable the script to load in DoneJS SSR

### DIFF
--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -142,7 +142,7 @@ window.matchMedia || (window.matchMedia = function() {
     style.type  = 'text/css';
     style.id    = 'matchmediajs-test';
 
-    script.parentNode.insertBefore(style, script);
+    script && script.parentNode && script.parentNode.insertBefore(style, script);
 
     // 'style.currentStyle' is used by IE <= 8 and 'window.getComputedStyle' for all other browsers
     info = ('getComputedStyle' in window) && window.getComputedStyle(style, null) || style.currentStyle;


### PR DESCRIPTION
Adding this check for `script && script.parentNode` allows foundation-sites to work with DoneJS's Server Side Rendering.

This fixes an issue where the limited DOM used by done-ssr would prevent the script from running and would fail with the following error:

```
Error evaluating file:/Users/marshall/Sites/gh-test/public/node_modules/foundation-sites/dist/foundation.js
Cannot read property 'parentNode' of undefined
    at file:/Users/marshall/Sites/gh-test/public/node_modules/foundation-sites/dist/foundation.js:855:13
```

I don't think I can make a test for this.
