### PR TITLE
Add ios >= 7 to autoprefixer

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -24,7 +24,8 @@ var LINT_PATHS = [
 var COMPATIBILITY = [
   'last 2 versions',
   'ie >= 9',
-  'Android >= 2.3'
+  'Android >= 2.3',
+  'ios >= 7'
 ];
 
 // Compiles Sass files into CSS


### PR DESCRIPTION
Fixes https://github.com/zurb/foundation-sites/issues/9290 and brings the build config for the css distribution up to par with what we're now including in the template.
