### PR TITLE
Modify cite element to use a variable for the pseudo content

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -160,6 +160,7 @@ $blockquote-padding: rem-calc(9 20 0 19);
 $blockquote-border: 1px solid $medium-gray;
 $cite-font-size: rem-calc(13);
 $cite-color: $dark-gray;
+$cite-pseudo-content: '\2014 \0020';
 $keystroke-font: $font-family-monospace;
 $keystroke-color: $black;
 $keystroke-background: $light-gray;

--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -203,6 +203,10 @@ $cite-font-size: rem-calc(13) !default;
 /// @type Color
 $cite-color: $dark-gray !default;
 
+/// Pseudo content for `<cite>` elements.
+/// @type String
+$cite-pseudo-content: '\2014 \0020' !default;
+
 /// Font family for `<kbd>` elements.
 /// @type String | List
 $keystroke-font: $font-family-monospace !default;
@@ -407,7 +411,7 @@ $abbr-underline: 1px dotted $black !default;
     color: $cite-color;
 
     &:before {
-      content: '\2014 \0020';
+      content: $cite-pseudo-content;
     }
   }
 


### PR DESCRIPTION
Adds an override variable to specify the cite element's pseudo ::before content.

This pull request resolves #8845

There is also an older pull request of this change in #8860 
