### PR TITLE
Fixed the scrolling behavior when auto-focus is active

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -69,8 +69,12 @@ class Tabs {
         'aria-labelledby': linkId
       });
 
-      if(isActive && _this.options.autoFocus){
-        $link.focus();
+      if(isActive && _this.options.autoFocus){  
+        $(window).load(function() {         
+          $('html, body').animate({ scrollTop: $elem.offset().top }, _this.options.deepLinkSmudgeDelay, () => {
+            $link.focus();
+          });
+        });
       }
 
       //use browser to open a tab, if it exists in this tabset


### PR DESCRIPTION
According to the [Tabs documentation](http://foundation.zurb.com/sites/docs/tabs.html#js-options), when the option `data-auto-focus` is enabled, the browser should scroll to the active (focused) tab. So this PR implements that feature.
