### PR TITLE
updating triggers for mutation listeners, and equalizer to use them

### DIFF
--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -36,6 +36,7 @@ class Equalizer {
 
     this.$watched = $watched.length ? $watched : this.$element.find('[data-equalizer-watch]');
     this.$element.attr('data-resize', (eqId || Foundation.GetYoDigits(6, 'eq')));
+	this.$element.attr('data-mutate', (eqId || Foundation.GetYoDigits(6, 'eq')));
 
     this.hasNested = this.$element.find('[data-equalizer]').length > 0;
     this.isNested = this.$element.parentsUntil(document.body, '[data-equalizer]').length > 0;
@@ -71,6 +72,7 @@ class Equalizer {
     this.$element.off({
       '.zf.equalizer': this._bindHandler.onPostEqualizedBound,
       'resizeme.zf.trigger': this._bindHandler.onResizeMeBound
+	  'mutateme.zf.trigger': this._bindHandler.onResizeMeBound
     });
   }
 
@@ -101,6 +103,7 @@ class Equalizer {
       this.$element.on('postequalized.zf.equalizer', this._bindHandler.onPostEqualizedBound);
     }else{
       this.$element.on('resizeme.zf.trigger', this._bindHandler.onResizeMeBound);
+	  this.$element.on('mutateme.zf.trigger', this._bindHandler.onResizeMeBound);
     }
     this.isOn = true;
   }

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -71,7 +71,7 @@ class Equalizer {
     this.isOn = false;
     this.$element.off({
       '.zf.equalizer': this._bindHandler.onPostEqualizedBound,
-      'resizeme.zf.trigger': this._bindHandler.onResizeMeBound
+      'resizeme.zf.trigger': this._bindHandler.onResizeMeBound,
 	  'mutateme.zf.trigger': this._bindHandler.onResizeMeBound
     });
   }

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -207,6 +207,9 @@ class Tabs {
      * @event Tabs#change
      */
     this.$element.trigger('change.zf.tabs', [$target]);
+	
+	//fire to children a mutation event
+	$targetContent.find("[data-mutate]").trigger("mutateme.zf.trigger");
   }
 
   /**

--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -152,21 +152,13 @@ function scrollListener(debounce){
 }
 
 function mutateListener(debounce) {
-    let timer,
-        $nodes = $('[data-mutate]');
-    if ($nodes.length) {
-        if (timer) {
-          clearTimeout(timer);
-        }
-
-        timer = setTimeout(function () {
-		
+    let $nodes = $('[data-mutate]');
+    if ($nodes.length && MutationObserver){
 			//trigger all listening elements and signal a mutate event
+      //no IE 9 or 10
 			$nodes.each(function () {
 			  $(this).triggerHandler('mutateme.zf.trigger');
 			});
-		  
-        }, debounce || 10); //default time to emit scroll event
     }
  }
 


### PR DESCRIPTION
Adding this as a "bug fix / feature" to develop because if it works will fix a lot of issues.
EX: https://github.com/zurb/foundation-sites/issues/8684 or https://github.com/zurb/foundation-sites/issues/8556

This is the implementation of mutation in addition to scroll and resize
triggers for universal plugin usage. Foundation can now fire events
when elements that are listening for mutation events or their children
change in the DOM either by element addition, element removal, or
attribute manipulation.

This can be very useful for ajax caused changes, display none on load
issues, element manipulation, and any other DOM mutation events.

To see what I mean, I added in the mutation trigger for Equalizer, see how it interacts with interchange, and a "display:none" div. And added in a fire event for Tabs as well.

This is what Foundation currently does with interchange and equalizer, and Tabs with JS modified content. (not so nice)
http://tangerineindustries.com/Foundation/feature-mutation-trigger/without_mut.html

This is with the new mutation trigger (everything lays out proper)
http://tangerineindustries.com/Foundation/feature-mutation-trigger/with_mut.html
