### PR TITLE
Added feature on abide to enable validation on blur event

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -62,6 +62,14 @@ class Abide {
           this.validateInput($(e.target));
         });
     }
+
+    if (this.options.validateOnBlur) {
+      this.$inputs
+        .off('blur.zf.abide')
+        .on('blur.zf.abide', (e) => {
+          this.validateInput($(e.target));
+        });
+    }
   }
 
   /**
@@ -502,6 +510,13 @@ Abide.defaults = {
    * @example false
    */
   liveValidate: false,
+
+  /**
+   * Set to true to validate inputs on blur.
+   * @option
+   * @example false
+   */
+  validateOnBlur: false,
 
   patterns: {
     alpha : /^[a-zA-Z]+$/,


### PR DESCRIPTION
This is an implementation of the Abide's **validate-on-blur** feature that was in Foundation 5. So Abide now has a new option that's called `data-validate-on-blur`, and it is `false` by default.

The feature has been requested here #8945 .