### PR TITLE
add normalize dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "jquery": "~2.2.0",
+    "normalize.scss": "^6.0.0",
     "what-input": "~2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "jquery": "^2.2.0",
+    "normalize-scss": "^6.0.0",
     "what-input": "^2.0.0"
   },
   "license": "MIT",
@@ -73,7 +74,6 @@
     "mocha-phantomjs": "^4.0.2",
     "motion-ui": "^1.1.0",
     "multiline": "^1.0.2",
-    "normalize-scss": "^6.0.0",
     "octophant": "^1.0.0",
     "opener": "^1.4.1",
     "panini": "^1.3.0",


### PR DESCRIPTION
Since we expect normalize in order to make Foundation function (at least in SCSS builds) now, it needs to be a true dependency, not just a dev dependency

Half the fix to #9412