### PR TITLE
custom button and hollow button hover lightness settings

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -51,6 +51,14 @@ $button-sizes: (
 /// @type List
 $button-opacity-disabled: 0.25 !default;
 
+/// Background color lightness on hover for buttons.
+/// @type Number
+$button-background-hover-lightness: -20% !default;
+
+/// Color lightness on hover for hollow buttons.
+/// @type Number
+$button-hollow-hover-lightness: -50% !default;
+
 // Internal: flip from margin-right to margin-left for defaults
 @if $global-text-direction == 'rtl' {
   $button-margin: 0 0 $global-margin $global-margin !default;
@@ -96,14 +104,15 @@ $button-opacity-disabled: 0.25 !default;
 @mixin button-style(
   $background: $button-background,
   $background-hover: $button-background-hover,
-  $color: $button-color
+  $color: $button-color,
+  $background-hover-lightness: $button-background-hover-lightness
 ) {
   @if $color == auto {
     $color: foreground($background, $button-color-alt, $button-color);
   }
 
   @if $background-hover == auto {
-    $background-hover: scale-color($background, $lightness: -20%);
+    $background-hover: scale-color($background, $lightness: $background-hover-lightness);
   }
 
   background-color: $background;
@@ -123,8 +132,11 @@ $button-opacity-disabled: 0.25 !default;
   }
 }
 
-@mixin button-hollow-style($color: $primary-color) {
-  $color-hover: scale-color($color, $lightness: -50%);
+@mixin button-hollow-style(
+  $color: $primary-color,
+  $hover-lightness: $button-hollow-hover-lightness
+) {
+  $color-hover: scale-color($color, $lightness: $hover-lightness);
 
   border: 1px solid $color;
   color: $color;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -248,6 +248,8 @@ $button-sizes: (
   large: 1.25rem,
 );
 $button-opacity-disabled: 0.25;
+$button-background-hover-lightness: -20%;
+$button-hollow-hover-lightness: -50%;
 
 // 12. Button Group
 // ----------------


### PR DESCRIPTION
I just didn't like the default -50% lightness for hollow buttons, maybe alowing further customization via settings could be a better solution for users
