### PR TITLE
Remove useless gulp sass-lint vendor path

### DIFF
--- a/gulp/lint.js
+++ b/gulp/lint.js
@@ -5,7 +5,6 @@ var eslint = require('gulp-eslint');
 
 var PATHS = [
   'scss/**/*.scss',
-  '!scss/vendor/**/*.scss',
   '!scss/components_old/**/*.scss'
 ];
 

--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -17,8 +17,7 @@ var PATHS = [
 ];
 
 var LINT_PATHS = [
-  'scss/**/*.scss',
-  '!scss/vendor/**/*.scss'
+  'scss/**/*.scss'
 ];
 
 var COMPATIBILITY = [


### PR DESCRIPTION
Remove useless gulp sass-lint vendor path rule in `gulp/sass.js`. `scss/vendor/**/*.scss` does not exists.

*Hourra ! This is not a breaking PR  :tada:* 