### PR TITLE
Fix back button/history behavior in deep linking

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -20,6 +20,7 @@ class Magellan {
     this.options  = $.extend({}, Magellan.defaults, this.$element.data(), options);
 
     this._init();
+    this.calcPoints();
 
     Foundation.registerPlugin(this, 'Magellan');
   }

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -94,6 +94,11 @@ class Magellan {
         e.preventDefault();
         var arrival   = this.getAttribute('href');
         _this.scrollToLoc(arrival);
+      });
+    $(window).on('popstate', function(e) {
+      if(_this.options.deepLinking) {
+        _this.scrollToLoc(window.location.hash);
+      }
     });
   }
 
@@ -105,9 +110,16 @@ class Magellan {
   scrollToLoc(loc) {
     // Do nothing if target does not exist to prevent errors
     if (!$(loc).length) {return false;}
-    var scrollPos = Math.round($(loc).offset().top - this.options.threshold / 2 - this.options.barOffset);
+    this._inTransition = true;
+    var _this = this,
+        scrollPos = Math.round($(loc).offset().top - this.options.threshold / 2 - this.options.barOffset);
 
-    $('html, body').stop(true).animate({ scrollTop: scrollPos }, this.options.animationDuration, this.options.animationEasing);
+    $('html, body').stop(true).animate(
+      { scrollTop: scrollPos },
+      this.options.animationDuration,
+      this.options.animationEasing,
+      function() {_this._inTransition = false; _this._updateActive()}
+    );
   }
 
   /**
@@ -126,6 +138,7 @@ class Magellan {
    * @fires Magellan#update
    */
   _updateActive(/*evt, elem, scrollPos*/) {
+    if(this._inTransition) {return;}
     var winPos = /*scrollPos ||*/ parseInt(window.pageYOffset, 10),
         curIdx;
 
@@ -144,14 +157,16 @@ class Magellan {
     this.$active = this.$links.filter('[href="#' + this.$targets.eq(curIdx).data('magellan-target') + '"]').addClass(this.options.activeClass);
 
     if(this.options.deepLinking){
-      var hash = " ";
+      var hash = "";
       if(curIdx != undefined){
         hash = this.$active[0].getAttribute('href');
       }
-      if(window.history.pushState){
-        window.history.pushState(null, null, hash);
-      }else{
-        window.location.hash = hash;
+      if(hash !== window.location.hash) {
+        if(window.history.pushState){
+          window.history.pushState(null, null, hash);
+        }else{
+          window.location.hash = hash;
+        }
       }
     }
 


### PR DESCRIPTION
Magellan added deep linking in 6.3, but QA turned up that the history behavior was broken, it would break your back button, and in some browsers scroll spasmotically due to overcalling of _updateActive.  This PR fixes this by 

1. Only updating history if the hash has actually changed
2. Not continuously updating active while we're scrolling to a position
3. adding clean handling of popstate events.