### PR TITLE
Allow vOffset option in floated dropdown alignment

### DIFF
--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -175,13 +175,13 @@ function GetOffsets(element, anchor, position, vOffset, hOffset, isOverflow) {
     case 'left bottom':
       return {
         left: $anchorDims.offset.left,
-        top: $anchorDims.offset.top + $anchorDims.height
+        top: $anchorDims.offset.top + $anchorDims.height + vOffset
       };
       break;
     case 'right bottom':
       return {
         left: $anchorDims.offset.left + $anchorDims.width + hOffset - $eleDims.width,
-        top: $anchorDims.offset.top + $anchorDims.height
+        top: $anchorDims.offset.top + $anchorDims.height + vOffset
       };
       break;
     default:


### PR DESCRIPTION
Left-bottom and right-bottom were added in 2d0eed, PR #8475, for dropdown alignment; but in these cases, the `vOffset` option is left off. Since the default positioning (which would correspond to ‘bottom’) adds vOffset, I’m assuming these were left off as an oversight.

Since `bottom` includes this vOffset option, I don't see why left-bottom and right-bottom wouldn't either. See below for an example before and after image.

Before (no offset, menu is crowded):
<img width="217" alt="no-offset" src="https://cloud.githubusercontent.com/assets/8288/19389928/e36dc242-91f3-11e6-86d4-60f3a824119d.png">

After, with vOffset, the avatar isn't so crowded:
<img width="213" alt="offset after" src="https://cloud.githubusercontent.com/assets/8288/19389932/e9205114-91f3-11e6-920a-264480533d96.png">
