### PR TITLE
Remove important from max-width on tooltip mixin

### DIFF
--- a/scss/components/_tooltip.scss
+++ b/scss/components/_tooltip.scss
@@ -56,7 +56,7 @@ $tooltip-radius: $global-radius !default;
   top: calc(100% + #{$tooltip-pip-height});
   z-index: 1200;
 
-  max-width: 10rem !important;
+  max-width: 10rem;
   padding: $tooltip-padding;
 
   border-radius: $tooltip-radius;


### PR DESCRIPTION
I was thinking about open an Issue, but I choose to use a Pull Request instead. 

I was using  tooltip element on my job and found this line of code, I can not find why on commit history. I guess the use of important will make the people who want customize the tooltip width very hard.  

