### PR TITLE
Set box-sizing for select elements

### DIFF
--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -20,7 +20,8 @@ $select-radius: $global-radius !default;
 
 @mixin form-select {
   $height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
-
+  
+  box-sizing: border-box;
   height: $height;
   margin: 0 0 $form-spacing;
   padding: ($form-spacing / 2);


### PR DESCRIPTION
Needed to face a bug in Chromium. Inheritance of box-sizing property in details elements does not work properly.
Described in [Issue #9535](https://github.com/zurb/foundation-sites/issues/9535).
