### PR TITLE
Avoid reveal modal closing upon click of an element not in the DOM

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -157,7 +157,11 @@ class Reveal {
 
     if (this.options.closeOnClick && this.options.overlay) {
       this.$overlay.off('.zf.reveal').on('click.zf.reveal', function(e) {
-        if (e.target === _this.$element[0] || $.contains(_this.$element[0], e.target)) { return; }
+        if (e.target === _this.$element[0] || 
+          $.contains(_this.$element[0], e.target) || 
+            !$.contains(document, e.target)) { 
+              return; 
+        }
         _this.close();
       });
     }
@@ -293,7 +297,9 @@ class Reveal {
 
     if (!this.options.overlay && this.options.closeOnClick && !this.options.fullScreen) {
       $('body').on('click.zf.reveal', function(e) {
-        if (e.target === _this.$element[0] || $.contains(_this.$element[0], e.target)) { return; }
+        if (e.target === _this.$element[0] || 
+          $.contains(_this.$element[0], e.target) || 
+            !$.contains(document, e.target)) { return; }
         _this.close();
       });
     }


### PR DESCRIPTION
Before submitting a pull request, make sure it's targeting the right branch:
- For documentation fixes, use `master`.
- For bug fixes, use `develop`.
- For new features, use the branch for the next minor version, which will be formatted `v6.x`.

If you're fixing a JavaScript issue, it would help to create a new test case under the folder `test/visual/` that recreates the issue and show's that it's been fixed. Run `npm test` to compile the testing folder.

Happy coding! :)

Added check to make sure e.target is still in the DOM. I came across a bug when I created a google map canvas inside reveal modal, whereby upon closing the info popup on a map marker, the entire reveal modal gets closed. This is because when the overlay click handler is invoked, Google code has already removed the e.target  element and the overlay handler only gets a ghost element and can not find it in the modal element
