### PR TITLE
Ally-compliant color palette & functions

### DIFF
--- a/docs/pages/badge.md
+++ b/docs/pages/badge.md
@@ -47,7 +47,7 @@ Badges can be colored with the same classes used for buttons and other component
 An icon can be used in place of text. We're using the [Foundation icon font](http://zurb.com/playground/foundation-icon-fonts-3) here, but any icon fonts or image-based icons will work fine.
 
 ```html_example
-<span class="info badge"><i class="fi-share"></i></span>
+<span class="secondary badge"><i class="fi-share"></i></span>
 <span class="success badge"><i class="fi-check"></i></span>
 <span class="warning badge"><i class="fi-wrench"></i></span>
 ```

--- a/docs/pages/button.md
+++ b/docs/pages/button.md
@@ -53,11 +53,12 @@ Give a button additional meaning by adding a coloring class, or `.disabled` to c
 </div>
 
 ```html_example
-<a class="secondary button" href="#">Secondary Color</a>
-<a class="success button" href="#">Success Color</a>
-<a class="alert button" href="#">Alert Color</a>
-<a class="warning button" href="#">Warning Color</a>
-<a class="disabled button" href="#">Disabled Button</a>
+<a class="button" href="#">Primary</a>
+<a class="secondary button" href="#">Secondary</a>
+<a class="success button" href="#">Success</a>
+<a class="alert button" href="#">Alert</a>
+<a class="warning button" href="#">Warning</a>
+<a class="disabled button" href="#">Disabled</a>
 ```
 
 ---

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -25,7 +25,7 @@ $global-lineheight: 1.5 !default;
 $foundation-palette: (
   primary: #1a7cbd,
   secondary: #767676,
-  success: #238748,
+  success: #3adb76,
   warning: #ffae00,
   alert: #cc4b37,
 ) !default;

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -23,11 +23,11 @@ $global-lineheight: 1.5 !default;
 /// Colors used for buttons, callouts, links, etc. There must always be a color called `primary`.
 /// @type Map
 $foundation-palette: (
-  primary: #2199e8,
-  secondary: #777,
-  success: #3adb76,
+  primary: #1a7cbd,
+  secondary: #767676,
+  success: #238748,
   warning: #ffae00,
-  alert: #ec5840,
+  alert: #cc4b37,
 ) !default;
 
 /// Color used for light gray UI items.

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -23,7 +23,7 @@ $global-lineheight: 1.5 !default;
 /// Colors used for buttons, callouts, links, etc. There must always be a color called `primary`.
 /// @type Map
 $foundation-palette: (
-  primary: #1a7cbd,
+  primary: #1779ba,
   secondary: #767676,
   success: #3adb76,
   warning: #ffae00,

--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -20,7 +20,7 @@ $accordion-title-font-size: rem-calc(12) !default;
 
 /// Default text color for items in a Menu.
 /// @type Color
-$accordion-item-color: foreground($accordion-background, $primary-color) !default;
+$accordion-item-color: pick-best-color($accordion-background, ($primary-color, $white)) !default;
 
 /// Default background color on hover for items in a Menu.
 /// @type Color
@@ -40,7 +40,7 @@ $accordion-content-border: 1px solid $light-gray !default;
 
 /// Default text color of tab content.
 /// @type Color
-$accordion-content-color: foreground($accordion-content-background, $body-font-color) !default;
+$accordion-content-color: pick-best-color($accordion-content-background, ($body-font-color, $white)) !default;
 
 /// Default padding for tab content.
 /// @type Number | List

--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -20,7 +20,7 @@ $accordion-title-font-size: rem-calc(12) !default;
 
 /// Default text color for items in a Menu.
 /// @type Color
-$accordion-item-color: pick-best-color($accordion-background, ($primary-color, $white)) !default;
+$accordion-item-color: $primary-color !default;
 
 /// Default background color on hover for items in a Menu.
 /// @type Color
@@ -40,16 +40,18 @@ $accordion-content-border: 1px solid $light-gray !default;
 
 /// Default text color of tab content.
 /// @type Color
-$accordion-content-color: pick-best-color($accordion-content-background, ($body-font-color, $white)) !default;
+$accordion-content-color: $body-font-color !default;
 
 /// Default padding for tab content.
 /// @type Number | List
 $accordion-content-padding: 1rem !default;
 
 /// Adds styles for an accordion container. Apply this to the same element that gets `data-accordion`.
-@mixin accordion-container {
+@mixin accordion-container (
+  $background: $accordion-background
+) {
   margin-#{$global-left}: 0;
-  background: $accordion-background;
+  background: $background;
   list-style-type: none;
 }
 
@@ -65,26 +67,32 @@ $accordion-content-padding: 1rem !default;
 }
 
 /// Adds styles for the title of an accordion item. Apply this to the link within an accordion item.
-@mixin accordion-title {
+@mixin accordion-title (
+  $padding: $accordion-item-padding,
+  $font-size: $accordion-title-font-size,
+  $color: $accordion-item-color,
+  $border: $accordion-content-border,
+  $background-hover: $accordion-item-background-hover
+) {
   position: relative;
   display: block;
-  padding: $accordion-item-padding;
+  padding: $padding;
 
-  border: $accordion-content-border;
+  border: $border;
   border-bottom: 0;
 
-  font-size: $accordion-title-font-size;
+  font-size: $font-size;
   line-height: 1;
-  color: $accordion-item-color;
+  color: $color;
 
   :last-child:not(.is-active) > & {
-    border-bottom: $accordion-content-border;
+    border-bottom: $border;
     border-radius: 0 0 $global-radius $global-radius;
   }
 
   &:hover,
   &:focus {
-    background-color: $accordion-item-background-hover;
+    background-color: $background-hover;
   }
 
   @if $accordion-plusminus {
@@ -103,18 +111,23 @@ $accordion-content-padding: 1rem !default;
 }
 
 /// Adds styles for accordion content. Apply this to the content pane below an accordion item's title.
-@mixin accordion-content {
+@mixin accordion-content (
+  $padding: $accordion-content-padding,
+  $border: $accordion-content-border,
+  $background: $accordion-content-background,
+  $color: $accordion-content-color
+) {
   display: none;
-  padding: $accordion-content-padding;
+  padding: $padding;
 
-  border: $accordion-content-border;
+  border: $border;
   border-bottom: 0;
-  background-color: $accordion-content-background;
+  background-color: $background;
 
-  color: $accordion-content-color;
+  color: $color;
 
   :last-child > &:last-child {
-    border-bottom: $accordion-content-border;
+    border-bottom: $border;
   }
 }
 

--- a/scss/components/_badge.scss
+++ b/scss/components/_badge.scss
@@ -53,7 +53,7 @@ $badge-font-size: 0.6rem !default;
       @if $name != primary {
         &.#{$name} {
           background: $color;
-          color: pick-best-color($color, ($badge-color, $badge-color-alt));
+          color: color-pick-contrast($color, ($badge-color, $badge-color-alt));
         }
       }
     }

--- a/scss/components/_badge.scss
+++ b/scss/components/_badge.scss
@@ -12,7 +12,11 @@ $badge-background: $primary-color !default;
 
 /// Default text color for badges.
 /// @type Color
-$badge-color: pick-best-color($badge-background) !default;
+$badge-color: $white !default;
+
+/// Default text color for badges.
+/// @type Color
+$badge-color-alt: $black !default;
 
 /// Default padding inside badges.
 /// @type Number
@@ -49,7 +53,7 @@ $badge-font-size: 0.6rem !default;
       @if $name != primary {
         &.#{$name} {
           background: $color;
-          color: pick-best-color($color, ($white, $black));
+          color: pick-best-color($color, ($badge-color, $badge-color-alt));
         }
       }
     }

