### PR TITLE
nix unnecessary negative right margin in docs' flex grid scss

### DIFF
--- a/docs/assets/scss/examples/_grid.scss
+++ b/docs/assets/scss/examples/_grid.scss
@@ -65,7 +65,6 @@
   .columns {
     float: none;
     width: auto;
-    margin-right: -1px; // Not sure why this has to be here
 
     &:nth-child(odd) {
       background: #eee;


### PR DESCRIPTION
Fixes #8893. 

This PR fixes a `margin-right` bug in the Flex Grid docs. 

There was a line with a comment in `docs/assets/scss/_grid.scss`: 

``` scss
margin-right: -1px; // Not sure why this has to be here
```

I found no reason for it to remain. So I nixed it. Everything works fine. 
