### PR TITLE
[WIP] Classes for all components

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -94,6 +94,10 @@ $global-text-direction: ltr !default;
 /// @type Boolean
 $global-flexbox: false !default;
 
+/// Always define components with classes instead of tags (besides the reset).
+/// @type Boolean
+$global-namespace: false !default;
+
 @if not map-has-key($foundation-palette, primary) {
   @error 'In $foundation-palette, you must have a color named "primary".';
 }

--- a/scss/forms/_label.scss
+++ b/scss/forms/_label.scss
@@ -40,7 +40,9 @@ $form-label-line-height: 1.8 !default;
 }
 
 @mixin foundation-form-label {
-  label {
+  $name: if($global-namespace, '.label', 'label');
+
+  #{$name} {
     @include form-label;
 
     &.middle {

--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -79,7 +79,9 @@ $select-radius: $global-radius !default;
 }
 
 @mixin foundation-form-select {
-  select {
+  $name: if($global-namespace, '.select', 'select');
+
+  #{$name} {
     @include form-select;
   }
 }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -72,6 +72,7 @@ $global-weight-bold: bold;
 $global-radius: 0;
 $global-text-direction: ltr;
 $global-flexbox: false;
+$global-namespace: false;
 $print-transparent-backgrounds: true;
 
 @include add-foundation-colors;


### PR DESCRIPTION
From: https://github.com/zurb/foundation-sites/pull/8718

### Planned changes:
- Separate *reset* properties from *component's structural and graphics* properties. Currently, this separations is unclear for all `foundation-forms` components
- Allow to make components be defined with always `.classes` instead of standard `<tags>`. Currently, lot of component define their non-reset properties on tags. It can lead to **unwanted properties** for someone using its own components.

### Previous changes:
_(30 April 2016)_
- Add `$global-namespace {Boolean} [false]` option which when enabled, make all components be defined in classes, instead of tags.
- Use `$global-namespace` for `label` and `select`

### Progress:
⚠️  Work in Progress

- 
