### PR TITLE
Fix display for .input-group-button

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -122,7 +122,9 @@ $input-prefix-padding: 1rem !default;
 
   // Specificity bump needed to prevent override by buttons
   // scss-lint:disable QualifyingSelector
-  .input-group .input-group-button {
-    display: table-cell;
+  @if not $global-flexbox {
+      .input-group .input-group-button {
+          display: table-cell;
+      }
   }
 }


### PR DESCRIPTION
I believe that in flexbox is no need to use display: table-cell. I tried that and it works happily without it.
