### PR TITLE
Correct path to JS dist in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "foundation-sites",
   "version": "6.3.0-rc2",
-  "main": "dist/foundation.js",
-  "typings": "dist/foundation.d.ts",
+  "main": "dist/js/foundation.js",
+  "typings": "dist/js/foundation.d.ts",
   "description": "The most advanced responsive front-end framework in the world.",
   "author": "ZURB <foundation@zurb.com> (http://foundation.zurb.com)",
   "homepage": "http://foundation.zurb.com/sites",


### PR DESCRIPTION
Looks like the path in dist were changed in build process but not in package.json
