### PR TITLE
[JS-dropdown] fix float-right is ommited when last in classes

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -71,7 +71,7 @@ class Dropdown {
   getPositionClass() {
     var verticalPosition = this.$element[0].className.match(/(top|left|right|bottom)/g);
         verticalPosition = verticalPosition ? verticalPosition[0] : '';
-    var horizontalPosition = /float-(\S+)\s?/.exec(this.$anchor[0].className);
+    var horizontalPosition = /float-(\S+)/.exec(this.$anchor[0].className);
         horizontalPosition = horizontalPosition ? horizontalPosition[1] : '';
     var position = horizontalPosition ? horizontalPosition + ' ' + verticalPosition : verticalPosition;
 

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -71,9 +71,10 @@ class Dropdown {
   getPositionClass() {
     var verticalPosition = this.$element[0].className.match(/(top|left|right|bottom)/g);
         verticalPosition = verticalPosition ? verticalPosition[0] : '';
-    var horizontalPosition = /float-(\S+)\s/.exec(this.$anchor[0].className);
+    var horizontalPosition = /float-(\S+)\s?/.exec(this.$anchor[0].className);
         horizontalPosition = horizontalPosition ? horizontalPosition[1] : '';
     var position = horizontalPosition ? horizontalPosition + ' ' + verticalPosition : verticalPosition;
+
     return position;
   }
 

--- a/test/javascript/components/dropdown.js
+++ b/test/javascript/components/dropdown.js
@@ -51,5 +51,14 @@ describe('Dropdown', function() {
 
       plugin.getPositionClass().trim().should.equal('right');
     });
+
+    it('has horizontal position and only one class', function() {
+      $dropdownController = $(getDropdownController('float-right'))
+        .appendTo('body');
+      $dropdownContainer = $(getDropdownContainer()).appendTo('body');
+      plugin = new Foundation.Dropdown($dropdownContainer, {});
+
+      plugin.getPositionClass().trim().should.equal('right');
+    });
   });
 });


### PR DESCRIPTION
the regex requires a empty character after `float-something` 

I didn't get why `\s` has been added (the unit test is ok without it) 
