### PR TITLE
parametrize menu arrows and vertical alignment

### DIFF
--- a/scss/components/_accordion-menu.scss
+++ b/scss/components/_accordion-menu.scss
@@ -10,23 +10,27 @@ $accordionmenu-arrows: true !default;
 /// @type Color
 $accordionmenu-arrow-color: $primary-color !default;
 
+/// Sets accordion menu arrow size if arrow is used.
+/// @type Length
+$accordionmenu-arrow-size: 6px !default;
+
 @mixin foundation-accordion-menu {
   @if $accordionmenu-arrows {
     .is-accordion-submenu-parent > a {
       position: relative;
 
       &::after {
-        @include css-triangle(6px, $accordionmenu-arrow-color, down);
+        @include css-triangle($accordionmenu-arrow-size, $accordionmenu-arrow-color, down);
         position: absolute;
         top: 50%;
-        margin-top: -4px;
+        transform: translateY(-50%);
         right: 1rem;
       }
     }
 
     .is-accordion-submenu-parent[aria-expanded='true'] > a::after {
       transform-origin: 50% 50%;
-      transform: scaleY(-1);
+      transform: scaleY(-1) translateY(50%);
     }
   }
 }

--- a/scss/components/_accordion-menu.scss
+++ b/scss/components/_accordion-menu.scss
@@ -23,14 +23,14 @@ $accordionmenu-arrow-size: 6px !default;
         @include css-triangle($accordionmenu-arrow-size, $accordionmenu-arrow-color, down);
         position: absolute;
         top: 50%;
-        transform: translateY(-50%);
+        margin-top: -1 * ($accordionmenu-arrow-size / 2);
         right: 1rem;
       }
     }
 
     .is-accordion-submenu-parent[aria-expanded='true'] > a::after {
       transform-origin: 50% 50%;
-      transform: scaleY(-1) translateY(50%);
+      transform: rotate(180deg);
     }
   }
 }

--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -18,6 +18,10 @@ $drilldown-arrows: true !default;
 /// @type Color
 $drilldown-arrow-color: $primary-color !default;
 
+/// Sets drilldown arrow size if arrow is used.
+/// @type Length
+$drilldown-arrow-size: 6px !default;
+
 /// Background color for drilldown submenus.
 /// @type Color
 $drilldown-background: $white !default;
@@ -64,16 +68,16 @@ $drilldown-background: $white !default;
       position: relative;
 
       &::after {
-        @include css-triangle(6px, $drilldown-arrow-color, $global-right);
+        @include css-triangle($drilldown-arrow-size, $drilldown-arrow-color, $global-right);
         position: absolute;
         top: 50%;
-        margin-top: -6px;
+        transform: translateY(-50%);
         #{$global-right}: 1rem;
       }
     }
 
     .js-drilldown-back > a::before {
-      @include css-triangle(6px, $drilldown-arrow-color, $global-left);
+      @include css-triangle($drilldown-arrow-size, $drilldown-arrow-color, $global-left);
       border-#{$global-left}-width: 0;
       display: inline-block;
       vertical-align: middle;

--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -71,7 +71,7 @@ $drilldown-background: $white !default;
         @include css-triangle($drilldown-arrow-size, $drilldown-arrow-color, $global-right);
         position: absolute;
         top: 50%;
-        transform: translateY(-50%);
+        margin-top: -1 * $drilldown-arrow-size;
         #{$global-right}: 1rem;
       }
     }

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -76,6 +76,7 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
       > li.is-dropdown-submenu-parent > a::after {
         @include css-triangle($dropdownmenu-arrow-size, $dropdownmenu-arrow-color, down);
         #{$global-right}: 5px;
+        margin-top: -1 * ($dropdownmenu-arrow-size / 2);
       }
     }
   }
@@ -163,7 +164,7 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
       position: absolute;
       top: 50%;
       #{$global-right}: 5px;
