### PR TITLE
Refactor slider and provide handle position fallback for hidden sliders

### DIFF
--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -130,3 +130,12 @@ It's possible to use both the JavaScript slider and the native slider in the sam
 - To disable the slider, add `disabled` as an attribute, instead of a class.
 - No support for vertical orientation.
 - No support for two handles.
+
+## Reflow
+
+The slider takes into account the width of the handles when calculating how to display itself. This means that if the slider is initially hidden, or hidden while the value is adjusted, the resulting visual will be slightly different because the width of the handle is indeterminate.  If this is problematic, you can use JavaScript to cause the slider to reflow at the time that you change it from being hidden.  Example:
+
+```js
+$('#my-slider').show();
+$('#my-slider').foundation('_reflow');
+```

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -574,27 +574,3 @@ Foundation.plugin(Slider, 'Slider');
 
 }(jQuery);
 
-//*********this is in case we go to static, absolute positions instead of dynamic positioning********
-// this.setSteps(function() {
-//   _this._events();
-//   var initStart = _this.options.positions[_this.options.initialStart - 1] || null;
-//   var initEnd = _this.options.initialEnd ? _this.options.position[_this.options.initialEnd - 1] : null;
-//   if (initStart || initEnd) {
-//     _this._handleEvent(initStart, initEnd);
-//   }
-// });
-
-//***********the other part of absolute positions*************
-// Slider.prototype.setSteps = function(cb) {
-//   var posChange = this.$element.outerWidth() / this.options.steps;
-//   var counter = 0
-//   while(counter < this.options.steps) {
-//     if (counter) {
-//       this.options.positions.push(this.options.positions[counter - 1] + posChange);
-//     } else {
-//       this.options.positions.push(posChange);
-//     }
-//     counter++;
-//   }
-//   cb();
-// };

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -58,9 +58,6 @@ class Slider {
     this.$input = this.inputs.length ? this.inputs.eq(0) : $(`#${this.$handle.attr('aria-controls')}`);
     this.$fill = this.$element.find('[data-slider-fill]').css(this.options.vertical ? 'height' : 'width', 0);
 
-    var id = this.$element.attr('id') || Foundation.GetYoDigits(6, 'slider');
-    this.$element.attr({id: id, 'data-slider': id, 'data-mutate': id});
-
     var isDbl = false,
         _this = this;
     if (this.options.disabled || this.$element.hasClass(this.options.disabledClass)) {
@@ -370,7 +367,6 @@ class Slider {
     if(this.handles[1]) {
       this._eventsForHandle(this.$handle2);
     }
-    this.$element.on('mutateme.zf.trigger', this._reflow.bind(this));
   }
 
 
@@ -476,7 +472,6 @@ class Slider {
     this.handles.off('.zf.slider');
     this.inputs.off('.zf.slider');
     this.$element.off('.zf.slider');
-    this.$element.off('mutateme.zf.trigger');
 
     clearTimeout(this.timeout);
 

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -202,8 +202,15 @@ class Slider {
     var moveTime = this.$element.data('dragging') ? 1000/60 : this.options.moveTime;
 
     Foundation.Move(moveTime, $hndl, function() {
-      //adjusting the left/top property of the handle, based on the percentage calculated above
-      $hndl.css(lOrT, `${movement}%`);
+      // adjusting the left/top property of the handle, based on the percentage calculated above
+      // if movement isNaN, that is because the slider is hidden and we cannot determine handle width,
+      // fall back to next best guess.
+      if (isNaN(movement)) {
+        $hndl.css(lOrT, `${pctOfBar * 100}%`);
+      }
+      else {
+        $hndl.css(lOrT, `${movement}%`);
+      }
 
       if (!_this.options.doubleSided) {
         //if single-handled, a simple method to expand the fill bar

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -104,6 +104,9 @@ class Slider {
     }
   }
 
+  _reflow() {
+    this.setHandles();
+  }
   /**
    * Sets the position of the selected handle and fill bar.
    * @function
@@ -367,7 +370,7 @@ class Slider {
     if(this.handles[1]) {
       this._eventsForHandle(this.$handle2);
     }
-    this.$element.on('mutateme.zf.trigger', this.setHandles.bind(this));
+    this.$element.on('mutateme.zf.trigger', this._reflow.bind(this));
   }
 
 


### PR DESCRIPTION
Refactors slider to make it easier to do a reinit, and then adds a mutation observer to do it. Provides a way to workaround https://github.com/zurb/foundation-sites/issues/8391.  @coreysyms as the mutation observer expert, can you take a look?