### PR TITLE
[DropdownMenu] Invalid ARIA usage #9072

### DIFF
--- a/docs/pages/dropdown-menu.md
+++ b/docs/pages/dropdown-menu.md
@@ -41,7 +41,7 @@ To create dropdown menus, nest a new `<ul>` inside an `<li>`. You can nest furth
 
 <ul class="dropdown menu" data-dropdown-menu>
   <li>
-    <a>Item 1</a>
+    <a href="#Item-1">Item 1</a>
     <ul class="menu">
       <li><a href="#Item-1A">Item 1A</a></li>
       <li>
@@ -97,7 +97,7 @@ Add the `.vertical` class to the top-level menu to make it vertical. Sub-menus a
 
 <ul class="vertical dropdown menu" data-dropdown-menu style="max-width: 300px;">
   <li>
-    <a>Item 1</a>
+    <a href="#Item-1">Item 1</a>
     <ul class="menu">
       <li><a href="#Item-1A">Item 1A</a></li>
       <li>
@@ -138,13 +138,13 @@ Add the `.vertical` class to the top-level menu to make it vertical. Sub-menus a
 
 ## Sticky Navigation
 
-See the documentation for the [Sticky](sticky.html#sticky-navigation) plugin to see how to easily make a sticky nav bar. 
+See the documentation for the [Sticky](sticky.html#sticky-navigation) plugin to see how to easily make a sticky nav bar.
 
 ---
 
 ### Preventing FOUC
 
-Before the JavaScript on your page loads, the dropdown menus will not have arrows. However, once the JavaScript file has loaded, the arrows will appear causing a [flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content). You can prevent this by adding the `.is-dropdown-submenu-parent` class manually. 
+Before the JavaScript on your page loads, the dropdown menus will not have arrows. However, once the JavaScript file has loaded, the arrows will appear causing a [flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content). You can prevent this by adding the `.is-dropdown-submenu-parent` class manually.
 
 ```html
 <ul class="dropdown menu" data-dropdown-menu>

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -250,8 +250,7 @@ class DropdownMenu {
     var $sibs = $sub.parent('li.is-dropdown-submenu-parent').siblings('li.is-dropdown-submenu-parent');
     this._hide($sibs, idx);
     $sub.css('visibility', 'hidden').addClass('js-dropdown-active').attr({'aria-hidden': false})
-        .parent('li.is-dropdown-submenu-parent').addClass('is-active')
-        .attr({'aria-expanded': true});
+        .parent('li.is-dropdown-submenu-parent').addClass('is-active');
     var clear = Foundation.Box.ImNotTouchingYou($sub, null, true);
     if (!clear) {
       var oldClass = this.options.alignment === 'left' ? '-right' : '-left',
@@ -295,7 +294,6 @@ class DropdownMenu {
 
     if (somethingToClose) {
       $toClose.find('li.is-active').add($toClose).attr({
-        'aria-expanded': false,
         'data-is-click': false
       }).removeClass('is-active');
 

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -249,7 +249,7 @@ class DropdownMenu {
     }));
     var $sibs = $sub.parent('li.is-dropdown-submenu-parent').siblings('li.is-dropdown-submenu-parent');
     this._hide($sibs, idx);
-    $sub.css('visibility', 'hidden').addClass('js-dropdown-active').attr({'aria-hidden': false})
+    $sub.css('visibility', 'hidden').addClass('js-dropdown-active')
         .parent('li.is-dropdown-submenu-parent').addClass('is-active');
     var clear = Foundation.Box.ImNotTouchingYou($sub, null, true);
     if (!clear) {
@@ -297,9 +297,7 @@ class DropdownMenu {
         'data-is-click': false
       }).removeClass('is-active');
 
-      $toClose.find('ul.js-dropdown-active').attr({
-        'aria-hidden': true
-      }).removeClass('js-dropdown-active');
+      $toClose.find('ul.js-dropdown-active').removeClass('js-dropdown-active');
 
       if (this.changed || $toClose.find('opens-inner').length) {
         var oldClass = this.options.alignment === 'left' ? 'right' : 'left';

--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -29,7 +29,6 @@ const Nest = {
           .addClass(`submenu ${subMenuClass}`)
           .attr({
             'data-submenu': '',
-            'aria-hidden': true,
             'role': 'menu'
           });
       }

--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -22,7 +22,6 @@ const Nest = {
           .addClass(hasSubClass)
           .attr({
             'aria-haspopup': true,
-            'aria-expanded': false,
             'aria-label': $item.children('a:first').text()
           });
 

--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -11,8 +11,6 @@ const Nest = {
         subItemClass = `${subMenuClass}-item`,
         hasSubClass = `is-${type}-submenu-parent`;
 
-    menu.find('a:first').attr('tabindex', 0);
-
     items.each(function() {
       var $item = $(this),
           $sub = $item.children('ul');
@@ -42,7 +40,7 @@ const Nest = {
   },
 
   Burn(menu, type) {
-    var items = menu.find('li').removeAttr('tabindex'),
+    var //items = menu.find('li'),
         subMenuClass = `is-${type}-submenu`,
         subItemClass = `${subMenuClass}-item`,
         hasSubClass = `is-${type}-submenu-parent`;


### PR DESCRIPTION
This PR addresses issue #9072 with the following:
1. Removed `aria-expanded` on menuitems's in dropdownMenu.js and nest.js. This state is unsupported with `role="menuitem"` and may cause incompatibility issues with assistive technologies. Changes to nest.js will affect DropdownMenu, DrilldownMenu, and AccordionMenu.
2. Removed unnecessary/ redundant `aria-hidden` on menuitems in dropdownMenu.js and nest.js. `display:none` is enough to hide from assistive technologies. This is just a cleanup change, and reduces surface area for future defects.
3. nest.js adds `tabindex="0"` to the first menu item, but this is not necessary since the `<a>` tag is already natively focusable. This is just a cleanup change, and reduces surface area for future defects.
4. Added a missing `href` in the DropdownMenu docs
## Recommendation

Examples show using an anchor (`<a>`) tag for each `menuitem` but the expected child of `menuitem` should just be a text node. Ideally, the `<a>` would not be required or at least marked with `role="presentation` except the intent/ usage of this widget is unclear to me. Based on the docs, it looks this like _could_ be used as an actual anchor (Item 3 and Item 4). This can also be seen with the main doc navigation at the upper right, which I believe is coming from the nest.js util. These are, in fact, navigational items but a `menubar` widget is a little overkill here, as simple navigation `<ul>` would suffice. I attempted to address this but without any context I did not want to break anything.

cc: @rafibomb @gakimball 
