### PR TITLE
Commenting out console.log in Reveal

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -238,7 +238,7 @@ class Reveal {
             'tabindex': -1
           })
           .focus();
-          console.log('focus');
+          // console.log('focus');
       }
       if (this.options.overlay) {
         Foundation.Motion.animateIn(this.$overlay, 'fade-in');


### PR DESCRIPTION
This appears to be left over from someone's debugging, but it's present in the current distribution of 6.2.3 and logs "focus" to console whenever Motion UI is used to animate-in a Reveal.
