### PR TITLE
Don't attach accordion elements that are not marked as accordion-item

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -38,7 +38,7 @@ class Accordion {
    */
   _init() {
     this.$element.attr('role', 'tablist');
-    this.$tabs = this.$element.children('li, [data-accordion-item]');
+    this.$tabs = this.$element.children('[data-accordion-item]');
 
     this.$tabs.each(function(idx, el) {
       var $el = $(el),


### PR DESCRIPTION
I think this is a relict from an older version, where data-accordion-item was not used.
I'm aware of the fact, that this is a breaking change, but as the documentation tell's the developer to use data-accordion-item I think it shouldn't fallback to use li. This way it is also possible to add list items to an accordion that have no content. Till now having to content section throws an ugly hard to debug javascript error.
