### PR TITLE
Test of new corrective flexbox class

### DIFF
--- a/test/visual/flex-grid/column-row-beam.html
+++ b/test/visual/flex-grid/column-row-beam.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+ <head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Foundation for Sites Testing</title>
+  <link href="../assets/css/foundation-flex.css" rel="stylesheet" />
+ </head>
+ <body id="body" data-toggler=".beam">
+  <style>
+    .beam {
+     max-width: 75em;
+     margin-left: auto;
+     margin-right: auto;
+     display: flex;
+     flex-direction: column;
+     flex-wrap: nowrap;
+    }
+
+  </style>
+  <header>
+   <p><a style="color:black" data-toggle="body">Beam me up!</a></p>
+   <style>
+
+     header {
+      border:1px solid #333;
+      background:#AfffCF;
+      min-height: 40px;
+
+      order: 0;
+      flex: 1 1 auto;
+      align-self: auto;
+      padding: 2px;
+     }
+   </style>
+  </header>
+  <main>
+   <style>
+     main {
+      border:1px solid #333;
+      background:#AAAAAA;
+      min-height: 20px;
+
+      order: 0;
+      flex: 4 1 auto;
+      align-self: auto;
+      padding: 2px;
+
+     }
+
+   </style>
+   <div class="row column">
+    <style>.row.column {border: 1px solid #333;}</style>
+    <h1>Flex Grid: Column Row Beam</h1>
+    <p>
+     The introduction of a class meant to further integrate flexbox attributes into the Foundation CSS core.
+    </p>
+    <p>
+     By designating 'body' as a column flexing flex container, this allows for flex children to fill the viewports entire vertical space even when content is sparse.
+    </p>
+    <p>
+     The added benefit is that containers do not "jump" when images load as container heights are predetermined according to flexbox rules.
+    </p>
+    <p>
+     Click the link in the header to see the difference.
+    </p>
+
+   </div>
+   <h3>Witness me!</h3>
+   <div class="row">
+    <div class="small-3 columns">
+     <img class="thumbnail" src="http://placekitten.com/1200/800" />
+    </div>
+    <div class="small-3 columns">
+     <img class="thumbnail" src="http://placekitten.com/1200/800" />
+
+    </div>
+    <div class="small-3 columns">
+     <img class="thumbnail" src="http://placekitten.com/1200/800" />
+
+    </div>
+    <div class="small-3 columns">
+     <img class="thumbnail" src="http://placekitten.com/1200/800" />
+
+    </div>
+
+
+   </div>
+
+   <script src="../assets/js/vendor.js"></script>
+   <script src="../assets/js/foundation.js"></script>
+   <script>
+     $(document).foundation();
+   </script>
+  </main>
+  <footer>
+   I am a footer section.
+   <style>
+     footer {
+      border:1px solid #333;
+      background:#FDFD96;
+      min-height: 20px;
+
+      order: 0;
+      flex: 1 1 auto;
+      align-self: auto;
+      padding: 2px;
+     }
+   </style>
+  </footer>
+ </body>
+</html>


### PR DESCRIPTION
So, I've mentioned elsewhere that there is a deficiency in the flexbox version of Foundation. This fix could come as a new class or could simply baked in (the latter is probably the way to go).

A so called "beam" class is meant to ensure that a flexbox based layout fills the viewport even when content is sparse.

Why?
• Makes it easy for sticky footer to stay at bottom no matter how sparse a page's content is.
• Heights of flexbox children are not affected by image load delay, which creates the nasty side effect of sudden height increases.

Why not set the height to 100%?
````html
<body>
<header></header>
<main></main>
<footer></footer>
</body>
````

Let's say that you have just a bit of content in the main element. Let's also say that you'd like your footer to stay at the bottom. The temptation is to set the height of main to 100%; however, this causes your layout to take up more than 100% of the viewport.

So, why not use auto height for main? Not only will the footer not be at the bottom of the viewport, elements will "snap" in place as images load in.


In order to demonstrate this, I am including a new test file at (http://localhost:3000/flex-grid/column-row-beam.html).


EDIT: grammar, clarifcation