### PR TITLE
Add option for non-closeable accordion menu. Parent links will be followed.

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -185,13 +185,19 @@ class AccordionMenu {
 
   /**
    * Toggles the open/close state of a submenu.
+   * If data option "closeable" is set to "false", submenu will not close
+   * but parent link will be followed then.
    * @function
    * @param {jQuery} $target - the submenu to toggle
    */
   toggle($target){
     if(!$target.is(':animated')) {
       if (!$target.is(':hidden')) {
-        this.up($target);
+        if (this.options.closeable === false) {
+          window.location.href = $target.parent().children('a').attr('href');
+        } else {
+          this.up($target);    
+        }
       }
       else {
         this.down($target);


### PR DESCRIPTION
Hi, 
according to [this](https://github.com/zurb/foundation-sites/issues/7770) discussion, I wrote a patch for the accordion menu that offers an option to follow the parent links of open submenus. You can see it in action [here](https://relthyg.github.io/foundation-sites/).

Basically, I check for a "data-option-closeable" attribute of the `<ul>`-Element. If this is set to "false", parent links will be followed instead of closing the submenu.
