### PR TITLE
parseValue() full match with string literals

### DIFF
--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -364,8 +364,8 @@ function functionName(fn) {
   }
 }
 function parseValue(str){
-  if(/true/.test(str)) return true;
-  else if(/false/.test(str)) return false;
+  if('true' === str) return true;
+  else if('false' === str) return false;
   else if(!isNaN(str * 1)) return parseFloat(str);
   return str;
 }

--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -364,9 +364,9 @@ function functionName(fn) {
   }
 }
 function parseValue(str){
-  if('true' === str) return true;
-  else if('false' === str) return false;
-  else if(!isNaN(str * 1)) return parseFloat(str);
+  if ('true' === str) return true;
+  else if ('false' === str) return false;
+  else if (!isNaN(str * 1)) return parseFloat(str);
   return str;
 }
 // Convert PascalCase to kebab-case


### PR DESCRIPTION
the original regex matching would have made values like "untrue" to be interpreted as `true` and values like "not-false" as `false`
see discussion here: https://github.com/zurb/foundation-sites/pull/9149

PS
i kept the `else`s this time even if not necessary as we return inside every conditions... :-)
