### PR TITLE
Moved $gutter calcs to dedicated function and added max-width 100% to shrunken column

### DIFF
--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -51,25 +51,23 @@
 
 /// Calculates the gutter sizes of a column based on the $gutter values and breakpoints.
 ///
-/// @returns {Number} The gutter width.
-@function grid-column-gutters {
+/// @param {String} the attribute to use.
+@mixin grid-column-gutters(
+  $attribute
+) {
   @if type-of($gutter) == 'map' {
     @each $breakpoint, $value in $gutter {
       $padding: rem-calc($value) / 2;
 
       @include breakpoint($breakpoint) {
-        padding-left: $padding;
-        padding-right: $padding;
+        #{$attribute}: $padding;
       }
     }
   }
   @else if type-of($gutter) == 'number' and strip-unit($gutter) > 0 {
     $padding: rem-calc($gutter) / 2;
-    padding-left: $padding;
-    padding-right: $padding;
+    #{$attribute}: $padding;
   }
-  
-  @return $padding;
 }
 
 /// Creates a grid column.
@@ -84,8 +82,8 @@
   float: $global-left;
 
   // Gutters
-  padding-left: grid-column-gutters;
-  padding-right: grid-column-gutters;
+  @include grid-column-gutters(padding-left);
+  @include grid-column-gutters(padding-right);
 
   // Last column alignment
   @if $grid-column-align-edge {

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -49,18 +49,10 @@
   @return $width;
 }
 
-/// Creates a grid column.
+/// Calculates the gutter sizes of a column based on the $gutter values and breakpoints.
 ///
-/// @param {Mixed} $columns [$grid-column-count] - Width of the column. Refer to the `grid-column()` function to see possible values.
-/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
-@mixin grid-column(
-  $columns: $grid-column-count,
-  $gutter: $grid-column-gutter
-) {
-  @include grid-column-size($columns);
-  float: $global-left;
-
-  // Gutters
+/// @returns {Number} The gutter width.
+@function grid-column-gutters {
   @if type-of($gutter) == 'map' {
     @each $breakpoint, $value in $gutter {
       $padding: rem-calc($value) / 2;
@@ -76,6 +68,24 @@
     padding-left: $padding;
     padding-right: $padding;
   }
+  
+  @return $padding;
+}
+
+/// Creates a grid column.
+///
+/// @param {Mixed} $columns [$grid-column-count] - Width of the column. Refer to the `grid-column()` function to see possible values.
+/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
+@mixin grid-column(
+  $columns: $grid-column-count,
+  $gutter: $grid-column-gutter
+) {
+  @include grid-column-size($columns);
+  float: $global-left;
+
+  // Gutters
+  padding-left: grid-column-gutters;
+  padding-right: grid-column-gutters;
 
   // Last column alignment
   @if $grid-column-align-edge {

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -101,9 +101,14 @@
   @if $columns == null {
     min-width: initial;
   }
-  // max-width fixes IE 10/11 not respecting the flex-basis property
-  @if $columns != null and $columns != shrink {
-    max-width: grid-column($columns);
+  @else {
+    @if $columns == shrink {
+      max-width: 100%;
+    }
+    @else {
+      // max-width fixes IE 10/11 not respecting the flex-basis property
+      max-width: grid-column($columns);
+    }
   }
 }
 
@@ -262,7 +267,6 @@
   // Sizing (shrink)
   .shrink {
     flex: flex-grid-column(shrink);
-    max-width: 100%;
   }
 
   // Vertical alignment using align-items and align-self

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -101,14 +101,12 @@
   @if $columns == null {
     min-width: initial;
   }
+  @else if $columns == shrink {
+    max-width: 100%;
+  }
   @else {
-    @if $columns == shrink {
-      max-width: 100%;
-    }
-    @else {
-      // max-width fixes IE 10/11 not respecting the flex-basis property
-      max-width: grid-column($columns);
-    }
+    // max-width fixes IE 10/11 not respecting the flex-basis property
+    max-width: grid-column($columns);
   }
 }
 

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -267,6 +267,7 @@
   // Sizing (shrink)
   .shrink {
     flex: flex-grid-column(shrink);
+    max-width: 100%;
   }
 
   // Vertical alignment using align-items and align-self


### PR DESCRIPTION
I've moved the calculations for $gutter padding to their own function as I would like to use the returned value for purposes of vertical rythm and various areas where I may not be using the row and column layout but I want spacing to be the same.

I've also added max-width 100% to shrunken columns based on feedback on http://foundation.zurb.com/forum/posts/43843-flex-column-shrink-max-width-issue
