### PR TITLE
orbit: add/trigger event beforeslidechange

### DIFF
--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -268,6 +268,8 @@ class Orbit {
     }
 
     if ($newSlide.length) {
+      this.$element.trigger('beforeslidechange.zf.orbit', [$curSlide, $newSlide]);
+      
       if (this.options.bullets) {
         idx = idx || this.$slides.index($newSlide); //grab index to update bullets
         this._updateBullets(idx);

--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -268,6 +268,10 @@ class Orbit {
     }
 
     if ($newSlide.length) {
+      /**
+      * Triggers before the next slide starts animating in and only if a next slide has been found.
+      * @event Orbit#beforeslidechange
+      */
       this.$element.trigger('beforeslidechange.zf.orbit', [$curSlide, $newSlide]);
       
       if (this.options.bullets) {


### PR DESCRIPTION
I use this event to smoothly resize the orbit container for carousels having images with different heights.
the callback will receive 2 arguments: the current slide and the next slide.
