### PR TITLE
Flexbox Helper Document Fix

### DIFF
--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -177,7 +177,7 @@ For parent-level alignment, use `flex-align()`. You can pass in a horizontal ali
 }
 ```
 
-For child-level alignment, use `flex-align-self()`. You can pass in any horizontal alignment.
+For child-level alignment, use `flex-align-self()`. You can pass in any vertical alignment.
 
 ```scss
 .sidebar {


### PR DESCRIPTION
The docs read to pass in any horizontal value with an example "bottom", but the function is requiring a vertical alignment (so 'bottom' would work but 'left, center, right' would not.)

Referencing https://github.com/zurb/foundation-sites/blob/develop/scss/util/_flex.scss#L55