### PR TITLE
focus state and input-transition

### DIFF
--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -43,6 +43,22 @@ $select-radius: $global-radius !default;
     padding-#{$global-right}: ($form-spacing * 1.5);
   }
 
+  @if has-value($input-transition) {
+    transition: $input-transition;
+  }
+
+  // Focus state
+  &:focus {
+    border: $input-border-focus;
+    background-color: $input-background-focus;
+    outline: none;
+    box-shadow: $input-shadow-focus;
+
+    @if has-value($input-transition) {
+      transition: $input-transition;
+    }
+  }
+  
   // Disabled state
   &:disabled {
     background-color: $input-background-disabled;


### PR DESCRIPTION
maybe it's simpler to just import (@extend) the global form-element
