### PR TITLE
Change title for drilldown page to fix drilldown event name generation

### DIFF
--- a/docs/pages/drilldown-menu.md
+++ b/docs/pages/drilldown-menu.md
@@ -1,5 +1,5 @@
 ---
-title: Drilldown Menu
+title: Drilldown
 description: Drilldown is one of Foundation's three menu patterns, which converts a series of nested lists into a vertical drilldown menu.
 scss: scss/components/_drilldown.scss
 js: js/foundation.drilldown.js


### PR DESCRIPTION
This is a documentation fix for https://github.com/zurb/foundation-sites/issues/9151

For some reason, the docs generator uses the title to auto-generate the event names.  I don't know why, but changing that seems like a big project, while updating the title in this case to make the event names correct is simple.
