### PR TITLE
Allow definition of global-font-size in rem

### DIFF
--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -40,7 +40,7 @@ $global-font-size: 100% !default;
     $base: ($base / 100%) * 16px;
   }
   
-  // Using rem as base allwos correct scaling
+  // Using rem as base allows correct scaling
   @if unit($base) == 'rem' {
     $base: strip-unit($base) * 16px;
   }

--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -39,6 +39,11 @@ $global-font-size: 100% !default;
   @if unit($base) == '%' {
     $base: ($base / 100%) * 16px;
   }
+  
+  // Using rem as base allwos correct scaling
+  @if unit($base) == 'rem' {
+    $base: strip-unit($base) * 16px;
+  }
 
   @if $count == 1 {
     @return -zf-to-rem($values, $base);


### PR DESCRIPTION
Browser scaling through changing the base font-size in browser settings doesn't work correctly if the base is defined in percent. To make this work we define the base in rem. But in this case rem-calc stops working.
