### PR TITLE
[Feature] Drilldown menu with individual width and dynamic height.

### DIFF
--- a/docs/pages/drilldown-menu.md
+++ b/docs/pages/drilldown-menu.md
@@ -28,19 +28,21 @@ Any `<a>` without a submenu will function like a normal link.
 
 <div class="primary callout">
   <p>The drilldown menu takes on the height of the tallest menu in the hierarchy, so the menu doesn't change height as the user navigates it.</p>
+  <p>The width of the drilldown menu will set to the width of the parent element.</p>
+  <p>The height and width is recalculated on a resize of the window size.</p>
 </div>
 
-<ul class="menu" data-drilldown style="width: 200px" id="m1">
+<ul class="menu" data-drilldown id="m1">
   <li>
     <a href="#">Item 1</a>
     <ul class="menu">
       <li>
         <a href="#">Item 1A</a>
         <ul class="menu">
-          <li><a href="#Item-1Aa">Item 1Aa</a></li>
+          <li><a href="#Item-1Aa">Item 1Aa with long Name and may be with a line break</a></li>
           <li><a href="#Item-1Ba">Item 1Ba</a></li>
           <li><a href="#Item-1Ca">Item 1Ca</a></li>
-          <li><a href="#Item-1Da">Item 1Da</a></li>
+          <li><a href="#Item-1Da">Item 1Da with long Name and may be with a line break</a></li>
           <li><a href="#Item-1Ea">Item 1Ea</a></li>
         </ul>
       </li>
@@ -54,7 +56,70 @@ Any `<a>` without a submenu will function like a normal link.
     <a href="#">Item 2</a>
     <ul class="menu">
       <li><a href="#Item-2A">Item 2A</a></li>
-      <li><a href="#Item-2B">Item 2B</a></li>
+      <li><a href="#Item-2B">Item 2B  with long Name and may be with a line break</a></li>
+      <li><a href="#Item-2C">Item 2C</a></li>
+      <li><a href="#Item-2D">Item 2D</a></li>
+      <li><a href="#Item-2E">Item 2E</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="#">Item 3</a>
+    <ul class="menu">
+      <li><a href="#Item-3A">Item 3A</a></li>
+      <li><a href="#Item-3B">Item 3B</a></li>
+      <li><a href="#Item-3C">Item 3C</a></li>
+      <li><a href="#Item-3D">Item 3D</a></li>
+      <li><a href="#Item-3E">Item 3E</a></li>
+    </ul>
+  </li>
+  <li><a href="#Item-4"> Item 4</a></li>
+</ul>
+
+## Respect Individual Width
+
+```html
+<ul class="vertical menu" data-drilldown style="width: 200px">
+  <li>
+    <a href="#Item-1">Item 1</a>
+    <ul class="vertical menu">
+      <li><a href="#Item-1A">Item 1A</a></li>
+      <!-- ... -->
+    </ul>
+  </li>
+  <li><a href="#Item-2">Item 2</a></li>
+</ul>
+```
+
+<div class="primary callout">
+  <p>The drilldown menu respects a given width from the style definition or from a css class. All submenus becomes the same width.</p>
+</div>
+
+
+<ul class="menu" data-drilldown id="m2" style="width:200px">
+  <li>
+    <a href="#">Item 1</a>
+    <ul class="menu">
+      <li>
+        <a href="#">Item 1A</a>
+        <ul class="menu">
+          <li><a href="#Item-1Aa">Item 1Aa with long Name and may be with a line break</a></li>
+          <li><a href="#Item-1Ba">Item 1Ba</a></li>
+          <li><a href="#Item-1Ca">Item 1Ca</a></li>
+          <li><a href="#Item-1Da">Item 1Da with long Name and may be with a line break</a></li>
+          <li><a href="#Item-1Ea">Item 1Ea</a></li>
+        </ul>
+      </li>
+      <li><a href="#Item-1B">Item 1B</a></li>
+      <li><a href="#Item-1C">Item 1C</a></li>
+      <li><a href="#Item-1D">Item 1D</a></li>
+      <li><a href="#Item-1E">Item 1E</a></li>
+    </ul>
+  </li>
+  <li>
+    <a href="#">Item 2</a>
+    <ul class="menu">
+      <li><a href="#Item-2A">Item 2A</a></li>
+      <li><a href="#Item-2B">Item 2B  with long Name and may be with a line break</a></li>
       <li><a href="#Item-2C">Item 2C</a></li>
       <li><a href="#Item-2D">Item 2D</a></li>
       <li><a href="#Item-2E">Item 2E</a></li>

