### PR TITLE
Explain $grid-column-align-edge in Incomplete Rows section

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -249,7 +249,7 @@ Move blocks up to 11 columns to the right by using classes like `.large-offset-1
 
 ### Incomplete Rows
 
-In order to work around browsers' different rounding behaviors, Foundation will float the last column in a row to the right so the edge aligns. If your row doesn't have a count that adds up to 12 columns, you can tag the last column with a class of `.end` in order to override that behavior.
+In order to work around browsers' different rounding behaviors, Foundation will float the last column in a row to the right so the edge aligns. If your row doesn't have a count that adds up to 12 columns, you can tag the last column with a class of `.end` in order to override that behavior. Alternatively, you can set the `$grid-column-align-edge` variable to `false` to turn off this behavior entirely.
 
 ```html
 <div class="row">


### PR DESCRIPTION
The $grid-column-align-edge variable turns off the behaviour described in the Incomplete Rows section, and in many cases, is an easier option than adding the .end class the docs currently recommend.
