### PR TITLE
[Bug Fix] Round rgb color values otherwise it will always be black

### DIFF
--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -114,7 +114,7 @@
 ///
 /// @param {Color} $color [$black] - Color to use for the triangle.
 @mixin background-triangle($color: $black) {
-  $rgb: 'rgb%28#{red($color)}, #{green($color)}, #{blue($color)}%29';
+  $rgb: 'rgb%28#{round(red($color))}, #{round(green($color))}, #{round(blue($color))}%29';
 
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='32' height='24' viewBox='0 0 32 24'><polygon points='0,0 32,0 16,24' style='fill: #{$rgb}'></polygon></svg>");
 


### PR DESCRIPTION
`$color: #b3b6bd`
`red($color)` = 178.7
Kind of dumb that red/green/blue return decimals, but I learned something new...
`rgb(178.7, 0, 0)` = invalid property value
