### PR TITLE
Add an option to the drilldown menu to position the back button at th…

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -85,7 +85,16 @@ class Drilldown {
       var $menu = $(this),
           $back = $menu.find('.js-drilldown-back');
       if(!$back.length){
-        $menu.prepend(_this.options.backButton);
+        switch (_this.options.backButtonPosition) {
+          case "bottom":
+            $menu.append(_this.options.backButton);
+            break;
+          case "top":
+            $menu.prepend(_this.options.backButton);
+            break;
+          default:
+            console.error("Unsupported backButtonPosition value '" + _this.options.backButtonPosition + "'");
+        }
       }
       _this._back($menu);
     });
@@ -389,11 +398,17 @@ class Drilldown {
 
 Drilldown.defaults = {
   /**
-   * Markup used for JS generated back button. Prepended to submenu lists and deleted on `destroy` method, 'js-drilldown-back' class required. Remove the backslash (`\`) if copy and pasting.
+   * Markup used for JS generated back button. Prepended  or appended (see backButtonPosition) to submenu lists and deleted on `destroy` method, 'js-drilldown-back' class required. Remove the backslash (`\`) if copy and pasting.
    * @option
    * @example '<\li><\a>Back<\/a><\/li>'
    */
   backButton: '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>',
+  /**
+   * Position the back button either at the top or bottom of drilldown submenus.
+   * @option
+   * @example bottom
+   */
+  backButtonPosition: 'top',
   /**
    * Markup used to wrap drilldown menu. Use a class name for independent styling; the JS applied class: `is-drilldown` is required. Remove the backslash (`\`) if copy and pasting.
    * @option


### PR DESCRIPTION
Because the drilldown menus are created and sized with javascript it's pretty difficult to change the positioning of the back button in CSS, so I added an attribute to the drilldown-menu component that allows the user to define if they want the back button prepended to the ul (the previous, and default behavior) or appeneded to the end.

This is my first FOSS commit so all feedback is welcome and I expect I still have plenty of work to do, fire away! 