--- a/scss/components/_badge.scss
+++ b/scss/components/_badge.scss
@@ -14,7 +14,7 @@ $badge-background: $primary-color !default;
 /// @type Color
 $badge-color: $white !default;
 
-/// Default text color for badges.
+/// Alternate text color for badges.
 /// @type Color
 $badge-color-alt: $black !default;
 

--- a/scss/components/_badge.scss
+++ b/scss/components/_badge.scss
@@ -12,7 +12,7 @@ $badge-background: $primary-color !default;
 
 /// Default text color for badges.
 /// @type Color
-$badge-color: foreground($badge-background) !default;
+$badge-color: pick-best-color($badge-background) !default;
 
 /// Default padding inside badges.
 /// @type Number
@@ -49,7 +49,7 @@ $badge-font-size: 0.6rem !default;
       @if $name != primary {
         &.#{$name} {
           background: $color;
-          color: foreground($color);
+          color: pick-best-color($color, ($white, $black));
         }
       }
     }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -28,11 +28,7 @@ $button-background-hover: scale-color($button-background, $lightness: -15%) !def
 
 /// Font color for buttons.
 /// @type List
-$button-color: $white !default;
-
-/// Font color for buttons, if the background is light.
-/// @type List
-$button-color-alt: $black !default;
+$button-color: pick-best-color($button-background) !default;
 
 /// Border radius for buttons, defaulted to global-radius.
 /// @type Number
