### PR TITLE
Feature - Foundation.MediaQuery.is() Method

### DIFF
--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -87,7 +87,7 @@ class Equalizer {
    * @private
    */
   _checkMQ() {
-    var tooSmall = !Foundation.MediaQuery.atLeast(this.options.equalizeOn);
+    var tooSmall = !Foundation.MediaQuery.is(this.options.equalizeOn);
     if(tooSmall){
       if(this.isOn){
         this._pauseEvents();

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -267,7 +267,7 @@ class Sticky {
    * @private
    */
   _setSizes(cb) {
-    this.canStick = Foundation.MediaQuery.atLeast(this.options.stickyOn);
+    this.canStick = Foundation.MediaQuery.is(this.options.stickyOn);
     if (!this.canStick) { cb(); }
     var _this = this,
         newElemWidth = this.$container[0].getBoundingClientRect().width,

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -170,7 +170,7 @@ class Tooltip {
    * @function
    */
   show() {
-    if (this.options.showOn !== 'all' && !Foundation.MediaQuery.atLeast(this.options.showOn)) {
+    if (this.options.showOn !== 'all' && !Foundation.MediaQuery.is(this.options.showOn)) {
       // console.error('The screen is too small to display this tooltip');
       return false;
     }

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -61,6 +61,22 @@ var MediaQuery = {
   },
 
   /**
+   * Checks if the screen matches to a breakpoint. 
+   * @function
+   * @param {String} size - Name of the breakpoint to check, either 'small only' or 'small'. Omitting 'only' falls back to using atLeast() method.
+   * @returns {Boolean} `true` if the breakpoint matches, `false` if it does not.
+   */
+  is(size) {
+    size = size.trim().split(' ');
+    if(size.length > 0 && size[1] === 'only') {
+      if(size[0] === this._getCurrentSize()) return true;
+    } else {
+      return this.atLeast(size[0]);
+    }
+    return false;
+  },
+
+  /**
    * Gets the media query of a breakpoint.
    * @function
    * @param {String} size - Name of the breakpoint to get.

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -68,7 +68,7 @@ var MediaQuery = {
    */
   is(size) {
     size = size.trim().split(' ');
-    if(size.length > 0 && size[1] === 'only') {
+    if(size.length > 1 && size[1] === 'only') {
       if(size[0] === this._getCurrentSize()) return true;
     } else {
       return this.atLeast(size[0]);


### PR DESCRIPTION
I was thinking this would be a good way for plugins to target a specific breakpoint, rather than being limited to a minimum breakpoint, as they are now with atLeast().  Accepts either ‘[breakpoint] only’ or ‘[breakpoint]’ - in the former case, it will see if the breakpoint matches exactly, and in the latter, it falls back to atLeast(). 

For instance: #8864 

@brettsmason @rafibomb  - Any thoughts on this? I would be happy to take a stab at integrating this into the plugins if the community thinks it is worthwhile. 

PS: It's my first attempt at contributing to Foundation - I hope I did not donk things up too badly!
