### PR TITLE
Fix drilldown keyboard

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -149,8 +149,6 @@ class Drilldown {
         }
       });
 
-      console.log('Next:', $nextElement, 'Prev', $prevElement);
-
       Foundation.Keyboard.handleKey(e, 'Drilldown', {
         next: function() {
           if ($element.is(_this.$submenuAnchors)) {
@@ -329,6 +327,7 @@ class Drilldown {
     });
     this.$element.find('a').each(function(){
       var $link = $(this);
+      $link.removeAttr('tabindex');
       if($link.data('savedHref')){
         $link.attr('href', $link.data('savedHref')).removeData('savedHref');
       }else{ return; }

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -71,7 +71,7 @@ class Drilldown {
       if(_this.options.parentLink){
         $link.clone().prependTo($sub.children('[data-submenu]')).wrap('<li class="is-submenu-parent-item is-submenu-item is-drilldown-submenu-item" role="menu-item"></li>');
       }
-      $link.data('savedHref', $link.attr('href')).removeAttr('href');
+      $link.data('savedHref', $link.attr('href')).removeAttr('href').attr('tabindex', 0);
       $link.children('[data-submenu]')
           .attr({
             'aria-hidden': true,
@@ -148,6 +148,8 @@ class Drilldown {
           return;
         }
       });
+
+      console.log('Next:', $nextElement, 'Prev', $prevElement);
 
       Foundation.Keyboard.handleKey(e, 'Drilldown', {
         next: function() {

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -188,13 +188,14 @@ class Drilldown {
                 $element.parent('li').parent('ul').parent('li').children('a').first().focus();
               }, 1);
             });
+            return true;            
           } else if ($element.is(_this.$submenuAnchors)) {
             _this._show($element.parent('li'));
             $element.parent('li').one(Foundation.transitionend($element), function(){
               $element.parent('li').find('ul li a').filter(_this.$menuItems).first().focus();
             });
+            return true;
           }
-          return true;
         },
         handled: function(preventDefault) {
           if (preventDefault) {


### PR DESCRIPTION
Quick fix for #8978 by adding tabindex to sub-menu parents.

Second commit removes the tabindex on destroy, messed up the message.