@@ -114,7 +110,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   $background-hover-lightness: $button-background-hover-lightness
 ) {
   @if $color == auto {
-    $color: pick-best-color($base: $background, $colors: ($button-color, $button-color-alt));
+    $color: pick-best-color($base: $background, $colors: ($white, $black));
   }
 
   @if $background-hover == auto {

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -114,7 +114,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   $background-hover-lightness: $button-background-hover-lightness
 ) {
   @if $color == auto {
-    $color: pick-best-color($background, ($button-color, $button-color-alt));
+    $color: color-pick-contrast($background, ($button-color, $button-color-alt));
   }
 
   @if $background-hover == auto {

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -114,7 +114,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   $background-hover-lightness: $button-background-hover-lightness
 ) {
   @if $color == auto {
-    $color: foreground($background, $button-color-alt, $button-color);
+    $color: pick-best-color($base: $background, $colors: ($button-color, $button-color-alt));
   }
 
   @if $background-hover == auto {

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -28,7 +28,11 @@ $button-background-hover: scale-color($button-background, $lightness: -15%) !def
 
 /// Font color for buttons.
 /// @type List
-$button-color: pick-best-color($button-background) !default;
+$button-color: $white !default;
+
+/// Alternative font color for buttons.
+/// @type List
+$button-color-alt: $black !default;
 
 /// Border radius for buttons, defaulted to global-radius.
 /// @type Number
@@ -110,7 +114,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   $background-hover-lightness: $button-background-hover-lightness
 ) {
   @if $color == auto {
-    $color: pick-best-color($base: $background, $colors: ($white, $black));
+    $color: pick-best-color($background, ($button-color, $button-color-alt));
   }
 
   @if $background-hover == auto {

--- a/scss/components/_label.scss
+++ b/scss/components/_label.scss
@@ -54,7 +54,7 @@ $label-radius: $global-radius !default;
       @if $name != primary {
         &.#{$name} {
           background: $color;
-          color: pick-best-color($color, ($label-color, $label-color-alt));
+          color: color-pick-contrast($color, ($label-color, $label-color-alt));
         }
       }
     }

--- a/scss/components/_label.scss
+++ b/scss/components/_label.scss
@@ -12,7 +12,7 @@ $label-background: $primary-color !default;
 
 /// Default text color for labels.
 /// @type Color
-$label-color: foreground($label-background) !default;
+$label-color: pick-best-color($label-background) !default;
 
 /// Default font size for labels.
 /// @type Number
@@ -50,7 +50,7 @@ $label-radius: $global-radius !default;
       @if $name != primary {
         &.#{$name} {
           background: $color;
-          color: foreground($color);
+          color: pick-best-color($color, ($black, $white));
         }
       }
     }

--- a/scss/components/_label.scss
+++ b/scss/components/_label.scss
@@ -12,7 +12,11 @@ $label-background: $primary-color !default;
 
 /// Default text color for labels.
 /// @type Color
-$label-color: pick-best-color($label-background) !default;
+$label-color: $white !default;
+
+/// Alternate text color for labels.
+/// @type Color
+$label-color-alt: $black !default;
 
 /// Default font size for labels.
 /// @type Number
@@ -50,7 +54,7 @@ $label-radius: $global-radius !default;
       @if $name != primary {
         &.#{$name} {
           background: $color;
-          color: pick-best-color($color, ($black, $white));
+          color: pick-best-color($color, ($label-color, $label-color-alt));
         }
       }
     }

--- a/scss/components/_orbit.scss
+++ b/scss/components/_orbit.scss
@@ -97,6 +97,7 @@ $orbit-control-zindex: 10 !default;
 
   background-color: $orbit-caption-background;
   color: color-pick-contrast($orbit-caption-background);
+  background-color: $orbit-caption-background;
 }
 
 /// Adds base styles for the next/previous buttons in an Orbit slider. These styles are shared between the `.orbit-next` and `.orbit-previous` classes in the default CSS.

--- a/scss/components/_orbit.scss
+++ b/scss/components/_orbit.scss
@@ -96,7 +96,7 @@ $orbit-control-zindex: 10 !default;
   padding: $orbit-caption-padding;
 
   background-color: $orbit-caption-background;
-  color: foreground($orbit-caption-background);
+  color: color-pick-contrast($orbit-caption-background);
 }
 
 /// Adds base styles for the next/previous buttons in an Orbit slider. These styles are shared between the `.orbit-next` and `.orbit-previous` classes in the default CSS.

--- a/scss/components/_orbit.scss
+++ b/scss/components/_orbit.scss
@@ -97,7 +97,6 @@ $orbit-control-zindex: 10 !default;
 
   background-color: $orbit-caption-background;
   color: color-pick-contrast($orbit-caption-background);
-  background-color: $orbit-caption-background;
 }
 
 /// Adds base styles for the next/previous buttons in an Orbit slider. These styles are shared between the `.orbit-next` and `.orbit-previous` classes in the default CSS.

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -40,7 +40,7 @@ $pagination-item-background-current: $primary-color !default;
 
 /// Text color of the pagination item for the current page.
 /// @type Color
-$pagination-item-color-current: pick-best-color($pagination-item-background-current) !default;
+$pagination-item-color-current: $white !default;
 
 /// Text color of a disabled pagination item.
 /// @type Color

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -40,7 +40,7 @@ $pagination-item-background-current: $primary-color !default;
 
 /// Text color of the pagination item for the current page.
 /// @type Color
-$pagination-item-color-current: foreground($pagination-item-background-current) !default;
+$pagination-item-color-current: pick-best-color($pagination-item-background-current) !default;
 
 /// Text color of a disabled pagination item.
 /// @type Color

--- a/scss/components/_pagination.scss
+++ b/scss/components/_pagination.scss
@@ -66,16 +66,24 @@ $pagination-mobile-current-item: false !default;
 $pagination-arrows: true !default;
 
 /// Adds styles for a pagination container. Apply this to a `<ul>`.
