### PR TITLE
Fixes aria roles in accordion menu

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -47,7 +47,7 @@ class AccordionMenu {
   _init() {
     this.$element.find('[data-submenu]').not('.is-active').slideUp(0);//.find('a').css('padding-left', '1rem');
     this.$element.attr({
-      'role': 'tablist',
+      'role': 'menu',
       'aria-multiselectable': this.options.multiOpen
     });
 
@@ -61,13 +61,13 @@ class AccordionMenu {
       $elem.attr({
         'aria-controls': subId,
         'aria-expanded': isActive,
-        'role': 'tab',
+        'role': 'menuitem',
         'id': linkId
       });
       $sub.attr({
         'aria-labelledby': linkId,
         'aria-hidden': !isActive,
-        'role': 'tabpanel',
+        'role': 'menu',
         'id': subId
       });
     });


### PR DESCRIPTION
This pr fixes the aria roles in the accordion menu by defining the <ul> as "menu." 

The original aria roles in the accordion menu defined it as a tablist, which was flagged as causing accessibility problems when I ran the following command line auditor: https://github.com/addyosmani/a11y

To replicate the issue, install and run "$ a11y http://localhost:3000/accordion-menu.html." Among other accessibility issues, you will see this one: 

"  ✖ Elements with ARIA roles must be in the correct scope

  #lsha5t-acc-menu > .is-submenu-item.is-accordion-submenu-item
  #lsha5t-acc-menu > LI:nth-of-type(2)
  #lsha5t-acc-menu > LI:nth-of-type(3)
  #c6n5i7-acc-menu > LI:nth-of-type(2)
  #c6n5i7-acc-menu > LI:nth-of-type(3)
  #pik1va-acc-menu > .is-submenu-item.is-accordion-submenu-item
  #pik1va-acc-menu > LI:nth-of-type(2)
  #docs > .vertical.menu > LI:nth-of-type(3)"

To validate that this pr corrects the problem, please pull this branch into your local repo and run "$ a11y http://localhost:3000/accordion-menu.html" again. You will see that this error no longer appears.

You can also use your inspector to view the aria roles and confirm that they are correct.
