### PR TITLE
Dropdown Menu keyboard accessibility

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -163,7 +163,7 @@ class DropdownMenu {
         open: openSub,
         close: function() {
           _this._hide(_this.$element);
-          _this.$menuItems.find('a:first').focus(); // focus to first element
+          _this.$tabs.has(e.target).children('a').focus(); // focus to first element
           e.preventDefault();
         },
         handled: function() {

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -131,16 +131,14 @@ class DropdownMenu {
       $elements.each(function(i) {
         if ($(this).is($element)) {
           $prevElement = $elements.eq(i-1);
-          $nextElement = $elements.eq(i+1);
+          $nextElement = $elements.length === i + 1 ? $elements.eq(0) : $elements.eq(i+1);
           return;
         }
       });
 
       var nextSibling = function() {
-        if (!$element.is(':last-child')) {
-          $nextElement.children('a:first').focus();
-          e.preventDefault();
-        }
+        $nextElement.children('a:first').focus();
+        e.preventDefault();
       }, prevSibling = function() {
         $prevElement.children('a:first').focus();
         e.preventDefault();


### PR DESCRIPTION
This fixes two accessibility issues with dropdown menu:
1.  When escape is pressed, focus returns to the last menuitem in the menubar.  It should go to the top level menuitem which contains the opened menu.
2.  Makes down arrow wrap to first element.  This matches the behavior of up arrow.  For accessibility, the menus should either wrap both ways (e.g. down on last item goes to first; up on first goes to last) or not at all.
