### PR TITLE
Changes Card variable naming

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -48,7 +48,7 @@ $card-margin-bottom: $global-margin !default;
 @mixin card-container(
   $background: $card-background,
   $color: $card-font-color,
-  $margin: $card-margin,
+  $margin: $card-margin-bottom,
   $border: $card-border,
   $radius: $card-border-radius,
   $shadow: $card-shadow

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -36,7 +36,7 @@ $card-padding: $global-padding !default;
 
 /// Default bottom margin.
 /// @type number
-$card-margin: $global-margin !default;
+$card-margin-bottom: $global-margin !default;
 
 /// Adds styles for a card container.
 /// @param {Color} $background - Background color of the card.

--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -12,7 +12,7 @@
 ///   Width of the column. Accepts multiple values:
 ///   - A percentage value will make the column that exact size.
 ///   - A single digit will make the column span that number of columns wide, taking into account the column count of the parent row.
-///   - A string of the format "x of y" will make a column that is *x* columns wide, assuming *y* total columns for the parent.
+///   - A list of the format "x of y" (without quotes) will make a column that is *x* columns wide, assuming *y* total columns for the parent.
 ///
 /// @returns {Number} A calculated percentage value.
 @function grid-column($columns) {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -292,7 +292,7 @@ $card-border: 1px solid $light-gray;
 $card-shadow: none;
 $card-border-radius: $global-radius;
 $card-padding: $global-padding;
-$card-margin: $global-margin;
+$card-margin-bottom: $global-margin;
 
 // 15. Close Button
 // ----------------


### PR DESCRIPTION
We're using margin-bottom on the `$card-margin variable`. All other components that use margin-bottom follow the `$component-margin-bottom` naming convention.

This PR changes the variable name to do the same.