### PR TITLE
Extend visibility classes

### DIFF
--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -29,12 +29,12 @@
   @if $upper-bound-size == null {
     @if $orientation == null {
       @media screen and (max-width: $lower-bound) {
-	display: none !important;
+	      display: none !important;
       }
     }
     @else {
       @media screen and (max-width: $lower-bound) and (orientation: $orientation) {
-	display: none !important;
+	      display: none !important;
       }
     }
   }
@@ -43,12 +43,12 @@
 
     @if $orientation == null {
       @media screen and (max-width: $lower-bound), screen and (min-width: $upper-bound) {
-	display: none !important;
+	      display: none !important;
       }
     }
     @else {
       @media screen and (max-width: $lower-bound) and (orientation: $orientation), screen and (min-width: $upper-bound) and (orientation: $orientation) {
-	display: none !important;
+	      display: none !important;
       }
     }
   }
@@ -90,10 +90,10 @@
   @each $size in $breakpoint-classes {
     @if $size != $-zf-zero-breakpoint {
       .hide-for-#{$size} {
-	@include hide-for($size);
+	      @include hide-for($size);
       }
       .show-for-#{$size} {
-	@include show-for($size);
+	      @include show-for($size);
       }
     }
     .hide-for-#{$size}-only {

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -5,128 +5,149 @@
 /// Hide an element by default, only displaying it above a certain screen size.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for($size) {
-  $size: map-get($breakpoints, $size);
-  $size: -zf-bp-to-em($size) - (1 / 16);
+    $size: map-get($breakpoints, $size);
+    $size: -zf-bp-to-em($size) - (1 / 16);
 
-  @include breakpoint($size down) {
-    display: none !important;
-  }
+    @include breakpoint($size down) {
+	display: none !important;
+    }
 }
 
 /// Hide an element by default, only displaying it within a certain breakpoint.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
-@mixin show-for-only($size) {
-  $lower-bound-size: map-get($breakpoints, $size);
-  $upper-bound-size: -zf-map-next($breakpoints, $size);
+@mixin show-for-only($size,$orientation:null) {
+    $lower-bound-size: map-get($breakpoints, $size);
+    $upper-bound-size: -zf-map-next($breakpoints, $size);
 
-  // more often than not this will be correct, just one time round the loop it won't so set in scope here
-  $lower-bound: -zf-bp-to-em($lower-bound-size) - (1 / 16);
-  // test actual lower-bound-size, if 0 set it to 0em
-  @if strip-unit($lower-bound-size) == 0 {
-    $lower-bound: -zf-bp-to-em($lower-bound-size);
-  }
-
-  @if $upper-bound-size == null {
-    @media screen and (max-width: $lower-bound) {
-      display: none !important;
+    // more often than not this will be correct, just one time round the loop it won't so set in scope here
+    $lower-bound: -zf-bp-to-em($lower-bound-size) - (1 / 16);
+    // test actual lower-bound-size, if 0 set it to 0em
+    @if strip-unit($lower-bound-size) == 0 {
+	$lower-bound: -zf-bp-to-em($lower-bound-size);
     }
-  }
-  @else {
-    $upper-bound: -zf-bp-to-em($upper-bound-size);
 
-    @media screen and (max-width: $lower-bound), screen and (min-width: $upper-bound) {
-      display: none !important;
+    @if $upper-bound-size == null {
+	@if $orientation == null {
+	    @media screen and (max-width: $lower-bound) {
+		display: none !important;
+	    }
+	}
+	@else {
+	    @media screen and (max-width: $lower-bound) and (orientation: $orientation) {
+		display: none !important;
+	    }
+	}
     }
-  }
+    @else {
+	$upper-bound: -zf-bp-to-em($upper-bound-size);
+
+	@if $orientation == null {
+	    @media screen and (max-width: $lower-bound), screen and (min-width: $upper-bound) {
+		display: none !important;
+	    }
+	}
+	@else {
+	    @media screen and (max-width: $lower-bound) and (orientation: $orientation), screen and (min-width: $upper-bound) and (orientation: $orientation) {
+		display: none !important;
+	    }
+	}
+    }
 }
 
 
 /// Show an element by default, and hide it above a certain screen size.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin hide-for($size) {
-  @include breakpoint($size) {
-    display: none !important;
-  }
+    @include breakpoint($size) {
+	display: none !important;
+    }
 }
 
 /// Show an element by default, and hide it above a certain screen size.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin hide-for-only($size) {
-  @include breakpoint($size only) {
-    display: none !important;
-  }
+    @include breakpoint($size only) {
+	display: none !important;
+    }
 }
 
 @mixin foundation-visibility-classes {
-  // Basic hiding classes
-  .hide {
-    display: none !important;
-  }
-
-  .invisible {
-    visibility: hidden;
-  }
-
-  // Responsive visibility classes
-  @each $size in $breakpoint-classes {
-    @if $size != $-zf-zero-breakpoint {
-      .hide-for-#{$size} {
-        @include hide-for($size);
-      }
-
-      .show-for-#{$size} {
-        @include show-for($size);
-      }
+    // Basic hiding classes
+    .hide {
+	display: none !important;
     }
 
-    .hide-for-#{$size}-only {
-      @include hide-for-only($size);
+    .invisible {
+	visibility: hidden;
     }
 
-    .show-for-#{$size}-only {
-      @include show-for-only($size);
-    }
-  }
+    // Responsive visibility classes
+    @each $size in $breakpoint-classes {
+	@if $size != $-zf-zero-breakpoint {
+	    .hide-for-#{$size} {
+		@include hide-for($size);
+	    }
 
-  // Screen reader visibility classes
-  // Need a "hide-for-sr" class? Add aria-hidden='true' to the element
-  .show-for-sr,
-  .show-on-focus {
-    @include element-invisible;
-  }
+	    .show-for-#{$size} {
+		@include show-for($size);
+	    }
+	}
 
