### PR TITLE
Avoid duplicate reveal-overlays

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -83,10 +83,10 @@ class Reveal {
    * @private
    */
   _makeOverlay(id) {
-    var $overlay = $('body').find(`.reveal-overlay-${id}`);
+    var $overlay = $('body').find(`.reveal-overlay.overlay-${id}`);
     if ($overlay.length < 1) {
       $overlay = $('<div></div>')
-        .addClass(`reveal-overlay-${id}`)
+        .addClass(`reveal-overlay overlay-${id}`)
         .appendTo('body');
     }
     return $overlay;

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -83,9 +83,12 @@ class Reveal {
    * @private
    */
   _makeOverlay(id) {
-    var $overlay = $('<div></div>')
-                    .addClass('reveal-overlay')
-                    .appendTo('body');
+    var $overlay = $('body').find(`.reveal-overlay-${id}`);
+    if ($overlay.length < 1) {
+      $overlay = $('<div></div>')
+        .addClass(`reveal-overlay-${id}`)
+        .appendTo('body');
+    }
     return $overlay;
   }
 


### PR DESCRIPTION
the _makeOverlay function is not save to create a new overlay although one already exists.
As id is already passed to the function using it to make it unique.

BTW: I couldn't run tests because _estraverse-fb_ is broken. May it be, that there is something missing in package.json in 6.3 branch?
