### PR TITLE
Partially fix #9464 - Incorrect documentation of DropdownMenu options

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -377,7 +377,7 @@ DropdownMenu.defaults = {
   /**
    * Allow a submenu to open/remain open on parent click event. Allows cursor to move away from menu.
    * @option
-   * @example true
+   * @example false
    */
   clickOpen: false,
   /**
@@ -420,7 +420,7 @@ DropdownMenu.defaults = {
   /**
    * Boolean to force overide the clicking of links to perform default action, on second touch event for mobile.
    * @option
-   * @example false
+   * @example true
    */
   forceFollow: true
 };


### PR DESCRIPTION
See: https://github.com/zurb/foundation-sites/issues/9464

At http://foundation.zurb.com/sites/docs/dropdown-menu.html#js-option, we can read:
- `data-click-open`, default `true`
- `data-force-follow`, default `false`

But in the code at https://github.com/zurb/foundation-sites/blob/v6.2.4/js/foundation.dropdownMenu.js#L362 (for `v6.4.2` and currently in `develop`):
- `clickOpen: false,`
- `forceFollow: true`

SuperCollider is using the `@example` value to generate what is presented as the "default" value. This is a partial fix. A better way to generate the JS documentation is required.