### PR TITLE
[Slider] Fixed copy-paste errors in JSDoc

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -13,9 +13,9 @@
 
 class Slider {
   /**
-   * Creates a new instance of a drilldown menu.
+   * Creates a new instance of a slider control.
    * @class
-   * @param {jQuery} element - jQuery object to make into an accordion menu.
+   * @param {jQuery} element - jQuery object to make into a slider control.
    * @param {Object} options - Overrides to the default plugin settings.
    */
   constructor(element, options) {


### PR DESCRIPTION
"drilldown menu" -> "slider control"
"an accordion menu" -> "a slider control"