### PR TITLE
Reveal modal example uses confusing response

### DIFF
--- a/docs/pages/reveal.md
+++ b/docs/pages/reveal.md
@@ -183,7 +183,7 @@ var $modal = $('#modal');
 
 $.ajax('/url')
   .done(function(resp){
-    $modal.html(resp.html).foundation('open');
+    $modal.html(resp).foundation('open');
 });
 ```
 


### PR DESCRIPTION
The .done() callback receives the data from the $.ajax request; if the request format is HTML, that `resp` will just be a string, not an object. So `resp.html` returns undefined and is non-sensical. This only makes sense if the request format is JSON.

Since my impression is most people are going to be hitting a URL that returns HTML, I'd suggest just changing the example to `$modal.html(resp)` as I've done in this pull request. If you expect most people to be making a request that returns JSON, I would at least imply that in the URL, eg `$.ajax('/api/url.json')`.
