### PR TITLE
Fix last child to float to the global left direction...

### DIFF
--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -52,7 +52,7 @@
     }
 
     &:last-child {
-      float: left;
+      float: $global-left;
     }
   }
 }


### PR DESCRIPTION
... on the `grid-layout` mixin.
Fixes #9092 
