### PR TITLE
[Reveal] Fix iOS bug where opening a modal would cause the page to jump to top.

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -116,7 +116,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   // html gets this class only in iOS
   html.is-reveal-open,
   html.is-reveal-open body {
-    height: 100%;
+    min-height: 100%;
     overflow: hidden;
     user-select: none;
   }


### PR DESCRIPTION
When opening a Reveal modal on iOS Safari, the page jumps the top of the screen while the modal is open, and jumps back to it's original position when the modal is closed. This is corrected by changing `height` to `min-height` for the iOS-only class `html.is-reveal-open, html.is-reveal-open body`.
