### PR TITLE
Fix #9230 menu-icon code duplication

### DIFF
--- a/scss/components/_title-bar.scss
+++ b/scss/components/_title-bar.scss
@@ -82,8 +82,4 @@ $titlebar-icon-spacing: 0.25rem !default;
     vertical-align: middle;
     display: inline-block;
   }
-
-  .menu-icon.dark {
-    @include hamburger;
-  }
 }


### PR DESCRIPTION
Fix https://github.com/zurb/foundation-sites/issues/9230

**Changes**:
- Remove `.menu-icon.dark` in `scss/components/_title-bar.scss`