-      transform: translateY(-50%);
+      margin-top: -1 * $dropdownmenu-arrow-size;
     }
 
     &.opens-inner > .is-dropdown-submenu {

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -14,6 +14,10 @@ $dropdownmenu-arrows: true !default;
 /// @type Color
 $dropdownmenu-arrow-color: $anchor-color !default;
 
+/// Sets dropdown menu arrow size if arrow is used.
+/// @type Length
+$dropdownmenu-arrow-size: 6px !default;
+
 /// Minimum width of dropdown sub-menus.
 /// @type Length
 $dropdownmenu-min-width: 200px !default;
@@ -34,15 +38,14 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
 @mixin left-right-arrows {
   > a::after {
     #{$global-right}: 14px;
-    margin-top: -5px;
   }
 
   &.opens-left > a::after {
-    @include css-triangle(5px, $dropdownmenu-arrow-color, left);
+    @include css-triangle($dropdownmenu-arrow-size, $dropdownmenu-arrow-color, left);
   }
 
   &.opens-right > a::after {
-    @include css-triangle(5px, $dropdownmenu-arrow-color, right);
+    @include css-triangle($dropdownmenu-arrow-size, $dropdownmenu-arrow-color, right);
   }
 }
 
@@ -71,9 +74,8 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
       }
 
       > li.is-dropdown-submenu-parent > a::after {
-        @include css-triangle(5px, $dropdownmenu-arrow-color, down);
+        @include css-triangle($dropdownmenu-arrow-size, $dropdownmenu-arrow-color, down);
         #{$global-right}: 5px;
-        margin-top: -2px;
       }
     }
   }
@@ -161,7 +163,7 @@ $dropdownmenu-border-width: nth($dropdownmenu-border, 1);
       position: absolute;
       top: 50%;
       #{$global-right}: 5px;
-      margin-top: -2px;
+      transform: translateY(-50%);
     }
 
     &.opens-inner > .is-dropdown-submenu {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -210,6 +210,7 @@ $accordion-content-padding: 1rem;
 
 $accordionmenu-arrows: true;
 $accordionmenu-arrow-color: $primary-color;
+$accordionmenu-arrow-size: 6px;
 
 // 9. Badge
 // --------
@@ -301,6 +302,7 @@ $closebutton-color-hover: $black;
 $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
 $drilldown-arrow-color: $primary-color;
+$drilldown-arrow-size: 6px;
 $drilldown-background: $white;
 
 // 16. Dropdown
@@ -323,6 +325,7 @@ $dropdown-sizes: (
 
 $dropdownmenu-arrows: true;
 $dropdownmenu-arrow-color: $anchor-color;
+$dropdownmenu-arrow-size: 6px;
 $dropdownmenu-min-width: 200px;
 $dropdownmenu-background: $white;
 $dropdownmenu-border: 1px solid $medium-gray;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -71,6 +71,7 @@ $global-weight-bold: bold;
 $global-radius: 0;
 $global-text-direction: ltr;
 $global-flexbox: false;
+$global-arrow-size: 6px;
 $print-transparent-backgrounds: true;
 
 @include add-foundation-colors;
@@ -210,7 +211,7 @@ $accordion-content-padding: 1rem;
 
 $accordionmenu-arrows: true;
 $accordionmenu-arrow-color: $primary-color;
-$accordionmenu-arrow-size: 6px;
+$accordionmenu-arrow-size: $global-arrow-size;
 
 // 9. Badge
 // --------
@@ -302,7 +303,7 @@ $closebutton-color-hover: $black;
 $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
 $drilldown-arrow-color: $primary-color;
-$drilldown-arrow-size: 6px;
+$drilldown-arrow-size: $global-arrow-size;
 $drilldown-background: $white;
 
 // 16. Dropdown
@@ -325,7 +326,7 @@ $dropdown-sizes: (
 
 $dropdownmenu-arrows: true;
 $dropdownmenu-arrow-color: $anchor-color;
-$dropdownmenu-arrow-size: 6px;
+$dropdownmenu-arrow-size: $global-arrow-size;
 $dropdownmenu-min-width: 200px;
 $dropdownmenu-background: $white;
 $dropdownmenu-border: 1px solid $medium-gray;


### PR DESCRIPTION
What this PR does:
- add a global parameter for menu arrow size `$global-arrow-size: 6px`
- add individual parameters for dropdown-menu, drilldown menu and accordion-menu (`$dropdownmenu-arrow-size`, `$drilldown-arrow-size`, `$accordionmenu-arrow-size`) . All of them inherits from global arrow size (note: the original foundation arrow size for dropdown-menu was 5px not 6px as in the other plugins). They can be also individually set to different sizes.
- use `transform: translateY(-50%)` to achieve vertical center alignment

demo: http://codepen.io/anon/pen/MjNzEx
- in the demo a span element is added inside all anchors to highlight the arrow position and a bottom margin is added to all menu list items
- the compiled default foundation.css is inserted inline in codepen
