### PR TITLE
Nix !important in drilldown, note components using !important

### DIFF
--- a/docs/pages/base-typography.md
+++ b/docs/pages/base-typography.md
@@ -56,7 +56,7 @@ The framework includes two typographic scales&mdash;one uses a narrow range of s
 Header  | Default | Medium and up
 --------|---------|--------------
 `<h1>`  | 24px    | 48px
-`<h2>`  | 20px    | 40px 
+`<h2>`  | 20px    | 40px
 `<h3>`  | 19px    | 31px
 `<h4>`  | 18px    | 25px
 `<h5>`  | 17px    | 20px
@@ -260,3 +260,7 @@ Foundation includes print styles developed by HTML5 Boilerplate to give you some
 - Page cleanup and window minimization
 
 On top of that, Foundation includes a couple of simple classes you can use to control elements printing, or not printing. Simply attach `.show-for-print` to an element to only show when printing, and `.hide-for-print` to hide something when printing.
+
+<div class="callout primary">
+  <p>Print styles use `!important` to ensure they aren't overriden by more specific selectors. This framework conscientiously avoids using `!important` declarations. This is one of the few components that does.</p>
+</div>

--- a/docs/pages/float-classes.md
+++ b/docs/pages/float-classes.md
@@ -7,6 +7,10 @@ description: Foundation includes a handful of helpful float classes to add commo
 
 You can change the float behavior of an element by adding the `.float-left` or `.float-right` classes to an element. To clear floats, add the class `.clearfix` to the parent element.
 
+<div class="callout primary">
+  <p>Float Left/Right classes use `!important` to ensure they aren't overriden by more specific selectors. This framework conscientiously avoids using `!important` declarations. This is one of the few components that does.</p>
+</div>
+
 <div class="warning callout">
   <p>Float classes don't flip direction in a <a href="rtl.html">right-to-left</a> environment&mdash;<code>left</code> always means left, and <code>right</code> always means right.</p>
 </div>

--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -8,10 +8,10 @@ tags:
 ---
 
 <div class="callout primary">
-  <p>Visibility classes use `!important` to ensure they aren't overriden by more specific selectors. This is the only component in the framework that uses `!important`.</p>
+  <p>Visibility classes use `!important` to ensure they aren't overriden by more specific selectors. This framework conscientiously avoids using `!important` declarations. This is one of the few components that does.</p>
 </div>
 
-<div class="callout primary">
+<div class="callout warning">
   <p>There are no classes to detect touchscreen devices, as both desktop and mobile browsers inconsistently report touch support. Learn more here: <a href="http://www.stucox.com/blog/you-cant-detect-a-touchscreen/">You Can't Detect a Touchscreen</a></p>
 </div>
 

--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -29,7 +29,7 @@ $drilldown-background: $white !default;
     overflow: hidden;
 
     li {
-      display: block !important;
+      display: block;
     }
 
     &.animate-height {


### PR DESCRIPTION
This PR closes #8837 by removing the `!important` from Drilldown Menu, amending the callout on Visibility Classes (which wrongly stated it was the only component using `!important`), and adding callouts for all components which use `!important`. 