### PR TITLE
Fixed path to import util scss file from util folder

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -40,7 +40,7 @@
 //  35. Tooltip
 //  36. Top Bar
 
-@import 'util/util';
+@import '../util/util';
 
 // 1. Global
 // ---------


### PR DESCRIPTION
Fix the path to import correctly the file `_util.scss`