-  // Only display the element when it's focused
-  .show-on-focus {
-    &:active,
-    &:focus {
-      @include element-invisible-off;
-    }
-  }
+	.hide-for-#{$size}-only {
+	    @include hide-for-only($size);
+	}
 
-  // Landscape and portrait visibility
-  .show-for-landscape,
-  .hide-for-portrait {
-    display: block !important;
+	.show-for-#{$size}-only {
+	    @include show-for-only($size);
+	}
 
-    @include breakpoint(landscape) {
-      display: block !important;
-    }
-
-    @include breakpoint(portrait) {
-      display: none !important;
-    }
-  }
-
-  .hide-for-landscape,
-  .show-for-portrait {
-    display: none !important;
-
-    @include breakpoint(landscape) {
-      display: none !important;
+	.show-for-#{$size}-only.show-for-landscape {
+	    @include show-for-only($size,landscape);
+	}
+	.show-for-#{$size}-only.show-for-portrait {
+	    @include show-for-only($size,portrait);
+	}
     }
 
-    @include breakpoint(portrait) {
-      display: block !important;
+    // Screen reader visibility classes
+    // Need a "hide-for-sr" class? Add aria-hidden='true' to the element
+    .show-for-sr,
+    .show-on-focus {
+	@include element-invisible;
     }
-  }
+
+    // Only display the element when it's focused
+    .show-on-focus {
+	&:active,
+	&:focus {
+	    @include element-invisible-off;
+	}
+    }
+
+    // Landscape and portrait visibility
+    .show-for-landscape,
+    .hide-for-portrait {
+	display: block !important;
+
+	@include breakpoint(landscape) {
+	    display: block !important;
+	}
+
+	@include breakpoint(portrait) {
+	    display: none !important;
+	}
+    }
+
+    .hide-for-landscape,
+    .show-for-portrait {
+	display: none !important;
+
+	@include breakpoint(landscape) {
+	    display: none !important;
+	}
+
+	@include breakpoint(portrait) {
+	    display: block !important;
+	}
+    }
 }

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -5,149 +5,156 @@
 /// Hide an element by default, only displaying it above a certain screen size.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for($size) {
