### PR TITLE
topbar-title-padding

### DIFF
--- a/scss/components/_top-bar.scss
+++ b/scss/components/_top-bar.scss
@@ -22,6 +22,10 @@ $topbar-submenu-background: $topbar-background !default;
 /// @type Number
 $topbar-title-spacing: 1rem !default;
 
+/// Padding for the top bar title.
+/// @type Number
+$topbar-title-padding: 0.7rem 0 !default;
+
 /// Maximum width of `<input>` elements inside the top bar.
 /// @type Number
 $topbar-input-width: 200px !default;
@@ -154,7 +158,8 @@ $topbar-unstack-breakpoint: medium !default;
     .top-bar-title {
       float: left;
       margin-right: $topbar-title-spacing;
-
+      padding: $topbar-title-padding;
+      line-height: 1;
     }
 
     .top-bar-left {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -563,6 +563,7 @@ $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
 $topbar-submenu-background: $topbar-background;
 $topbar-title-spacing: 1rem;
+$topbar-title-padding: 0.7rem 0;
 $topbar-input-width: 200px;
 $topbar-unstack-breakpoint: medium;
 


### PR DESCRIPTION
Add the same vertical padding and line-height as the ones used for topbar menus in order to achieve a centered vertical alignment of the top-bar-title element in the default foundation setup.
