### PR TITLE
Check outdated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # [Foundation for Sites](http://foundation.zurb.com)
 
-[![npm version](https://badge.fury.io/js/foundation-sites.svg)](https://badge.fury.io/js/foundation-sites) [![Bower version](https://badge.fury.io/bo/foundation-sites.svg)](https://badge.fury.io/bo/foundation-sites) [![Gem Version](https://badge.fury.io/rb/foundation-rails.svg)](https://badge.fury.io/rb/foundation-rails) [![devDependency Status](https://david-dm.org/zurb/foundation-sites/dev-status.svg)](https://david-dm.org/zurb/foundation-sites#info=devDependencies) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/zurb/foundation-sites?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![npm version](https://badge.fury.io/js/foundation-sites.svg)](https://badge.fury.io/js/foundation-sites)
+[![Bower version](https://badge.fury.io/bo/foundation-sites.svg)](https://badge.fury.io/bo/foundation-sites)
+[![Gem Version](https://badge.fury.io/rb/foundation-rails.svg)](https://badge.fury.io/rb/foundation-rails)
+[![dependencies Status](https://david-dm.org/zurb/foundation-sites/status.svg)](https://david-dm.org/zurb/foundation-sites)
+[![devDependencies Status](https://david-dm.org/zurb/foundation-sites/dev-status.svg)](https://david-dm.org/zurb/foundation-sites?type=dev)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/zurb/foundation-sites?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Foundation is the most advanced responsive front-end framework in the world. Quickly go from prototype to production, building sites or apps that work on any kind of device with Foundation. Includes a fully customizable, responsive grid, a large library of Sass mixins, commonly used JavaScript plugins, and full accessibility support.
 

--- a/gulp/tasks/check.js
+++ b/gulp/tasks/check.js
@@ -1,10 +1,18 @@
 'use strict';
 
 var gulp = require('gulp');
+var checkDeps = require('gulp-check-deps');
 var postcss = require('gulp-postcss');
 var doiuse = require('doiuse');
 
 var CONFIG = require('../config.js');
+
+gulp.task('check', ['check:deps', 'check:browserSupport']);
+
+// Check npm dependencies
+gulp.task('check:deps', function() {
+    return gulp.src('package.json').pipe(checkDeps());
+});
 
 // Check browser support
 gulp.task('check:browserSupport', function() {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gulp-autoprefixer": "^2.3.1",
     "gulp-babel": "^6.1.1",
     "gulp-cache-bust": "1.0.2",
+    "gulp-check-deps": "^1.4.1",
     "gulp-concat": "^2.4.3",
     "gulp-cssnano": "^2.1.0",
     "gulp-eslint": "^2.0.0",


### PR DESCRIPTION
- Add [gulp-check-deps](https://www.npmjs.com/package/gulp-check-deps) in gulp to check outdated dependencies
- Add [david-dm](https://david-dm.org/zurb/foundation-sites) badge in README.md to check outdated dependencies

Preview of david-dm badge: [![dependencies Status](https://david-dm.org/zurb/foundation-sites/status.svg)](https://david-dm.org/zurb/foundation-sites)

---

- [x] :warning:  Require #9382 