### PR TITLE
Fix #9499 - Add simple menu behavior for align-right

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -289,6 +289,10 @@ $menu-border: $light-gray !default;
     // Simple
     &.simple {
       @include menu-simple;
+
+      &.align-#{$global-right} {
+        @include menu-simple-direction($global-right);
+      }
     }
 
     // Align right

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -140,15 +140,31 @@ $menu-border: $light-gray !default;
 }
 
 /// Creates a simple Menu, which has no padding or hover state.
-@mixin menu-simple {
+/// @param {Keyword} $dir [$global-left] - Direction of the menu. Set to `null` to do not generate styles for direction.
+@mixin menu-simple($dir: $global-left) {
   li {
     display: inline-block;
-    margin-#{$global-right}: get-side($menu-item-padding, $global-right);
     line-height: 1;
   }
 
   a {
     padding: 0;
+  }
+
+  @if $dir != null {
+    @include menu-simple-direction($dir);
+  }
+}
+
+/// Direction modifier for a simple Menu
+/// @param {Keyword} $dir [$global-left] - Direction of the menu
+@mixin menu-simple-direction($dir: $global-left) {
+  $no-margin-dir: $dir;
+  $margin-dir: direction-opposite($dir);
+
+  li {
+    margin-#{$no-margin-dir}: 0;
+    margin-#{$margin-dir}: get-side($menu-item-padding, $margin-dir);
   }
 }
 

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -144,6 +144,7 @@ $menu-border: $light-gray !default;
 @mixin menu-simple($dir: $global-left) {
   li {
     display: inline-block;
+    vertical-align: top;
     line-height: 1;
   }
 

--- a/scss/util/_direction.scss
+++ b/scss/util/_direction.scss
@@ -1,0 +1,31 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group functions
+////
+
+/// Return the opposite direction of $dir
+///
+/// @param {Keyword} $dir - Used direction between "top", "right", "bottom" and "left".
+/// @return {Keyword} Opposite direction of $dir
+@function direction-opposite(
+  $dir
+) {
+  $dirs: (top, right, bottom, left);
+  $place: index($dirs, $dir);
+
+  @if $place == null {
+    @error 'direction-opposite: Invalid $dir parameter, expected a value from "' + $dirs + '", found "' + $dir + '".';
+    @return null;
+  }
+
+  // Calcul the opposite place in a circle, with a starting index of 1
+  $length: length($dirs);
+  $demi: $length / 2;
+  $opposite-place: (($place + $demi - 1) % $length) + 1;
+
+  @return nth($dirs, $opposite-place);
+}
+

--- a/scss/util/_direction.scss
+++ b/scss/util/_direction.scss
@@ -17,7 +17,7 @@
   $place: index($dirs, $dir);
 
   @if $place == null {
-    @error 'direction-opposite: Invalid $dir parameter, expected a value from "' + $dirs + '", found "' + $dir + '".';
+    @error 'direction-opposite: Invalid $dir parameter, expected a value from "#{$dirs}", found "#{$dir}".';
     @return null;
   }
 

--- a/scss/util/_direction.scss
+++ b/scss/util/_direction.scss
@@ -6,7 +6,7 @@
 /// @group functions
 ////
 
-/// Return the opposite direction of $dir
+/// Returns the opposite direction of $dir
 ///
 /// @param {Keyword} $dir - Used direction between "top", "right", "bottom" and "left".
 /// @return {Keyword} Opposite direction of $dir

--- a/scss/util/_util.scss
+++ b/scss/util/_util.scss
@@ -5,6 +5,7 @@
 @import 'math';
 @import 'unit';
 @import 'value';
+@import 'direction';
 @import 'color';
 @import 'selector';
 @import 'flex';


### PR DESCRIPTION
Fix #9499.

#### Changes:
- Make `@mixin menu-simple` taking a `$dir` parameter to generate margins.
- Add `@mixin menu-simple-direction($dir: $global-left)`: Direction modifier for a simple Menu.
- Add a special case for simple menu `.menu.simple` with `.align-right`. Use `@mixin menu-simple-direction` to change the menu direction to the right.

#### Other changes:
- Add `@function direction-opposite($dir)`: Return the opposite direction of $dir, between "top", "right", "bottom" and "left".
- Add documentation for `@mixin menu-simple`.
- Fix simple menu height (see https://github.com/zurb/foundation-sites/pull/9539)