### PR TITLE
Adds pow and log transforms to the Slider component

### DIFF
--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -140,7 +140,7 @@ Alternatively there is also a `pow`-type position value function available, maki
 
 ```html_example
 <div class="small-10 columns">
-<div class="slider" data-slider data-initial-start="50" data-step="1" data-position-value-function="log" data-non-linear-base="10">
+<div class="slider" data-slider data-initial-start="50" data-step="1" data-position-value-function="log" data-non-linear-base="5">
   <span class="slider-handle" data-slider-handle role="slider" tabindex="1" aria-controls="sliderOutputNonLinear"></span>
 </div>
 </div>
@@ -150,4 +150,4 @@ Alternatively there is also a `pow`-type position value function available, maki
 </div>
 ```
 
-The nonLinearBase-option is optional and defaults to 10.
+The nonLinearBase-option is optional and defaults to 5.

--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -130,3 +130,24 @@ It's possible to use both the JavaScript slider and the native slider in the sam
 - To disable the slider, add `disabled` as an attribute, instead of a class.
 - No support for vertical orientation.
 - No support for two handles.
+
+---
+
+## Non-linear value translation
+
+Sometimes not every value is of equal importance. In the example below, the slider focusses on the higher numbers by adding a `log`-type position value funtion.
+Alternatively there is also a `pow`-type position value function available, making the reverse possible.
+
+```html_example
+<div class="small-10 columns">
+<div class="slider" data-slider data-initial-start="50" data-step="1" data-position-value-function="log" data-non-linear-base="10">
+  <span class="slider-handle" data-slider-handle role="slider" tabindex="1" aria-controls="sliderOutputNonLinear"></span>
+</div>
+</div>
+<div class="small-2 columns">
+  <input type="number" id="sliderOutputNonLinear">
+</div>
+</div>
+```
+
+The nonLinearBase-option is optional and defaults to 10.


### PR DESCRIPTION
Introduces two settings, `nonLinearBase` and `positionValueFunction` which change the way in which the position of the slider is translated to an actual value. 

Besides the default value of ‘linear' for `positionValueFunction`, 'pow' and a 'log' can be used.

*Example application*

In example below we want to focus on the most recent years, hence we use a logarithmic transformation of the slider:

          <div class="slider" data-slider data-initial-start="2010" data-initial-end="2015" data-step="1" data-start="1950" data-end="2016" data-position-value-function="log">
            <span class="slider-handle" data-slider-handle role="slider" tabindex="1" aria-controls="car_search_year_from"></span>
            <span class="slider-fill" data-slider-fill></span>
            <span class="slider-handle" data-slider-handle role="slider" tabindex="1" aria-controls="car_search_year_to"></span>
          </div>

Since I didn't get the test-framework to run I submitting this for now without tests, if it is absolutely necessary to do so, and this functionality is desired, allow me some time to fix that.