### PR TITLE
add block-grid-column so bottom margin matches gutters

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -433,26 +433,26 @@ Using these source ordering classes, you can shift columns around between our br
 
 ### Block Grids
 
-Block grids are a shorthand way to create equally-sized columns. Add a class of the format `.[size]-up-[n]` to change the number of columns within the row. By default, the max number of columns you can use with block grid are 8. Adding the `.block-grid-column` class to columns will apply a bottom margin equal to the width of gutters.
+Block grids are a shorthand way to create equally-sized columns. Add a class of the format `.[size]-up-[n]` to change the number of columns within the row. By default, the max number of columns you can use with block grid are 8. Adding the `.column-block` class to columns will apply a bottom margin equal to the width of gutters.
 
 ```html_example
 <div class="row small-up-2 medium-up-3 large-up-4">
-  <div class="column block-grid-column">
+  <div class="column column-block">
     <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column block-grid-column">
+  <div class="column column-block">
     <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column block-grid-column">
+  <div class="column column-block">
     <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column block-grid-column">
+  <div class="column column-block">
     <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column block-grid-column">
+  <div class="column column-block">
     <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column block-grid-column">
+  <div class="column column-block">
     <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
 </div>

--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -433,27 +433,27 @@ Using these source ordering classes, you can shift columns around between our br
 
 ### Block Grids
 
-The block grid from Foundation 5 has been merged into the main grid. Add a class of the format `[size]-up-[n]` to change the size of all columns within the row. By default, the max number of columns you can use with block grid are 8.
+Block grids are a shorthand way to create equally-sized columns. Add a class of the format `.[size]-up-[n]` to change the number of columns within the row. By default, the max number of columns you can use with block grid are 8. Adding the `.block-grid-column` class to columns will apply a bottom margin equal to the width of gutters.
 
 ```html_example
-<div class="row small-up-1 medium-up-2 large-up-4">
-  <div class="column">
-    <img src="//placehold.it/300x300" class="thumbnail" alt="">
+<div class="row small-up-2 medium-up-3 large-up-4">
+  <div class="column block-grid-column">
+    <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column">
-    <img src="//placehold.it/300x300" class="thumbnail" alt="">
+  <div class="column block-grid-column">
+    <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column">
-    <img src="//placehold.it/300x300" class="thumbnail" alt="">
+  <div class="column block-grid-column">
+    <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column">
-    <img src="//placehold.it/300x300" class="thumbnail" alt="">
+  <div class="column block-grid-column">
+    <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column">
-    <img src="//placehold.it/300x300" class="thumbnail" alt="">
+  <div class="column block-grid-column">
+    <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
-  <div class="column">
-    <img src="//placehold.it/300x300" class="thumbnail" alt="">
+  <div class="column block-grid-column">
+    <img src="//placehold.it/600x600" class="thumbnail" alt="">
   </div>
 </div>
 ```

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -22,7 +22,7 @@
   $offset: 'offset',
   $end: 'end',
   $expanded: 'expanded',
-  $block-grid: 'block-grid'
+  $block: 'block'
 ) {
   // Row
   .#{$row} {
@@ -156,8 +156,8 @@
   }
 
   // Block grid columns
-  .#{$block-grid}-#{$column} {
-    @include block-grid-column;
+  .#{$column}-#{$block} {
+    @include grid-column-margin;
   }
 
   @if $column == 'column' {

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -21,7 +21,8 @@
   $uncollapse: 'uncollapse',
   $offset: 'offset',
   $end: 'end',
-  $expanded: 'expanded'
+  $expanded: 'expanded',
+  $block-grid: 'block-grid'
 ) {
   // Row
   .#{$row} {
@@ -152,6 +153,11 @@
     .#{$-zf-size}-#{$pull}-0 {
       @include grid-col-unpos;
     }
+  }
+
+  // Block grid columns
+  .#{$block-grid}-#{$column} {
+    @include block-grid-column;
   }
 
   @if $column == 'column' {

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -95,9 +95,9 @@
 /// @param {Number|Keyword} $margin [auto]
 ///   The bottom margin on block grid columns, accepts multiple values:
 ///   - A single value will make the margin that exact size.
-///   - A breakpoint name will make the margin the corresponding size in the $gutters map.
-///   - "auto" will make the margin responsive, using the $gutters map values.
-/// @param {Number|Map} $margins [$grid-column-gutter] - Gutter map or single value to use. Responsive gutter settings by default.
+///   - A breakpoint name will make the margin the corresponding size in the $margins map.
+///   - "auto" will make the margin responsive, using the $margins map values.
+/// @param {Number|Map} $margins [$grid-column-gutter] - Map or single value to use. Responsive gutter settings by default.
 @mixin block-grid-column (
   $margin: auto,
   $margins: $grid-column-gutter

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -91,14 +91,14 @@
   @include grid-column-uncollapse($gutter);
 }
 
-/// Sets bottom marin on block grid columns to match gutters
+/// Sets bottom marin on grid columns to match gutters
 /// @param {Number|Keyword} $margin [auto]
-///   The bottom margin on block grid columns, accepts multiple values:
+///   The bottom margin on grid columns, accepts multiple values:
 ///   - A single value will make the margin that exact size.
 ///   - A breakpoint name will make the margin the corresponding size in the $margins map.
 ///   - "auto" will make the margin responsive, using the $margins map values.
 /// @param {Number|Map} $margins [$grid-column-gutter] - Map or single value to use. Responsive gutter settings by default.
-@mixin block-grid-column (
+@mixin grid-column-margin (
   $margin: auto,
   $margins: $grid-column-gutter
 ) {
@@ -106,7 +106,7 @@
     // "auto"
     @each $breakpoint, $value in $margins {
       @include breakpoint($breakpoint) {
-        @include block-grid-column($value);
+        @include grid-column-margin($value);
       }
     }
   } @else {

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -90,3 +90,37 @@
   @warn 'This mixin is being replaced by grid-col-gutter(). grid-col-uncollapse() will be removed in Foundation 6.4.';
   @include grid-column-uncollapse($gutter);
 }
+
+/// Sets bottom marin on block grid columns to match gutters
+/// @param {Number|Keyword} $margin [auto]
+///   The bottom margin on block grid columns, accepts multiple values:
+///   - A single value will make the margin that exact size.
+///   - A breakpoint name will make the margin the corresponding size in the $gutters map.
+///   - "auto" will make the margin responsive, using the $gutters map values.
+/// @param {Number|Map} $margins [$grid-column-gutter] - Gutter map or single value to use. Responsive gutter settings by default.
+@mixin block-grid-column (
+  $margin: auto,
+  $margins: $grid-column-gutter
+) {
+  @if $margin == auto and type-of($margins) == 'map' {
+    // "auto"
+    @each $breakpoint, $value in $margins {
+      @include breakpoint($breakpoint) {
+        @include block-grid-column($value);
+      }
+    }
+  } @else {
+    // breakpoint name
+    @if type-of($margin) == 'string' {
+      $margin: grid-column-gutter($margin, $margins);
+    }
+
+    // single value
+    $margin-bottom: rem-calc($margin);
+
+    margin-bottom: $margin-bottom;
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -117,8 +117,8 @@
 
     // single value
     $margin-bottom: rem-calc($margin);
-
     margin-bottom: $margin-bottom;
+    
     > :last-child {
       margin-bottom: 0;
     }


### PR DESCRIPTION
Closes #8668. 

Adds a `.block-grid-column` class to allow block grid's columns to use responsive gutter sizes for their `margin-bottom`. Now the space between rows can easily match the space between columns.