### PR TITLE
fix unset var on foundation slider

### DIFF
--- a/dist/foundation.js
+++ b/dist/foundation.js
@@ -7272,7 +7272,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
           } else {
             barXY = eventFromBar;
           }
-          offsetPct = percent(barXY, barDim);
+          var offsetPct = percent(barXY, barDim);
 
           value = (this.options.end - this.options.start) * offsetPct + this.options.start;
 

--- a/dist/plugins/foundation.slider.js
+++ b/dist/plugins/foundation.slider.js
@@ -328,7 +328,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
           } else {
             barXY = eventFromBar;
           }
-          offsetPct = percent(barXY, barDim);
+          var offsetPct = percent(barXY, barDim);
 
           value = (this.options.end - this.options.start) * offsetPct + this.options.start;
 

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -292,7 +292,7 @@ class Slider {
       } else {
         barXY = eventFromBar;
       }
-      offsetPct = percent(barXY, barDim);
+      var offsetPct = percent(barXY, barDim);
 
       value = (this.options.end - this.options.start) * offsetPct + this.options.start;
 


### PR DESCRIPTION
Foundation slider has an unset variable where the result is the slider renders properly, but when slid the slider throws a console error stating the variable 'offsetPct' is undefined.

Please see issue #8900 
