### PR TITLE
Disable Travis CI email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
 install:
   - npm install -g bower
   - npm install
+notifications:
+  email: false


### PR DESCRIPTION
We have Travis CI integrated to Github, we can easily know the build status of all branches and pull requests. I think Travis CI email notifications are not necessary and disturbing.

#### Changes:
- Disable Travis CI email notifications in `.travis.yml`