### PR TITLE
Fix bug #9361

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -188,8 +188,7 @@
   // Column row
   // The double .row class is needed to bump up the specificity
   .column.row.row {
-    float: none;
-    display: block;
+    display: flex;
   }
 
   // To properly nest a column row, padding and margin is removed


### PR DESCRIPTION
The flex grid sets the display of a row that is aslo a column as 'block', remove this declaration since its not needed.