### PR TITLE
Fix deploy dist build

### DIFF
--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -46,9 +46,10 @@ gulp.task('deploy:version', function() {
 
 // Generates compiled CSS and JS files and puts them in the dist/ folder
 gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function() {
-  var cssFilter = filter(['*.css'], { restore: true });
-  var jsFilter  = filter(['*.js'], { restore: true });
+  var cssFilter = filter(['**/*.css'], { restore: true });
+  var jsFilter  = filter(['**/*.js'], { restore: true });
 
+  console.log(CONFIG.DIST_FILES)
   return gulp.src(CONFIG.DIST_FILES)
     .pipe(plumber())
     .pipe(cssFilter)


### PR DESCRIPTION
Fix bug that appears to have been introduced when we nested into `/dist` directory causing some things to not end up getting copied properly as they were built.

Does not invalidate prior QA on 6.3 which has been done *in repo* but has been a problem for 6.3 rcs used in templates.