### PR TITLE
Add license to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "foundation-sites",
   "version": "6.2.3",
+  "license": "MIT",
   "main": [
     "scss/foundation.scss",
     "dist/foundation.js"


### PR DESCRIPTION
Notes the MIT license in bower.json. This is good practice, and stops VersionEye from complaining :)
