### PR TITLE
Fix #9521 - Single button in expanded button group

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -94,6 +94,12 @@ $buttongroup-radius-on-each: true !default;
       flex: 1 1 0px; // sass-lint:disable-line zero-unit
     }
     @else {
+      // One child
+      &:first-child:last-child {
+        width: 100%
+      }
+
+      // Two or more childreen
       @for $i from 2 through $buttongroup-expand-max {
         &:first-child:nth-last-child(#{$i}) {
           &, &:first-child:nth-last-child(#{$i}) ~ #{$selector} {


### PR DESCRIPTION
Fix https://github.com/zurb/foundation-sites/issues/9521
A single button in a expanded button group was not expanded.

#### Changes:
- Add `width:100%` to the button when it is the only one in the button group.

**Note:** The way we are currently handling button groups is really dirty.