### PR TITLE
Force input-group buttons to match input size

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -114,7 +114,8 @@ $input-prefix-padding: 1rem !default;
 
     a,
     input,
-    button {
+    button,
+    label {
       @extend %input-group-child;
       font-size: $input-font-size;
       height: $height;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -115,7 +115,11 @@ $input-prefix-padding: 1rem !default;
     a,
     input,
     button {
-      margin: 0;
+      @extend %input-group-child;
+      font-size: $input-font-size;
+      height: $height;
+      padding-top: 0;
+      padding-bottom: 0;
     }
   }
 


### PR DESCRIPTION
This PR closes #7373 and #9307, by making sure that buttons in input groups match the size of inputs, regardless of button settings vars. 
