### PR TITLE
updates card variable to fit standard naming

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -36,7 +36,7 @@ $card-padding: $global-padding !default;
 
 /// Default bottom margin.
 /// @type number
-$card-margin: $global-margin !default;
+$card-margin-bottom: $global-margin !default;
 
 /// Adds styles for a card container.
 /// @param {Color} $background - Background color of the card.

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -292,7 +292,7 @@ $card-border: 1px solid $light-gray;
 $card-shadow: none;
 $card-border-radius: $global-radius;
 $card-padding: $global-padding;
-$card-margin: $global-margin;
+$card-margin-bottom: $global-margin;
 
 // 15. Close Button
 // ----------------


### PR DESCRIPTION
We're using margin-bottom on the `$card-margin` variable. All other components that use margin-bottom follow the `$component-margin-bottom` naming convention.

This PR changes the variable name to do the same.