-    $size: map-get($breakpoints, $size);
-    $size: -zf-bp-to-em($size) - (1 / 16);
+  $size: map-get($breakpoints, $size);
+  $size: -zf-bp-to-em($size) - (1 / 16);
 
-    @include breakpoint($size down) {
-	display: none !important;
-    }
+  @include breakpoint($size down) {
+    display: none !important;
+  }
 }
 
 /// Hide an element by default, only displaying it within a certain breakpoint.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for-only($size,$orientation:null) {
-    $lower-bound-size: map-get($breakpoints, $size);
-    $upper-bound-size: -zf-map-next($breakpoints, $size);
+  $lower-bound-size: map-get($breakpoints, $size);
+  $upper-bound-size: -zf-map-next($breakpoints, $size);
 
-    // more often than not this will be correct, just one time round the loop it won't so set in scope here
-    $lower-bound: -zf-bp-to-em($lower-bound-size) - (1 / 16);
-    // test actual lower-bound-size, if 0 set it to 0em
-    @if strip-unit($lower-bound-size) == 0 {
-	$lower-bound: -zf-bp-to-em($lower-bound-size);
-    }
+  // more often than not this will be correct, just one time round the loop it won't so set in scope here
+  $lower-bound: -zf-bp-to-em($lower-bound-size) - (1 / 16);
+  // test actual lower-bound-size, if 0 set it to 0em
+  @if strip-unit($lower-bound-size) == 0 {
+    $lower-bound: -zf-bp-to-em($lower-bound-size);
+  }
 
-    @if $upper-bound-size == null {
-	@if $orientation == null {
-	    @media screen and (max-width: $lower-bound) {
-		display: none !important;
-	    }
-	}
-	@else {
-	    @media screen and (max-width: $lower-bound) and (orientation: $orientation) {
-		display: none !important;
-	    }
-	}
+  @if $upper-bound-size == null {
+    @if $orientation == null {
+      @media screen and (max-width: $lower-bound) {
+	display: none !important;
+      }
     }
     @else {
-	$upper-bound: -zf-bp-to-em($upper-bound-size);
-
-	@if $orientation == null {
-	    @media screen and (max-width: $lower-bound), screen and (min-width: $upper-bound) {
-		display: none !important;
-	    }
-	}
-	@else {
-	    @media screen and (max-width: $lower-bound) and (orientation: $orientation), screen and (min-width: $upper-bound) and (orientation: $orientation) {
-		display: none !important;
-	    }
-	}
+      @media screen and (max-width: $lower-bound) and (orientation: $orientation) {
+	display: none !important;
+      }
     }
+  }
+  @else {
+    $upper-bound: -zf-bp-to-em($upper-bound-size);
+
+    @if $orientation == null {
+      @media screen and (max-width: $lower-bound), screen and (min-width: $upper-bound) {
+	display: none !important;
+      }
+    }
+    @else {
+      @media screen and (max-width: $lower-bound) and (orientation: $orientation), screen and (min-width: $upper-bound) and (orientation: $orientation) {
+	display: none !important;
+      }
+    }
+  }
 }
 
 
 /// Show an element by default, and hide it above a certain screen size.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin hide-for($size) {
-    @include breakpoint($size) {
-	display: none !important;
-    }
+  @include breakpoint($size) {
+    display: none !important;
+  }
 }
 
 /// Show an element by default, and hide it above a certain screen size.
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
-@mixin hide-for-only($size) {
+@mixin hide-for-only($size, $orientation:null) {
+  @if $orientation == null {
     @include breakpoint($size only) {
-	display: none !important;
+      display: none !important;
     }
+  }
+  else {
+
+  }
 }
 
 @mixin foundation-visibility-classes {
-    // Basic hiding classes
-    .hide {
-	display: none !important;
+  // Basic hiding classes
+  .hide {
+    display: none !important;
+  }
+
+  .invisible {
+    visibility: hidden;
+  }
+
+  // Responsive visibility classes
+  @each $size in $breakpoint-classes {
+    @if $size != $-zf-zero-breakpoint {
+      .hide-for-#{$size} {
+	@include hide-for($size);
+      }
+      .show-for-#{$size} {
+	@include show-for($size);
+      }
+    }
+    .hide-for-#{$size}-only {
+      @include hide-for-only($size);
+    }
+    .show-for-#{$size}-only {
+      @include show-for-only($size);
     }
 
