### PR TITLE
Fix #8880 - remove unused parameter in Reveal

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -81,10 +81,9 @@ class Reveal {
    * @private
    */
   _makeOverlay() {
-    var $overlay = $('<div></div>')
-                    .addClass('reveal-overlay')
-                    .appendTo(this.options.appendTo);
-    return $overlay;
+    return $('<div></div>')
+      .addClass('reveal-overlay')
+      .appendTo(this.options.appendTo);
   }
 
   /**

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -80,7 +80,7 @@ class Reveal {
    * Creates an overlay div to display behind the modal.
    * @private
    */
-  _makeOverlay(id) {
+  _makeOverlay() {
     var $overlay = $('<div></div>')
                     .addClass('reveal-overlay')
                     .appendTo(this.options.appendTo);


### PR DESCRIPTION
Fix https://github.com/zurb/foundation-sites/issues/8880

- Remove useless `id` parameter in `_makeOverlay`.
- Return the Reveal overlay directly, without defining a variable in `_makeOverlay()`

Based on @ocularrhythm's suggestions.