### PR TITLE
Bind 'load' event instead of using the ajax function

### DIFF
--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -63,7 +63,7 @@ $(document).on('focus.zf.trigger blur.zf.trigger', '[data-toggle-focus]', functi
 * @function
 * @private
 */
-$(window).load(() => {
+$(window).on('load', () => {
   checkListeners();
 });
 


### PR DESCRIPTION
Everything is in the title :)
We don't need to load `window` but to know when it is loaded.
