### PR TITLE
Fix #9427 - Dropdown menu mouseout ignored

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -118,8 +118,8 @@ class DropdownMenu {
             hasSub = $elem.hasClass(parClass);
 
         if (hasSub) {
-          clearTimeout(_this.delay);
-          _this.delay = setTimeout(function() {
+          clearTimeout(this.delay);
+          this.delay = setTimeout(function() {
             _this._show($elem.children('.is-dropdown-submenu'));
           }, _this.options.hoverDelay);
         }
@@ -129,8 +129,8 @@ class DropdownMenu {
         if (hasSub && _this.options.autoclose) {
           if ($elem.attr('data-is-click') === 'true' && _this.options.clickOpen) { return false; }
 
-          clearTimeout(_this.delay);
-          _this.delay = setTimeout(function() {
+          clearTimeout(this.delay);
+          this.delay = setTimeout(function() {
             _this._hide($elem);
           }, _this.options.closingTime);
         }

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -118,21 +118,22 @@ class DropdownMenu {
             hasSub = $elem.hasClass(parClass);
 
         if (hasSub) {
-          clearTimeout(this.delay);
-          this.delay = setTimeout(function() {
+          clearTimeout($elem.data('_delay'));
+          $elem.data('_delay', setTimeout(function() {
             _this._show($elem.children('.is-dropdown-submenu'));
-          }, _this.options.hoverDelay);
+          }, _this.options.hoverDelay));
         }
       }).on('mouseleave.zf.dropdownmenu', function(e) {
         var $elem = $(this),
+            elemStore = Foundation.ElemStore(this).store,
             hasSub = $elem.hasClass(parClass);
         if (hasSub && _this.options.autoclose) {
           if ($elem.attr('data-is-click') === 'true' && _this.options.clickOpen) { return false; }
 
-          clearTimeout(this.delay);
-          this.delay = setTimeout(function() {
+          clearTimeout($elem.data('_delay'));
+          $elem.data('_delay', setTimeout(function() {
             _this._hide($elem);
-          }, _this.options.closingTime);
+          }, _this.options.closingTime));
         }
       });
     }

--- a/test/visual/dropdown-menu/dropdown-menu-cross-leave.html
+++ b/test/visual/dropdown-menu/dropdown-menu-cross-leave.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="row column">
+      <ul class="dropdown menu" data-dropdown-menu>
+        <li>
+          <a href="#">Item 1</a>
+          <ul class="menu vertical">
+            <li><a href="#">Content</a></li>
+          </ul>
+        </li>
+        <li>
+          <a href="#">Item 2</a>
+          <ul class="menu vertical">
+            <li><a href="#">Content</a></li>
+          </ul>
+        </li>
+        <li>
+          <a href="#">Item 3</a>
+          <ul class="menu vertical">
+            <li><a href="#">Content</a></li>
+          </ul>
+        </li>
+      </ul>
+      <div class="callout">
+        <p>Move the Mouse on Item 1 to open it, then quicly leave the window though the Item 2 (in a 45 degree angel). Panels should close.</p>
+
+        <p>
+          Checked bug: <a href="https://github.com/zurb/foundation-sites/issues/9427">https://github.com/zurb/foundation-sites/issues/9427</a><br/>
+          <img src="https://cloud.githubusercontent.com/assets/9939075/20866285/0a24819c-ba2a-11e6-93d8-1a69363f2c57.gif"/>
+        </p>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Fix https://github.com/zurb/foundation-sites/issues/9427

**What happens**:
The hide delay of the visible dropdown is replaced by the delays of the lastly triggered dropdown, so the hide function is never called on the currently visible dropdown.

**Solution**:
Remember and cancel the delay inside each element. So a visible dropdown remember its hide delay even if several dropdown must be hidden.

**Changes**:
- Use `this.delay` instead of `_this.delay`
- Add a visual test

⚠️  I don't know the Foundation JS enough. I checked the dropdown work (even with different show/close delays options), but I can't ensure this is a correct fix.