### PR TITLE
@Import util's with relative path

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -40,7 +40,7 @@
 //  35. Tooltip
 //  36. Top Bar
 
-@import 'util/util';
+@import '../util/util';
 
 // 1. Global
 // ---------


### PR DESCRIPTION
Import util's with a relative path so foundation-sites scss can be used without depending on sass include_paths.

This is needed to use foundation-sites with angular-cli at the moment because include_paths can't be set using angular-cli's webpack setup