### PR TITLE
Make access to $foundation-palette a bit easier

### DIFF
--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -40,6 +40,19 @@
   @return scale-color($color, $lightness: $scale);
 }
 
+/// Get color from foundation-palette
+///
+/// @param {key} color key from foundation-palette
+///
+/// @returns {Color} color from foundation-palette
+@function get-color($key) {
+  @if map-has-key($foundation-palette, $key) {
+    @return map-get($foundation-palette, $key);
+  } @else {
+    @error 'given $key is not available in $foundation-palette';
+  }
+}
+
 /// Transfers the colors in the `$foundation-palette` variable into the legacy color variables, such as `$primary-color` and `$secondary-color`. Call this mixin below the Global section of your settings file to properly migrate your codebase.
 @mixin add-foundation-colors() {
   @if map-has-key($foundation-palette, primary) {


### PR DESCRIPTION
Accessing colors from $foundation-palette through map-get needs a lot of code. This way it would be a lot easier to use colors from palette.
