### PR TITLE
rename tab-background-active-color to tab-active-color

### DIFF
--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -24,7 +24,7 @@ $tab-background-active: $light-gray !default;
 
 /// Active font color of tab item.
 /// @type Color
-$tab-background-active-color: $primary-color !default;
+$tab-active-color: $primary-color !default;
 
 /// Font size of tab items.
 /// @type Number
@@ -84,7 +84,7 @@ $tab-content-padding: 1rem !default;
   $padding: $tab-item-padding,
   $font-size: $tab-item-font-size,
   $color: $tab-color,
-  $color-active: $tab-background-active-color,
+  $color-active: $tab-active-color,
   $background-hover: $tab-item-background-hover,
   $background-active: $tab-background-active
 ) {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -538,7 +538,7 @@ $tab-margin: 0;
 $tab-background: $white;
 $tab-color: $primary-color;
 $tab-background-active: $light-gray;
-$tab-background-active-color: $primary-color;
+$tab-active-color: $primary-color;
 $tab-item-font-size: rem-calc(12);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;


### PR DESCRIPTION
This variable was incorrectly named in #9319. 