### PR TITLE
Only remove #modalId from the url on close

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -453,7 +453,7 @@ class Reveal {
     this.isActive = false;
      if (_this.options.deepLink) {
        if (window.history.replaceState) {
-         window.history.replaceState("", document.title, window.location.pathname);
+         window.history.replaceState('', document.title, window.location.href.replace(`#${this.id}`, ''));
        } else {
          window.location.hash = '';
        }


### PR DESCRIPTION
Fixes #8908 - Made URL retain query string on close of deep-linked modal