### PR TITLE
Don't listen to touchend events on dropdown element leafs.

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -108,7 +108,7 @@ class DropdownMenu {
         var $elem = $(this),
             hasSub = $elem.hasClass(parClass);
         if(!hasSub){
-          _this._hide($elem);
+          _this._hide();
         }
       });
     }

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -104,7 +104,7 @@ class DropdownMenu {
 
     // Handle Leaf element Clicks
     if(_this.options.closeOnClickInside){
-      this.$menuItems.on('click.zf.dropdownmenu touchend.zf.dropdownmenu', function(e) {
+      this.$menuItems.on('click.zf.dropdownmenu', function(e) {
         var $elem = $(this),
             hasSub = $elem.hasClass(parClass);
         if(!hasSub){

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -108,7 +108,7 @@ class DropdownMenu {
         var $elem = $(this),
             hasSub = $elem.hasClass(parClass);
         if(!hasSub){
-          _this._hide();
+          _this._hide($elem);
         }
       });
     }


### PR DESCRIPTION
Don't listen to ``touchend`` events on dropdown element leafs. This seems to be missing and was causing issues on touch devices.

Steps to reproduce using Foundation Sites 6.3.0:
 * Use the example dropdown menu code from http://foundation.zurb.com/sites/docs/dropdown-menu.html
 * Add a real link to on submenu Item 1A (i.e. http://foundation.zurb.com)
 * On iPad (or any touch device) click the link for Item 1A

Result:
On the iPad the site doesn't navigate to the link added, while on desktop it does.

Expect:
Both touch and desktop to navigate to the link added.

fix #9484