### PR TITLE
[Drilldown] Add an 'else' clause to not let the $wrapper property undefined

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -108,6 +108,8 @@ class Drilldown {
       this.$wrapper = $(this.options.wrapper).addClass('is-drilldown');
       if(this.options.animateHeight) this.$wrapper.addClass('animate-height');
       this.$wrapper = this.$element.wrap(this.$wrapper).parent().css(this._getMaxDims());
+    } else {
+      this.$wrapper = this.$element.parent().css(this._getMaxDims());
     }
   }
 

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -103,14 +103,16 @@ class Drilldown {
     if(!this.options.autoHeight) {
       this.$submenus.addClass('drilldown-submenu-cover-previous');
     }
-
+    
+    // create a wrapper on element if it doesn't exist.
     if(!this.$element.parent().hasClass('is-drilldown')){
       this.$wrapper = $(this.options.wrapper).addClass('is-drilldown');
       if(this.options.animateHeight) this.$wrapper.addClass('animate-height');
-      this.$wrapper = this.$element.wrap(this.$wrapper).parent().css(this._getMaxDims());
-    } else {
-      this.$wrapper = this.$element.parent().css(this._getMaxDims());
+      this.$element.wrap(this.$wrapper);
     }
+    // set wrapper
+    this.$wrapper = this.$element.parent();
+    this.$wrapper.css(this._getMaxDims());
   }
 
   _resize() {


### PR DESCRIPTION
If the parent of the drilldown menu already has the 'is-drilldown' css class, the $wrapper property used everywhere in the plugin stays undefined. Fixes that issue.