### PR TITLE
Tabs: account updateHistory only if deepLink:true.

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -156,13 +156,13 @@ Add the attribute `data-deep-link="true" to a tabstrip to allow anchoring to and
 
 ```html_example
 <ul class="tabs" data-deep-link="true" data-tabs id="deeplinked-tabs">
-  <li class="tabs-title is-active"><a href="#panel1c" aria-selected="true">Tab 1</a></li>
+  <li class="tabs-title is-active"><a href="#panel1d" aria-selected="true">Tab 1</a></li>
   <li class="tabs-title"><a href="#panel2d">Tab 2</a></li>
   <li class="tabs-title"><a href="#panel3d">Tab 3</a></li>
   <li class="tabs-title"><a href="#panel4d">Tab 4</a></li>
 </ul>
 
-<div class="tabs-content" data-tabs-content="collapsing-tabs">
+<div class="tabs-content" data-tabs-content="deeplinked-tabs">
   <div class="tabs-panel is-active" id="panel1d">
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
   </div>

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -246,7 +246,7 @@ class Tabs {
         history.replaceState({}, '', anchor);
       }
     } else {
-      location.hash = '';
+      history.replaceState({}, '', window.location.pathname);
     }
 
     /**

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -237,11 +237,16 @@ class Tabs {
     this._openTab($target);
 
     //either replace or update browser history
-    var anchor = $target.find('a').attr('href');
-    if (this.options.updateHistory) {
-      history.pushState({}, "", anchor);
+    if (this.options.deepLink) {
+      var anchor = $target.find('a').attr('href');
+
+      if (this.options.updateHistory) {
+        history.pushState({}, '', anchor);
+      } else {
+        history.replaceState({}, '', anchor);
+      }
     } else {
-      history.replaceState({}, "", anchor);
+      location.hash = '';
     }
 
     /**


### PR DESCRIPTION
The advent of deep links feature to F6 Tabs was a real boon to the component.
I couldn't refrain from manually updating my local copy of `foundation.tabs.js` just to face a new issue; regardless whether the deepLink option is set **true/false**, tab hashes are always being appended to the URL.

I honestly don't think that was the intended outcome from the work of @ahebrank . I think it makes sense to restrict accounting for `updateHistory` if and only if `deepLink:true`, otherwise never bother and continue to function like it used to.

P.S. I've also fixed docs depicting tabs with deepLink attribute. Wasn't aware that it should go to the master branch.