### PR TITLE
Remove yeti launch references

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -8,7 +8,7 @@ tags:
 
 ## Installing
 
-There are a number of ways to install Foundation for Sites. If you're just getting started, we recommend downloading Yeti Launch, which allows you to quickly set up starter projects with any Foundation framework. You can also install our Node CLI to do the same thing.
+There are a number of ways to install Foundation for Sites. If you're just getting started, we recommend installing our Node CLI, which allows you to quickly set up starter projects with any Foundation framework.
 
 It's also possible to manually install Foundation for Sites into your project through npm, Bower, Meteor, or Composer.
 

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -3,12 +3,6 @@ title: Installation
 description: There are many ways to install Foundation, but if you're just getting started, we have a few suggestions.
 ---
 
-<!--## Yeti Launch-->
-
-<!--Yeti Launch is our Mac app for quickly spinning up blank projects for any of the three Foundation frameworks. If you're just getting started with Foundation, we recommend downloading Yeti Launch to get going right away.-->
-
-<!--<a href="http://foundation.zurb.com/develop/yeti-launch" class="large button">Download Yeti Launch</a>-->
-
 ### Command-Line Tool
 
 Not a fan of GUIs? The Node-powered Foundation CLI can install the same template projects for you. Install it with npm:

--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -32,7 +32,7 @@ autoprefixer({
 
 ## Loading the Framework
 
-If you're using Yeti Launch or the CLI to create a project, the Sass compilation process is already set up for you. If not, you can compile our Sass files yourself, or drop in a pre-built CSS file.
+If you're the CLI to create a project, the Sass compilation process is already set up for you. If not, you can compile our Sass files yourself, or drop in a pre-built CSS file.
 
 To get started, first install the framework files using Bower or npm.
 
@@ -117,7 +117,7 @@ Our [starter projects](starter-projects.html) include the full list of imports, 
 
 ## The Settings File
 
-All Foundation projects include a settings file, named `_settings.scss`. If you're using Yeti Launch or the CLI to create a Foundation for Sites project, you can find the settings file under scss/ (basic template) or src/assets/scss/ (ZURB template). If you're installing the framework standalone using Bower or npm, there's a settings file included in those packages, which you can move into your own Sass files to work with.
+All Foundation projects include a settings file, named `_settings.scss`. If you're using the CLI to create a Foundation for Sites project, you can find the settings file under scss/ (basic template) or src/assets/scss/ (ZURB template). If you're installing the framework standalone using Bower or npm, there's a settings file included in those packages, which you can move into your own Sass files to work with.
 
 Every component includes a set of variables that modify core structural or visual styles. If there's something you can't customize with a variable, you can just write your own CSS to add it.
 

--- a/docs/partials/off-canvi.html
+++ b/docs/partials/off-canvi.html
@@ -3,7 +3,7 @@
     <span aria-hidden="true">&times;</span>
   </button>
   <ul class="mobile-ofc vertical menu">
-    
+
     <li>
       <a href="http://zurb.com/responsive">Showcase</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -15,7 +15,7 @@
         <li><a href="http://foundation.zurb.com/showcase/about.html">About Foundation</a></li>
       </ul>
     </li>
-    
+
     <li>
       <a href="http://foundation.zurb.com/develop/getting-started.html">Develop</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -27,7 +27,6 @@
         <li><a href="http://foundation.zurb.com/templates.html">HTML Templates</a></li>
         <li><a href="http://foundation.zurb.com/sites/resources.html">Resources</a></li>
         <li><a href="http://foundation.zurb.com/develop/building-blocks.html">Building Blocks</a></li>
-        <li><a href="http://foundation.zurb.com/develop/yeti-launch.html">Yeti Launch</a></li>
         <li><a href="http://foundation.zurb.com/develop/contribute.html">Contribute</a></li>
       </ul>
     </li>
@@ -42,7 +41,7 @@
         <li><a href="http://foundation.zurb.com/learn/responsive-reading.html">Responsive Reading</a></li>
       </ul>
     </li>
-    
+
     <li>
       <a href="http://foundation.zurb.com/get-involved/support.html">Get Involved</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -55,7 +54,7 @@
         <li><a href="http://foundation.zurb.com/get-involved/yetinauts.html">Yetinauts</a></li>
       </ul>
     </li>
-    
+
     <li>
       <a href="http://foundation.zurb.com/frameworks-docs.html">Docs</a>
       <ul class="submenu menu vertical" data-submenu>
@@ -63,7 +62,7 @@
         <li><a href="http://zurb.com/ink/docs.php" target="_blank">Email Docs</a></li>
       </ul>
     </li>
-    
+
     <li><a href="http://foundation.zurb.com/develop/getting-started.html" class="button">Getting Started</a></li>
 
   </ul>


### PR DESCRIPTION
Resubmitting #9480 against master. As highlighted by @MattWilcox, some pieces in the docs still reference Yeti Launch, which is no longer available. Remove those.