### PR TITLE
Fix proportions of children in input-group

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -91,7 +91,6 @@ $input-prefix-padding: 1rem !default;
     // scss-lint:disable ZeroUnit
     @if $global-flexbox {
       flex: 1 1 0px;
-      width: auto;
       height: auto;
     }
     @else {


### PR DESCRIPTION
If I understand flex model correctly, there is no need to force the ‘.input-group-field‘ item to have certain width. Actually it breaks the design in some cases.

The point is, the flexbox container calculates the width of its items itself. If we set flex-grow to 1 for ‘.input-group-field‘ (which we did), the flexbox gives that item “width priority” over the rest, which is set 0 (default).

Before commit:
![input-group-error](https://cloud.githubusercontent.com/assets/3864012/15854476/59dd11a8-2caa-11e6-962d-6a9dc86fcb79.png)

After commit:
![input-group-fix](https://cloud.githubusercontent.com/assets/3864012/15854485/7078b7e6-2caa-11e6-9348-e38c3bbf1696.png)
