### PR TITLE
Check readyState that works with different browsers.

### DIFF
--- a/js/foundation.util.timerAndImageLoader.js
+++ b/js/foundation.util.timerAndImageLoader.js
@@ -59,12 +59,11 @@ function onImagesLoaded(images, callback){
   }
 
   images.each(function() {
-    if (this.complete) {
+    // Check if image is loaded
+    if (this.complete || (this.readyState === 4) || (this.readyState === 'complete')) {
       singleImageLoaded();
     }
-    else if (typeof this.naturalWidth !== 'undefined' && this.naturalWidth > 0) {
-      singleImageLoaded();
-    }
+    // Force load the image
     else {
       $(this).one('load', function() {
         singleImageLoaded();


### PR DESCRIPTION
This fixes #8478 and #8955 and probably others with regards to image loading from cache.

I removed usage of `this.naturalWidth` as this produces unexpected behaviour in some browsers. Apparently, it only works reliably the first time.
