### PR TITLE
Bug fixes for sticky

### DIFF
--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -273,7 +273,8 @@ class Sticky {
     var _this = this,
         newElemWidth = this.$container[0].getBoundingClientRect().width,
         comp = window.getComputedStyle(this.$container[0]),
-        pdng = parseInt(comp['padding-right'], 10);
+        pdngl = parseInt(comp['padding-right'], 10),
+        pdngr = parseInt(comp['padding-right'], 10);
 
     if (this.$anchor && this.$anchor.length) {
       this.anchorHeight = this.$anchor[0].getBoundingClientRect().height;
@@ -282,7 +283,7 @@ class Sticky {
     }
 
     this.$element.css({
-      'max-width': `${newElemWidth - pdng}px`
+      'max-width': `${newElemWidth - pdngl - pdngr}px`
     });
 
     var newContainerHeight = this.$element[0].getBoundingClientRect().height || this.containerHeight;

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -273,7 +273,7 @@ class Sticky {
     var _this = this,
         newElemWidth = this.$container[0].getBoundingClientRect().width,
         comp = window.getComputedStyle(this.$container[0]),
-        pdngl = parseInt(comp['padding-right'], 10),
+        pdngl = parseInt(comp['padding-left'], 10),
         pdngr = parseInt(comp['padding-right'], 10);
 
     if (this.$anchor && this.$anchor.length) {

--- a/scss/components/_sticky.scss
+++ b/scss/components/_sticky.scss
@@ -8,7 +8,7 @@
   }
 
   .sticky {
-    position: absolute;
+    position: relative;
     z-index: 0;
     transform: translate3d(0, 0, 0);
   }
@@ -27,7 +27,7 @@
   }
 
   .sticky.is-anchored {
-    position: absolute;
+    position: relative;
     left: auto;
     right: auto;
 

--- a/test/visual/sticky/simple-menu.html
+++ b/test/visual/sticky/simple-menu.html
@@ -8,10 +8,6 @@
   <link href="../assets/css/foundation.css" rel="stylesheet" />
 
   <style>
-    .container {
-      background-color: rgba(255, 0, 0, 0.7);
-    }
-    
     .menue {
       background-color: white;
       text-align: right;
@@ -32,10 +28,6 @@
 
     main .row {
       background: yellow;
-    }
-
-    .first {
-      height: 20px;
     }
   </style>
 

--- a/test/visual/sticky/simple-menu.html
+++ b/test/visual/sticky/simple-menu.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en" class="no-js">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Foundation for Sites Testing</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+  <link href="../assets/css/foundation.css" rel="stylesheet" />
+
+  <style>
+    .container {
+      background-color: rgba(255, 0, 0, 0.7);
+    }
+    
+    .menue {
+      background-color: white;
+      text-align: right;
+      display: block;
+      background: $white;
+      padding-top: 8px;
+      padding-bottom: 8px;
+      width: 100%
+    }
+  
+    .is-stuck {
+      width: 100%;
+    }
+    
+    .row {
+      background: gray;
+    }
+
+    main .row {
+      background: yellow;
+    }
+
+    .first {
+      height: 20px;
+    }
+  </style>
+
+</head>
+
+<body>
+
+  <div class="row">
+    <div class="small-12 columns">
+      <h2>This could be a logo</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <hr>
+    <div class="small-12 columns" data-sticky-container>
+        <div class="menue sticky" data-sticky-on="small" data-top-anchor="200" data-margin-top="1" data-sticky>
+            <span>Menu 1: </span>
+            <a href="simple-menu.html">Issue 1</a>
+            <span>&middot;</span>
+            <a href="simple-menu.html">Issue 2</a>
+            <span>&middot;</span>
+            <a href="simple-menu.html">Issue 3</a>
+        </div>
+    </div>
+    <hr>
+  </div>
+
+
+<main>
+  <div class="row">
+    <div class="small-12 columns">
+      <h1>This could be content</h2>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsa quis veritatis sapiente itaque at nesciunt quos deserunt dolor minima quas, nihil, molestias deleniti, dignissimos corporis libero quidem quisquam et optio debitis fugiat explicabo beatae
+        aperiam ducimus. Quisquam non ex explicabo aliquid, suscipit minus sed minima doloremque repellendus facere aut rerum eius beatae optio eos animi iusto provident, id quo possimus quibusdam officia est nihil omnis. Autem quo, quod, eum saepe sunt
+        odio impedit nam architecto sint expedita repellat. Omnis ipsum pariatur nobis sequi, et labore voluptates officia facere asperiores doloremque enim tempora hic eum illo obcaecati sapiente tempore vitae ex praesentium quam, fugiat molestias quod?
+        Quasi, perspiciatis? Optio architecto asperiores eveniet aliquam magnam atque eius eos nemo laboriosam numquam repudiandae assumenda, ut perferendis vel saepe qui, tempora, dolorem sapiente ad doloribus minus a veniam possimus amet. Ratione amet
+        qui quo consequatur reprehenderit, ad esse perspiciatis similique nobis est. Labore accusamus suscipit itaque corrupti reiciendis consectetur natus cumque, error est repellat dolorem illo iste expedita. Iure culpa minus ducimus totam, ratione
+        delectus non cupiditate consequatur ipsum eius. Maxime, alias. Soluta, delectus, cumque! Consequuntur excepturi velit eos. Repellendus ea ut reiciendis beatae similique earum quaerat blanditiis dolor temporibus amet. Voluptatum, consequuntur,
+        nostrum? Libero tempore provident, nihil necessitatibus maxime voluptates! Totam fugit repellendus commodi at nam, officiis eaque deleniti voluptatem suscipit quas cumque illum nisi optio beatae tempore doloribus veritatis tenetur neque, sunt
+        officia aliquam obcaecati omnis, perferendis. Nam labore quis voluptas nisi beatae ipsam sunt eligendi mollitia praesentium ducimus iusto excepturi officia, tenetur neque perferendis cumque libero? Incidunt nesciunt architecto tempore atque expedita
+        tenetur, voluptates, debitis cupiditate quaerat est magni maiores! Maxime rerum temporibus dolor! Ducimus doloremque facilis illo quam adipisci voluptatem, suscipit amet optio ipsam sunt dignissimos perspiciatis omnis error esse neque pariatur
+        eaque totam possimus dolorum magni nemo quidem. In harum illum quod officiis quo mollitia cum, ducimus corporis vitae eligendi cupiditate pariatur, tempore repellat ratione. Nobis pariatur alias aspernatur repudiandae laborum maiores unde debitis
+        neque maxime earum accusamus eaque illum, iusto velit similique culpa, perspiciatis hic, et ipsum. Neque nisi vero unde sunt, suscipit aliquid, animi at accusantium laboriosam natus repudiandae temporibus vel fuga porro, mollitia saepe alias nihil
+        distinctio, quaerat dolore consequuntur vitae aut. Odit omnis nisi, atque voluptatem alias quod, iusto aut ipsum odio reiciendis rem laudantium est eos! Corporis laudantium sit deserunt adipisci odio quasi eaque amet, illo et explicabo, laborum
+        repudiandae id culpa, voluptatum earum fugiat mollitia suscipit placeat in. Facilis tenetur provident temporibus aliquid! Incidunt magni enim voluptatum iure suscipit excepturi laudantium dolorem eum, sapiente, non hic deserunt veniam minima voluptate
+        ab nobis eligendi expedita! Eaque ad voluptatibus maiores cumque fugiat accusantium doloremque tempore minima ullam repellat, atque nostrum consequatur, quo debitis? Nihil consectetur, dolorem, nostrum vitae, earum hic debitis quia fugit dolor
+        cum architecto error molestiae in facilis incidunt tenetur eos culpa. Laboriosam nostrum similique, cum, quae, voluptatum eos molestiae aperiam praesentium animi sapiente commodi explicabo? Asperiores saepe reprehenderit beatae aliquam id, officiis
+        omnis pariatur in tenetur nulla optio sint hic quisquam, repellat aliquid. Corporis illo ducimus illum, rem tempora recusandae esse atque temporibus sit ut mollitia id quae nobis dignissimos doloremque error iure consequuntur autem, itaque unde
+        totam. Quam, similique, at. Exercitationem accusantium asperiores nam omnis quis magnam, ipsa id placeat error consectetur, minima. Minima quaerat perspiciatis molestiae delectus error ad libero, architecto nesciunt consequatur at suscipit reprehenderit.
+        Culpa consequuntur eos dicta necessitatibus. Eum provident veniam odio nam ratione facere blanditiis vero doloremque, maxime culpa corrupti modi sapiente possimus. Saepe, quos odio laboriosam nulla. Adipisci, facere iusto natus quaerat quam quidem
+        id expedita libero illo magnam asperiores odit, cum dolores eveniet voluptatem reiciendis, assumenda quos. Quam, ab officiis, quasi placeat aperiam laudantium quidem deserunt blanditiis. Officia rerum eos neque qui temporibus quaerat ullam. Aut
+        exercitationem nobis aliquam voluptatibus non reiciendis eius, voluptatum sed quidem in cumque aspernatur est harum error dolore amet beatae accusamus, illo totam sapiente nesciunt perferendis optio commodi? Voluptates, aliquam, officiis. Dolores
+        suscipit ipsam cumque alias nostrum, doloribus temporibus, vel in veniam facilis sit ad labore. Iste adipisci, ipsam hic molestias libero! Labore, suscipit praesentium quam pariatur veritatis ea, sapiente repellat optio rerum autem, molestiae
+        architecto! Tempore maiores impedit excepturi, dolore ea quaerat doloremque eligendi aut officiis veniam consequuntur iure, laborum necessitatibus corrupti voluptates, quo, magnam maxime. Deserunt ipsam ratione fugiat illum odit commodi, blanditiis
+        optio corrupti. Sint modi distinctio provident obcaecati maiores unde debitis veritatis, animi incidunt, accusantium numquam placeat veniam aliquam quod dolor, quae dolore blanditiis. Voluptatum rerum aperiam magnam consequatur hic quod nostrum
+        recusandae! Assumenda dolores, voluptates harum, inventore, odio voluptatem cumque qui porro officia eveniet minus esse nihil suscipit consectetur rerum accusamus cupiditate, ab maxime labore veritatis. Soluta, porro optio eligendi deserunt maxime
+        sit dolorum repellat libero esse, saepe ea. Dicta est quaerat excepturi aperiam beatae, consequatur molestias, magnam ut sit assumenda obcaecati, mollitia rerum. Assumenda odio quo eum error quisquam, ad, commodi suscipit animi voluptatum. Architecto
+        a ea quisquam temporibus rerum praesentium tenetur soluta repellat repellendus non doloribus odio vel consequuntur impedit aut voluptatum sapiente, inventore harum aspernatur dolore corrupti reprehenderit velit blanditiis minus. Hic dignissimos
+        facere ipsa quae facilis ducimus at, nihil quas illum recusandae maxime deleniti explicabo porro nam, ex modi? Quas amet, repellat eius voluptates provident quos ipsa autem vitae suscipit a, odit, cupiditate vero reprehenderit temporibus dicta
+        nemo veritatis distinctio id! Amet officiis eos quia mollitia sint quam aliquam magnam possimus, ducimus qui aspernatur blanditiis ex eum omnis, sed repellendus maiores alias, similique tempore adipisci numquam voluptatibus corporis! Quas distinctio
+        architecto quaerat, odio officia blanditiis sequi cupiditate, laboriosam quae, tempore voluptate? Minima, inventore obcaecati beatae ipsa reiciendis dolores, magnam totam alias magni praesentium fugiat culpa officiis! Dolorum assumenda deleniti
+        incidunt beatae accusantium laborum dicta commodi repellat odio obcaecati voluptates esse, minus nemo optio omnis fuga! Sapiente beatae voluptates, dolorum obcaecati facere, repellat deleniti quam veritatis laborum accusantium atque expedita debitis
+        perferendis laboriosam minima ab excepturi odio eaque. Assumenda facere ex, officia repellendus nulla illum saepe eum magni dolore suscipit officiis culpa? Impedit nihil soluta illum aliquam sunt reiciendis nesciunt cumque.
+      </p>
+
+    </div>
+  </div>
+</main>
+
+  <script src="../assets/js/vendor.js"></script>
+  <script src="../assets/js/foundation.js"></script>
+  <script>
+    $(document).foundation();
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
I have added a test-case for sticky, that is showing a simple menu. The test case reveals two issues:
1. Refreshing the page or pressing the links shows an artefact (only visible in blinks) which is fixed with changing the `position` from `absolute` to `relative`
2. The menu, when stuck jumps to the right, since the `max-width` calculation does not take account of the padding-left from the parent. 
