### PR TITLE
Fix magellan `_updateActive()` behavior. Fixes #8960

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -139,7 +139,7 @@ class Magellan {
     }
 
     this.$active.removeClass(this.options.activeClass);
-    this.$active = this.$links.eq(curIdx).addClass(this.options.activeClass);
+    this.$active = this.$links.filter('[href="#' + this.$targets.eq(curIdx).data('magellan-target') + '"]').addClass(this.options.activeClass);
 
     if(this.options.deepLinking){
       var hash = this.$active[0].getAttribute('href');

--- a/test/visual/magellan/unordered-links.html
+++ b/test/visual/magellan/unordered-links.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+    <style type="text/css">
+      [data-magellan] {
+        position: fixed;
+        top: 0;
+        right: 0;
+      }
+      [data-magellan] a.active {
+        font-weight: bold;
+        color: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <ul class="vertical menu" data-magellan>
+      <li><a href="#one">Section One</a></li>
+      <li><a href="#three">Section Three</a></li>
+      <li><a href="#two">Section Two</a></li>
+      <li><a href="#four">Section Four</a></li>
+      <li><a href="#five">Section Five</a></li>
+      <li><a href="#three">Section Three</a></li>
+    </ul>
+    <div class="row">
+      <div class="column small-10 medium-6 large-4">
+        <section id="one" data-magellan-target="one">
+          <h1>Section One</h1>
+          <p>
+            <strong>This test checks if the correct link gets the active class when scrolling.</strong> This section is in the same place as the corresponding link. All should go well.
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer ultricies porttitor lorem. Fusce condimentum in erat id pellentesque. Ut id lacus non nulla sodales suscipit. Donec dictum ante lacus, id fermentum ex dictum id. Pellentesque vel ullamcorper nisi. In hac habitasse platea dictumst. Morbi vehicula egestas tellus, non pulvinar leo viverra in. Maecenas eget est ut nisi scelerisque semper a sed quam. Suspendisse viverra ornare lacus, vehicula sagittis est condimentum a. Aliquam erat volutpat. Nullam consequat aliquam eros quis dictum. Suspendisse dapibus massa eget felis convallis dapibus. Nam vestibulum ligula velit, egestas faucibus justo pellentesque a.
+          </p>
+        </section>
+        <section id="two" data-magellan-target="two">
+          <h1>Section Two</h1>
+          <p>
+            This section is not in the same place as the corresponding link. Notice that the corresponding link comes third in the menu, but the section comes second in the page.
+          </p>
+          <p>
+            Mauris non metus porttitor, iaculis arcu in, ultrices metus. Maecenas et est lacus. Ut a diam rutrum, iaculis leo vitae, commodo felis. Donec molestie, elit in mollis consequat, mauris arcu auctor tortor, non feugiat felis mauris eu tellus. In hac habitasse platea dictumst. Phasellus condimentum nulla a orci varius placerat. Integer vitae orci tristique, convallis ligula ac, sodales dui. Morbi pharetra eros ut semper egestas. Donec ornare velit vel felis tempor tempor. Nullam egestas rhoncus elit et rhoncus.
+          </p>
+        </section>
+        <section id="three" data-magellan-target="three">
+          <h1>Section Three</h1>
+          <p>
+            This section has two corresponding links in the menu. Both should get the active class.
+          </p>
+          <p>
+            Cras in nunc ultricies, eleifend nisl ut, volutpat ipsum. In a neque nulla. Donec varius tempus fringilla. Nunc massa tellus, lobortis a imperdiet vel, placerat quis leo. Pellentesque vel accumsan lacus, aliquam tristique eros. Proin bibendum purus quis feugiat egestas. Vivamus facilisis libero tortor, ut finibus eros lobortis sed. Donec a blandit erat. Morbi et purus urna. Ut orci libero, sodales dapibus molestie id, pretium quis mi. Nam et lacinia quam.
+          </p>
+        </section>
+        <section id="five" data-magellan-target="five">
+          <h1>Section Five</h1>
+          <p>
+            This section comes fourth in the page because Section Four is missing. The Section Four link should not get the active class. Instead, the corresponding Section Five link should.
+          </p>
+          <p>
+            Donec aliquet dictum mauris nec volutpat. Nunc id mauris neque. Aenean venenatis, massa laoreet fermentum convallis, purus tellus luctus tellus, nec pharetra quam nisi non dolor. Aliquam quam mi, aliquam non leo eu, tincidunt aliquam nibh. Sed malesuada, ligula at maximus imperdiet, risus arcu hendrerit dolor, ac rutrum elit leo nec dolor. Nulla eu dolor eget sapien eleifend pulvinar finibus ac nisl. Nulla augue lorem, ullamcorper id felis sit amet, pretium viverra lectus. Praesent ullamcorper orci sed convallis pulvinar. Sed accumsan orci vel blandit sodales. Duis lobortis sem at fermentum scelerisque. Cras sed turpis at est sollicitudin sollicitudin dignissim vel libero. Maecenas sit amet mauris elementum, tincidunt sem vitae, pharetra ex. Curabitur viverra erat ut ipsum cursus mattis. Vestibulum consectetur, ligula id gravida tristique, nisi lorem gravida ex, in imperdiet risus turpis eget neque.
+          </p>
+        </section>
+      </div>
+    </div>
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
When the links are not in the same order as the targets, or a link exists without a corresponding target, or several links with the same `href` are in a magellan container, the wrong link may get the .active class.

A visual test has been added for this case.
