### PR TITLE
Equalizer now works for any number of elements.

### DIFF
--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -158,6 +158,9 @@ class Equalizer {
    * @private
    */
   _isStacked() {
+    if (!this.$watched[0] || !this.$watched[1]) {
+      return true;
+    }
     return this.$watched[0].getBoundingClientRect().top !== this.$watched[1].getBoundingClientRect().top;
   }
 


### PR DESCRIPTION
The equalizer was programmed for >= 2 elements. For static pages this might make sense, but for dynamic pages the number of elements is not always predictable. 

Included is a very simple fix. Also Fixes #9314.