### PR TITLE
Issue #9535: Set box-sizing for select elements

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -167,6 +167,7 @@ $alert-color: get-color(alert);
 
   // Make select elements are 100% width by default
   select {
+    box-sizing: border-box;
     width: 100%;
     border-radius: $global-radius;
   }


### PR DESCRIPTION
#9535 is fixed by setting `box-sizing: border-box;` explicitly for select elements

@ncoden thx for the reminder and your advice 
