### PR TITLE
restrict selector to menus and menu-items

### DIFF
--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -50,7 +50,7 @@ const Nest = {
         hasSubClass = `is-${type}-submenu-parent`;
 
     menu
-      .find('*')
+      .find('>li, .menu, .menu > li')
       .removeClass(`${subMenuClass} ${subItemClass} ${hasSubClass} is-submenu-item submenu is-active`)
       .removeAttr('data-submenu').css('display', '');
 


### PR DESCRIPTION
this allows to have elements inside li with the "is-active" class not removed by the Burn method
