### PR TITLE
Fix #9412 - Import normalize-scss with its full path

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -22,6 +22,10 @@ module.exports = {
   ],
 
   // Sass
+  SASS_DEPS_PATHS: [
+    'node_modules'
+  ],
+
   SASS_DOC_PATHS: [
     'scss',
     'node_modules/motion-ui/src',

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -22,10 +22,6 @@ module.exports = {
   ],
 
   // Sass
-  SASS_DEPS_PATHS: [
-    'node_modules/normalize-scss/sass'
-  ],
-
   SASS_DOC_PATHS: [
     'scss',
     'node_modules/motion-ui/src',

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -20,7 +20,9 @@ gulp.task('sass:foundation', function() {
   return gulp.src(['assets/*'])
     .pipe(sourcemaps.init())
     .pipe(plumber())
-    .pipe(sass().on('error', sass.logError))
+    .pipe(sass({
+      includePaths: CONFIG.SASS_DEPS_PATHS
+    }).on('error', sass.logError))
     .pipe(autoprefixer({
       browsers: CONFIG.CSS_COMPATIBILITY
     }))
@@ -40,7 +42,7 @@ gulp.task('sass:docs', function() {
   return gulp.src('docs/assets/scss/docs.scss')
     .pipe(sourcemaps.init())
     .pipe(sass({
-      includePaths: CONFIG.SASS_DOC_PATHS
+      includePaths: CONFIG.SASS_DEPS_PATHS.concat(CONFIG.SASS_DOC_PATHS)
     }).on('error', sass.logError))
     .pipe(autoprefixer({
       browsers: CONFIG.CSS_COMPATIBILITY

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -20,9 +20,7 @@ gulp.task('sass:foundation', function() {
   return gulp.src(['assets/*'])
     .pipe(sourcemaps.init())
     .pipe(plumber())
-    .pipe(sass({
-      includePaths: CONFIG.SASS_DEPS_PATHS
-    }).on('error', sass.logError))
+    .pipe(sass().on('error', sass.logError))
     .pipe(autoprefixer({
       browsers: CONFIG.CSS_COMPATIBILITY
     }))
@@ -42,7 +40,7 @@ gulp.task('sass:docs', function() {
   return gulp.src('docs/assets/scss/docs.scss')
     .pipe(sourcemaps.init())
     .pipe(sass({
-      includePaths: CONFIG.SASS_DEPS_PATHS.concat(CONFIG.SASS_DOC_PATHS)
+      includePaths: CONFIG.SASS_DOC_PATHS
     }).on('error', sass.logError))
     .pipe(autoprefixer({
       browsers: CONFIG.CSS_COMPATIBILITY

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -6,7 +6,7 @@
  */
 
 // Dependencies
-@import "normalize";
+@import "../node_modules/normalize-scss/sass/normalize";
 
 // Settings
 // import your own `settings` here or 

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -6,7 +6,7 @@
  */
 
 // Dependencies
-@import "../node_modules/normalize-scss/sass/normalize";
+@import "normalize-scss/sass/normalize";
 
 // Settings
 // import your own `settings` here or 


### PR DESCRIPTION
Import normalize-scss with its full path instead of including the assets path in gulp-sass.

Fix https://github.com/zurb/foundation-sites/issues/9412