-    .invisible {
-	visibility: hidden;
+    // Boolean conjunction of visibility classes
+    .show-for-#{$size}-only.show-for-landscape {
+      @include show-for-only($size,landscape);
+    }
+    .show-for-#{$size}-only.show-for-portrait {
+      @include show-for-only($size,portrait);
+    }
+    .hide-for-#{$size}-only.hide-for-landscape {
+      @include hide-for-only($size);
     }
 
-    // Responsive visibility classes
-    @each $size in $breakpoint-classes {
-	@if $size != $-zf-zero-breakpoint {
-	    .hide-for-#{$size} {
-		@include hide-for($size);
-	    }
+  }
 
-	    .show-for-#{$size} {
-		@include show-for($size);
-	    }
-	}
+  // Screen reader visibility classes
+  // Need a "hide-for-sr" class? Add aria-hidden='true' to the element
+  .show-for-sr,
+  .show-on-focus {
+    @include element-invisible;
+  }
 
-	.hide-for-#{$size}-only {
-	    @include hide-for-only($size);
-	}
+  // Only display the element when it's focused
+  .show-on-focus {
+    &:active,
+    &:focus {
+      @include element-invisible-off;
+    }
+  }
 
-	.show-for-#{$size}-only {
-	    @include show-for-only($size);
-	}
+  // Landscape and portrait visibility
+  .show-for-landscape,
+  .hide-for-portrait {
+    display: block !important;
 
-	.show-for-#{$size}-only.show-for-landscape {
-	    @include show-for-only($size,landscape);
-	}
-	.show-for-#{$size}-only.show-for-portrait {
-	    @include show-for-only($size,portrait);
-	}
+    @include breakpoint(landscape) {
+      display: block !important;
     }
 
-    // Screen reader visibility classes
-    // Need a "hide-for-sr" class? Add aria-hidden='true' to the element
-    .show-for-sr,
-    .show-on-focus {
-	@include element-invisible;
+    @include breakpoint(portrait) {
+      display: none !important;
+    }
+  }
+
+  .hide-for-landscape,
+  .show-for-portrait {
+    display: none !important;
+
+    @include breakpoint(landscape) {
+      display: none !important;
     }
 
-    // Only display the element when it's focused
-    .show-on-focus {
-	&:active,
-	&:focus {
-	    @include element-invisible-off;
-	}
+    @include breakpoint(portrait) {
+      display: block !important;
     }
-
-    // Landscape and portrait visibility
-    .show-for-landscape,
-    .hide-for-portrait {
-	display: block !important;
-
-	@include breakpoint(landscape) {
-	    display: block !important;
-	}
-
-	@include breakpoint(portrait) {
-	    display: none !important;
-	}
-    }
-
-    .hide-for-landscape,
-    .show-for-portrait {
-	display: none !important;
-
-	@include breakpoint(landscape) {
-	    display: none !important;
-	}
-
-	@include breakpoint(portrait) {
-	    display: block !important;
-	}
-    }
+  }
 }

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -102,7 +102,6 @@
     .show-for-#{$size}-only {
       @include show-for-only($size);
     }
-
     // Boolean conjunction of visibility classes
     .show-for-#{$size}-only.show-for-landscape {
       @include show-for-only($size,landscape);