-@mixin pagination-container {
+@mixin pagination-container (
+  $margin-bottom: $pagination-margin-bottom,
+  $font-size: $pagination-font-size,
+  $spacing: $pagination-item-spacing,
+  $radius: $pagination-radius,
+  $color: $pagination-item-color,
+  $padding: $pagination-item-padding,
+  $background-hover: $pagination-item-background-hover
+) {
   @include clearfix;
   margin-#{$global-left}: 0;
-  margin-bottom: $pagination-margin-bottom;
+  margin-bottom: $margin-bottom;
 
   // List item
   li {
-    margin-#{$global-right}: $pagination-item-spacing;
-    border-radius: $pagination-radius;
-    font-size: $pagination-font-size;
+    margin-#{$global-right}: $spacing;
+    border-radius: $radius;
+    font-size: $font-size;
 
     @if $pagination-mobile-items {
       display: inline-block;
@@ -104,28 +112,35 @@ $pagination-arrows: true !default;
   a,
   button {
     display: block;
-    padding: $pagination-item-padding;
+    padding: $padding;
     border-radius: $global-radius;
-    color: $pagination-item-color;
+    color: $color;
 
     &:hover {
-      background: $pagination-item-background-hover;
+      background: $background-hover;
     }
   }
 }
 
 /// Adds styles for the current pagination item. Apply this to an `<a>`.
-@mixin pagination-item-current {
-  padding: $pagination-item-padding;
-  background: $pagination-item-background-current;
-  color: $pagination-item-color-current;
+@mixin pagination-item-current (
+  $padding: $pagination-item-padding,
+  $background-current: $pagination-item-background-current,
+  $color-current: $pagination-item-color-current
+) {
+  padding: $padding;
+  background: $background-current;
+  color: $color-current;
   cursor: default;
 }
 
 /// Adds styles for a disabled pagination item. Apply this to an `<a>`.
-@mixin pagination-item-disabled {
-  padding: $pagination-item-padding;
-  color: $pagination-item-color-disabled;
+@mixin pagination-item-disabled (
+  $padding: $pagination-item-padding,
+  $color: $pagination-item-color-disabled
+) {
+  padding: $padding;
+  color: $color;
   cursor: not-allowed;
 
   &:hover {
@@ -134,10 +149,13 @@ $pagination-arrows: true !default;
 }
 
 /// Adds styles for an ellipsis for use in a pagination list.
-@mixin pagination-ellipsis {
-  padding: $pagination-item-padding;
+@mixin pagination-ellipsis (
+  $padding: $pagination-item-padding,
+  $color: $pagination-ellipsis-color
+) {
+  padding: $padding;
   content: '\2026';
-  color: $pagination-ellipsis-color;
+  color: $color;
 }
 
 @mixin foundation-pagination {

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -169,7 +169,7 @@ $tab-content-padding: 1rem !default;
     background: $primary-color;
 
     > li > a {
-      color: pick-best-color($primary-color);
+      color: color-pick-contrast($primary-color);
 
       &:hover,
       &:focus {

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -16,7 +16,7 @@ $tab-background: $white !default;
 
 /// Font color of tab item.
 /// @type Color
-$tab-color: pick-best-color($tab-background, ($primary-color, $white)) !default;
+$tab-color: $primary-color !default;
 
 /// Active background color of a tab bar.
 /// @type Color
@@ -24,7 +24,7 @@ $tab-background-active: $light-gray !default;
 
 /// Active font color of tab item.
 /// @type Color
-$tab-background-active-color: pick-best-color($tab-background-active, ($primary-color, $white)) !default;
+$tab-background-active-color: $primary-color !default;
 
 /// Font size of tab items.
 /// @type Number
@@ -51,18 +51,22 @@ $tab-content-border: $light-gray !default;
 
 /// Default text color of tab content.
 /// @type Color
-$tab-content-color: pick-best-color($tab-content-background) !default;
+$tab-content-color: $body-font-color !default;
 
 /// Default padding for tab content.
 /// @type Number | List
 $tab-content-padding: 1rem !default;
 
 /// Adds styles for a tab container. Apply this to a `<ul>`.
-@mixin tabs-container {
+@mixin tabs-container (
+  $margin: $tab-margin,
+  $background: $tab-background,
+  $border-color: $tab-content-border
+) {
   @include clearfix;
-  margin: $tab-margin;
-  border: 1px solid $tab-content-border;
-  background: $tab-background;
+  margin: $margin;
+  border: 1px solid $border-color;
+  background: $background;
   list-style-type: none;
 }
 
@@ -94,13 +98,14 @@ $tab-content-padding: 1rem !default;
     color: $color;
 
     &:hover {
-      background: $tab-item-background-hover;
+      background: $background-hover;
+      color: scale-color($color, $lightness: -14%);
     }
 
     &:focus,
     &[aria-selected='true'] {
-      background: $tab-background-active;
-      color: $tab-background-active-color;
+      background: $background-active;
+      color: $color-active;
     }
   }
 }
@@ -119,15 +124,19 @@ $tab-content-padding: 1rem !default;
 }
 
 /// Augments a tab content container to have a vertical style, by shifting the border around. Use this in conjunction with `tabs-content()`.
-@mixin tabs-content-vertical {
-  border: 1px solid $tab-content-border;
+@mixin tabs-content-vertical (
+  $border-color: $tab-content-border
+) {
+  border: 1px solid $border-color;
   border-#{$global-left}: 0;
 }
 
 /// Adds styles for an individual tab content panel within the tab content container.
-@mixin tabs-panel {
+@mixin tabs-panel (
+  $padding: $tab-content-padding
+) {
   display: none;
-  padding: $tab-content-padding;
+  padding: $padding;
 
   &[aria-hidden="false"] {
     display: block;

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -14,9 +14,17 @@ $tab-margin: 0 !default;
 /// @type Color
 $tab-background: $white !default;
 
-/// active background color of a tab bar.
+/// Font color of tab item.
+/// @type Color
+$tab-color: pick-best-color($tab-background, ($primary-color, $white)) !default;
+
+/// Active background color of a tab bar.
 /// @type Color
 $tab-background-active: $light-gray !default;
+
+/// Active font color of tab item.
+/// @type Color
+$tab-background-active-color: pick-best-color($tab-background-active, ($primary-color, $white)) !default;
 
 /// Font size of tab items.
 /// @type Number
@@ -43,7 +51,7 @@ $tab-content-border: $light-gray !default;
 
 /// Default text color of tab content.
 /// @type Color
-$tab-content-color: foreground($tab-background, $primary-color) !default;
+$tab-content-color: pick-best-color($tab-content-background) !default;
 
 /// Default padding for tab content.
 /// @type Number | List
@@ -68,14 +76,22 @@ $tab-content-padding: 1rem !default;
 }
 
 /// Adds styles for the links within a tab container. Apply this to the `<li>` elements inside a tab container.
-@mixin tabs-title {
+@mixin tabs-title (
+  $padding: $tab-item-padding,
+  $font-size: $tab-item-font-size,
+  $color: $tab-color,
+  $color-active: $tab-background-active-color,
+  $background-hover: $tab-item-background-hover,
+  $background-active: $tab-background-active
+) {
   float: #{$global-left};
 
   > a {
     display: block;
-    padding: $tab-item-padding;
-    font-size: $tab-item-font-size;
+    padding: $padding;
+    font-size: $font-size;
     line-height: 1;
+    color: $color;
 
     &:hover {
       background: $tab-item-background-hover;
@@ -84,15 +100,21 @@ $tab-content-padding: 1rem !default;
     &:focus,
     &[aria-selected='true'] {
       background: $tab-background-active;
+      color: $tab-background-active-color;
     }
   }
 }
 
 /// Adds styles for the wrapper that surrounds a tab group's content panes.
-@mixin tabs-content {
-  border: 1px solid $tab-content-border;
+@mixin tabs-content (
+  $background: $tab-content-background,
+  $color: $tab-content-color,
+  $border-color: $tab-content-border
+) {
+  border: 1px solid $border-color;
   border-top: 0;
-  background: $tab-content-background;
+  background: $background;
+  color: $color;
   transition: all 0.5s ease;
 }
 
@@ -138,7 +160,7 @@ $tab-content-padding: 1rem !default;
     background: $primary-color;
 
     > li > a {
-      color: foreground($primary-color);
+      color: pick-best-color($primary-color);
 
       &:hover,
       &:focus {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -51,7 +51,7 @@ $global-lineheight: 1.5;
 $foundation-palette: (
   primary: #1a7cbd,
   secondary: #767676,
-  success: #238748,
+  success: #3adb76,
   warning: #ffae00,
   alert: #cc4b37,
 );

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -197,12 +197,12 @@ $input-error-font-weight: $global-weight-bold;
 $accordion-background: $white;
 $accordion-plusminus: true;
 $accordion-title-font-size: rem-calc(12);
-$accordion-item-color: pick-best-color($accordion-background, ($primary-color, $white));
+$accordion-item-color: $primary-color;
 $accordion-item-background-hover: $light-gray;
 $accordion-item-padding: 1.25rem 1rem;
 $accordion-content-background: $white;
 $accordion-content-border: 1px solid $light-gray;
-$accordion-content-color: pick-best-color($accordion-content-background, ($body-font-color, $white));
+$accordion-content-color: $body-font-color;
 $accordion-content-padding: 1rem;
 
 // 8. Accordion Menu

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -241,8 +241,7 @@ $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
 $button-background: $primary-color;
 $button-background-hover: scale-color($button-background, $lightness: -15%);
-$button-color: $white;
-$button-color-alt: $black;
+$button-color: pick-best-color($button-background);
 $button-radius: $global-radius;
 $button-sizes: (
   tiny: 0.6rem,

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -240,7 +240,8 @@ $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
 $button-background: $primary-color;
 $button-background-hover: scale-color($button-background, $lightness: -15%);
-$button-color: pick-best-color($button-background);
+$button-color: $white;
+$button-color-alt: $black;
 $button-radius: $global-radius;
 $button-sizes: (
   tiny: 0.6rem,

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -49,7 +49,7 @@ $global-font-size: 100%;
 $global-width: rem-calc(1200);
 $global-lineheight: 1.5;
 $foundation-palette: (
-  primary: #1a7cbd,
+  primary: #1779ba,
   secondary: #767676,
   success: #3adb76,
   warning: #ffae00,
@@ -197,12 +197,12 @@ $input-error-font-weight: $global-weight-bold;
 $accordion-background: $white;
 $accordion-plusminus: true;
 $accordion-title-font-size: rem-calc(12);
-$accordion-item-color: foreground($accordion-background, $primary-color);
+$accordion-item-color: pick-best-color($accordion-background, ($primary-color, $white));
 $accordion-item-background-hover: $light-gray;
 $accordion-item-padding: 1.25rem 1rem;
 $accordion-content-background: $white;
 $accordion-content-border: 1px solid $light-gray;
-$accordion-content-color: foreground($accordion-content-background, $body-font-color);
+$accordion-content-color: pick-best-color($accordion-content-background, ($body-font-color, $white));
 $accordion-content-padding: 1rem;
 
 // 8. Accordion Menu
@@ -215,7 +215,7 @@ $accordionmenu-arrow-color: $primary-color;
 // --------
 
 $badge-background: $primary-color;
-$badge-color: foreground($badge-background);
+$badge-color: pick-best-color($badge-background);
 $badge-padding: 0.3em;
 $badge-minwidth: 2.1em;
 $badge-font-size: 0.6rem;
@@ -240,8 +240,7 @@ $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
 $button-background: $primary-color;
 $button-background-hover: scale-color($button-background, $lightness: -15%);
-$button-color: $white;
-$button-color-alt: $black;
+$button-color: pick-best-color($button-background);
 $button-radius: $global-radius;
 $button-sizes: (
   tiny: 0.6rem,
@@ -371,7 +370,7 @@ $form-button-radius: $global-radius;
 // ---------
 
 $label-background: $primary-color;
-$label-color: foreground($label-background);
+$label-color: pick-best-color($label-background);
 $label-font-size: 0.8rem;
 $label-padding: 0.33333rem 0.5rem;
 $label-radius: $global-radius;
@@ -443,7 +442,7 @@ $pagination-item-spacing: rem-calc(1);
 $pagination-radius: $global-radius;
 $pagination-item-background-hover: $light-gray;
 $pagination-item-background-current: $primary-color;
-$pagination-item-color-current: foreground($pagination-item-background-current);
+$pagination-item-color-current: pick-best-color($pagination-item-background-current);
 $pagination-item-color-disabled: $medium-gray;
 $pagination-ellipsis-color: $black;
 $pagination-mobile-items: false;
@@ -534,14 +533,16 @@ $show-header-for-stacked: false;
 
 $tab-margin: 0;
 $tab-background: $white;
+$tab-color: pick-best-color($tab-background, ($primary-color, $white));
 $tab-background-active: $light-gray;
+$tab-background-active-color: pick-best-color($tab-background-active, ($primary-color, $white));
 $tab-item-font-size: rem-calc(12);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;
 $tab-content-background: $white;
 $tab-content-border: $light-gray;
-$tab-content-color: foreground($tab-background, $primary-color);
+$tab-content-color: pick-best-color($tab-content-background);
 $tab-content-padding: 1rem;
 
 // 33. Thumbnail

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -49,11 +49,11 @@ $global-font-size: 100%;
 $global-width: rem-calc(1200);
 $global-lineheight: 1.5;
 $foundation-palette: (
-  primary: #2199e8,
-  secondary: #777,
-  success: #3adb76,
+  primary: #1a7cbd,
+  secondary: #767676,
+  success: #238748,
   warning: #ffae00,
-  alert: #ec5840,
+  alert: #cc4b37,
 );
 $light-gray: #e6e6e6;
 $medium-gray: #cacaca;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -215,7 +215,8 @@ $accordionmenu-arrow-color: $primary-color;
 // --------
 
 $badge-background: $primary-color;
-$badge-color: pick-best-color($badge-background);
+$badge-color: $white;
+$badge-color-alt: $black;
 $badge-padding: 0.3em;
 $badge-minwidth: 2.1em;
 $badge-font-size: 0.6rem;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -534,16 +534,16 @@ $show-header-for-stacked: false;
 
 $tab-margin: 0;
 $tab-background: $white;
-$tab-color: pick-best-color($tab-background, ($primary-color, $white));
+$tab-color: $primary-color;
 $tab-background-active: $light-gray;
-$tab-background-active-color: pick-best-color($tab-background-active, ($primary-color, $white));
+$tab-background-active-color: $primary-color;
 $tab-item-font-size: rem-calc(12);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;
 $tab-content-background: $white;
 $tab-content-border: $light-gray;
-$tab-content-color: pick-best-color($tab-content-background);
+$tab-content-color: $body-font-color;
 $tab-content-padding: 1rem;
 
 // 33. Thumbnail

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -372,7 +372,8 @@ $form-button-radius: $global-radius;
 // ---------
 
 $label-background: $primary-color;
-$label-color: pick-best-color($label-background);
+$label-color: $white;
+$label-color-alt: $black;
 $label-font-size: 0.8rem;
 $label-padding: 0.33333rem 0.5rem;
 $label-radius: $global-radius;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -445,7 +445,7 @@ $pagination-item-spacing: rem-calc(1);
 $pagination-radius: $global-radius;
 $pagination-item-background-hover: $light-gray;
 $pagination-item-background-current: $primary-color;
-$pagination-item-color-current: pick-best-color($pagination-item-background-current);
+$pagination-item-color-current: $white;
 $pagination-item-color-disabled: $medium-gray;
 $pagination-ellipsis-color: $black;
 $pagination-mobile-items: false;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -241,7 +241,8 @@ $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;
 $button-background: $primary-color;
 $button-background-hover: scale-color($button-background, $lightness: -15%);
-$button-color: pick-best-color($button-background);
+$button-color: $white;
+$button-color-alt: $black;
 $button-radius: $global-radius;
 $button-sizes: (
   tiny: 0.6rem,

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -2,6 +2,8 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
+@import 'math';
+
 ////
 /// @group functions
 ////

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -51,13 +51,13 @@
   @return $ratio;
 }
 
-/// Checks the luminance of `$base`, and if it passes the `$threshold` of lightness, it returns the `$yes` color. Otherwise, it returns the `$no` color. Use this function to dynamically output a foreground color based on a given background color.
+/// Checks the luminance of `$base`, and returns the color from `$colors` (list of colors) that has the most contrast.
 ///
 /// @param {Color} $color1 - First color to compare.
 /// @param {Color} $color2 - Second color to compare.
 ///
 /// @returns {Number} The contrast ratio of the compared colors.
-@function pick-best-color($base, $colors: ($white, $black), $tolerance: 0) {
+@function color-pick-contrast($base, $colors: ($white, $black), $tolerance: 0) {
   $contrast: color-contrast($base, nth($colors, 1));
   $best: nth($colors, 1);
 

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -6,24 +6,74 @@
 /// @group functions
 ////
 
-/// Checks the lightness of `$color`, and if it passes the `$threshold` of lightness, it returns the `$yes` color. Otherwise, it returns the `$no` color. Use this function to dynamically output a foreground color based on a given background color.
+/// Checks the luminance of `$color`.
 ///
-/// @param {Color} $color - Color to check the lightness of.
-/// @param {Color} $yes [$black] - Color to return if `$color` is light.
-/// @param {Color} $no [$white] - Color to return if `$color` is dark.
-/// @param {Percentage} $threshold [60%] - Threshold of lightness to check against.
+/// @param {Color} $color - Color to check the luminance of.
 ///
-/// @returns {Color} The $yes color or $no color.
-@function foreground($color, $yes: $black, $no: $white, $threshold: 60%) {
-  @if $color == transparent {
-    $color: $body-background;
+/// @returns {Number} The luminance of `$color`.
+@function color-luminance($color) {
+  // Adapted from: https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/color.js
+  // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
+  $rgba: red($color), green($color), blue($color);
+  $rgba2: ();
+
+  @for $i from 1 through 3 {
+    $rgb: nth($rgba, $i);
+    $rgb: $rgb / 255;
+
+    $rgb: if($rgb < 0.03928, $rgb / 12.92, pow(($rgb + 0.055) / 1.055, 2.4));
+
+    $rgba2: append($rgba2, $rgb);
   }
-  @if (lightness($color) > $threshold) {
-    @return $yes;
+
+  @return 0.2126 * nth($rgba2, 1) + 0.7152 * nth($rgba2, 2) + 0.0722 * nth($rgba2, 3);
+}
+
+/// Checks the contrast ratio of two colors.
+///
+/// @param {Color} $color1 - First color to compare.
+/// @param {Color} $color2 - Second color to compare.
+///
+/// @returns {Number} The contrast ratio of the compared colors.
+@function color-contrast($color1, $color2) {
+  // Adapted from: https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/color.js
+  // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+  $luminance1: color-luminance($color1) + 0.05;
+  $luminance2: color-luminance($color2) + 0.05;
+  $ratio: $luminance1 / $luminance2;
+
+  @if $luminance2 > $luminance1 {
+    $ratio: 1 / $ratio;
   }
-  @else {
-    @return $no;
+
+  $ratio: round($ratio * 10) / 10;
+
+  @return $ratio;
+}
+
+/// Checks the luminance of `$base`, and if it passes the `$threshold` of lightness, it returns the `$yes` color. Otherwise, it returns the `$no` color. Use this function to dynamically output a foreground color based on a given background color.
+///
+/// @param {Color} $color1 - First color to compare.
+/// @param {Color} $color2 - Second color to compare.
+///
+/// @returns {Number} The contrast ratio of the compared colors.
+@function pick-best-color($base, $colors: ($button-color, $button-color-alt), $tolerance: 0) {
+  $contrast: color-contrast($base, nth($colors, 1));
+  $best: nth($colors, 1);
+
+  @for $i from 2 through length($colors) {
+    $current-contrast: color-contrast($base, nth($colors, $i));
+    @if ($current-contrast - $contrast > $tolerance) {
+      $contrast: color-contrast($base, nth($colors, $i));
+      $best: nth($colors, $i);
+    }
   }
+
+  @if ($contrast < 3) {
+    @warn "Contrast ratio of #{$best} on #{$base} is pretty bad, just #{$contrast}";
+  }
+
+  @return $best;
 }
 
 /// Scales a color to be darker if it's light, or lighter if it's dark. Use this function to tint a color appropriate to its lightness.

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -57,7 +57,7 @@
 /// @param {Color} $color2 - Second color to compare.
 ///
 /// @returns {Number} The contrast ratio of the compared colors.
-@function pick-best-color($base, $colors: ($button-color, $button-color-alt), $tolerance: 0) {
+@function pick-best-color($base, $colors: ($white, $black), $tolerance: 0) {
   $contrast: color-contrast($base, nth($colors, 1));
   $best: nth($colors, 1);
 

--- a/scss/util/_math.scss
+++ b/scss/util/_math.scss
@@ -1,0 +1,63 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group functions
+////
+
+/// Finds the greatest common divisor of two integers.
+///
+/// @param {Number} $a - First number to compare.
+/// @param {Number} $b - Second number to compare.
+///
+/// @returns {Number} The greatest common divisor.
+@function gcd($a, $b) {
+  // From: http://rosettacode.org/wiki/Greatest_common_divisor#JavaScript
+  @if ($b != 0) {
+    @return gcd($b, $a % $b);
+  }
+  @else {
+    @return abs($a);
+  }
+}
+
+/// Handles decimal exponents by trying to convert them into a fraction and then use a nth-root-algorithm for parts of the calculation
+///
+/// @param {Number} $base - The base number.
+/// @param {Number} $exponent - The exponent.
+///
+/// @returns {Number} The product of the exponentiation.
+@function pow($base, $exponent, $prec: 12) {
+  @if (floor($exponent) != $exponent) {
+    $prec2 : pow(10, $prec);
+    $exponent: round($exponent * $prec2);
+    $denominator: gcd($exponent, $prec2);
+    @return nth-root(pow($base, $exponent / $denominator), $prec2 / $denominator, $prec);
+  }
+
+  $value: $base;
+  @if $exponent > 1 {
+    @for $i from 2 through $exponent {
+      $value: $value * $base;
+    }
+  }
+  @else if $exponent < 1 {
+    @for $i from 0 through -$exponent {
+      $value: $value / $base;
+    }
+  }
+
+  @return $value;
+}
+
+@function nth-root($num, $n: 2, $prec: 12) {
+  // From: http://rosettacode.org/wiki/Nth_root#JavaScript
+  $x: 1;
+
+  @for $i from 0 through $prec {
+    $x: 1 / $n * (($n - 1) * $x + ($num / pow($x, $n - 1)));
+  }
+
+  @return $x;
+}

--- a/scss/util/_util.scss
+++ b/scss/util/_util.scss
@@ -2,6 +2,7 @@
 // foundation.zurb.com
 // Licensed under MIT Open Source
 
+@import 'math';
 @import 'unit';
 @import 'value';
 @import 'color';

--- a/test/sass/_color.scss
+++ b/test/sass/_color.scss
@@ -6,7 +6,7 @@
 @include test-module('Color') {
 
   @include test('Foreground (Black) [function]') {
-    $test: foreground($white);
+    $test: pick-best-color($white);
     $expect: $black;
 
     @include assert-equal($test, $expect,
@@ -14,7 +14,7 @@
   }
 
   @include test('Foreground (White) [function]') {
-    $test: foreground($black);
+    $test: pick-best-color($black);
     $expect: $white;
 
     @include assert-equal($test, $expect,

--- a/test/sass/_color.scss
+++ b/test/sass/_color.scss
@@ -6,7 +6,7 @@
 @include test-module('Color') {
 
   @include test('Foreground (Black) [function]') {
-    $test: pick-best-color($white);
+    $test: color-pick-contrast($white);
     $expect: $black;
 
     @include assert-equal($test, $expect,
@@ -14,7 +14,7 @@
   }
 
   @include test('Foreground (White) [function]') {
-    $test: pick-best-color($black);
+    $test: color-pick-contrast($black);
     $expect: $white;
 
     @include assert-equal($test, $expect,


### PR DESCRIPTION
This PR, which effects every component that used the `foreground()` function, addresses #7387. I've adjusted the `$foundation-palette` to meet AA contrast requirements. The `foreground()` function has been replaced with a new `pick-best-color()` function that uses luminosity instead of lightness (which fails as #7387 explains). 