### PR TITLE
Fix dropdown alternative anchor selection

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -41,7 +41,7 @@ class Dropdown {
   _init() {
     var $id = this.$element.attr('id');
 
-    this.$anchor = $(`[data-toggle="${$id}"]`) || $(`[data-open="${$id}"]`);
+    this.$anchor = $(`[data-toggle="${$id}"]`).length ? $(`[data-toggle="${$id}"]`) : $(`[data-open="${$id}"]`);
     this.$anchor.attr({
       'aria-controls': $id,
       'data-is-focus': false,


### PR DESCRIPTION
According to the dropdown JavaScript source code, the anchor could be defined either with `data-toggle` or `data-open`. The later will actually never be selected due to `$(`[data-toggle="${$id}"]`)` which will always be true - even if no object is found. Note that I took this syntax from the reveal component - see [here](https://github.com/zurb/foundation-sites/blob/master/js/foundation.reveal.js#L47).
