### PR TITLE
WIP - Frame Grid

### DIFF
--- a/docs/assets/scss/examples/_grid.scss
+++ b/docs/assets/scss/examples/_grid.scss
@@ -74,3 +74,34 @@
     }
   }
 }
+
+// Frame Grid
+.frame-grid-sample.frame {
+  width: 80%;
+  height: 350px;
+  background: #eee;
+  font-size: 11px;
+  margin-bottom: 10px;
+  line-height: 2rem;
+  border: solid 1px #c6c6c6;
+  text-align: center;
+
+  p {
+    text-align: left;
+  }
+
+  .frame-group, .frame-block {
+
+    &:nth-child(odd) {
+      background: #eee;
+    }
+    &:nth-child(even) {
+      background: #ddd;
+    }
+
+    &.test-header, &.test-footer {
+      background: $dark-gray;
+    }
+  }
+
+}

--- a/docs/layout/test.html
+++ b/docs/layout/test.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{description}}">
+  <link rel="icon" href="assets/img/icons/foundation-favicon.ico" type="image/x-icon">
+  <title>Foundation for Sites 6 Docs{{#unlesspage 'index'}} | {{title}}{{/unlesspage}}</title>
+  <link href="assets/css/docs.css" rel="stylesheet" />
+  <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+  <!-- <link rel="stylesheet" href="./node_modules/motion-ui/dist/motion-ui.css" /> -->
+</head>
+<body>
+
+{{> body}}
+
+  <script>
+  var _gaq = _gaq || [];
+  _gaq.push(
+    ['_setAccount', 'UA-2195009-2'],
+    ['_trackPageview'],
+    ['b._setAccount', 'UA-2195009-27'],
+    ['b._trackPageview']
+  );
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+  </script>
+
+  <script src="assets/js/vendor.js"></script>
+  <script src="assets/js/foundation.js"></script>
+  <script src="assets/js/docs.js"></script>
+  <script type="text/javascript" src="https://intercom.zurb.com/scripts/zcom.js"></script>
+  <script type="text/javascript">
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
+
+    fbq('init', '585552368271130');
+    fbq('track', "PageView");
+  </script>
+  <!-- Twitter universal website tag code -->
+  <script>
+    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+    },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
+    a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+    // Insert Twitter Pixel ID and Standard Event data below
+    twq('init','nvkjx');
+    twq('track','PageView');
+  </script>
+  <!-- End Twitter universal website tag code -->
+
+
+</body>
+</html>

--- a/docs/pages/frame-grid.md
+++ b/docs/pages/frame-grid.md
@@ -1,0 +1,310 @@
+---
+title: The Frame Grid
+description: Built to be the outermost shell of an application, the Frame-grid helps create fixed header, fixed footers and any number of separate scrolling sections. The normal Foundation grid can be nested within grid blocks to create complex content arrangements..
+sass:
+  - scss/grid/apps-grid-classes.scss
+  - scss/grid/apps-grid.scss
+  - scss/grid/apps-grid-elements.scss
+  - scss/grid/apps-grid-modifiers.scss
+tags:
+  - apps grid
+---
+
+### The Grid in Action
+
+The new grid is a complex beast, with a lot of different options, especially when it comes to creating responsive layouts. Check out the sample version below to see how the frame-grid can be used to create complex app layouts.
+
+
+
+---
+
+### The App Frame
+
+For most apps, you'll want to contain all of your UI elements in the space of the window, and then make certain sections of the app scrollable. To achieve this, wrap your entire app in a grid frame:
+
+```html
+<div class="frame">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+```
+
+The app frame always takes up 100% of the width and 100% of the height of the user's browser window.
+
+---
+
+### The Basics: Grid Blocks
+
+Blocks are the... *building blocks* of apps in Foundation for Apps. They're flexbox-powered elements that can be intelligently sized, re-oriented, and re-ordered. Blocks are most analagous to rows in Foundation 5, but there's much more to them than that.
+
+---
+
+#### Automatic sizing
+
+You're probably used to pairing grid classes with sizing classes, like `.small-12`, `.medium-6`, and so on. In Foundation for Apps, when grid blocks don't have sizing classes, they take up an even amount of space.
+
+```html
+<div class="frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+
+```html
+<div class="frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+
+While these blocks *expand* to fill available space, it's also possible to have a block *shrink*, which means it only takes up as much space as its content needs. This is useful for title bars, tabs, or any other content that's secondary to the main content area.
+
+```html
+<div class="frame-block">
+  <div id="tabs" class="frame-block shrink"></div>
+  <div id="main" class="frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div id="tabs" class="frame-block shrink"></div>
+  <div id="main" class="frame-block"></div>
+</div>
+
+#### Manual sizing
+
+It's also possible to size the grid using column-based sizing classes. By default, the Foundation for Apps grid uses a 12-column grid, but you can change this by modifying the `$total-columns` variable in your settings file.
+
+```
+<div class="frame-block">
+  <div id="sidebar" class="medium-4 frame-block"></div>
+  <div id="main" class="medium-8 frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo manual-size frame-block">
+  <div id="sidebar" class="medium-4 frame-block"></div>
+  <div id="main" class="medium-7 frame-block"></div>
+</div>
+
+
+#### Parent-level sizing
+
+<p>Lastly, the sizing of blocks can be set on the parent, rather than individual children. Add the class `[size]-up-[n]` to a parent block to automatically size all children to be the same width. `[size]` is a breakpoint, like `small` or `medium`, and `n` is the number of items to fit on each row. By default, `n` only goes up to six, but this can be changed by modifying the `$block-grid-max-size` variable in your settings file.</p>
+
+```html
+<div class="frame-block small-up-3">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block small-up-3">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+
+Note that this sizing method only works with horizontal grids.
+
+
+### Content Blocks
+
+If basic blocks are the *rows* of a Foundation for Apps layout, then content blocks are the *columns*. They can be sized and re-ordered just like normal blocks, but they're meant to house actual content, not just more blocks.
+
+```html
+<div class="frame-block">
+  <div class="frame-block">
+    <div class="grid-content"></div>
+    <div class="grid-content"></div>
+  </div>
+  <div class="grid-content"></div>
+</div>
+```
+
+In the above example, you can see that `grid-content` elements are the bottommost elements of the basic layout. Use `frame-block` when you intend to keep nesting more blocks for your layout, and use `grid-content` when you're filling the element with "normal" content, like lists, text, tabs, or menus.
+
+### The Vertical Grid
+
+By default, blocks in a grid are laid out horizontally. A grid can be reoriented to be vertical by adding the `vertical` class to a parent element.
+
+```html
+<div class="vertical frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo vertical-demo vertical frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+
+This behavior doesn't cascade down to child blocks&mdash;they'll be horizontal by default also.
+
+You can also reorient the grid at different screen sizes by using adding breakpoint names to the classes.
+
+```html
+<div class="vertical medium-horizontal frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo vertical medium-horizontal frame-block">
+  <div class="frame-block"></div>
+  <div class="frame-block"></div>
+</div>
+
+
+### Other Options
+
+<h4>Prevent Scrolling</h4>
+
+<p>By default, all content blocks scroll vertically. This allows you to create independently-scrolling panes of content in your apps. However, in CSS, if an element scrolls vertically, any horizontal overflow will be hidden. To disable scrolling on a block, just add the class `.noscroll`.</p>
+
+```html
+<div class="frame-block wrap">
+  <!-- Won't have scroll bars ever -->
+  <div class="small-6 grid-content noscroll"></div>
+  <!-- Will have scroll bars if there's enough content -->
+  <div class="small-6 grid-content"></div>
+</div>
+```
+
+#### Block Alignment
+
+By default, all blocks in a grid align to the left of a grid, or the top if the grid is vertical. We can leverage the Flexbox `justify-content` property to easily re-align the blocks in a grid.
+
+```html
+<div class="align-right frame-block">
+  <div class="small-4 frame-block"></div>
+  <div class="small-4 frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo align-right frame-block">
+  <div class="small-4 frame-block"></div>
+  <div class="small-4 frame-block"></div>
+</div>
+
+In this example, our blocks only take up eight columns of space, leaving four columns worth of empty space. By adding the `align-right` class to the parent block, the empty space will appear on the left instead of the right.
+
+Grids can be aligned in five ways:
+
+  - `align-left`: Blocks clump together on the left. This is the default.
+  - `align-right`: Blocks clump together on the right.
+  - `align-center`: Blocks clump together in the middle.
+  - `align-justify`: Blocks spread out so that the space *between* each one is the same.
+  - `align-spaced`: Blocks spread out so that the space *around* each one is the same.
+
+##### Center
+
+<div class="docs-grid-demo align-center frame-block">
+  <div class="small-4 frame-block"></div>
+  <div class="small-4 frame-block"></div>
+</div>
+
+##### Justify
+
+<div class="docs-grid-demo align-justify frame-block">
+  <div class="small-4 frame-block"></div>
+  <div class="small-4 frame-block"></div>
+</div>
+
+##### Spaced
+
+<div class="docs-grid-demo align-spaced frame-block">
+  <div class="small-4 frame-block"></div>
+  <div class="small-4 frame-block"></div>
+</div>
+
+---
+
+#### Source Ordering
+
+Blocks can be reordered to be different from the order they appear in the HTML. This is known as *source ordering*.
+
+```html
+<div class="frame-block">
+  <div class="frame-block order-2">2</div>
+  <div class="frame-block order-1">1</div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div class="frame-block order-2 text">2</div>
+  <div class="frame-block order-1 text">1</div>
+</div>
+
+In the above example, the first child block will actually appear <em>after</em> the second one, because it has a lower order number. Blocks with the lower order (e.g. 1 is lower than 2) number appear first in the layout. If multiple blocks share an order, they're then grouped by their order in the HTML.
+
+```
+<div class="frame-block">
+  <!-- 3rd -->
+  <div class="frame-block order-2">3</div>
+  <!-- 1st -->
+  <div class="frame-block order-1">1</div>
+  <!-- 2nd -->
+  <div class="frame-block order-1">2</div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div class="frame-block order-2 text">3</div>
+  <div class="frame-block order-1 text">1</div>
+  <div class="frame-block order-1 text">2</div>
+</div>
+
+The ordering classes also come in responsive flavors, allowing you to reorder grid blocks at different screen sizes. In the below example, the two blocks will switch places on medium screens and larger.
+
+```html
+<div class="frame-block">
+  <div class="frame-block medium-order-2">1</div>
+  <div class="frame-block medium-order-1">2</div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div class="frame-block medium-order-2 text">1</div>
+  <div class="frame-block medium-order-1 text">2</div>
+</div>
+
+---
+
+#### Offsets
+
+The same offset classes from Foundation for Sites can be used in Foundation for Apps. To create a left-hand margin on a block, add the class `[size]-offset-[n]`, where `[size]` is a breakpoint name, and `[n]` is the number of columns to offset by. In the below example, the second column will be offset by 3, which is equal to 25% of the width of the entire container.
+
+```html
+<div class="frame-block">
+  <div class="small-6 frame-block"></div>
+  <div class="small-2 small-offset-2 frame-block"></div>
+</div>
+```
+
+<div class="docs-grid-demo frame-block">
+  <div class="small-6 frame-block"></div>
+  <div class="small-2 small-offset-2 frame-block"></div>
+</div>
+
+Offset classes allow you to fine-tune the spacing of blocks at different screen sizes. However, many common spacing options can also be achieved with the grid alignment classes described above.

--- a/docs/pages/frame-grid.md
+++ b/docs/pages/frame-grid.md
@@ -14,7 +14,25 @@ tags:
 
 The new grid is a complex beast, with a lot of different options, especially when it comes to creating responsive layouts. Check out the sample version below to see how the frame-grid can be used to create complex app layouts.
 
+<div class="frame-grid-sample vertical frame">
+  <div class="frame-block test-header shrink">Header</div>
+  <div class="frame-group">
+    <div class="frame-block medium-4">
+      <p>Sidebar</p>
+    </div>
+    <div class="frame-block medium-9">
+      <p>The Future of Seldon's Plan."The Foundation's past history is, I am sure, well-known to all of us who have had the good fortune to be educated in our planet's efficient and well-staffed school system.</p>
 
+      <p>(There! That would start things off right with Miss Erlking, that mean old hag.)</p>
+      <p>That past history is largely the past history of the great Plan of Hari Seldon. The two are</p>
+      <p>one. But the question in the mind of most people today is whether this Plan will continue in all its great wisdom, or whether it will be foully destroyed, or, perhaps, has been so destroyed already.</p>
+      <p>"To understand this, it may be best to pass quickly over some of the highlights of the Plan as it has been revealed to humanity thus far.</p>
+      <p>(This part was easy because she had taken Modern History the semester before.)</p>
+      <p>"In the days, nearly four centuries ago, when the First Galactic Empire was decaying into the paralysis that preceded final death, one man - the great Hari Seldon - foresaw the approaching end. Through the science of psychohistory, the intrissacies of whose mathematics has long since been forgotten.</p>
+    </div>
+  </div>
+  <div class="frame-block test-footer shrink">Footer</div>
+</div>
 
 ---
 
@@ -24,139 +42,126 @@ For most apps, you'll want to contain all of your UI elements in the space of th
 
 ```html
 <div class="frame">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
 </div>
 ```
 
+<div class="frame frame-grid-sample">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
+</div>
+
 The app frame always takes up 100% of the width and 100% of the height of the user's browser window.
+
+<small>These demos are setting a height and width for their purposes only</small>
 
 ---
 
-### The Basics: Grid Blocks
+### The Basics: Frame Group
 
-Blocks are the... *building blocks* of apps in Foundation for Apps. They're flexbox-powered elements that can be intelligently sized, re-oriented, and re-ordered. Blocks are most analagous to rows in Foundation 5, but there's much more to them than that.
+Frame-groups are flexbox-powered elements that can be intelligently sized, re-oriented, and re-ordered. Frame-groups are most analagous to rows in traditional grid, but there's much more to them than that.
 
 ---
 
 #### Automatic sizing
 
-You're probably used to pairing grid classes with sizing classes, like `.small-12`, `.medium-6`, and so on. In Foundation for Apps, when grid blocks don't have sizing classes, they take up an even amount of space.
+You're probably used to pairing grid classes with sizing classes, like `.small-12`, `.medium-6`, and so on. In Foundation for Apps, when frame-groups don't have sizing classes, they take up an even amount of space.
+
 
 ```html
-<div class="frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+<div class="frame-group">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
+</div>
+```
+<div class="frame frame-grid-sample">
+  <div class="docs-grid-demo frame-group">
+    <div class="frame-group"></div>
+    <div class="frame-group"></div>
+  </div>
+</div>
+
+```html
+<div class="frame-group">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
+</div>
+```
+<div class="frame frame-grid-sample">
+  <div class="docs-grid-demo frame-group">
+    <div class="frame-group"></div>
+    <div class="frame-group"></div>
+    <div class="frame-group"></div>
+  </div>
+</div>
+
+While these groups *expand* to fill available space, it's also possible to have a group *shrink*, which means it only takes up as much space as its content needs. This is useful for title bars, tabs, or any other content that's secondary to the main content area.
+
+```html
+<div class="frame-group">
+  <div id="tabs" class="frame-group shrink"></div>
+  <div id="main" class="frame-group"></div>
 </div>
 ```
 
-<div class="docs-grid-demo frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-</div>
-
-```html
-<div class="frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-</div>
-```
-
-<div class="docs-grid-demo frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-</div>
-
-While these blocks *expand* to fill available space, it's also possible to have a block *shrink*, which means it only takes up as much space as its content needs. This is useful for title bars, tabs, or any other content that's secondary to the main content area.
-
-```html
-<div class="frame-block">
-  <div id="tabs" class="frame-block shrink"></div>
-  <div id="main" class="frame-block"></div>
-</div>
-```
-
-<div class="docs-grid-demo frame-block">
-  <div id="tabs" class="frame-block shrink"></div>
-  <div id="main" class="frame-block"></div>
+<div class="frame frame-grid-sample">
+  <div class="docs-grid-demo frame-group">
+    <div id="tabs" class="frame-group shrink">Sidebar</div>
+    <div id="main" class="frame-group">Main content</div>
+  </div>
 </div>
 
 #### Manual sizing
 
-It's also possible to size the grid using column-based sizing classes. By default, the Foundation for Apps grid uses a 12-column grid, but you can change this by modifying the `$total-columns` variable in your settings file.
+It's also possible to size the grid using column-based sizing classes. By default, the Foundation Frame grid uses a 12-column grid, but you can change this by modifying the `$total-columns` variable in your settings file.
 
 ```
-<div class="frame-block">
-  <div id="sidebar" class="medium-4 frame-block"></div>
-  <div id="main" class="medium-8 frame-block"></div>
-</div>
-```
-
-<div class="docs-grid-demo manual-size frame-block">
-  <div id="sidebar" class="medium-4 frame-block"></div>
-  <div id="main" class="medium-7 frame-block"></div>
-</div>
-
-
-#### Parent-level sizing
-
-<p>Lastly, the sizing of blocks can be set on the parent, rather than individual children. Add the class `[size]-up-[n]` to a parent block to automatically size all children to be the same width. `[size]` is a breakpoint, like `small` or `medium`, and `n` is the number of items to fit on each row. By default, `n` only goes up to six, but this can be changed by modifying the `$block-grid-max-size` variable in your settings file.</p>
-
-```html
-<div class="frame-block small-up-3">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+<div class="frame-group">
+  <div id="sidebar" class="medium-4 frame-group"></div>
+  <div id="main" class="medium-8 frame-group"></div>
 </div>
 ```
 
-<div class="docs-grid-demo frame-block small-up-3">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
-</div>
-
-Note that this sizing method only works with horizontal grids.
-
-
-### Content Blocks
-
-If basic blocks are the *rows* of a Foundation for Apps layout, then content blocks are the *columns*. They can be sized and re-ordered just like normal blocks, but they're meant to house actual content, not just more blocks.
-
-```html
-<div class="frame-block">
-  <div class="frame-block">
-    <div class="grid-content"></div>
-    <div class="grid-content"></div>
+<div class="frame frame-grid-sample">
+  <div class="docs-grid-demo manual-size frame-group">
+    <div id="sidebar" class="medium-4 frame-group">Medium 4</div>
+    <div id="main" class="medium-7 frame-group"> Medium 7</div>
   </div>
-  <div class="grid-content"></div>
+</div>
+
+
+### Frame Blocks
+
+If basic groups are the *rows* of a Foundation Frame Grid, then frame-blocks are the *columns*. They can be sized and re-ordered just like normal groups, but they're meant to house actual content, not just more blocks.
+
+```html
+<div class="frame-group">
+  <div class="frame-group">
+    <div class="frame-block"></div>
+    <div class="frame-block"></div>
+  </div>
+  <div class="frame-block"></div>
 </div>
 ```
 
-In the above example, you can see that `grid-content` elements are the bottommost elements of the basic layout. Use `frame-block` when you intend to keep nesting more blocks for your layout, and use `grid-content` when you're filling the element with "normal" content, like lists, text, tabs, or menus.
+In the above example, you can see that `frame-block` elements are the bottommost elements of the basic layout. Use `frame-group` when you intend to keep nesting more blocks for your layout, and use `frame-block` when you're filling the element with "normal" content, like lists, text, tabs, or menus.
 
 ### The Vertical Grid
 
 By default, blocks in a grid are laid out horizontally. A grid can be reoriented to be vertical by adding the `vertical` class to a parent element.
 
 ```html
-<div class="vertical frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+<div class="vertical frame-group">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
 </div>
 ```
 
-<div class="docs-grid-demo vertical-demo vertical frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+<div class="docs-grid-demo vertical-demo vertical frame-group">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
 </div>
 
 This behavior doesn't cascade down to child blocks&mdash;they'll be horizontal by default also.
@@ -164,15 +169,15 @@ This behavior doesn't cascade down to child blocks&mdash;they'll be horizontal b
 You can also reorient the grid at different screen sizes by using adding breakpoint names to the classes.
 
 ```html
-<div class="vertical medium-horizontal frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+<div class="vertical medium-horizontal frame-group">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
 </div>
 ```
 
-<div class="docs-grid-demo vertical medium-horizontal frame-block">
-  <div class="frame-block"></div>
-  <div class="frame-block"></div>
+<div class="docs-grid-demo vertical medium-horizontal frame-group">
+  <div class="frame-group"></div>
+  <div class="frame-group"></div>
 </div>
 
 
@@ -183,11 +188,11 @@ You can also reorient the grid at different screen sizes by using adding breakpo
 <p>By default, all content blocks scroll vertically. This allows you to create independently-scrolling panes of content in your apps. However, in CSS, if an element scrolls vertically, any horizontal overflow will be hidden. To disable scrolling on a block, just add the class `.noscroll`.</p>
 
 ```html
-<div class="frame-block wrap">
+<div class="frame-group wrap">
   <!-- Won't have scroll bars ever -->
-  <div class="small-6 grid-content noscroll"></div>
+  <div class="small-6 frame-block noscroll"></div>
   <!-- Will have scroll bars if there's enough content -->
-  <div class="small-6 grid-content"></div>
+  <div class="small-6 frame-block"></div>
 </div>
 ```
 
@@ -196,15 +201,15 @@ You can also reorient the grid at different screen sizes by using adding breakpo
 By default, all blocks in a grid align to the left of a grid, or the top if the grid is vertical. We can leverage the Flexbox `justify-content` property to easily re-align the blocks in a grid.
 
 ```html
-<div class="align-right frame-block">
-  <div class="small-4 frame-block"></div>
-  <div class="small-4 frame-block"></div>
+<div class="align-right frame-group">
+  <div class="small-4 frame-group"></div>
+  <div class="small-4 frame-group"></div>
 </div>
 ```
 
-<div class="docs-grid-demo align-right frame-block">
-  <div class="small-4 frame-block"></div>
-  <div class="small-4 frame-block"></div>
+<div class="docs-grid-demo align-right frame-group">
+  <div class="small-4 frame-group"></div>
+  <div class="small-4 frame-group"></div>
 </div>
 
 In this example, our blocks only take up eight columns of space, leaving four columns worth of empty space. By adding the `align-right` class to the parent block, the empty space will appear on the left instead of the right.
@@ -219,23 +224,23 @@ Grids can be aligned in five ways:
 
 ##### Center
 
-<div class="docs-grid-demo align-center frame-block">
-  <div class="small-4 frame-block"></div>
-  <div class="small-4 frame-block"></div>
+<div class="docs-grid-demo align-center frame-group">
+  <div class="small-4 frame-group"></div>
+  <div class="small-4 frame-group"></div>
 </div>
 
 ##### Justify
 
-<div class="docs-grid-demo align-justify frame-block">
-  <div class="small-4 frame-block"></div>
-  <div class="small-4 frame-block"></div>
+<div class="docs-grid-demo align-justify frame-group">
+  <div class="small-4 frame-group"></div>
+  <div class="small-4 frame-group"></div>
 </div>
 
 ##### Spaced
 
-<div class="docs-grid-demo align-spaced frame-block">
-  <div class="small-4 frame-block"></div>
-  <div class="small-4 frame-block"></div>
+<div class="docs-grid-demo align-spaced frame-group">
+  <div class="small-4 frame-group"></div>
+  <div class="small-4 frame-group"></div>
 </div>
 
 ---
@@ -245,66 +250,46 @@ Grids can be aligned in five ways:
 Blocks can be reordered to be different from the order they appear in the HTML. This is known as *source ordering*.
 
 ```html
-<div class="frame-block">
-  <div class="frame-block order-2">2</div>
-  <div class="frame-block order-1">1</div>
+<div class="frame-group">
+  <div class="frame-group order-2">2</div>
+  <div class="frame-group order-1">1</div>
 </div>
 ```
 
-<div class="docs-grid-demo frame-block">
-  <div class="frame-block order-2 text">2</div>
-  <div class="frame-block order-1 text">1</div>
+<div class="docs-grid-demo frame-group">
+  <div class="frame-group order-2 text">2</div>
+  <div class="frame-group order-1 text">1</div>
 </div>
 
 In the above example, the first child block will actually appear <em>after</em> the second one, because it has a lower order number. Blocks with the lower order (e.g. 1 is lower than 2) number appear first in the layout. If multiple blocks share an order, they're then grouped by their order in the HTML.
 
 ```
-<div class="frame-block">
+<div class="frame-group">
   <!-- 3rd -->
-  <div class="frame-block order-2">3</div>
+  <div class="frame-group order-2">3</div>
   <!-- 1st -->
-  <div class="frame-block order-1">1</div>
+  <div class="frame-group order-1">1</div>
   <!-- 2nd -->
-  <div class="frame-block order-1">2</div>
+  <div class="frame-group order-1">2</div>
 </div>
 ```
 
-<div class="docs-grid-demo frame-block">
-  <div class="frame-block order-2 text">3</div>
-  <div class="frame-block order-1 text">1</div>
-  <div class="frame-block order-1 text">2</div>
+<div class="docs-grid-demo frame-group">
+  <div class="frame-group order-2 text">3</div>
+  <div class="frame-group order-1 text">1</div>
+  <div class="frame-group order-1 text">2</div>
 </div>
 
 The ordering classes also come in responsive flavors, allowing you to reorder grid blocks at different screen sizes. In the below example, the two blocks will switch places on medium screens and larger.
 
 ```html
-<div class="frame-block">
-  <div class="frame-block medium-order-2">1</div>
-  <div class="frame-block medium-order-1">2</div>
+<div class="frame-group">
+  <div class="frame-group medium-order-2">1</div>
+  <div class="frame-group medium-order-1">2</div>
 </div>
 ```
 
-<div class="docs-grid-demo frame-block">
-  <div class="frame-block medium-order-2 text">1</div>
-  <div class="frame-block medium-order-1 text">2</div>
+<div class="docs-grid-demo frame-group">
+  <div class="frame-group medium-order-2 text">1</div>
+  <div class="frame-group medium-order-1 text">2</div>
 </div>
-
----
-
-#### Offsets
-
-The same offset classes from Foundation for Sites can be used in Foundation for Apps. To create a left-hand margin on a block, add the class `[size]-offset-[n]`, where `[size]` is a breakpoint name, and `[n]` is the number of columns to offset by. In the below example, the second column will be offset by 3, which is equal to 25% of the width of the entire container.
-
-```html
-<div class="frame-block">
-  <div class="small-6 frame-block"></div>
-  <div class="small-2 small-offset-2 frame-block"></div>
-</div>
-```
-
-<div class="docs-grid-demo frame-block">
-  <div class="small-6 frame-block"></div>
-  <div class="small-2 small-offset-2 frame-block"></div>
-</div>
-
-Offset classes allow you to fine-tune the spacing of blocks at different screen sizes. However, many common spacing options can also be achieved with the grid alignment classes described above.

--- a/docs/pages/test-frame.html
+++ b/docs/pages/test-frame.html
@@ -1,0 +1,6 @@
+---
+title: hello
+layout: test
+---
+
+Hello

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -23,6 +23,7 @@
   <li class="docs-nav-title">General</li>
   <li{{#ifpage 'grid'}} class="current"{{/ifpage}}><a href="grid.html">Grid</a></li>
   <li{{#ifpage 'flex-grid'}} class="current"{{/ifpage}}><a href="flex-grid.html">Flex Grid</a></li>
+  <li{{#ifpage 'frame-grid'}} class="current"{{/ifpage}}><a href="frame-grid.html">Flex Grid</a></li>
   <li{{#ifpage 'forms'}} class="current"{{/ifpage}}><a href="forms.html">Forms</a></li>
   <li{{#ifpage 'visibility'}} class="current"{{/ifpage}}><a href="visibility.html">Visibility Classes</a></li>
   <li{{#ifpage 'float-classes'}} class="current"{{/ifpage}}><a href="float-classes.html">Float Classes</a></li>

--- a/scss/foundation.scss
+++ b/scss/foundation.scss
@@ -9,7 +9,7 @@
 @import "normalize";
 
 // Settings
-// import your own `settings` here or 
+// import your own `settings` here or
 // import and modify the default settings through
 // @import "settings/settings";
 
@@ -21,6 +21,7 @@
 
 // Components
 @import 'grid/grid';
+@import 'grid/apps-grid';
 @import 'typography/typography';
 @import 'forms/forms';
 @import 'components/visibility';

--- a/scss/grid/_apps-grid-classes.scss
+++ b/scss/grid/_apps-grid-classes.scss
@@ -1,0 +1,75 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group frame
+////
+
+// Shared styles for frames and groups (parent elements)
+%parent-core {
+  // Change the direction children flow
+  &.vertical { @include grid-orient(vertical); }
+
+  @each $size in $breakpoint-classes {
+    @include breakpoint($size) {
+      &.#{$size}-vertical   { @include grid-orient(vertical); }
+      &.#{$size}-horizontal { @include grid-orient(horizontal); }
+    }
+  }
+}
+
+// Shared styles for groups and blocks (child elements)
+%child-core {
+  // Shrink a flex item so it only takes up the space it needs
+  &.shrink { @include grid-size(shrink); }
+
+  // Prevent an element from scrolling
+  &.noscroll { overflow: visible; }
+}
+
+// The core grid elements:
+//  - Frame
+//  - Group
+//  - Block
+.frame {
+  @extend %parent-core;
+  @include frame;
+}
+
+.frame-group {
+  @extend %parent-core;
+  @extend %child-core;
+  @include frame-group;
+}
+
+.frame-block {
+  @extend %child-core;
+  @include frame-block;
+
+  &.collapse {
+    padding: 0;
+  }
+}
+
+// Breakpoint classes for blocks
+@each $size in $breakpoint-classes {
+  .#{$size}-frame-group {
+    @extend %parent-core;
+    @extend %child-core;
+  }
+
+  .#{$size}-frame-block {
+    @extend %child-core;
+  }
+
+  @include breakpoint($size) {
+    .#{$size}-frame-group { @include frame-group; }
+    .#{$size}-frame-block { @include frame-block; }
+
+    .#{$size}-frame-group,
+    .#{$size}-frame-block {
+      &.panel { @include frame-panel-reset; }
+    }
+  }
+}

--- a/scss/grid/_apps-grid-elements.scss
+++ b/scss/grid/_apps-grid-elements.scss
@@ -9,7 +9,7 @@
 /// Creates the top-level app frame.
 @mixin frame($size: expand, $orientation: horizontal, $align: left) {
   display: flex;
-  height: 100vh;
+  height: calc(100% - 0px);
   position: relative;
   overflow: hidden;
   backface-visibility: hidden;

--- a/scss/grid/_apps-grid-elements.scss
+++ b/scss/grid/_apps-grid-elements.scss
@@ -1,0 +1,42 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group frame
+////
+
+/// Creates the top-level app frame.
+@mixin frame($size: expand, $orientation: horizontal, $align: left) {
+  display: flex;
+  height: 100vh;
+  position: relative;
+  overflow: hidden;
+  backface-visibility: hidden;
+  flex-wrap: nowrap;
+  align-items: stretch;
+
+  @include grid-size($size);
+  @include grid-orient($orientation);
+  @include grid-align($align);
+}
+
+/// Creates a frame group, which is used to nest multiple blocks together.
+@mixin frame-group($size: expand, $orientation: horizontal, $align: left) {
+  @include frame($size, $orientation, $align);
+  height: auto;
+}
+
+/// Creates a frame block, which is an independently-scrolling pane of content.
+@mixin frame-block($size: expand) {
+  // Content blocks are not flex items and have padding
+  display: block;
+  padding: $block-padding;
+
+  // Add scrolling with inertia
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+
+  @include grid-size($size);
+}

--- a/scss/grid/_apps-grid-modifiers.scss
+++ b/scss/grid/_apps-grid-modifiers.scss
@@ -1,0 +1,92 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group frame
+////
+
+/// Define the size of a grid block. Blocks are flex items. By default, they stretch to fill all available space, based on the size of sibling blocks. This is the "expand" behavior.
+/// If set to "shrink", the block will contract and only fill as much space as it needs for its content.
+/// If set to a number, the block will be given a percentage width, based on the total number of columns (12 by default). Percentage widths don't work if a block is inside a vertical grid.
+/// @param {number|string} $size - Sizing behavior of the block. Should be expand, shrink, or a number.
+/// @output The flex-basis, flex-grow, and flex-shrink properties.
+@mixin grid-size($size: expand) {
+  @if (type-of($size) == 'number') {
+    $pct: percentage($size / $total-columns);
+    flex: 0 0 $pct;
+    // max-width prevents columns from wrapping early in IE10/11
+    max-width: $pct;
+  }
+  @else if ($size == shrink) {
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+  @else if ($size == expand) {
+    flex: 1 1 auto;
+  }
+}
+
+/// Set the orientation of blocks within this block. The grid is re-oriented by changing the flex direction of the block.
+/// @param {string} $orientation - Direction of the grid, either horizontal or vertical.
+/// @output A flex-flow property to match the direction given.
+@mixin grid-orient($orientation: horizontal) {
+  @if ($orientation == vertical) {
+    flex-direction: column;
+  }
+  @else {
+    flex-direction: row;
+  }
+}
+
+/// Set the alignment of blocks within a grid.
+///  - left: Items align to the left.
+///  - right: Items align to the right.
+///  - center: Items align to the center.
+///  - justify: Items are spaced equally apart so they occupy the space of the entire grid.
+///  - spaced: Items are given equal space to their left and right.
+/// @param {string} $align - Alignment to use.
+/// @output An appropriate justify-content value.
+@mixin grid-align($align: left) {
+  $options: (
+    left: flex-start,
+    right: flex-end,
+    center: center,
+    justify: space-between,
+    spaced: space-around,
+  );
+  justify-content: map-get($options, $align);
+}
+
+/// Set the source order of a block. Items with lower numbers appear first. If multiple items have the same number, the one in the HTML first will appear first.
+/// @param {number} $order - Position in source order.
+/// @output An order property.
+@mixin grid-order($order: 0) {
+  order: $order;
+}
+
+/// Offset a block by adding a left margin.
+/// @param {number | bool} $offset - If false, nothing is output. If a number, offsets the column by the specified number of columns.
+/// @output A left margin based on the number of columns specified, and the global number of columns.
+@mixin grid-offset($offset: false) {
+  @if ($offset != false) {
+    margin-left: percentage($offset / $total-columns);
+  }
+}
+
+/// Resets styles set by panels. Use this when a panel transforms into a block on larger screens.
+/// @output Resets to transform, position, and a few visual styles.
+@mixin frame-panel-reset {
+  position: relative;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+  z-index: auto;
+  width: auto;
+  height: auto;
+  padding: $block-padding;
+  background: transparent;
+  box-shadow: none;
+  transform: none;
+}

--- a/scss/grid/_apps-grid.scss
+++ b/scss/grid/_apps-grid.scss
@@ -1,0 +1,19 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group frame
+////
+
+/// Padding of frame blocks.
+/// @type Length
+$block-padding: $global-padding !default;
+
+/// Column count to use when sizing grid elements.
+/// @type Number
+$total-columns: $grid-column-count !default;
+
+@import 'apps-grid-elements';
+@import 'apps-grid-modifiers';
+@import 'apps-grid-classes';

--- a/test/visual/_template.html
+++ b/test/visual/_template.html
@@ -9,9 +9,6 @@
     <link href="../assets/css/foundation.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="row column">
-      <p>Use this template to create a new test page.</p>
-    </div>
 
     <script src="../assets/js/vendor.js"></script>
     <script src="../assets/js/foundation.js"></script>

--- a/test/visual/apps-grid/frame.html
+++ b/test/visual/apps-grid/frame.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation-flex.css" rel="stylesheet" />
+    <style>
+      .column .column {
+        background: #eee;
+      }
+      .column .column .column {
+        background: #ddd;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="frame vertical">
+      <div class="frame-group shrink">
+        <h1>Flex Grid: Unstack and Block Grid</h1>
+      </div>
+      <div class="frame-block">
+        <h1>Vivamus Luctus Urna Sed Urna Ultricies</h1>
+
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas.</p>
+
+<p>Est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed molestie augue sit amet leo consequat posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin vel ante a orci tempus eleifend ut et magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus luctus urna sed urna ultricies ac tempor dui sagittis. In condimentum facilisis porta. Sed nec diam eu diam mattis viverra. Nulla fringilla, orci ac euismod semper.</p>
+
+<p>Magna diam porttitor mauris.</p>
+
+<p>Quis sollicitudin sapien justo in libero. Vestibulum mollis mauris enim. Morbi euismod magna ac lorem rutrum elementum. Donec viverra auctor lobortis. Pellentesque eu est a nulla placerat dignissim. Morbi a enim in magna semper bibendum. Etiam scelerisque, nunc ac egestas consequat, odio nibh euismod nulla, eget auctor orci nibh vel nisi. Aliquam erat volutpat. Mauris vel neque sit amet nunc.</p>
+
+<p>Gravida congue sed sit amet purus. Quisque lacus quam, egestas ac tincidunt a, lacinia vel velit. Aenean facilisis nulla vitae urna tincidunt congue sed ut dui. Morbi malesuada nulla nec purus convallis consequat. Vivamus id mollis quam. Morbi ac commodo nulla. In condimentum orci id nisl volutpat bibendum. Quisque commodo hendrerit lorem quis egestas. Maecenas quis tortor arcu. Vivamus rutrum nunc non neque consectetur quis placerat neque lobortis. Nam vestibulum, arcu sodales feugiat consectetur, nisl orci bibendum elit, eu euismod magna sapien ut nibh. Donec semper quam scelerisque tortor dictum gravida. In hac habitasse platea dictumst. Nam pulvinar, odio sed rhoncus suscipit, sem diam ultrices mauris, eu consequat purus metus eu.</p>
+
+<p>Velit. Proin metus odio, aliquam eget molestie nec, gravida ut sapien. Phasellus quis est sed turpis sollicitudin venenatis sed eu odio. Praesent eget neque eu eros interdum malesuada non vel leo. Sed fringilla porta ligula egestas tincidunt. Nullam risus magna, ornare vitae varius eget, scelerisque a libero. Morbi eu porttitor ipsum. Nullam lorem nisi, posuere quis volutpat eget, luctus nec massa. Pellentesque aliquam lacinia tellus sit amet bibendum. Ut posuere justo in enim pretium scelerisque. Etiam ornare vehicula euismod. Vestibulum at risus augue. Sed non semper dolor. Sed fringilla consequat velit a porta. Pellentesque sed.</p>
+
+<p>Lectus pharetra ipsum ultricies commodo non.</p>
+
+<p>Sit amet velit. Suspendisse volutpat lobortis ipsum, in scelerisque nisi iaculis a. Duis pulvinar lacinia commodo. Integer in lorem id nibh luctus aliquam. Sed elementum, est ac sagittis porttitor, neque metus ultricies ante, in accumsan massa nisl non metus. Vivamus sagittis quam a lacus dictum tempor. Nullam in semper ipsum. Cras a est id massa malesuada tincidunt. Etiam a urna tellus. Ut rutrum vehicula dui, eu cursus magna tincidunt pretium. Donec malesuada accumsan quam, et commodo orci viverra et. Integer tincidunt sagittis lectus. Mauris ac ligula quis orci auctor tincidunt. Suspendisse odio justo, varius id posuere sit amet, iaculis sit amet orci. Suspendisse potenti. Suspendisse potenti. Aliquam erat volutpat. Sed posuere dignissim odio, nec cursus odio mollis et. Praesent cursus, orci ut dictum adipiscing, tellus.</p>
+
+<p>Ante porttitor leo, vel gravida lacus lorem vitae est. Duis ultricies feugiat ante nec aliquam. Maecenas varius, nulla vel fermentum semper, metus nibh bibendum nunc, vitae suscipit mauris velit ac nunc. Mauris nunc eros, egestas at vehicula tincidunt, commodo ac mauris. Nulla facilisi. Nunc eros sem, lobortis non pulvinar id, blandit in eros.</p>
+
+<p>In bibendum suscipit porta. Quisque vitae erat.</p>
+
+<p>Eget nulla cursus malesuada. Nulla venenatis feugiat quam, sed rutrum tellus suscipit quis. Aliquam placerat velit in quam imperdiet vel vehicula nulla interdum. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Morbi commodo, ipsum sed pharetra gravida, orci magna rhoncus neque, id pulvinar odio lorem non turpis. Nullam sit amet enim. Suspendisse id velit vitae ligula volutpat condimentum. Aliquam erat volutpat. Sed quis velit.</p>
+
+<p>Nulla facilisi. Nulla libero. Vivamus pharetra posuere sapien. Nam consectetuer. Sed aliquam, nunc eget euismod ullamcorper, lectus nunc ullamcorper orci, fermentum bibendum enim nibh eget ipsum. Donec porttitor ligula eu dolor. Maecenas vitae nulla consequat libero cursus venenatis. Nam magna enim, accumsan eu, blandit sed, blandit a, eros. Quisque facilisis erat a dui. Nam malesuada ornare dolor. Cras gravida, diam sit amet rhoncus ornare, erat elit consectetuer erat, id egestas pede nibh eget odio. Proin tincidunt, velit vel porta elementum, magna diam molestie sapien, non aliquet massa pede eu diam.</p>
+
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>

--- a/test/visual/apps-grid/frame.html
+++ b/test/visual/apps-grid/frame.html
@@ -20,7 +20,7 @@
       <div class="frame-group shrink">
         <h1>Flex Grid: Unstack and Block Grid</h1>
       </div>
-      <div class="frame-block">
+      <div class="frame-group">
         <h1>Vivamus Luctus Urna Sed Urna Ultricies</h1>
 
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas.</p>

--- a/test/visual/flex-grid/column-row.html
+++ b/test/visual/flex-grid/column-row.html
@@ -8,14 +8,14 @@
     <link href="../assets/css/foundation-flex.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="row column">
-      <style>.row.column {border: 1px solid #333;}</style>
-      <h1>Flex Grid: Column Row</h1>
-
-      <p>This text is inside a combined column/row.</p>
-
-      <p>An element with the classes <code>.row</code> and <code>.column</code> should have <code>display: block</code> and not <code>display: flex</code>, so the elements inside flow normally.</p>
-    </div>
+    <div class="frame">
+      <div class="grid-group shrink">
+        Hello
+      </div>
+      <div class="grid-group">
+        The rest
+      </div>
+    <div>
 
     <script src="../assets/js/vendor.js"></script>
     <script src="../assets/js/foundation.js"></script>


### PR DESCRIPTION
Taking the best parts of the Foundation for Apps grid and adding it into sites as an optional extension of the grid. 

Meant to work in conjunction with the Foundation for Sites grid or flex grid, but act as the outer shell of a complex web app layout.

This WIP is mainly complete for features of the grid overall and the docs should be about 75% there. Still need some additional browser testing and some improvements to the docs demos. Could also benefit from a template to better show the power of deep nesting with this grid. 

Still to do in the wishlist would be the Panel functionality we had developed for Apps. Where on smaller screens a frame-block or frame-group could be made fixed position and triggered as a panel on from off screen. This syntax could use some help and the actual trigger would be need to created using JS. This however was a HUGE help in the Foundation for Apps grid, as it allowed me to have 2-3 columns share horizontal space on large screens, but then have less important content called from off screen on smaller screens. 

Looking for help pushing this past the finish. 