### PR TITLE
Add settings for the hover color for thead and tfoot

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -48,9 +48,17 @@ $table-stripe: even !default;
 /// @type Color
 $table-head-background: smart-scale($table-background, $table-color-scale / 2) !default;
 
+/// Default color of header rows on hover.
+/// @type List
+$table-head-row-hover: darken($table-head-background, $table-hover-scale) !default;
+
 /// Default color for footer background.
 /// @type Color
 $table-foot-background: smart-scale($table-background, $table-color-scale) !default;
+
+/// Default color of footer rows on hover.
+/// @type List
+$table-foot-row-hover: darken($table-foot-background, $table-hover-scale) !default;
 
 /// Default font color for header.
 /// @type Color
@@ -161,7 +169,21 @@ $show-header-for-stacked: false !default;
 
 /// Slightly darkens the table rows on hover.
 @mixin table-hover {
-  tr {
+  thead tr {
+    //Darkens the table header rows on hover.
+    &:hover {
+      background-color: $table-head-row-hover;
+    }
+  }
+
+  tfoot tr {
+    //Darkens the table footer rows on hover.
+    &:hover {
+      background-color: $table-foot-row-hover;
+    }
+  }
+
+  tbody tr {
     //Darkens the non-striped table rows on hover.
     &:hover {
       background-color: $table-row-hover;


### PR DESCRIPTION
This fixes a bug where hovering the header or footer with a modified background color, would change the background color to be the same as the body.
