### PR TITLE
Add the Travis-ci badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [Foundation for Sites](http://foundation.zurb.com)
 
+[![Build Status](https://travis-ci.org/zurb/foundation-sites.svg?branch=develop)](https://travis-ci.org/zurb/foundation-sites)
 [![npm version](https://badge.fury.io/js/foundation-sites.svg)](https://badge.fury.io/js/foundation-sites)
 [![Bower version](https://badge.fury.io/bo/foundation-sites.svg)](https://badge.fury.io/bo/foundation-sites)
 [![Gem Version](https://badge.fury.io/rb/foundation-rails.svg)](https://badge.fury.io/rb/foundation-rails)


### PR DESCRIPTION
Add the Travis-ci badge for `zurb/foundation-sites:develop` in README.md

Preview of the badge: [![Build Status](https://travis-ci.org/zurb/foundation-sites.svg?branch=develop)](https://travis-ci.org/zurb/foundation-sites)