### PR TITLE
stop changeSlide if carousel is hidden

### DIFF
--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -248,7 +248,9 @@ class Orbit {
   */
   changeSlide(isLTR, chosenSlide, idx) {
     var $curSlide = this.$slides.filter('.is-active').eq(0);
-
+    
+    if (this.$element.is(':hidden')) { return false; } // do not changeSlide if the element is not visible because mui fisnish event will not be called leaving mui classes on in current and next slides
+    
     if (/mui/g.test($curSlide[0].className)) { return false; } //if the slide is currently animating, kick out of the function
 
     var $firstSlide = this.$slides.first(),


### PR DESCRIPTION
fixes the 2nd part of https://github.com/zurb/foundation-sites/issues/9103

motion-ui finish method is not called if the element is hidden (or inside hidden elements).
Therefore if changeSlide() is called for hidden carousels the "is-active" class attribute will be set for the next/chosen slide but mui-transition classes will be not removed from current/next slide. Further changeSlide() calls will therefore exit early as mui-classes are found in the current  lide (= the previous transition's next/chosen slide).
