### PR TITLE
Fix #9336

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -339,12 +339,9 @@ class Tooltip {
    */
   destroy() {
     this.$element.attr('title', this.template.text())
-                 .off('.zf.trigger .zf.tootip')
-                //  .removeClass('has-tip')
-                 .removeAttr('aria-describedby')
-                 .removeAttr('data-yeti-box')
-                 .removeAttr('data-toggle')
-                 .removeAttr('data-resize');
+                 .off('.zf.trigger .zf.tooltip')
+                 .removeClass('has-tip top right left')
+                 .removeAttr('aria-describedby aria-haspopup data-disable-hover data-resize data-toggle data-tooltip data-yeti-box');
 
     this.template.remove();
 


### PR DESCRIPTION
This solves issue #9336. When the destroy method is called on a tooltip, the instance of the tooltip is not fully removed. Instead, it causes console errors and leaves behind tooltip-specific classes and attributes.

This commit:

- Corrects a typo (`.zf.tootip` to `.zf.tooltip`) that was preventing the event handler from properly being removed from the tooltip
- Removes all tooltip-specific classes, including `.has-tip`, `.top`, `.right`, and `.left`
- Removes all tooltip-specific attributes including `aria-describedby`, `aria-haspopup`, `data-disable-hover`, `data-resize`, `data-toggle`, `data-tooltip`, and `data-yeti-box`