### PR TITLE
Add "alert" as required map value to $foundation-palette

### DIFF
--- a/docs/pages/global.md
+++ b/docs/pages/global.md
@@ -83,7 +83,7 @@ Many components can also be colored with four other colors: secondary, alert, su
   </div>
 </div>
 
-If you're using the Sass version of Foundation, it's possible to edit the default color palette, by changing the `$foundation-palette` variable in your settings file. The only required color is one named "primary". The names used in the palette will be output as CSS classes.
+If you're using the Sass version of Foundation, it's possible to edit the default color palette, by changing the `$foundation-palette` variable in your settings file. The only required colors are ones named "primary" and "alert". The names used in the palette will be output as CSS classes.
 
 ```scss
 $foundation-palette: (


### PR DESCRIPTION
Before submitting a pull request, make sure it's targeting the right branch:
- For documentation fixes, use `master`.
- For bug fixes, use `develop`.
- For new features, use the branch for the next minor version, which will be formatted `v6.x`.

If you're fixing a JavaScript issue, it would help to create a new test case under the folder `test/visual/` that recreates the issue and show's that it's been fixed. Run `npm test` to compile the testing folder.

Happy coding! :)

Undefined "alert" color in $foundation-palette breaks SCSS compilation. Documentation incorrectly identifies "primary" as the only required value in the user redefined map.
