### PR TITLE
Update _menu.scss

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -339,6 +339,7 @@ $menu-border: $light-gray !default;
 
     > .menu {
       display: inline-block;
+      vertical-align: top;
     }
   }
 


### PR DESCRIPTION
It appears that centering the menu adds unnecessary/undesired height to the container.
My Proposed update to add vertical-align: top; to the inline-block applied container, fixes this issue.
Thank you
Bert (PixelGrinch)