### PR TITLE
drilldown height calculation

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -299,13 +299,16 @@ class Drilldown {
    * @private
    */
   _getMaxDims() {
-    var max = 0, result = {};
-    this.$submenus.add(this.$element).each(function(){
-      var numOfElems = $(this).children('li').length;
-      max = numOfElems > max ? numOfElems : max;
+    var minHeight = 0, result = {};
+    this.$element.find('.menu').each(function () {
+      var height = 0;
+      $(this).find('>li').each(function () {
+        height += $(this).outerHeight();
+      });
+      minHeight = Math.max(height, minHeight);
     });
 
-    result['min-height'] = `${max * this.$menuItems[0].getBoundingClientRect().height}px`;
+    result['min-height'] = `${minHeight}px`;
     result['max-width'] = `${this.$element[0].getBoundingClientRect().width}px`;
 
     return result;


### PR DESCRIPTION
Calculate min-height by iterating through all menus and submenus and building each menu/submenu height with the sum of its li outerHeight, then take the max height of each menu.

multiplying max li number x 1st li height does not take into account variable/multirows li height.