--- a/docs/pages/javascript-utilities.md
+++ b/docs/pages/javascript-utilities.md
@@ -15,6 +15,11 @@ One of the useful libraries is `Foundation.Box`, and it has a couple methods des
 ```js
 
 var dims = Foundation.Box.GetDimensions(element);
+
+// or to get dimension on an hidden element
+
+var dims = Foundation.Box.GetDimensions(element, true);
+
 ```
 Will return an object that contains the dimensions of the `element` passed. The object return looks like:
 

--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -54,14 +54,35 @@ function ImNotTouchingYou(element, parent, lrOnly, tbOnly) {
  * Uses native methods to return an object of dimension values.
  * @function
  * @param {jQuery || HTML} element - jQuery object or DOM element for which to get the dimensions. Can be any element other that document or window.
+ * @param {Boolean} element - If true, get dimensions on an hidden element.
  * @returns {Object} - nested object of integer pixel values
  * TODO - if element is window, return only those values.
  */
-function GetDimensions(elem, test){
+function GetDimensions(elem, checkHidden){
   elem = elem.length ? elem[0] : elem;
 
   if (elem === window || elem === document) {
     throw new Error("I'm sorry, Dave. I'm afraid I can't do that.");
+  }
+
+  if (checkHidden) {
+    var savedStyles = [],
+        visibleStyle = 'visibility: hidden !important; display: block !important; ',
+        hiddenParents = [],
+        parseElem = elem;
+    // Get all hidden parents and make them visible and store original style
+    do {
+      if ( !(parseElem.offsetWidth > 0 || parseElem.offsetHeight > 0 || parseElem.getClientRects().length > 0)) {
+        var computedStyle = window.getComputedStyle(parseElem);
+        if (computedStyle.getPropertyValue('display') === 'none') {
+          var thisStyle = parseElem.style.cssText;
+          savedStyles.push(thisStyle);
+          parseElem.style.cssText = thisStyle ? thisStyle + ';' + visibleStyle : visibleStyle;
+          hiddenParents.push(parseElem);
+        }
+      }
+      parseElem = parseElem.parentNode;
+    } while (parseElem && parseElem !== document.body);
   }
 
   var rect = elem.getBoundingClientRect(),
@@ -70,7 +91,7 @@ function GetDimensions(elem, test){
       winY = window.pageYOffset,
       winX = window.pageXOffset;
 
-  return {
+  var dimensions = {
     width: rect.width,
     height: rect.height,
     offset: {
@@ -93,7 +114,22 @@ function GetDimensions(elem, test){
         left: winX
       }
     }
+  };
+
+  if (checkHidden) {
+    // Restore all hidden parents to their original style
+    for (var i = 0; i < hiddenParents.length; i++) {
+      var style = savedStyles[i];
+      if (typeof style == "string" && style !=='') {
+        hiddenParents[i].style.cssText = style;
+      } else {
+        hiddenParents[i].removeAttribute("style");
+      }
+    }
   }
+
+  return dimensions;
+
 }
 
 /**

--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -39,7 +39,7 @@ $drilldown-background: $white !default;
     top: 0;
     #{$global-left}: 100%;
     z-index: -1;
-    // height: 100%;
+    height: 100%;
     width: 100%;
     background: $drilldown-background;
     transition: $drilldown-transition;


### PR DESCRIPTION
The width of the drilldronw menu will set to the width of the parent element .
The drilldown menu respects a given width from the style property or from a css class. All submenus becomes the same width.
Drilldown class now check a resize event, so the height and width is recalculated on a resize of the window size.
The correct dimensions are also calculated on a hidden drilldown menu.
- changes in foundation.util.box.js (the drilldown menu is temporarly visible during calculation.)
