### PR TITLE
Fix button-radius config naming collision

### DIFF
--- a/scss/forms/_text.scss
+++ b/scss/forms/_text.scss
@@ -70,9 +70,9 @@ $input-number-spinners: true !default;
 /// @type Border
 $input-radius: $global-radius !default;
 
-/// Border radius for buttons, defaulted to global-radius.
+/// Border radius for form buttons, defaulted to global-radius.
 /// @type Number
-$button-radius: $global-radius !default;
+$form-button-radius: $global-radius !default;
 
 @mixin form-element {
   $height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
@@ -146,7 +146,7 @@ $button-radius: $global-radius !default;
   // Reset styles on button-like inputs
   [type='submit'],
   [type='button'] {
-    border-radius: $button-radius;
+    border-radius: $form-button-radius;
     -webkit-appearance: none;
     -moz-appearance: none;
   }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -365,7 +365,7 @@ $input-cursor-disabled: not-allowed;
 $input-transition: box-shadow 0.5s, border-color 0.25s ease-in-out;
 $input-number-spinners: true;
 $input-radius: $global-radius;
-$button-radius: $global-radius;
+$form-button-radius: $global-radius;
 
 // 19. Label
 // ---------


### PR DESCRIPTION
Fix naming collision with the `$button-radius` config variable between Button component and Form buttons : rename the config variable for Forms buttons to `$form-button-radius`.

The bug was introduced in https://github.com/zurb/foundation-sites/pull/9109, and pointed out in https://github.com/zurb/foundation-sites/pull/9346, but with a wrong fix.