### PR TITLE
Fixed deploy:dist and deploy:plugins tasks

### DIFF
--- a/gulp/deploy.js
+++ b/gulp/deploy.js
@@ -84,6 +84,9 @@ gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function(
 // Copies standalone JavaScript plugins to dist/ folder
 gulp.task('deploy:plugins', function() {
   gulp.src('_build/assets/js/plugins/*.js')
+    .pipe(gulp.dest('dist/js/plugins'))
+    .pipe(uglify())
+    .pipe(rename({ suffix: '.min' }))
     .pipe(gulp.dest('dist/js/plugins'));
 });
 

--- a/gulp/deploy.js
+++ b/gulp/deploy.js
@@ -69,22 +69,22 @@ gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function(
   return gulp.src(DIST_FILES)
     .pipe(plumber())
     .pipe(cssFilter)
-      .pipe(gulp.dest('./dist'))
+      .pipe(gulp.dest('./dist/css'))
       .pipe(cssnano())
       .pipe(rename({ suffix: '.min' }))
-      .pipe(gulp.dest('./dist'))
+      .pipe(gulp.dest('./dist/css'))
     .pipe(cssFilter.restore)
     .pipe(jsFilter)
-      .pipe(gulp.dest('./dist'))
+      .pipe(gulp.dest('./dist/js'))
       .pipe(uglify())
       .pipe(rename({ suffix: '.min' }))
-      .pipe(gulp.dest('./dist'));
+      .pipe(gulp.dest('./dist/js'));
 });
 
 // Copies standalone JavaScript plugins to dist/ folder
 gulp.task('deploy:plugins', function() {
   gulp.src('_build/assets/js/plugins/*.js')
-    .pipe(gulp.dest('dist/plugins'));
+    .pipe(gulp.dest('dist/js/plugins'));
 });
 
 // Generates a settings file


### PR DESCRIPTION
Fixed the gulp tasks: `deploy:dist` and `deploy:plugins`, so the output will be:
- `dist/`: Compiled files.
  - `css/`: Compiled CSS files. Includes minified and unminified files.
  - `js/`: Concatenated JavaScript files. Includes minified and unminified files.
    - `plugins/`: Standalone JavaScript plugins.

Look at this for more details #8863 
### Note :exclamation:

This PR is a replacement for that PR #8862
