### PR TITLE
allow easier mega-menu like items

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -207,7 +207,7 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
       }
     }
 
-    > li {
+    > li:not('.column') {
       width: 100%;
     }
 


### PR DESCRIPTION
I often use `.menu.[size]-[num]-up li.column` to build mega menus. This small change will allow more complex mega menus for dropdown list items instead of equally divided boxes only, without redefining all grid column classes ad hoc.
