### PR TITLE
Fix docs of JS options

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -472,49 +472,49 @@ Abide.defaults = {
    * The default event to validate inputs. Checkboxes and radios validate immediately.
    * Remove or change this value for manual validation.
    * @option
-   * @example 'fieldChange'
+   * @default 'fieldChange'
    */
   validateOn: 'fieldChange',
 
   /**
    * Class to be applied to input labels on failed validation.
    * @option
-   * @example 'is-invalid-label'
+   * @default 'is-invalid-label'
    */
   labelErrorClass: 'is-invalid-label',
 
   /**
    * Class to be applied to inputs on failed validation.
    * @option
-   * @example 'is-invalid-input'
+   * @default 'is-invalid-input'
    */
   inputErrorClass: 'is-invalid-input',
 
   /**
    * Class selector to use to target Form Errors for show/hide.
    * @option
-   * @example '.form-error'
+   * @default '.form-error'
    */
   formErrorSelector: '.form-error',
 
   /**
    * Class added to Form Errors on failed validation.
    * @option
-   * @example 'is-visible'
+   * @default 'is-visible'
    */
   formErrorClass: 'is-visible',
 
   /**
    * Set to true to validate text inputs on any value change.
    * @option
-   * @example false
+   * @default false
    */
   liveValidate: false,
 
   /**
    * Set to true to validate inputs on blur.
    * @option
-   * @example false
+   * @default false
    */
   validateOnBlur: false,
 

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -472,6 +472,7 @@ Abide.defaults = {
    * The default event to validate inputs. Checkboxes and radios validate immediately.
    * Remove or change this value for manual validation.
    * @option
+   * @type {?string}
    * @default 'fieldChange'
    */
   validateOn: 'fieldChange',
@@ -479,6 +480,7 @@ Abide.defaults = {
   /**
    * Class to be applied to input labels on failed validation.
    * @option
+   * @type {string}
    * @default 'is-invalid-label'
    */
   labelErrorClass: 'is-invalid-label',
@@ -486,6 +488,7 @@ Abide.defaults = {
   /**
    * Class to be applied to inputs on failed validation.
    * @option
+   * @type {string}
    * @default 'is-invalid-input'
    */
   inputErrorClass: 'is-invalid-input',
@@ -493,6 +496,7 @@ Abide.defaults = {
   /**
    * Class selector to use to target Form Errors for show/hide.
    * @option
+   * @type {string}
    * @default '.form-error'
    */
   formErrorSelector: '.form-error',
@@ -500,6 +504,7 @@ Abide.defaults = {
   /**
    * Class added to Form Errors on failed validation.
    * @option
+   * @type {string}
    * @default 'is-visible'
    */
   formErrorClass: 'is-visible',
@@ -507,6 +512,7 @@ Abide.defaults = {
   /**
    * Set to true to validate text inputs on any value change.
    * @option
+   * @type {boolean}
    * @default false
    */
   liveValidate: false,
@@ -514,6 +520,7 @@ Abide.defaults = {
   /**
    * Set to true to validate inputs on blur.
    * @option
+   * @type {boolean}
    * @default false
    */
   validateOnBlur: false,

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -203,18 +203,21 @@ Accordion.defaults = {
   /**
    * Amount of time to animate the opening of an accordion pane.
    * @option
+   * @type {number}
    * @default 250
    */
   slideSpeed: 250,
   /**
    * Allow the accordion to have multiple open panes.
    * @option
+   * @type {boolean}
    * @default false
    */
   multiExpand: false,
   /**
    * Allow the accordion to close all panes.
    * @option
+   * @type {boolean}
    * @default false
    */
   allowAllClosed: false

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -203,19 +203,19 @@ Accordion.defaults = {
   /**
    * Amount of time to animate the opening of an accordion pane.
    * @option
-   * @example 250
+   * @default 250
    */
   slideSpeed: 250,
   /**
    * Allow the accordion to have multiple open panes.
    * @option
-   * @example false
+   * @default false
    */
   multiExpand: false,
   /**
    * Allow the accordion to close all panes.
    * @option
-   * @example false
+   * @default false
    */
   allowAllClosed: false
 };

--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -264,13 +264,13 @@ AccordionMenu.defaults = {
   /**
    * Amount of time to animate the opening of a submenu in ms.
    * @option
-   * @example 250
+   * @default 250
    */
   slideSpeed: 250,
   /**
    * Allow the menu to have multiple open panes.
    * @option
-   * @example true
+   * @default true
    */
   multiOpen: true
 };

--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -264,12 +264,14 @@ AccordionMenu.defaults = {
   /**
    * Amount of time to animate the opening of a submenu in ms.
    * @option
+   * @type {number}
    * @default 250
    */
   slideSpeed: 250,
   /**
    * Allow the menu to have multiple open panes.
    * @option
+   * @type {boolean}
    * @default true
    */
   multiOpen: true

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -417,72 +417,84 @@ Drilldown.defaults = {
   /**
    * Markup used for JS generated back button. Prepended  or appended (see backButtonPosition) to submenu lists and deleted on `destroy` method, 'js-drilldown-back' class required. Remove the backslash (`\`) if copy and pasting.
    * @option
+   * @type {string}
    * @default '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>'
    */
   backButton: '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>',
   /**
    * Position the back button either at the top or bottom of drilldown submenus.
    * @option
+   * @type {string}
    * @default top
    */
   backButtonPosition: 'top',
   /**
    * Markup used to wrap drilldown menu. Use a class name for independent styling; the JS applied class: `is-drilldown` is required. Remove the backslash (`\`) if copy and pasting.
    * @option
+   * @type {string}
    * @default '<div></div>'
    */
   wrapper: '<div></div>',
   /**
    * Adds the parent link to the submenu.
    * @option
+   * @type {boolean}
    * @default false
    */
   parentLink: false,
   /**
    * Allow the menu to return to root list on body click.
    * @option
+   * @type {boolean}
    * @default false
    */
   closeOnClick: false,
   /**
    * Allow the menu to auto adjust height.
    * @option
+   * @type {boolean}
    * @default false
    */
   autoHeight: false,
   /**
    * Animate the auto adjust height.
    * @option
+   * @type {boolean}
    * @default false
    */
   animateHeight: false,
   /**
    * Scroll to the top of the menu after opening a submenu or navigating back using the menu back button
    * @option
+   * @type {boolean}
    * @default false
    */
   scrollTop: false,
   /**
    * String jquery selector (for example 'body') of element to take offset().top from, if empty string the drilldown menu offset().top is taken
    * @option
+   * @type {string}
    * @default ''
    */
   scrollTopElement: '',
   /**
    * ScrollTop offset
    * @option
+   * @type {number}
    * @default 0
    */
   scrollTopOffset: 0,
   /**
    * Scroll animation duration
    * @option
+   * @type {number}
    * @default 500
    */
   animationDuration: 500,
   /**
    * Scroll animation easing
    * @option
+   * @type {string}
    * @default 'swing'
    */
   animationEasing: 'swing'

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -417,73 +417,73 @@ Drilldown.defaults = {
   /**
    * Markup used for JS generated back button. Prepended  or appended (see backButtonPosition) to submenu lists and deleted on `destroy` method, 'js-drilldown-back' class required. Remove the backslash (`\`) if copy and pasting.
    * @option
-   * @example '<\li><\a>Back<\/a><\/li>'
+   * @default '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>'
    */
   backButton: '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>',
   /**
    * Position the back button either at the top or bottom of drilldown submenus.
    * @option
-   * @example bottom
+   * @default top
    */
   backButtonPosition: 'top',
   /**
    * Markup used to wrap drilldown menu. Use a class name for independent styling; the JS applied class: `is-drilldown` is required. Remove the backslash (`\`) if copy and pasting.
    * @option
-   * @example '<\div class="is-drilldown"><\/div>'
+   * @default '<div></div>'
    */
   wrapper: '<div></div>',
   /**
    * Adds the parent link to the submenu.
    * @option
-   * @example false
+   * @default false
    */
   parentLink: false,
   /**
    * Allow the menu to return to root list on body click.
    * @option
-   * @example false
+   * @default false
    */
   closeOnClick: false,
   /**
    * Allow the menu to auto adjust height.
    * @option
-   * @example false
+   * @default false
    */
   autoHeight: false,
   /**
    * Animate the auto adjust height.
    * @option
-   * @example false
+   * @default false
    */
   animateHeight: false,
   /**
    * Scroll to the top of the menu after opening a submenu or navigating back using the menu back button
    * @option
-   * @example false
+   * @default false
    */
   scrollTop: false,
   /**
    * String jquery selector (for example 'body') of element to take offset().top from, if empty string the drilldown menu offset().top is taken
    * @option
-   * @example ''
+   * @default ''
    */
   scrollTopElement: '',
   /**
    * ScrollTop offset
    * @option
-   * @example 100
+   * @default 0
    */
   scrollTopOffset: 0,
   /**
    * Scroll animation duration
    * @option
-   * @example 500
+   * @default 500
    */
   animationDuration: 500,
   /**
    * Scroll animation easing
    * @option
-   * @example 'swing'
+   * @default 'swing'
    */
   animationEasing: 'swing'
   // holdOpen: false

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -422,7 +422,7 @@ Drilldown.defaults = {
    */
   backButton: '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>',
   /**
-   * Position the back button either at the top or bottom of drilldown submenus.
+   * Position the back button either at the top or bottom of drilldown submenus. Can be `'left'` or `'bottom'`.
    * @option
    * @type {string}
    * @default top
@@ -492,9 +492,10 @@ Drilldown.defaults = {
    */
   animationDuration: 500,
   /**
-   * Scroll animation easing
+   * Scroll animation easing. Can be `'swing'` or `'linear'`.
    * @option
    * @type {string}
+   * @see {@link https://api.jquery.com/animate|JQuery animate}
    * @default 'swing'
    */
   animationEasing: 'swing'

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -357,61 +357,61 @@ Dropdown.defaults = {
   /**
    * Class that designates bounding container of Dropdown (Default: window)
    * @option
-   * @example 'dropdown-parent'
+   * @default null
    */
   parentClass: null,
   /**
    * Amount of time to delay opening a submenu on hover event.
    * @option
-   * @example 250
+   * @default 250
    */
   hoverDelay: 250,
   /**
    * Allow submenus to open on hover events
    * @option
-   * @example false
+   * @default false
    */
   hover: false,
   /**
    * Don't close dropdown when hovering over dropdown pane
    * @option
-   * @example true
+   * @default false
    */
   hoverPane: false,
   /**
    * Number of pixels between the dropdown pane and the triggering element on open.
    * @option
-   * @example 1
+   * @default 1
    */
   vOffset: 1,
   /**
    * Number of pixels between the dropdown pane and the triggering element on open.
    * @option
-   * @example 1
+   * @default 1
    */
   hOffset: 1,
   /**
    * Class applied to adjust open position. JS will test and fill this in.
    * @option
-   * @example 'top'
+   * @default ''
    */
   positionClass: '',
   /**
    * Allow the plugin to trap focus to the dropdown pane if opened with keyboard commands.
    * @option
-   * @example false
+   * @default false
    */
   trapFocus: false,
   /**
    * Allow the plugin to set focus to the first focusable element within the pane, regardless of method of opening.
    * @option
-   * @example true
+   * @default false
    */
   autoFocus: false,
   /**
    * Allows a click on the body to close the dropdown.
    * @option
-   * @example false
+   * @default false
    */
   closeOnClick: false
 }

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -355,7 +355,7 @@ class Dropdown {
 
 Dropdown.defaults = {
   /**
-   * Class that designates bounding container of Dropdown (Default: window)
+   * Class that designates bounding container of Dropdown (default: window)
    * @option
    * @type {?string}
    * @default null

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -357,60 +357,70 @@ Dropdown.defaults = {
   /**
    * Class that designates bounding container of Dropdown (Default: window)
    * @option
+   * @type {?string}
    * @default null
    */
   parentClass: null,
   /**
    * Amount of time to delay opening a submenu on hover event.
    * @option
+   * @type {number}
    * @default 250
    */
   hoverDelay: 250,
   /**
    * Allow submenus to open on hover events
    * @option
+   * @type {boolean}
    * @default false
    */
   hover: false,
   /**
    * Don't close dropdown when hovering over dropdown pane
    * @option
+   * @type {boolean}
    * @default false
    */
   hoverPane: false,
   /**
    * Number of pixels between the dropdown pane and the triggering element on open.
    * @option
+   * @type {number}
    * @default 1
    */
   vOffset: 1,
   /**
    * Number of pixels between the dropdown pane and the triggering element on open.
    * @option
+   * @type {number}
    * @default 1
    */
   hOffset: 1,
   /**
    * Class applied to adjust open position. JS will test and fill this in.
    * @option
+   * @type {string}
    * @default ''
    */
   positionClass: '',
   /**
    * Allow the plugin to trap focus to the dropdown pane if opened with keyboard commands.
    * @option
+   * @type {boolean}
    * @default false
    */
   trapFocus: false,
   /**
    * Allow the plugin to set focus to the first focusable element within the pane, regardless of method of opening.
    * @option
+   * @type {boolean}
    * @default false
    */
   autoFocus: false,
   /**
    * Allows a click on the body to close the dropdown.
    * @option
+   * @type {boolean}
    * @default false
    */
   closeOnClick: false

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -359,68 +359,68 @@ DropdownMenu.defaults = {
   /**
    * Disallows hover events from opening submenus
    * @option
-   * @example false
+   * @default false
    */
   disableHover: false,
   /**
    * Allow a submenu to automatically close on a mouseleave event, if not clicked open.
    * @option
-   * @example true
+   * @default true
    */
   autoclose: true,
   /**
    * Amount of time to delay opening a submenu on hover event.
    * @option
-   * @example 50
+   * @default 50
    */
   hoverDelay: 50,
   /**
    * Allow a submenu to open/remain open on parent click event. Allows cursor to move away from menu.
    * @option
-   * @example false
+   * @default false
    */
   clickOpen: false,
   /**
    * Amount of time to delay closing a submenu on a mouseleave event.
    * @option
-   * @example 500
+   * @default 500
    */
 
   closingTime: 500,
   /**
    * Position of the menu relative to what direction the submenus should open. Handled by JS.
    * @option
-   * @example 'left'
+   * @default 'left'
    */
   alignment: 'left',
   /**
    * Allow clicks on the body to close any open submenus.
    * @option
-   * @example true
+   * @default true
    */
   closeOnClick: true,
   /**
    * Allow clicks on leaf anchor links to close any open submenus.
    * @option
-   * @example true
+   * @default true
    */
   closeOnClickInside: true,
   /**
    * Class applied to vertical oriented menus, Foundation default is `vertical`. Update this if using your own class.
    * @option
-   * @example 'vertical'
+   * @default 'vertical'
    */
   verticalClass: 'vertical',
   /**
    * Class applied to right-side oriented menus, Foundation default is `align-right`. Update this if using your own class.
    * @option
-   * @example 'align-right'
+   * @default 'align-right'
    */
   rightClass: 'align-right',
   /**
    * Boolean to force overide the clicking of links to perform default action, on second touch event for mobile.
    * @option
-   * @example true
+   * @default true
    */
   forceFollow: true
 };

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -359,30 +359,35 @@ DropdownMenu.defaults = {
   /**
    * Disallows hover events from opening submenus
    * @option
+   * @type {boolean}
    * @default false
    */
   disableHover: false,
   /**
    * Allow a submenu to automatically close on a mouseleave event, if not clicked open.
    * @option
+   * @type {boolean}
    * @default true
    */
   autoclose: true,
   /**
    * Amount of time to delay opening a submenu on hover event.
    * @option
+   * @type {number}
    * @default 50
    */
   hoverDelay: 50,
   /**
    * Allow a submenu to open/remain open on parent click event. Allows cursor to move away from menu.
    * @option
+   * @type {boolean}
    * @default false
    */
   clickOpen: false,
   /**
    * Amount of time to delay closing a submenu on a mouseleave event.
    * @option
+   * @type {number}
    * @default 500
    */
 
@@ -390,36 +395,42 @@ DropdownMenu.defaults = {
   /**
    * Position of the menu relative to what direction the submenus should open. Handled by JS.
    * @option
+   * @type {string}
    * @default 'left'
    */
   alignment: 'left',
   /**
    * Allow clicks on the body to close any open submenus.
    * @option
+   * @type {boolean}
    * @default true
    */
   closeOnClick: true,
   /**
    * Allow clicks on leaf anchor links to close any open submenus.
    * @option
+   * @type {boolean}
    * @default true
    */
   closeOnClickInside: true,
   /**
    * Class applied to vertical oriented menus, Foundation default is `vertical`. Update this if using your own class.
    * @option
+   * @type {string}
    * @default 'vertical'
    */
   verticalClass: 'vertical',
   /**
    * Class applied to right-side oriented menus, Foundation default is `align-right`. Update this if using your own class.
    * @option
+   * @type {string}
    * @default 'align-right'
    */
   rightClass: 'align-right',
   /**
    * Boolean to force overide the clicking of links to perform default action, on second touch event for mobile.
    * @option
+   * @type {boolean}
    * @default true
    */
   forceFollow: true

--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -393,7 +393,7 @@ DropdownMenu.defaults = {
 
   closingTime: 500,
   /**
-   * Position of the menu relative to what direction the submenus should open. Handled by JS.
+   * Position of the menu relative to what direction the submenus should open. Handled by JS. Can be `'left'` or `'right'`.
    * @option
    * @type {string}
    * @default 'left'

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -291,19 +291,19 @@ Equalizer.defaults = {
   /**
    * Enable height equalization when stacked on smaller screens.
    * @option
-   * @example true
+   * @default false
    */
   equalizeOnStack: false,
   /**
    * Enable height equalization row by row.
    * @option
-   * @example false
+   * @default false
    */
   equalizeByRow: false,
   /**
    * String representing the minimum breakpoint size the plugin should equalize heights on.
    * @option
-   * @example 'medium'
+   * @default ''
    */
   equalizeOn: ''
 };

--- a/js/foundation.equalizer.js
+++ b/js/foundation.equalizer.js
@@ -291,18 +291,21 @@ Equalizer.defaults = {
   /**
    * Enable height equalization when stacked on smaller screens.
    * @option
+   * @type {boolean}
    * @default false
    */
   equalizeOnStack: false,
   /**
    * Enable height equalization row by row.
    * @option
+   * @type {boolean}
    * @default false
    */
   equalizeByRow: false,
   /**
    * String representing the minimum breakpoint size the plugin should equalize heights on.
    * @option
+   * @type {string}
    * @default ''
    */
   equalizeOn: ''

--- a/js/foundation.interchange.js
+++ b/js/foundation.interchange.js
@@ -183,6 +183,8 @@ Interchange.defaults = {
   /**
    * Rules to be applied to Interchange elements. Set with the `data-interchange` array notation.
    * @option
+   * @type {?array}
+   * @default null
    */
   rules: null
 };

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -203,37 +203,37 @@ Magellan.defaults = {
   /**
    * Amount of time, in ms, the animated scrolling should take between locations.
    * @option
-   * @example 500
+   * @default 500
    */
   animationDuration: 500,
   /**
    * Animation style to use when scrolling between locations.
    * @option
-   * @example 'ease-in-out'
+   * @default 'linear'
    */
   animationEasing: 'linear',
   /**
    * Number of pixels to use as a marker for location changes.
    * @option
-   * @example 50
+   * @default 50
    */
   threshold: 50,
   /**
    * Class applied to the active locations link on the magellan container.
    * @option
-   * @example 'active'
+   * @default 'active'
    */
   activeClass: 'active',
   /**
    * Allows the script to manipulate the url of the current page, and if supported, alter the history.
    * @option
-   * @example true
+   * @default false
    */
   deepLinking: false,
   /**
    * Number of pixels to offset the scroll of the page on item click if using a sticky nav bar.
    * @option
-   * @example 25
+   * @default 0
    */
   barOffset: 0
 }

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -208,10 +208,11 @@ Magellan.defaults = {
    */
   animationDuration: 500,
   /**
-   * Animation style to use when scrolling between locations.
+   * Animation style to use when scrolling between locations. Can be `'swing'` or `'linear'`.
    * @option
    * @type {string}
    * @default 'linear'
+   * @see {@link https://api.jquery.com/animate|Jquery animate}
    */
   animationEasing: 'linear',
   /**

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -203,36 +203,42 @@ Magellan.defaults = {
   /**
    * Amount of time, in ms, the animated scrolling should take between locations.
    * @option
+   * @type {number}
    * @default 500
    */
   animationDuration: 500,
   /**
    * Animation style to use when scrolling between locations.
    * @option
+   * @type {string}
    * @default 'linear'
    */
   animationEasing: 'linear',
   /**
    * Number of pixels to use as a marker for location changes.
    * @option
+   * @type {number}
    * @default 50
    */
   threshold: 50,
   /**
    * Class applied to the active locations link on the magellan container.
    * @option
+   * @type {string}
    * @default 'active'
    */
   activeClass: 'active',
   /**
    * Allows the script to manipulate the url of the current page, and if supported, alter the history.
    * @option
+   * @type {boolean}
    * @default false
    */
   deepLinking: false,
   /**
    * Number of pixels to offset the scroll of the page on item click if using a sticky nav bar.
    * @option
+   * @type {number}
    * @default 0
    */
   barOffset: 0

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -298,63 +298,63 @@ OffCanvas.defaults = {
   /**
    * Allow the user to click outside of the menu to close it.
    * @option
-   * @example true
+   * @default true
    */
   closeOnClick: true,
 
   /**
    * Adds an overlay on top of `[data-off-canvas-content]`.
    * @option
-   * @example true
+   * @default true
    */
   contentOverlay: true,
 
   /**
    * Enable/disable scrolling of the main content when an off canvas panel is open.
    * @option
-   * @example true
+   * @default true
    */
   contentScroll: true,
 
   /**
    * Amount of time in ms the open and close transition requires. If none selected, pulls from body style.
    * @option
-   * @example 500
+   * @default 0
    */
   transitionTime: 0,
 
   /**
    * Type of transition for the offcanvas menu. Options are 'push', 'detached' or 'slide'.
    * @option
-   * @example push
+   * @default push
    */
   transition: 'push',
 
   /**
    * Force the page to scroll to top or bottom on open.
    * @option
-   * @example top
+   * @default null
    */
   forceTo: null,
 
   /**
    * Allow the offcanvas to remain open for certain breakpoints.
    * @option
-   * @example false
+   * @default false
    */
   isRevealed: false,
 
   /**
    * Breakpoint at which to reveal. JS will use a RegExp to target standard classes, if changing classnames, pass your class with the `revealClass` option.
    * @option
-   * @example reveal-for-large
+   * @default null
    */
   revealOn: null,
 
   /**
    * Force focus to the offcanvas on open. If true, will focus the opening trigger on close.
    * @option
-   * @example true
+   * @default true
    */
   autoFocus: true,
 
@@ -362,14 +362,14 @@ OffCanvas.defaults = {
    * Class used to force an offcanvas to remain open. Foundation defaults for this are `reveal-for-large` & `reveal-for-medium`.
    * @option
    * TODO improve the regex testing for this.
-   * @example reveal-for-large
+   * @default reveal-for-
    */
   revealClass: 'reveal-for-',
 
   /**
    * Triggers optional focus trapping when opening an offcanvas. Sets tabindex of [data-off-canvas-content] to -1 for accessibility purposes.
    * @option
-   * @example true
+   * @default false
    */
   trapFocus: false
 }

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -298,6 +298,7 @@ OffCanvas.defaults = {
   /**
    * Allow the user to click outside of the menu to close it.
    * @option
+   * @type {boolean}
    * @default true
    */
   closeOnClick: true,
@@ -305,6 +306,7 @@ OffCanvas.defaults = {
   /**
    * Adds an overlay on top of `[data-off-canvas-content]`.
    * @option
+   * @type {boolean}
    * @default true
    */
   contentOverlay: true,
@@ -312,6 +314,7 @@ OffCanvas.defaults = {
   /**
    * Enable/disable scrolling of the main content when an off canvas panel is open.
    * @option
+   * @type {boolean}
    * @default true
    */
   contentScroll: true,
@@ -319,6 +322,7 @@ OffCanvas.defaults = {
   /**
    * Amount of time in ms the open and close transition requires. If none selected, pulls from body style.
    * @option
+   * @type {number}
    * @default 0
    */
   transitionTime: 0,
@@ -326,6 +330,7 @@ OffCanvas.defaults = {
   /**
    * Type of transition for the offcanvas menu. Options are 'push', 'detached' or 'slide'.
    * @option
+   * @type {string}
    * @default push
    */
   transition: 'push',
@@ -333,6 +338,7 @@ OffCanvas.defaults = {
   /**
    * Force the page to scroll to top or bottom on open.
    * @option
+   * @type {?string}
    * @default null
    */
   forceTo: null,
@@ -340,6 +346,7 @@ OffCanvas.defaults = {
   /**
    * Allow the offcanvas to remain open for certain breakpoints.
    * @option
+   * @type {boolean}
    * @default false
    */
   isRevealed: false,
@@ -347,6 +354,7 @@ OffCanvas.defaults = {
   /**
    * Breakpoint at which to reveal. JS will use a RegExp to target standard classes, if changing classnames, pass your class with the `revealClass` option.
    * @option
+   * @type {?string}
    * @default null
    */
   revealOn: null,
@@ -354,6 +362,7 @@ OffCanvas.defaults = {
   /**
    * Force focus to the offcanvas on open. If true, will focus the opening trigger on close.
    * @option
+   * @type {boolean}
    * @default true
    */
   autoFocus: true,
@@ -361,14 +370,16 @@ OffCanvas.defaults = {
   /**
    * Class used to force an offcanvas to remain open. Foundation defaults for this are `reveal-for-large` & `reveal-for-medium`.
    * @option
-   * TODO improve the regex testing for this.
+   * @type {string}
    * @default reveal-for-
+   * @todo improve the regex testing for this.
    */
   revealClass: 'reveal-for-',
 
   /**
    * Triggers optional focus trapping when opening an offcanvas. Sets tabindex of [data-off-canvas-content] to -1 for accessibility purposes.
    * @option
+   * @type {boolean}
    * @default false
    */
   trapFocus: false

--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -391,110 +391,110 @@ Orbit.defaults = {
   /**
   * Tells the JS to look for and loadBullets.
   * @option
-  * @example true
+  * @default true
   */
   bullets: true,
   /**
   * Tells the JS to apply event listeners to nav buttons
   * @option
-  * @example true
+  * @default true
   */
   navButtons: true,
   /**
   * motion-ui animation class to apply
   * @option
-  * @example 'slide-in-right'
+  * @default 'slide-in-right'
   */
   animInFromRight: 'slide-in-right',
   /**
   * motion-ui animation class to apply
   * @option
-  * @example 'slide-out-right'
+  * @default 'slide-out-right'
   */
   animOutToRight: 'slide-out-right',
   /**
   * motion-ui animation class to apply
   * @option
-  * @example 'slide-in-left'
+  * @default 'slide-in-left'
   *
   */
   animInFromLeft: 'slide-in-left',
   /**
   * motion-ui animation class to apply
   * @option
-  * @example 'slide-out-left'
+  * @default 'slide-out-left'
   */
   animOutToLeft: 'slide-out-left',
   /**
   * Allows Orbit to automatically animate on page load.
   * @option
-  * @example true
+  * @default true
   */
   autoPlay: true,
   /**
   * Amount of time, in ms, between slide transitions
   * @option
-  * @example 5000
+  * @default 5000
   */
   timerDelay: 5000,
   /**
   * Allows Orbit to infinitely loop through the slides
   * @option
-  * @example true
+  * @default true
   */
   infiniteWrap: true,
   /**
   * Allows the Orbit slides to bind to swipe events for mobile, requires an additional util library
   * @option
-  * @example true
+  * @default true
   */
   swipe: true,
   /**
   * Allows the timing function to pause animation on hover.
   * @option
-  * @example true
+  * @default true
   */
   pauseOnHover: true,
   /**
   * Allows Orbit to bind keyboard events to the slider, to animate frames with arrow keys
   * @option
-  * @example true
+  * @default true
   */
   accessible: true,
   /**
   * Class applied to the container of Orbit
   * @option
-  * @example 'orbit-container'
+  * @default 'orbit-container'
   */
   containerClass: 'orbit-container',
   /**
   * Class applied to individual slides.
   * @option
-  * @example 'orbit-slide'
+  * @default 'orbit-slide'
   */
   slideClass: 'orbit-slide',
   /**
   * Class applied to the bullet container. You're welcome.
   * @option
-  * @example 'orbit-bullets'
+  * @default 'orbit-bullets'
   */
   boxOfBullets: 'orbit-bullets',
   /**
   * Class applied to the `next` navigation button.
   * @option
-  * @example 'orbit-next'
+  * @default 'orbit-next'
   */
   nextClass: 'orbit-next',
   /**
   * Class applied to the `previous` navigation button.
   * @option
-  * @example 'orbit-previous'
+  * @default 'orbit-previous'
   */
   prevClass: 'orbit-previous',
   /**
   * Boolean to flag the js to use motion ui classes or not. Default to true for backwards compatability.
   * @option
-  * @example true
+  * @default true
   */
   useMUI: true
 };

--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -391,30 +391,35 @@ Orbit.defaults = {
   /**
   * Tells the JS to look for and loadBullets.
   * @option
+   * @type {boolean}
   * @default true
   */
   bullets: true,
   /**
   * Tells the JS to apply event listeners to nav buttons
   * @option
+   * @type {boolean}
   * @default true
   */
   navButtons: true,
   /**
   * motion-ui animation class to apply
   * @option
+   * @type {string}
   * @default 'slide-in-right'
   */
   animInFromRight: 'slide-in-right',
   /**
   * motion-ui animation class to apply
   * @option
+   * @type {string}
   * @default 'slide-out-right'
   */
   animOutToRight: 'slide-out-right',
   /**
   * motion-ui animation class to apply
   * @option
+   * @type {string}
   * @default 'slide-in-left'
   *
   */
@@ -422,78 +427,91 @@ Orbit.defaults = {
   /**
   * motion-ui animation class to apply
   * @option
+   * @type {string}
   * @default 'slide-out-left'
   */
   animOutToLeft: 'slide-out-left',
   /**
   * Allows Orbit to automatically animate on page load.
   * @option
+   * @type {boolean}
   * @default true
   */
   autoPlay: true,
   /**
   * Amount of time, in ms, between slide transitions
   * @option
+   * @type {number}
   * @default 5000
   */
   timerDelay: 5000,
   /**
   * Allows Orbit to infinitely loop through the slides
   * @option
+   * @type {boolean}
   * @default true
   */
   infiniteWrap: true,
   /**
   * Allows the Orbit slides to bind to swipe events for mobile, requires an additional util library
   * @option
+   * @type {boolean}
   * @default true
   */
   swipe: true,
   /**
   * Allows the timing function to pause animation on hover.
   * @option
+   * @type {boolean}
   * @default true
   */
   pauseOnHover: true,
   /**
   * Allows Orbit to bind keyboard events to the slider, to animate frames with arrow keys
   * @option
+   * @type {boolean}
   * @default true
   */
   accessible: true,
   /**
   * Class applied to the container of Orbit
   * @option
+   * @type {string}
   * @default 'orbit-container'
   */
   containerClass: 'orbit-container',
   /**
   * Class applied to individual slides.
   * @option
+   * @type {string}
   * @default 'orbit-slide'
   */
   slideClass: 'orbit-slide',
   /**
   * Class applied to the bullet container. You're welcome.
   * @option
+   * @type {string}
   * @default 'orbit-bullets'
   */
   boxOfBullets: 'orbit-bullets',
   /**
   * Class applied to the `next` navigation button.
   * @option
+   * @type {string}
   * @default 'orbit-next'
   */
   nextClass: 'orbit-next',
   /**
   * Class applied to the `previous` navigation button.
   * @option
+   * @type {string}
   * @default 'orbit-previous'
   */
   prevClass: 'orbit-previous',
   /**
   * Boolean to flag the js to use motion ui classes or not. Default to true for backwards compatability.
   * @option
+   * @type {boolean}
   * @default true
   */
   useMUI: true

--- a/js/foundation.responsiveToggle.js
+++ b/js/foundation.responsiveToggle.js
@@ -141,6 +141,7 @@ ResponsiveToggle.defaults = {
   /**
    * The breakpoint after which the menu is always shown, and the tab bar is hidden.
    * @option
+   * @type {string}
    * @default 'medium'
    */
   hideFor: 'medium',
@@ -148,6 +149,7 @@ ResponsiveToggle.defaults = {
   /**
    * To decide if the toggle should be animated or not.
    * @option
+   * @type {boolean}
    * @default false
    */
   animate: false

--- a/js/foundation.responsiveToggle.js
+++ b/js/foundation.responsiveToggle.js
@@ -141,14 +141,14 @@ ResponsiveToggle.defaults = {
   /**
    * The breakpoint after which the menu is always shown, and the tab bar is hidden.
    * @option
-   * @example 'medium'
+   * @default 'medium'
    */
   hideFor: 'medium',
 
   /**
    * To decide if the toggle should be animated or not.
    * @option
-   * @example false
+   * @default false
    */
   animate: false
 };

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -475,91 +475,91 @@ Reveal.defaults = {
   /**
    * Motion-UI class to use for animated elements. If none used, defaults to simple show/hide.
    * @option
-   * @example 'slide-in-left'
+   * @default ''
    */
   animationIn: '',
   /**
    * Motion-UI class to use for animated elements. If none used, defaults to simple show/hide.
    * @option
-   * @example 'slide-out-right'
+   * @default ''
    */
   animationOut: '',
   /**
    * Time, in ms, to delay the opening of a modal after a click if no animation used.
    * @option
-   * @example 10
+   * @default 0
    */
   showDelay: 0,
   /**
    * Time, in ms, to delay the closing of a modal after a click if no animation used.
    * @option
-   * @example 10
+   * @default 0
    */
   hideDelay: 0,
   /**
    * Allows a click on the body/overlay to close the modal.
    * @option
-   * @example true
+   * @default true
    */
   closeOnClick: true,
   /**
    * Allows the modal to close if the user presses the `ESCAPE` key.
    * @option
-   * @example true
+   * @default true
    */
   closeOnEsc: true,
   /**
    * If true, allows multiple modals to be displayed at once.
    * @option
-   * @example false
+   * @default false
    */
   multipleOpened: false,
   /**
    * Distance, in pixels, the modal should push down from the top of the screen.
    * @option
-   * @example auto
+   * @default auto
    */
   vOffset: 'auto',
   /**
    * Distance, in pixels, the modal should push in from the side of the screen.
    * @option
-   * @example auto
+   * @default auto
    */
   hOffset: 'auto',
   /**
    * Allows the modal to be fullscreen, completely blocking out the rest of the view. JS checks for this as well.
    * @option
-   * @example false
+   * @default false
    */
   fullScreen: false,
   /**
    * Percentage of screen height the modal should push up from the bottom of the view.
    * @option
-   * @example 10
+   * @default 10
    */
   btmOffsetPct: 10,
   /**
    * Allows the modal to generate an overlay div, which will cover the view when modal opens.
    * @option
-   * @example true
+   * @default true
    */
   overlay: true,
   /**
    * Allows the modal to remove and reinject markup on close. Should be true if using video elements w/o using provider's api, otherwise, videos will continue to play in the background.
    * @option
-   * @example false
+   * @default false
    */
   resetOnClose: false,
   /**
    * Allows the modal to alter the url on open/close, and allows the use of the `back` button to close modals. ALSO, allows a modal to auto-maniacally open on page load IF the hash === the modal's user-set id.
    * @option
-   * @example false
+   * @default false
    */
   deepLink: false,
     /**
    * Allows the modal to append to custom div.
    * @option
-   * @example false
+   * @default "body"
    */
   appendTo: "body"
 

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -475,90 +475,105 @@ Reveal.defaults = {
   /**
    * Motion-UI class to use for animated elements. If none used, defaults to simple show/hide.
    * @option
+   * @type {string}
    * @default ''
    */
   animationIn: '',
   /**
    * Motion-UI class to use for animated elements. If none used, defaults to simple show/hide.
    * @option
+   * @type {string}
    * @default ''
    */
   animationOut: '',
   /**
    * Time, in ms, to delay the opening of a modal after a click if no animation used.
    * @option
+   * @type {number}
    * @default 0
    */
   showDelay: 0,
   /**
    * Time, in ms, to delay the closing of a modal after a click if no animation used.
    * @option
+   * @type {number}
    * @default 0
    */
   hideDelay: 0,
   /**
    * Allows a click on the body/overlay to close the modal.
    * @option
+   * @type {boolean}
    * @default true
    */
   closeOnClick: true,
   /**
    * Allows the modal to close if the user presses the `ESCAPE` key.
    * @option
+   * @type {boolean}
    * @default true
    */
   closeOnEsc: true,
   /**
    * If true, allows multiple modals to be displayed at once.
    * @option
+   * @type {boolean}
    * @default false
    */
   multipleOpened: false,
   /**
    * Distance, in pixels, the modal should push down from the top of the screen.
    * @option
+   * @type {number|string}
    * @default auto
    */
   vOffset: 'auto',
   /**
    * Distance, in pixels, the modal should push in from the side of the screen.
    * @option
+   * @type {number|string}
    * @default auto
    */
   hOffset: 'auto',
   /**
    * Allows the modal to be fullscreen, completely blocking out the rest of the view. JS checks for this as well.
    * @option
+   * @type {boolean}
    * @default false
    */
   fullScreen: false,
   /**
    * Percentage of screen height the modal should push up from the bottom of the view.
    * @option
+   * @type {number}
    * @default 10
    */
   btmOffsetPct: 10,
   /**
    * Allows the modal to generate an overlay div, which will cover the view when modal opens.
    * @option
+   * @type {boolean}
    * @default true
    */
   overlay: true,
   /**
    * Allows the modal to remove and reinject markup on close. Should be true if using video elements w/o using provider's api, otherwise, videos will continue to play in the background.
    * @option
+   * @type {boolean}
    * @default false
    */
   resetOnClose: false,
   /**
    * Allows the modal to alter the url on open/close, and allows the use of the `back` button to close modals. ALSO, allows a modal to auto-maniacally open on page load IF the hash === the modal's user-set id.
    * @option
+   * @type {boolean}
    * @default false
    */
   deepLink: false,
     /**
    * Allows the modal to append to custom div.
    * @option
+   * @type {string}
    * @default "body"
    */
   appendTo: "body"

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -547,66 +547,77 @@ Slider.defaults = {
   /**
    * Minimum value for the slider scale.
    * @option
+   * @type {number}
    * @default 0
    */
   start: 0,
   /**
    * Maximum value for the slider scale.
    * @option
+   * @type {number}
    * @default 100
    */
   end: 100,
   /**
    * Minimum value change per change event.
    * @option
+   * @type {number}
    * @default 1
    */
   step: 1,
   /**
    * Value at which the handle/input *(left handle/first input)* should be set to on initialization.
    * @option
+   * @type {number}
    * @default 0
    */
   initialStart: 0,
   /**
    * Value at which the right handle/second input should be set to on initialization.
    * @option
+   * @type {number}
    * @default 100
    */
   initialEnd: 100,
   /**
    * Allows the input to be located outside the container and visible. Set to by the JS
    * @option
+   * @type {boolean}
    * @default false
    */
   binding: false,
   /**
    * Allows the user to click/tap on the slider bar to select a value.
    * @option
+   * @type {boolean}
    * @default true
    */
   clickSelect: true,
   /**
    * Set to true and use the `vertical` class to change alignment to vertical.
    * @option
+   * @type {boolean}
    * @default false
    */
   vertical: false,
   /**
    * Allows the user to drag the slider handle(s) to select a value.
    * @option
+   * @type {boolean}
    * @default true
    */
   draggable: true,
   /**
    * Disables the slider and prevents event listeners from being applied. Double checked by JS with `disabledClass`.
    * @option
+   * @type {boolean}
    * @default false
    */
   disabled: false,
   /**
    * Allows the use of two handles. Double checked by the JS. Changes some logic handling.
    * @option
+   * @type {boolean}
    * @default false
    */
   doubleSided: false,
@@ -617,6 +628,7 @@ Slider.defaults = {
   /**
    * Number of decimal places the plugin should go to for floating point precision.
    * @option
+   * @type {number}
    * @default 2
    */
   decimal: 2,
@@ -627,36 +639,42 @@ Slider.defaults = {
   /**
    * Time, in ms, to animate the movement of a slider handle if user clicks/taps on the bar. Needs to be manually set if updating the transition time in the Sass settings.
    * @option
+   * @type {number}
    * @default 200
    */
   moveTime: 200,//update this if changing the transition time in the sass
   /**
    * Class applied to disabled sliders.
    * @option
+   * @type {string}
    * @default 'disabled'
    */
   disabledClass: 'disabled',
   /**
    * Will invert the default layout for a vertical<span data-tooltip title="who would do this???"> </span>slider.
    * @option
+   * @type {boolean}
    * @default false
    */
   invertVertical: false,
   /**
    * Milliseconds before the `changed.zf-slider` event is triggered after value change.
    * @option
+   * @type {number}
    * @default 500
    */
   changedDelay: 500,
   /**
   * Basevalue for non-linear sliders
   * @option
+  * @type {number}
   * @default 5
   */
   nonLinearBase: 5,
   /**
   * Basevalue for non-linear sliders, possible values are: 'linear', 'pow' & 'log'. Pow and Log use the nonLinearBase setting.
   * @option
+  * @type {string}
   * @default 'linear'
   */
   positionValueFunction: 'linear',

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -672,7 +672,7 @@ Slider.defaults = {
   */
   nonLinearBase: 5,
   /**
-  * Basevalue for non-linear sliders, possible values are: 'linear', 'pow' & 'log'. Pow and Log use the nonLinearBase setting.
+  * Basevalue for non-linear sliders, possible values are: `'linear'`, `'pow'` & `'log'`. Pow and Log use the nonLinearBase setting.
   * @option
   * @type {string}
   * @default 'linear'

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -547,67 +547,67 @@ Slider.defaults = {
   /**
    * Minimum value for the slider scale.
    * @option
-   * @example 0
+   * @default 0
    */
   start: 0,
   /**
    * Maximum value for the slider scale.
    * @option
-   * @example 100
+   * @default 100
    */
   end: 100,
   /**
    * Minimum value change per change event.
    * @option
-   * @example 1
+   * @default 1
    */
   step: 1,
   /**
    * Value at which the handle/input *(left handle/first input)* should be set to on initialization.
    * @option
-   * @example 0
+   * @default 0
    */
   initialStart: 0,
   /**
    * Value at which the right handle/second input should be set to on initialization.
    * @option
-   * @example 100
+   * @default 100
    */
   initialEnd: 100,
   /**
    * Allows the input to be located outside the container and visible. Set to by the JS
    * @option
-   * @example false
+   * @default false
    */
   binding: false,
   /**
    * Allows the user to click/tap on the slider bar to select a value.
    * @option
-   * @example true
+   * @default true
    */
   clickSelect: true,
   /**
    * Set to true and use the `vertical` class to change alignment to vertical.
    * @option
-   * @example false
+   * @default false
    */
   vertical: false,
   /**
    * Allows the user to drag the slider handle(s) to select a value.
    * @option
-   * @example true
+   * @default true
    */
   draggable: true,
   /**
    * Disables the slider and prevents event listeners from being applied. Double checked by JS with `disabledClass`.
    * @option
-   * @example false
+   * @default false
    */
   disabled: false,
   /**
    * Allows the use of two handles. Double checked by the JS. Changes some logic handling.
    * @option
-   * @example false
+   * @default false
    */
   doubleSided: false,
   /**
@@ -617,7 +617,7 @@ Slider.defaults = {
   /**
    * Number of decimal places the plugin should go to for floating point precision.
    * @option
-   * @example 2
+   * @default 2
    */
   decimal: 2,
   /**
@@ -627,37 +627,37 @@ Slider.defaults = {
   /**
    * Time, in ms, to animate the movement of a slider handle if user clicks/taps on the bar. Needs to be manually set if updating the transition time in the Sass settings.
    * @option
-   * @example 200
+   * @default 200
    */
   moveTime: 200,//update this if changing the transition time in the sass
   /**
    * Class applied to disabled sliders.
    * @option
-   * @example 'disabled'
+   * @default 'disabled'
    */
   disabledClass: 'disabled',
   /**
    * Will invert the default layout for a vertical<span data-tooltip title="who would do this???"> </span>slider.
    * @option
-   * @example false
+   * @default false
    */
   invertVertical: false,
   /**
    * Milliseconds before the `changed.zf-slider` event is triggered after value change.
    * @option
-   * @example 500
+   * @default 500
    */
   changedDelay: 500,
   /**
   * Basevalue for non-linear sliders
   * @option
-  * @example 5
+  * @default 5
   */
   nonLinearBase: 5,
   /**
   * Basevalue for non-linear sliders, possible values are: 'linear', 'pow' & 'log'. Pow and Log use the nonLinearBase setting.
   * @option
-  * @example 'linear'
+  * @default 'linear'
   */
   positionValueFunction: 'linear',
 };

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -389,7 +389,7 @@ Sticky.defaults = {
    */
   container: '<div data-sticky-container></div>',
   /**
-   * Location in the view the element sticks to.
+   * Location in the view the element sticks to. Can be `'top'` or `'bottom'`.
    * @option
    * @type {string}
    * @default 'top'

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -384,67 +384,67 @@ Sticky.defaults = {
   /**
    * Customizable container template. Add your own classes for styling and sizing.
    * @option
-   * @example '&lt;div data-sticky-container class="small-6 columns"&gt;&lt;/div&gt;'
+   * @default '&lt;div data-sticky-container&gt;&lt;/div&gt;'
    */
   container: '<div data-sticky-container></div>',
   /**
    * Location in the view the element sticks to.
    * @option
-   * @example 'top'
+   * @default 'top'
    */
   stickTo: 'top',
   /**
    * If anchored to a single element, the id of that element.
    * @option
-   * @example 'exampleId'
+   * @default ''
    */
   anchor: '',
   /**
    * If using more than one element as anchor points, the id of the top anchor.
    * @option
-   * @example 'exampleId:top'
+   * @default ''
    */
   topAnchor: '',
   /**
    * If using more than one element as anchor points, the id of the bottom anchor.
    * @option
-   * @example 'exampleId:bottom'
+   * @default ''
    */
   btmAnchor: '',
   /**
    * Margin, in `em`'s to apply to the top of the element when it becomes sticky.
    * @option
-   * @example 1
+   * @default 1
    */
   marginTop: 1,
   /**
    * Margin, in `em`'s to apply to the bottom of the element when it becomes sticky.
    * @option
-   * @example 1
+   * @default 1
    */
   marginBottom: 1,
   /**
    * Breakpoint string that is the minimum screen size an element should become sticky.
    * @option
-   * @example 'medium'
+   * @default 'medium'
    */
   stickyOn: 'medium',
   /**
    * Class applied to sticky element, and removed on destruction. Foundation defaults to `sticky`.
    * @option
-   * @example 'sticky'
+   * @default 'sticky'
    */
   stickyClass: 'sticky',
   /**
    * Class applied to sticky container. Foundation defaults to `sticky-container`.
    * @option
-   * @example 'sticky-container'
+   * @default 'sticky-container'
    */
   containerClass: 'sticky-container',
   /**
    * Number of scroll events between the plugin's recalculating sticky points. Setting it to `0` will cause it to recalc every scroll event, setting it to `-1` will prevent recalc on scroll.
    * @option
-   * @example 50
+   * @default -1
    */
   checkEvery: -1
 };

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -384,66 +384,77 @@ Sticky.defaults = {
   /**
    * Customizable container template. Add your own classes for styling and sizing.
    * @option
+   * @type {string}
    * @default '&lt;div data-sticky-container&gt;&lt;/div&gt;'
    */
   container: '<div data-sticky-container></div>',
   /**
    * Location in the view the element sticks to.
    * @option
+   * @type {string}
    * @default 'top'
    */
   stickTo: 'top',
   /**
    * If anchored to a single element, the id of that element.
    * @option
+   * @type {string}
    * @default ''
    */
   anchor: '',
   /**
    * If using more than one element as anchor points, the id of the top anchor.
    * @option
+   * @type {string}
    * @default ''
    */
   topAnchor: '',
   /**
    * If using more than one element as anchor points, the id of the bottom anchor.
    * @option
+   * @type {string}
    * @default ''
    */
   btmAnchor: '',
   /**
    * Margin, in `em`'s to apply to the top of the element when it becomes sticky.
    * @option
+   * @type {number}
    * @default 1
    */
   marginTop: 1,
   /**
    * Margin, in `em`'s to apply to the bottom of the element when it becomes sticky.
    * @option
+   * @type {number}
    * @default 1
    */
   marginBottom: 1,
   /**
    * Breakpoint string that is the minimum screen size an element should become sticky.
    * @option
+   * @type {string}
    * @default 'medium'
    */
   stickyOn: 'medium',
   /**
    * Class applied to sticky element, and removed on destruction. Foundation defaults to `sticky`.
    * @option
+   * @type {string}
    * @default 'sticky'
    */
   stickyClass: 'sticky',
   /**
    * Class applied to sticky container. Foundation defaults to `sticky-container`.
    * @option
+   * @type {string}
    * @default 'sticky-container'
    */
   containerClass: 'sticky-container',
   /**
    * Number of scroll events between the plugin's recalculating sticky points. Setting it to `0` will cause it to recalc every scroll event, setting it to `-1` will prevent recalc on scroll.
    * @option
+   * @type {number}
    * @default -1
    */
   checkEvery: -1

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -373,28 +373,28 @@ Tabs.defaults = {
   /**
    * Allows the window to scroll to content of pane specified by hash anchor
    * @option
-   * @example false
+   * @default false
    */
   deepLink: false,
 
   /**
    * Adjust the deep link scroll to make sure the top of the tab panel is visible
    * @option
-   * @example false
+   * @default false
    */
   deepLinkSmudge: false,
 
   /**
    * Animation time (ms) for the deep link adjustment
    * @option
-   * @example 300
+   * @default 300
    */
   deepLinkSmudgeDelay: 300,
 
   /**
    * Update the browser history with the open tab
    * @option
-   * @example false
+   * @default false
    */
   updateHistory: false,
 
@@ -402,56 +402,56 @@ Tabs.defaults = {
    * Allows the window to scroll to content of active pane on load if set to true.
    * Not recommended if more than one tab panel per page.
    * @option
-   * @example false
+   * @default false
    */
   autoFocus: false,
 
   /**
    * Allows keyboard input to 'wrap' around the tab links.
    * @option
-   * @example true
+   * @default true
    */
   wrapOnKeys: true,
 
   /**
    * Allows the tab content panes to match heights if set to true.
    * @option
-   * @example false
+   * @default false
    */
   matchHeight: false,
 
   /**
    * Allows active tabs to collapse when clicked.
    * @option
-   * @example false
+   * @default false
    */
   activeCollapse: false,
 
   /**
    * Class applied to `li`'s in tab link list.
    * @option
-   * @example 'tabs-title'
+   * @default 'tabs-title'
    */
   linkClass: 'tabs-title',
 
   /**
    * Class applied to the active `li` in tab link list.
    * @option
-   * @example 'is-active'
+   * @default 'is-active'
    */
   linkActiveClass: 'is-active',
 
   /**
    * Class applied to the content containers.
    * @option
-   * @example 'tabs-panel'
+   * @default 'tabs-panel'
    */
   panelClass: 'tabs-panel',
 
   /**
    * Class applied to the active content container.
    * @option
-   * @example 'is-active'
+   * @default 'is-active'
    */
   panelActiveClass: 'is-active'
 };

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -373,6 +373,7 @@ Tabs.defaults = {
   /**
    * Allows the window to scroll to content of pane specified by hash anchor
    * @option
+   * @type {boolean}
    * @default false
    */
   deepLink: false,
@@ -380,6 +381,7 @@ Tabs.defaults = {
   /**
    * Adjust the deep link scroll to make sure the top of the tab panel is visible
    * @option
+   * @type {boolean}
    * @default false
    */
   deepLinkSmudge: false,
@@ -387,6 +389,7 @@ Tabs.defaults = {
   /**
    * Animation time (ms) for the deep link adjustment
    * @option
+   * @type {number}
    * @default 300
    */
   deepLinkSmudgeDelay: 300,
@@ -394,6 +397,7 @@ Tabs.defaults = {
   /**
    * Update the browser history with the open tab
    * @option
+   * @type {boolean}
    * @default false
    */
   updateHistory: false,
@@ -402,6 +406,7 @@ Tabs.defaults = {
    * Allows the window to scroll to content of active pane on load if set to true.
    * Not recommended if more than one tab panel per page.
    * @option
+   * @type {boolean}
    * @default false
    */
   autoFocus: false,
@@ -409,6 +414,7 @@ Tabs.defaults = {
   /**
    * Allows keyboard input to 'wrap' around the tab links.
    * @option
+   * @type {boolean}
    * @default true
    */
   wrapOnKeys: true,
@@ -416,6 +422,7 @@ Tabs.defaults = {
   /**
    * Allows the tab content panes to match heights if set to true.
    * @option
+   * @type {boolean}
    * @default false
    */
   matchHeight: false,
@@ -423,6 +430,7 @@ Tabs.defaults = {
   /**
    * Allows active tabs to collapse when clicked.
    * @option
+   * @type {boolean}
    * @default false
    */
   activeCollapse: false,
@@ -430,6 +438,7 @@ Tabs.defaults = {
   /**
    * Class applied to `li`'s in tab link list.
    * @option
+   * @type {string}
    * @default 'tabs-title'
    */
   linkClass: 'tabs-title',
@@ -437,6 +446,7 @@ Tabs.defaults = {
   /**
    * Class applied to the active `li` in tab link list.
    * @option
+   * @type {string}
    * @default 'is-active'
    */
   linkActiveClass: 'is-active',
@@ -444,6 +454,7 @@ Tabs.defaults = {
   /**
    * Class applied to the content containers.
    * @option
+   * @type {string}
    * @default 'tabs-panel'
    */
   panelClass: 'tabs-panel',
@@ -451,6 +462,7 @@ Tabs.defaults = {
   /**
    * Class applied to the active content container.
    * @option
+   * @type {string}
    * @default 'is-active'
    */
   panelActiveClass: 'is-active'

--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -136,6 +136,7 @@ Toggler.defaults = {
   /**
    * Tells the plugin if the element should animated when toggled.
    * @option
+   * @type {boolean}
    * @default false
    */
   animate: false

--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -136,7 +136,7 @@ Toggler.defaults = {
   /**
    * Tells the plugin if the element should animated when toggled.
    * @option
-   * @example false
+   * @default false
    */
   animate: false
 };

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -354,93 +354,93 @@ Tooltip.defaults = {
   /**
    * Time, in ms, before a tooltip should open on hover.
    * @option
-   * @example 200
+   * @default 200
    */
   hoverDelay: 200,
   /**
    * Time, in ms, a tooltip should take to fade into view.
    * @option
-   * @example 150
+   * @default 150
    */
   fadeInDuration: 150,
   /**
    * Time, in ms, a tooltip should take to fade out of view.
    * @option
-   * @example 150
+   * @default 150
    */
   fadeOutDuration: 150,
   /**
    * Disables hover events from opening the tooltip if set to true
    * @option
-   * @example false
+   * @default false
    */
   disableHover: false,
   /**
    * Optional addtional classes to apply to the tooltip template on init.
    * @option
-   * @example 'my-cool-tip-class'
+   * @default ''
    */
   templateClasses: '',
   /**
    * Non-optional class added to tooltip templates. Foundation default is 'tooltip'.
    * @option
-   * @example 'tooltip'
+   * @default 'tooltip'
    */
   tooltipClass: 'tooltip',
   /**
    * Class applied to the tooltip anchor element.
    * @option
-   * @example 'has-tip'
+   * @default 'has-tip'
    */
   triggerClass: 'has-tip',
   /**
    * Minimum breakpoint size at which to open the tooltip.
    * @option
-   * @example 'small'
+   * @default 'small'
    */
   showOn: 'small',
   /**
    * Custom template to be used to generate markup for tooltip.
    * @option
-   * @example '&lt;div class="tooltip"&gt;&lt;/div&gt;'
+   * @default ''
    */
   template: '',
   /**
    * Text displayed in the tooltip template on open.
    * @option
-   * @example 'Some cool space fact here.'
+   * @default ''
    */
   tipText: '',
   touchCloseText: 'Tap to close.',
   /**
    * Allows the tooltip to remain open if triggered with a click or touch event.
    * @option
-   * @example true
+   * @default true
    */
   clickOpen: true,
   /**
    * Additional positioning classes, set by the JS
    * @option
-   * @example 'top'
+   * @default ''
    */
   positionClass: '',
   /**
    * Distance, in pixels, the template should push away from the anchor on the Y axis.
    * @option
-   * @example 10
+   * @default 10
    */
   vOffset: 10,
   /**
    * Distance, in pixels, the template should push away from the anchor on the X axis, if aligned to a side.
    * @option
-   * @example 12
+   * @default 12
    */
   hOffset: 12,
     /**
    * Allow HTML in tooltip. Warning: If you are loading user-generated content into tooltips,
    * allowing HTML may open yourself up to XSS attacks.
    * @option
-   * @example false
+   * @default false
    */
   allowHtml: false
 };

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -354,60 +354,70 @@ Tooltip.defaults = {
   /**
    * Time, in ms, before a tooltip should open on hover.
    * @option
+   * @type {number}
    * @default 200
    */
   hoverDelay: 200,
   /**
    * Time, in ms, a tooltip should take to fade into view.
    * @option
+   * @type {number}
    * @default 150
    */
   fadeInDuration: 150,
   /**
    * Time, in ms, a tooltip should take to fade out of view.
    * @option
+   * @type {number}
    * @default 150
    */
   fadeOutDuration: 150,
   /**
    * Disables hover events from opening the tooltip if set to true
    * @option
+   * @type {boolean}
    * @default false
    */
   disableHover: false,
   /**
    * Optional addtional classes to apply to the tooltip template on init.
    * @option
+   * @type {string}
    * @default ''
    */
   templateClasses: '',
   /**
    * Non-optional class added to tooltip templates. Foundation default is 'tooltip'.
    * @option
+   * @type {string}
    * @default 'tooltip'
    */
   tooltipClass: 'tooltip',
   /**
    * Class applied to the tooltip anchor element.
    * @option
+   * @type {string}
    * @default 'has-tip'
    */
   triggerClass: 'has-tip',
   /**
    * Minimum breakpoint size at which to open the tooltip.
    * @option
+   * @type {string}
    * @default 'small'
    */
   showOn: 'small',
   /**
    * Custom template to be used to generate markup for tooltip.
    * @option
+   * @type {string}
    * @default ''
    */
   template: '',
   /**
    * Text displayed in the tooltip template on open.
    * @option
+   * @type {string}
    * @default ''
    */
   tipText: '',
@@ -415,24 +425,28 @@ Tooltip.defaults = {
   /**
    * Allows the tooltip to remain open if triggered with a click or touch event.
    * @option
+   * @type {boolean}
    * @default true
    */
   clickOpen: true,
   /**
    * Additional positioning classes, set by the JS
    * @option
+   * @type {string}
    * @default ''
    */
   positionClass: '',
   /**
    * Distance, in pixels, the template should push away from the anchor on the Y axis.
    * @option
+   * @type {number}
    * @default 10
    */
   vOffset: 10,
   /**
    * Distance, in pixels, the template should push away from the anchor on the X axis, if aligned to a side.
    * @option
+   * @type {number}
    * @default 12
    */
   hOffset: 12,
@@ -440,6 +454,7 @@ Tooltip.defaults = {
    * Allow HTML in tooltip. Warning: If you are loading user-generated content into tooltips,
    * allowing HTML may open yourself up to XSS attacks.
    * @option
+   * @type {boolean}
    * @default false
    */
   allowHtml: false


### PR DESCRIPTION
Fix #9464.
Partially fix #8843.

#### Changes:
- Use `@default` instead of `@example`.
- Add `@type`.
- Add possible values when relevant.

#### Other changes:
- Fix typo in Dropdown docs.

#### ⚠️  Require:
- [x] https://github.com/zurb/foundation-docs/pull/6