### PR TITLE
Fix -zf-each-breakpoint without small

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .sass-cache
 _build
+_vendor
 bower_components
 config
 docs

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,6 @@
   ],
   "dependencies": {
     "jquery": "~2.2.0",
-    "normalize.scss": "^6.0.0",
     "what-input": "~4.0.3"
   }
 }

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -23,7 +23,8 @@ module.exports = {
 
   // Sass
   SASS_DEPS_FILES: [
-    'node_modules/@(normalize-scss)/sass/**/*.scss'
+    'node_modules/@(normalize-scss)/sass/**/*.scss',
+    'node_modules/@(sassy-lists)/stylesheets/**/*.scss'
   ],
 
   SASS_DOC_PATHS: [

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -22,8 +22,8 @@ module.exports = {
   ],
 
   // Sass
-  SASS_DEPS_PATHS: [
-    'node_modules/normalize-scss/sass'
+  SASS_DEPS_FILES: [
+    'node_modules/@(normalize-scss)/sass/**/*.scss'
   ],
 
   SASS_DOC_PATHS: [

--- a/gulp/tasks/customizer.js
+++ b/gulp/tasks/customizer.js
@@ -46,8 +46,16 @@ gulp.task('customizer:loadConfig', function(done) {
   });
 });
 
+// Prepare dependencies
+gulp.task('customizer:prepareSassDeps', function() {
+  return gulp.src([
+      'node_modules/@(normalize-scss)/sass/**/*.scss'
+    ])
+    .pipe(gulp.dest('_vendor/scss'));
+});
+
 // Creates a Sass file from the module/variable list and creates foundation.css and foundation.min.css
-gulp.task('customizer:sass', ['customizer:loadConfig'], function() {
+gulp.task('customizer:sass', ['customizer:loadConfig', 'customizer:prepareSassDeps'], function() {
   var sassFile = customizer.sass(CUSTOMIZER_CONFIG, MODULE_LIST, VARIABLE_LIST);
 
   // Create a stream with our makeshift Sass file

--- a/gulp/tasks/customizer.js
+++ b/gulp/tasks/customizer.js
@@ -49,7 +49,8 @@ gulp.task('customizer:loadConfig', function(done) {
 // Prepare dependencies
 gulp.task('customizer:prepareSassDeps', function() {
   return gulp.src([
-      'node_modules/@(normalize-scss)/sass/**/*.scss'
+      'node_modules/@(normalize-scss)/sass/**/*.scss',
+      'node_modules/@(sassy-lists)/stylesheets/**/*'
     ])
     .pipe(gulp.dest('_vendor/scss'));
 });

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -15,14 +15,18 @@ var CONFIG = require('../config.js');
 // Compiles Sass files into CSS
 gulp.task('sass', ['sass:foundation', 'sass:docs']);
 
+// Prepare dependencies
+gulp.task('sass:deps', function() {
+  return gulp.src(CONFIG.SASS_DEPS_FILES)
+    .pipe(gulp.dest('_vendor/scss'));
+});
+
 // Compiles Foundation Sass
-gulp.task('sass:foundation', function() {
+gulp.task('sass:foundation', ['sass:deps'], function() {
   return gulp.src(['assets/*'])
     .pipe(sourcemaps.init())
     .pipe(plumber())
-    .pipe(sass({
-      includePaths: CONFIG.SASS_DEPS_PATHS
-    }).on('error', sass.logError))
+    .pipe(sass().on('error', sass.logError))
     .pipe(autoprefixer({
       browsers: CONFIG.CSS_COMPATIBILITY
     }))
@@ -38,11 +42,11 @@ gulp.task('sass:foundation', function() {
 });
 
 // Compiles docs Sass (includes Foundation code also)
-gulp.task('sass:docs', function() {
+gulp.task('sass:docs', ['sass:deps'], function() {
   return gulp.src('docs/assets/scss/docs.scss')
     .pipe(sourcemaps.init())
     .pipe(sass({
-      includePaths: CONFIG.SASS_DEPS_PATHS.concat(CONFIG.SASS_DOC_PATHS)
+      includePaths: CONFIG.SASS_DOC_PATHS
     }).on('error', sass.logError))
     .pipe(autoprefixer({
       browsers: CONFIG.CSS_COMPATIBILITY

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "jquery": "^2.2.0",
-    "normalize-scss": "^6.0.0",
     "what-input": "^4.0.3"
   },
   "license": "MIT",
@@ -74,6 +73,7 @@
     "mocha-phantomjs": "^4.0.2",
     "motion-ui": "^1.1.0",
     "multiline": "^1.0.2",
+    "normalize-scss": "^6.0.0",
     "octophant": "^1.0.0",
     "opener": "^1.4.1",
     "panini": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "rimraf": "^2.3.2",
     "run-sequence": "^1.1.4",
     "sass-true": "^2.0.3",
+    "sassy-lists": "^3.0.0",
     "sinon": "^1.17.3",
     "supercollider": "^1.4.0",
     "touch": "^1.0.0",

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -6,10 +6,10 @@
  */
 
 // Dependencies
-@import "normalize";
+@import "../_vendor/scss/normalize-scss/sass/normalize";
 
 // Settings
-// import your own `settings` here or 
+// import your own `settings` here or
 // import and modify the default settings through
 // @import "settings/settings";
 

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -7,6 +7,7 @@
 
 // Dependencies
 @import "../_vendor/scss/normalize-scss/sass/normalize";
+@import "../_vendor/scss/sassy-lists/stylesheets/SassyLists";
 
 // Settings
 // import your own `settings` here or

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -228,16 +228,16 @@
 ///
 /// @param {Boolean} $small [true] - If `false`, the mixin will skip the `small` breakpoint. Use this with components that don't prefix classes with `small-`, only `medium-` and up.
 @mixin -zf-each-breakpoint($small: true) {
-  $map: $breakpoint-classes;
+  $list: $breakpoint-classes;
 
   @if not $small {
-    $map: map-remove($map, $-zf-zero-breakpoint);
+    $list: sl-remove($list, $-zf-zero-breakpoint);
   }
 
-  @each $size in $map {
-    $-zf-size: $size !global;
+  @each $name in $list {
+    $-zf-size: $name !global;
 
-    @include breakpoint($size) {
+    @include breakpoint($name) {
       @content;
     }
   }


### PR DESCRIPTION
Fix #9440.

`$breakpoint-classes` is a list, not a map. Use `sl-remove()` from [SassyList](https://github.com/at-import/SassyLists) instead of `map-remove()` to remove the small breakpoint from `$breakpoint-classes`.

**Other changes:**
- Add `bower install` in Travis and README for consistency with the documentation. SassyList is only available on Bower.
- Rename `$map` to `$list`.
- Rename `$size` to `$name`. `$breakpoint-classes` contains breakpoint names, not sizes. Keep `$-zf-size` for compatibility.

---

⚠️  Require:
- [x] #9458 