### PR TITLE
Don't run through motion ui if orbit element is hidden

### DIFF
--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -280,7 +280,7 @@ class Orbit {
         this._updateBullets(idx);
       }
 
-      if (this.options.useMUI) {
+      if (this.options.useMUI && !this.$element.is(':hidden')) {
         Foundation.Motion.animateIn(
           $newSlide.addClass('is-active').css({'position': 'absolute', 'top': 0}),
           this.options[`animInFrom${dirIn}`],


### PR DESCRIPTION
Alternate to https://github.com/zurb/foundation-sites/pull/9152 addressing second half of https://github.com/zurb/foundation-sites/issues/9103
