### PR TITLE
Should't the foundation.css build process depend on settings?

### DIFF
--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -9,7 +9,7 @@
 @import "normalize";
 
 // Settings
-// include your own `settings` here or 
+// import your own `settings` here or 
 // import and modify the default settings through
 // @import "settings/settings";
 

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -8,6 +8,9 @@
 // Dependencies
 @import "normalize";
 
+// Settings
+@import "settings/settings";
+
 // Sass utilities
 @import 'util/util';
 

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -9,7 +9,9 @@
 @import "normalize";
 
 // Settings
-@import "settings/settings";
+// include your own `settings` here or 
+// import and modify the default settings through
+// @import "settings/settings";
 
 // Sass utilities
 @import 'util/util';

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -40,7 +40,7 @@
 //  35. Tooltip
 //  36. Top Bar
 
-@import 'util/util';
+@import '../util/util';
 
 // 1. Global
 // ---------


### PR DESCRIPTION
`foundation.scss` pulls in all files from under `/scss/`, but ignores the `settings/settings.scss`. As a result `foundation.scss` uses the `!default` values instead of the values from the `settings.scss`. I discovered this behaviour when I was testing something and a change in the settings did not change the resulting `foundation.css`. 

