### PR TITLE
Fix bug in orbit and other sizing on old IE

### DIFF
--- a/js/foundation.util.timerAndImageLoader.js
+++ b/js/foundation.util.timerAndImageLoader.js
@@ -65,6 +65,9 @@ function onImagesLoaded(images, callback){
     }
     // Force load the image
     else {
+      // fix for IE. See https://css-tricks.com/snippets/jquery/fixing-load-in-ie-for-cached-images/
+      var src = $(this).attr('src');
+      $(this).attr('src', src + '?' + (new Date().getTime()));
       $(this).one('load', function() {
         singleImageLoaded();
       });


### PR DESCRIPTION
Fixes a bug where image loads aren't registering on older versions of IE.  This resulted in Orbit not showing up on IE9.