--- a/test/visual/visibility/index.html
+++ b/test/visual/visibility/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+ <head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Foundation for Sites Testing</title>
+  <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+  <link href="../assets/css/foundation.css" rel="stylesheet" />
+ </head>
+ <body>
+  <h1>Visibility by Screen size AND Orientation</h1>
+  <div class="callout success">
+   <h4><code>Show for landscape AND medium only</code></h4>
+   <div class="show-for-medium-only show-for-landscape">
+    <p>Landscape orientation and medium</p>
+   </div>
+  </div>
+
+  <h1>Visibility by screen size</h1>
+  <div class="callout alert">
+   <h4><code>Show for small only:</code></h4>
+   <div class="show-for-small-only">
+    <p>Time, Dr. Freeman? Is it really that time again?</p>
+   </div>
+   <hr />
+   <h4><code>Hide for small and up:</code></h4>
+   <div class="hide">
+    <p>42</p>
+   </div>
+   <h4><code>Hide for small only:</code></h4>
+   <div class="hide-for-small-only">
+    <p>42</p>
+   </div>
+  </div>
+
+  <div class="callout success">
+   <h4><code>Show for medium and up:</code></h4>
+   <div class="show-for-medium">
+    <p>Welcome. Welcome, to City 17.</p>
+   </div>
+   <h4><code>Show for medium only:</code></h4>
+   <div class="show-for-medium-only">
+    <p>Dr. Wallace Breen</p>
+   </div>
+   <hr />
+   <h4><code>Hide for medium and up:</code></h4>
+   <div class="hide-for-medium">
+    <p>What you say?!</p>
+   </div>
+   <h4><code>Hide for medium only:</code></h4>
+   <div class="hide-for-medium-only">
+    <p>What about Bob?</p>
+   </div>
+  </div>
+
+
+  <div class="primary callout">
+   <h4><code>Show for large and up:</code></h4>
+   <div class="show-for-large">
+    <p>Throwing that switch and all, I can see your MIT education really pays for itself.</p>
+   </div>
+   <h4><code>Show for large only:</code></h4>
+   <div class="show-for-large-only">
+    <p>Barney Gumble</p>
+   </div>
+   <hr />
+   <h4><code>Hide for large and up:</code></h4>
+   <div class="hide-for-large">
+    <p>Someone setup us the bomb.</p>
+   </div>
+   <h4><code>Hide for large only:</code></h4>
+   <div class="hide-for-large-only">
+    <p>Pink elephants on parade.</p>
+   </div>
+  </div>
+
+  <h1>Visibility by orientation</h1>
+  <div class="callout alert">
+   <h4><code>Show for landscape:</code></h4>
+   <div class="show-for-landscape">
+    <p>Landscape orientation.</p>
+   </div>
+   <h4><code>Show for portrait:</code></h4>
+   <div class="show-for-portrait">
+    <p>Portrait orientation.</p>
+   </div>
+  </div>
+
+
+  <script src="../assets/js/vendor.js"></script>
+  <script src="../assets/js/foundation.js"></script>
+  <script>
+    $(document).foundation();
+  </script>
+ </body>
+</html>

--- a/test/visual/visibility/index.html
+++ b/test/visual/visibility/index.html
@@ -16,6 +16,13 @@
     <p>Landscape orientation and medium</p>
    </div>
   </div>
+  <div class="callout success">
+   <h4><code>Hide for portrait AND medium only</code></h4>
+   <div class="hide-for-medium-only hide-for-landcape">
+    <p>Landscape orientation and medium</p>
+   </div>
+  </div>
+
 
   <h1>Visibility by screen size</h1>
   <div class="callout alert">


### PR DESCRIPTION
I am working on a visibility test with intention to extend visibility classes in two ways:

* Boolean conjunction: EG: elements with the hypothetical class `.show-for-medium-and-landscape` would be visible *only* when the screen size is "small" *and* in "landscape" orientation. 

* Boolean exclusive disjunction: Elements with both `.show-for-medium` and `.show-for-landscape` should display *only* when either condition is true; element should be invisible when both are true and when both are false.

