### PR TITLE
Missing Keyboard util reference in Offcanvas documentation

### DIFF
--- a/dist/js/foundation.js
+++ b/dist/js/foundation.js
@@ -5393,6 +5393,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
   /**
    * OffCanvas module.
    * @module foundation.offcanvas
+   * @requires foundation.util.keyboard
    * @requires foundation.util.mediaQuery
    * @requires foundation.util.triggers
    * @requires foundation.util.motion

--- a/dist/js/plugins/foundation.offcanvas.js
+++ b/dist/js/plugins/foundation.offcanvas.js
@@ -9,6 +9,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
   /**
    * OffCanvas module.
    * @module foundation.offcanvas
+   * @requires foundation.util.keyboard
    * @requires foundation.util.mediaQuery
    * @requires foundation.util.triggers
    * @requires foundation.util.motion

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -5,6 +5,7 @@
 /**
  * OffCanvas module.
  * @module foundation.offcanvas
+ * @requires foundation.util.keyboard
  * @requires foundation.util.mediaQuery
  * @requires foundation.util.triggers
  * @requires foundation.util.motion


### PR DESCRIPTION
With the release of v6.2.4 a number of keyboard changes were added to the various modules. This included the Offcanvas module (#9011).

However, since this new dependency wasn't included in the `@requires` section of the module, it means that the current documentation does not mention this requirement. 
And that means a JS error will be thrown if you choose to pick the individual `foundation.offcanvas.js` file in your web project without including the `foundation.util.keyboard.js` file. 
This is something I ran into when upgrading from v6.2.3 to the latest version. When I figured out that the keyboard JS was missing, it was easy to fix.

This pull request contains a few commits that update the `@requires` for the Offcanvas module to include the missing keyboard reference, which then should update the current documentation.