### PR TITLE
Fix dropdown destroy method

### DIFF
--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -63,7 +63,7 @@ const Nest = {
         hasSubClass = `is-${type}-submenu-parent`;
 
     menu
-      .find('>li, .menu, .menu > li')
+      .find('>li, > li > ul, .menu, .menu > li')
       .removeClass(`${subMenuClass} ${subItemClass} ${hasSubClass} is-submenu-item submenu is-active`)
       .removeAttr('data-submenu').css('display', '');
 


### PR DESCRIPTION
This fixes issue #9339. When destroying a dropdown menu, the dropdown classes wouldn’t be removed if using a different class structure (e.g.:, using custom class names instead of `.menu`). Previous versions selected all child elements of the menu, but on the latest version only direct `li` child elements  or  elements with `.menu` class are targeted.

This commit ensures `ul` elements also get the classes removed, for those cases where custom classes are used. Not sure if this is the best way, but seems to cover most cases.