### PR TITLE
Fixes for better compatibility with jQuery 3: removed deprecated $.load-function for events

### DIFF
--- a/dist/plugins/foundation.interchange.js
+++ b/dist/plugins/foundation.interchange.js
@@ -164,7 +164,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
         // Replacing images
         if (this.$element[0].nodeName === 'IMG') {
-          this.$element.attr('src', path).load(function () {
+          this.$element.attr('src', path).on('load', function () {
             _this.currentPath = path;
           }).trigger(trigger);
         }

--- a/dist/plugins/foundation.util.triggers.js
+++ b/dist/plugins/foundation.util.triggers.js
@@ -62,7 +62,7 @@
   * @function
   * @private
   */
-  $(window).load(function () {
+  $(window).on('load', function () {
     checkListeners();
   });
 

--- a/js/foundation.interchange.js
+++ b/js/foundation.interchange.js
@@ -139,7 +139,7 @@ class Interchange {
 
     // Replacing images
     if (this.$element[0].nodeName === 'IMG') {
-      this.$element.attr('src', path).load(function() {
+      this.$element.attr('src', path).on('load', function() {
         _this.currentPath = path;
       })
       .trigger(trigger);

--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -63,7 +63,7 @@ $(document).on('focus.zf.trigger blur.zf.trigger', '[data-toggle-focus]', functi
 * @function
 * @private
 */
-$(window).load(() => {
+$(window).on('load', () => {
   checkListeners();
 });
 


### PR DESCRIPTION
jQuery deprecated the load function used as event. Replaced $.load with
$.on('load')
