### PR TITLE
Fix up behavior when element has open submenu

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -115,8 +115,8 @@ class AccordionMenu {
           }
           if ($(this).is(':first-child')) { // is first element of sub menu
             $prevElement = $element.parents('li').first().find('a').first();
-          } else if ($prevElement.children('[data-submenu]:visible').length) { // if previous element has open sub menu
-            $prevElement = $prevElement.find('li:last-child').find('a').first();
+          } else if ($prevElement.parents('li').first().children('[data-submenu]:visible').length) { // if previous element has open sub menu
+            $prevElement = $prevElement.parents('li').find('li:last-child').find('a').first();
           }
           if ($(this).is(':last-child')) { // is last element of sub menu
             $nextElement = $element.parents('li').first().next('li').find('a').first();


### PR DESCRIPTION
Fixes behavior of up key when there is an open submenu.  See in visual test: https://github.com/zurb/foundation-sites/blob/develop/test/visual/accordion-menu/keyboard.html

Before: if you expand accordion menu and go all the way down, going up with keyboard will take you to first link rather than last link of expanded submenu.

After:  up has expected behavior.
