### PR TITLE
Upgrade node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4.0"
 before_install:
   - rvm install 2.2.2
 install:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lastly, if you're rolling your own setup, you can install Foundation through a v
 
 ## Documentation
 
-The documentation can be found at <https://foundation.zurb.com/sites/docs>. To run the documentation locally on your machine, you need [Node.js](https://nodejs.org/en/) and [Ruby](https://www.ruby-lang.org/en/) installed on your computer. (Your Node.js version must be 0.12 or higher.)
+The documentation can be found at <https://foundation.zurb.com/sites/docs>. To run the documentation locally on your machine, you need [Node.js](https://nodejs.org/en/) and [Ruby](https://www.ruby-lang.org/en/) installed on your computer. (Your Node.js version must be **4.0** or higher.)
 
 Run these commands to set up the documentation:
 


### PR DESCRIPTION
Upgrade node version to v4.0 to prevent future bugs with sass-lint (see https://github.com/zurb/foundation-sites/pull/9301) and probably others new packages. I think the v0.12 begin to be outdated.

The v4.0 seems to work with most of packages for now, and is often recommended to resolve bugs of v0.12.