### PR TITLE
Increase the precision of the pow function when calculating luminance

### DIFF
--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -23,7 +23,7 @@
     $rgb: nth($rgba, $i);
     $rgb: $rgb / 255;
 
-    $rgb: if($rgb < 0.03928, $rgb / 12.92, pow(($rgb + 0.055) / 1.055, 2.4, 18));
+    $rgb: if($rgb < 0.03928, $rgb / 12.92, pow(($rgb + 0.055) / 1.055, 2.4));
 
     $rgba2: append($rgba2, $rgb);
   }

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -23,7 +23,7 @@
     $rgb: nth($rgba, $i);
     $rgb: $rgb / 255;
 
-    $rgb: if($rgb < 0.03928, $rgb / 12.92, pow(($rgb + 0.055) / 1.055, 2.4));
+    $rgb: if($rgb < 0.03928, $rgb / 12.92, pow(($rgb + 0.055) / 1.055, 2.4, 18));
 
     $rgba2: append($rgba2, $rgb);
   }

--- a/scss/util/_math.scss
+++ b/scss/util/_math.scss
@@ -28,7 +28,7 @@
 /// @param {Number} $exponent - The exponent.
 ///
 /// @returns {Number} The product of the exponentiation.
-@function pow($base, $exponent, $prec: 12) {
+@function pow($base, $exponent, $prec: 16) {
   @if (floor($exponent) != $exponent) {
     $prec2 : pow(10, $prec);
     $exponent: round($exponent * $prec2);


### PR DESCRIPTION
When calculating the luminance of a color, the wrong value was being returned.

This was discovered when using `color-pick-contrast()` using `#ff364c` and `#313942`.
The contrast ratio calculator by Lea Verou returns 3.3, while Foundation was calculating 2.9. Foundation returns 3.3 after increasing the precision.

Link: http://leaverou.github.io/contrast-ratio/#%23313942-on-%23ff364c