### PR TITLE
Factorize breakpoints map handling

### DIFF
--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -60,7 +60,7 @@
   @include grid-column-uncollapse($gutter);
 }
 
-/// Sets bottom marin on grid columns to match gutters
+/// Sets bottom margin on grid columns to match gutters
 /// @param {Number|Keyword} $margin [auto]
 ///   The bottom margin on grid columns, accepts multiple values:
 ///   - A single value will make the margin that exact size.

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -6,24 +6,6 @@
 /// @group grid
 ////
 
-/// Get a gutter size for a given breakpoint
-/// @param {Keyword} $breakpoint [small] - Breakpoint name.
-/// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use. Responsive gutter settings by default.
-///
-/// @returns {Number} Gutter size.
-@function grid-column-gutter(
-  $breakpoint: $-zf-zero-breakpoint,
-  $gutters: $grid-column-gutter
-) {
-  // If gutter is single value, return it
-  @if type-of($gutters) == 'number' {
-    @return $gutters;
-  }
-
-  // Else, return the corresponding responsive value
-  @return -zf-get-bp-val($gutters, $breakpoint);
-}
-
 /// Set the gutters on a column
 /// @param {Number|Keyword} $gutter [auto]
 ///   Spacing between columns, accepts multiple values:
@@ -35,22 +17,8 @@
   $gutter: auto,
   $gutters: $grid-column-gutter
 ) {
-  @if $gutter == auto and type-of($gutters) == 'map' {
-    // "auto"
-    @each $breakpoint, $value in $gutters {
-      @include breakpoint($breakpoint) {
-        @include grid-column-gutter($value);
-      }
-    }
-  }
-  @else {
-    // breakpoint name
-    @if type-of($gutter) == 'string' {
-      $gutter: grid-column-gutter($gutter, $gutters);
-    }
-
-    // single value
-    $padding: rem-calc($gutter) / 2;
+  @include -zf-breakpoint-value($gutter, $gutters) {
+    $padding: rem-calc($-zf-bp-value) / 2;
 
     padding-right: $padding;
     padding-left: $padding;
@@ -103,23 +71,10 @@
   $margin: auto,
   $margins: $grid-column-gutter
 ) {
-  @if $margin == auto and type-of($margins) == 'map' {
-    // "auto"
-    @each $breakpoint, $value in $margins {
-      @include breakpoint($breakpoint) {
-        @include grid-column-margin($value);
-      }
-    }
-  } @else {
-    // breakpoint name
-    @if type-of($margin) == 'string' {
-      $margin: grid-column-gutter($margin, $margins);
-    }
-
-    // single value
-    $margin-bottom: rem-calc($margin);
+  @include -zf-breakpoint-value($margin, $margins) {
+    $margin-bottom: rem-calc($-zf-bp-value);
     margin-bottom: $margin-bottom;
-    
+
     > :last-child {
       margin-bottom: 0;
     }

--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -80,7 +80,7 @@
 /// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use when inverting margins. Responsive gutter settings by default.
 @mixin grid-row-nest($gutters: $grid-column-gutter) {
   @include -zf-each-breakpoint {
-    $margin: rem-calc(grid-column-gutter($-zf-size, $gutters)) / 2 * -1;
+    $margin: rem-calc(-zf-breakpoint-value($-zf-size, $gutters)) / 2 * -1;
 
     margin-right: $margin;
     margin-left: $margin;

--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -80,7 +80,7 @@
 /// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use when inverting margins. Responsive gutter settings by default.
 @mixin grid-row-nest($gutters: $grid-column-gutter) {
   @include -zf-each-breakpoint {
-    $margin: rem-calc(-zf-breakpoint-value($-zf-size, $gutters)) / 2 * -1;
+    $margin: rem-calc(-zf-get-bp-val($gutters, $-zf-size)) / 2 * -1;
 
     margin-right: $margin;
     margin-left: $margin;

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -211,14 +211,22 @@ $breakpoint-classes: (small medium large) !default;
 
 }
 
-/// Get a value for a breakpoint from a responsive config map. If the config map has the key `$value`, the exact breakpoint value is returned. If the config map does *not* have the breakpoint, the value matching the next lowest breakpoint in the config map is returned.
+/// Get a value for a breakpoint from a responsive config map or single value.
+/// - If the config is a single value, return it regardless of `$value`.
+/// - If the config is a map and has the key `$value`, the exact breakpoint value is returned.
+/// - If the config is a map and does *not* have the breakpoint, the value matching the next lowest breakpoint in the config map is returned.
 /// @access private
 ///
-/// @param {Map} $map - Input config map.
+/// @param {Number|Map} $map - Responsive config map or single value.
 /// @param {Keyword} $value - Breakpoint name to use.
 ///
 /// @return {Mixed} The corresponding breakpoint value.
 @function -zf-get-bp-val($map, $value) {
+  // If the given map is a single value, return it
+  @if type-of($map) == 'number' {
+    @return $map;
+  }
+
   // Check if the breakpoint name exists globally
   @if not map-has-key($breakpoints, $value) {
     @return null;
@@ -246,24 +254,6 @@ $breakpoint-classes: (small medium large) !default;
 
     @return map-get($map, $anchor);
   }
-}
-
-/// Get a value in a map for a given breakpoint name
-/// @param {Keyword} $bp-name [small] - Breakpoint name.
-/// @param {Number|Map} $bp-values-map - Map of breakpoints and values or single value to use.
-///
-/// @returns {Number} Breakpoint-related value from `$bp-values-map`.
-@function -zf-breakpoint-value(
-  $bp-name: $-zf-zero-breakpoint,
-  $bp-values-map: null
-) {
-  // If the map is a single value, return it
-  @if type-of($bp-values-map) == 'number' {
-    @return $bp-values-map;
-  }
-
-  // Else, return the corresponding breakpoint value
-  @return -zf-get-bp-val($bp-values-map, $bp-name);
 }
 
 // Legacy breakpoint variables

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -248,6 +248,24 @@ $breakpoint-classes: (small medium large) !default;
   }
 }
 
+/// Get a value in a map for a given breakpoint name
+/// @param {Keyword} $bp-name [small] - Breakpoint name.
+/// @param {Number|Map} $bp-values-map - Map of breakpoints and values or single value to use.
+///
+/// @returns {Number} Breakpoint-related value from `$bp-values-map`.
+@function -zf-breakpoint-value(
+  $bp-name: $-zf-zero-breakpoint,
+  $bp-values-map: null
+) {
+  // If the map is a single value, return it
+  @if type-of($bp-values-map) == 'number' {
+    @return $bp-values-map;
+  }
+
+  // Else, return the corresponding breakpoint value
+  @return -zf-get-bp-val($bp-values-map, $bp-name);
+}
+
 // Legacy breakpoint variables
 // These will be removed in 6.3
 $small-up: null;

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -243,12 +243,11 @@
   }
 }
 
-/// Generate the content passed to the mixin with a value `$-zf-bp-value` related to a breakpoint, depending on the `$name` parameter.
-/// @param {Number|Keyword} $name [auto]
-///   The $name parameter accepts multiple values:
-///   - A single value will be directly passed as `$-zf-bp-value` to the mixin content.
-///   - A breakpoint name will make `$-zf-bp-value` the corresponding value in `$map`.
-///   - "auto" will generate the mixin content for each breakpoint in `$map` with the corresponding value as `$-zf-bp-value`.
+/// Generate the `@content` passed to the mixin with a value `$-zf-bp-value` related to a breakpoint, depending on the `$name` parameter:
+/// - For a single value, `$-zf-bp-value` is this value.
+/// - For a breakpoint name, `$-zf-bp-value` is the corresponding breakpoint value in `$map`.
+/// - For "auto", `$-zf-bp-value` is the corresponding breakpoint value in `$map` and is passed to `@content`, which is made responsive for each breakpoint of `$map`.
+/// @param {Number|Keyword} $name [auto] - Single value or breakpoint name to use. "auto" by default.
 /// @param {Number|Map} $map - Map of breakpoints and values or single value to use.
 @mixin -zf-breakpoint-value(
   $name: auto,

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -267,7 +267,7 @@
   @else {
     // breakpoint name
     @if type-of($name) == 'string' {
-      $name: -zf-breakpoint-value($name, $map);
+      $name: -zf-get-bp-val($map, $name);
     }
 
     // breakpoint value

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -242,3 +242,36 @@
     }
   }
 }
+
+/// Generate the content passed to the mixin with a value `$-zf-bp-value` related to a breakpoint, depending on the `$name` parameter.
+/// @param {Number|Keyword} $name [auto]
+///   The $name parameter accepts multiple values:
+///   - A single value will be directly passed as `$-zf-bp-value` to the mixin content.
+///   - A breakpoint name will make `$-zf-bp-value` the corresponding value in `$map`.
+///   - "auto" will generate the mixin content for each breakpoint in `$map` with the corresponding value as `$-zf-bp-value`.
+/// @param {Number|Map} $map - Map of breakpoints and values or single value to use.
+@mixin -zf-breakpoint-value(
+  $name: auto,
+  $map: null
+) {
+  @if $name == auto and type-of($map) == 'map' {
+    // "auto"
+    @each $k, $v in $map {
+      @include breakpoint($k) {
+        @include -zf-breakpoint-value($v, $map) {
+          @content;
+        }
+      }
+    }
+  }
+  @else {
+    // breakpoint name
+    @if type-of($name) == 'string' {
+      $name: -zf-breakpoint-value($name, $map);
+    }
+
+    // breakpoint value
+    $-zf-bp-value: $name !global;
+    @content;
+  }
+}


### PR DESCRIPTION
Fix #9425 - Factorize the handling of breakpoints map in `grid-column-gutter` and `grid-column-margin` mixins.

Changes:
- Add `@mixin -zf-breakpoint-value` which generate its content with the value `$-zf-bp-value` depending on its parameter, like `@mixin grid-column-gutter` and `@mixin grid-column-margin` did (see the `@mixin -zf-breakpoint-value` doc)
- Use `@mixin -zf-breakpoint-value` in `@mixin grid-column-gutter` and `@mixin grid-column-margin` and remove duplicated code.
- Allow `@function -zf-get-bp-val` to take a single value as responsive config `$map` and return it regardless of `$value`.
- Remove useless `@function grid-column-gutter`