### PR TITLE
add specificity to centered columns to override :last-child

### DIFF
--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -17,7 +17,9 @@
     #{$global-left}: $offset;
   }
   @else if $position == center {
-    float: none;
+    &, &:last-child:not(:first-child) {
+      float: none;
+    }
     margin-left: auto;
     margin-right: auto;
   }

--- a/test/visual/grid/centered-columns.html
+++ b/test/visual/grid/centered-columns.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="row">
+      <div class="medium-7 medium-centered columns">
+        <p style="background-color:#eee;">all these columns should be centered, even the last</p>
+      </div>
+      <div class="medium-7 medium-centered columns">
+        <p style="background-color:#eee;">all these columns should be centered, even the last</p>
+      </div>
+      <div class="medium-7 medium-centered columns">
+        <p style="background-color:#eee;">all these columns should be centered, even the last</p>
+      </div>
+      <div class="medium-7 medium-centered columns">
+        <p style="background-color:#eee;">all these columns should be centered, even the last</p>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>

--- a/test/visual/grid/centered-columns.html
+++ b/test/visual/grid/centered-columns.html
@@ -9,6 +9,13 @@
     <link href="../assets/css/foundation.css" rel="stylesheet" />
   </head>
   <body>
+
+    <div class="row">
+      <div class="medium-7 medium-centered columns">
+        <p style="background-color:#eee;">all these columns should be centered, even the last</p>
+      </div>
+    </div>
+
     <div class="row">
       <div class="medium-7 medium-centered columns">
         <p style="background-color:#eee;">all these columns should be centered, even the last</p>


### PR DESCRIPTION
This PR addresses #8899. The specificity of `:last-child:not(:first-child)` caused columns to float right even if they should be centered. Now the `grid-column-position` mixin will work for the last grid column. 
