### PR TITLE
Remove the margin on Figure elements 

### DIFF
--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -427,6 +427,11 @@ $abbr-underline: 1px dotted $black !default;
     cursor: help;
   }
 
+  // Figures
+  figure {
+    margin: 0;
+  }
+  
   // Code
   code {
     padding: $code-padding;


### PR DESCRIPTION
Fix for issue #9287,  adds `margin: 0` to `figure` elements.