### PR TITLE
remove redundant else

### DIFF
--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -209,14 +209,16 @@ var Foundation = {
         end = transitions[t];
       }
     }
+    
     if(end){
       return end;
-    }else{
-      end = setTimeout(function(){
-        $elem.triggerHandler('transitionend', [$elem]);
-      }, 1);
-      return 'transitionend';
     }
+    
+    end = setTimeout(function(){
+      $elem.triggerHandler('transitionend', [$elem]);
+    }, 1);
+      
+    return 'transitionend';
   }
 };
 
@@ -356,17 +358,17 @@ function functionName(fn) {
     var results = (funcNameRegex).exec((fn).toString());
     return (results && results.length > 1) ? results[1].trim() : "";
   }
-  else if (fn.prototype === undefined) {
+  
+  if (fn.prototype === undefined) {
     return fn.constructor.name;
   }
-  else {
-    return fn.prototype.constructor.name;
-  }
+  
+  return fn.prototype.constructor.name;
 }
 function parseValue(str){
   if(/true/.test(str)) return true;
-  else if(/false/.test(str)) return false;
-  else if(!isNaN(str * 1)) return parseFloat(str);
+  if(/false/.test(str)) return false;
+  if(!isNaN(str * 1)) return parseFloat(str);
   return str;
 }
 // Convert PascalCase to kebab-case


### PR DESCRIPTION
expressions like:

``` js
function func() {
    if (a) {
        //...
        return x;
    } else if (b) {
        //...
        return y;
    } else {
        //...
        return z;
    }
}
```

can be safely rewritten as

``` js
function func() {
    if (a) {
        //...
        return x;
    }

    if (b) {
        //...
        return y;
    }

    //...

    return z;
}
```

question 1:
why in line 215 inside the transitionend method the local variable `end` is being assigned to the value of a timer?

question 2:
inside parseValue should we just test for equality with string literals 'false', 'true'...otherwise a string like 'untrue' would be converted to the boolean true.

kind regards
