### PR TITLE
vertically center left-right dropdown arrows

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -34,7 +34,7 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
 @mixin left-right-arrows {
   > a::after {
     #{$global-right}: 14px;
-    margin-top: -3px;
+    margin-top: -5px;
   }
 
   &.opens-left > a::after {


### PR DESCRIPTION
height is 10px (2*5px = 2xtriangle-border). To center vertically top: 50%, margin-top: height/2 => triangle border size 5px

what about parameterizing the triangle size (now 5px hardcoded ) as well to allow custom arrow sizes via configuration?
