### PR TITLE
Reload focusableElments at every keydown to fix issue #9130

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -249,7 +249,7 @@ class Dropdown {
             if(_this.$anchor.is(e.target) || _this.$anchor.find(e.target).length) {
               return;
             }
-            if(_this.$element.find(e.target).length) {
+            if(_this.$element.find(e.target).length || !$(document).find(e.target).length) {
               return;
             }
             _this.close();

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -289,7 +289,6 @@ class Reveal {
    */
   _extraHandlers() {
     var _this = this;
-    this.focusableElements = Foundation.Keyboard.findFocusable(this.$element);
 
     if (!this.options.overlay && this.options.closeOnClick && !this.options.fullScreen) {
       $('body').on('click.zf.reveal', function(e) {
@@ -314,6 +313,8 @@ class Reveal {
     // lock focus within modal while tabbing
     this.$element.on('keydown.zf.reveal', function(e) {
       var $target = $(this);
+      _this.focusableElements = Foundation.Keyboard.findFocusable(_this.$element);
+
       // handle keyboard event with keyboard util
       Foundation.Keyboard.handleKey(e, 'Reveal', {
         tab_forward: function() {


### PR DESCRIPTION
Fixes #9130 
Reload focusableElments at every keydown for the tab key to work properly when the content inside the reveal changes after opening.

Also avoid dropdown closing upon click of an element not in the DOM like in pr #9146
