### PR TITLE
Fix mouseenter issue with touch devices

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -169,12 +169,14 @@ class Dropdown {
 
     if(this.options.hover){
       this.$anchor.off('mouseenter.zf.dropdown mouseleave.zf.dropdown')
-          .on('mouseenter.zf.dropdown', function(){
-            clearTimeout(_this.timeout);
-            _this.timeout = setTimeout(function(){
-              _this.open();
-              _this.$anchor.data('hover', true);
-            }, _this.options.hoverDelay);
+      .on('mouseenter.zf.dropdown', function(){
+            if($('body[data-whatinput="mouse"]').is('*')) {
+              clearTimeout(_this.timeout);
+              _this.timeout = setTimeout(function(){
+                _this.open();
+                _this.$anchor.data('hover', true);
+              }, _this.options.hoverDelay);
+            }
           }).on('mouseleave.zf.dropdown', function(){
             clearTimeout(_this.timeout);
             _this.timeout = setTimeout(function(){


### PR DESCRIPTION
Fixes an odd issue encountered in a client project.  Hoverable dropdowns fall back to be clickable on touch devices, but due to some touch devices triggering a mouseenter event on click, you can end up in a situation where the hover show is getting triggered on click, with the result being that a dropdown can be opened on mobile but never closed.  This fixes it.

I'm open about if we want to use a javascript API to whatinput instead of the dom reference... anyone have an opinion on that?
