### PR TITLE
[docs] fixed programmatic use of interchange

### DIFF
--- a/docs/pages/interchange.md
+++ b/docs/pages/interchange.md
@@ -85,5 +85,11 @@ When using Interchange programmatically, you need to pass in your ruleset in the
 
 ```js
 var $photoFrame = $('#some-container');
-var interchange = new Foundation.Interchange($photoFrame, {rules: "[path/to/default.jpg, small], [path/to/medium.jpg, medium], [path/to/large.jpg, large]"});
+var interchange = new Foundation.Interchange($photoFrame, {
+  rules: [
+    "[path/to/default.jpg, small]", 
+    "[path/to/medium.jpg, medium]",
+    "[path/to/large.jpg, large]"
+  ]
+ });
 ```


### PR DESCRIPTION
I was running into this issue and it took me a while to figure out that by providing a single string with multiple rules as `rules` option the [loop](https://github.com/zurb/foundation-sites/blob/develop/js/foundation.interchange.js#L109) iterates over each character in the option string.  
Providing the rules as an array works. 

I also propose to do the [`.match`](https://github.com/zurb/foundation-sites/blob/develop/js/foundation.interchange.js#L106) right after the condition which desides where the options are loaded from and simply do

```javascript
rules =  typeof rules === 'string' ? rules.match(/\[.*?\]/g) : rules;
```

right before entering the loop. I could also create a pull request for it if you like.