### PR TITLE
[Sticky] Ensure that unstuck classes are set on load

### DIFF
--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -58,7 +58,12 @@ class Sticky {
       }
 
       _this._setSizes(function(){
-        _this._calc(false);
+        var scroll = window.pageYOffset;
+        _this._calc(false, scroll);
+        //Unstick the element will ensure that proper classes are set.
+        if (!_this.isStuck) {
+          _this._removeSticky((scroll >= _this.topPoint) ? false : true);
+        }
       });
       _this._events(id.split('-').reverse().join('-'));
     });


### PR DESCRIPTION
This ensures that the proper classes are set on an unstuck element on load.

Currently, the unstuck classes will not be applied to the element until it became stuck - if I understand things correctly. As the `isStuck` variable is initialized with `false`, the first call to `_calc` - and the next ones - will never call `_removeSticky`. This function set the proper CSS properties and classes for an unstuck element.

An example of the consequence of this behavior can be seen on the [Sticky demo webpage](http://foundation.zurb.com/sites/docs/sticky.html). If you load the page and go directly to the bottom of the page - i.e. by adding the `#javascript-reference` anchor, the images will be at the top - instead of the bottom - of its containers when you will scroll up and reach one of the them.

However, I realize that it will fire Sticky#unstuckfrom on load. Is it a problem? Do you see a better *fix* for this behavior? Thanks in advance!