### PR TITLE
Fix the slider to set var on offset percent

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -292,7 +292,7 @@ class Slider {
       } else {
         barXY = eventFromBar;
       }
-      offsetPct = percent(barXY, barDim);
+      var offsetPct = percent(barXY, barDim);
 
       value = (this.options.end - this.options.start) * offsetPct + this.options.start;
 


### PR DESCRIPTION
When I ran npm test locally, both before and after the change and it was successful. After the change, I am able to compile and successfully run foundation.slider.js through both gulp (laravel elixir) and webpack with gulp.
