### PR TITLE
production's files for browsers (bower.json)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,10 @@
     "scss/foundation.scss",
     "dist/foundation.js"
   ],
+  "browser": [
+    "dist/foundation.min.css",
+    "dist/foundation.min.js"
+  ],
   "ignore": [
     "config",
     "docs",


### PR DESCRIPTION
> because development files (ex: `.scss`, `.coffee`, ...)  isn't actually good for browsers to digest.

useful for project which behavior [like this one](https://github.com/tnga/bowerder); considering this conversation bower/bower#2312
