### PR TITLE
Update what-input to latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,6 @@
   "dependencies": {
     "jquery": "~2.2.0",
     "normalize.scss": "^6.0.0",
-    "what-input": "~2.0.0"
+    "what-input": "~4.0.3"
   }
 }

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -10,7 +10,7 @@ module.exports = {
   JS_DEPS: [
     'node_modules/jquery/dist/jquery.js',
     'node_modules/motion-ui/dist/motion-ui.js',
-    'node_modules/what-input/what-input.js'
+    'node_modules/what-input/dist/what-input.js'
   ],
 
   JS_DOCS: [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "jquery": "^2.2.0",
     "normalize-scss": "^6.0.0",
-    "what-input": "^2.0.0"
+    "what-input": "^4.0.3"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Update [what-input](https://www.npmjs.com/package/what-input) to the latest and stable version `v4.0.3`.

**Changes:**
- No breaking changes between `v2.0.0` and `v4.0.3` for the codebase.
- Update the dist file path.

**Outdated dependencies:** https://david-dm.org/zurb/foundation-sites

_Personal note: I didn't know this package before. Now I find it really useful !_