### PR TITLE
Fix responsive navigation docs

### DIFF
--- a/js/foundation.responsiveMenu.js
+++ b/js/foundation.responsiveMenu.js
@@ -7,9 +7,6 @@
  * @module foundation.responsiveMenu
  * @requires foundation.util.triggers
  * @requires foundation.util.mediaQuery
- * @requires foundation.util.accordionMenu
- * @requires foundation.util.drilldown
- * @requires foundation.util.dropdown-menu
  */
 
 class ResponsiveMenu {

--- a/js/foundation.responsiveToggle.js
+++ b/js/foundation.responsiveToggle.js
@@ -93,23 +93,19 @@ class ResponsiveToggle {
    */
   toggleMenu() {
     if (!Foundation.MediaQuery.atLeast(this.options.hideFor)) {
+      /**
+       * Fires when the element attached to the tab bar toggles.
+       * @event ResponsiveToggle#toggled
+       */
       if(this.options.animate) {
         if (this.$targetMenu.is(':hidden')) {
           Foundation.Motion.animateIn(this.$targetMenu, this.animationIn, () => {
-            /**
-             * Fires when the element attached to the tab bar toggles.
-             * @event ResponsiveToggle#toggled
-             */
             this.$element.trigger('toggled.zf.responsiveToggle');
             this.$targetMenu.find('[data-mutate]').triggerHandler('mutateme.zf.trigger');
           });
         }
         else {
           Foundation.Motion.animateOut(this.$targetMenu, this.animationOut, () => {
-            /**
-             * Fires when the element attached to the tab bar toggles.
-             * @event ResponsiveToggle#toggled
-             */
             this.$element.trigger('toggled.zf.responsiveToggle');
           });
         }
@@ -117,11 +113,6 @@ class ResponsiveToggle {
       else {
         this.$targetMenu.toggle(0);
         this.$targetMenu.find('[data-mutate]').trigger('mutateme.zf.trigger');
-
-        /**
-         * Fires when the element attached to the tab bar toggles.
-         * @event ResponsiveToggle#toggled
-         */
         this.$element.trigger('toggled.zf.responsiveToggle');
       }
     }


### PR DESCRIPTION
Partially fix https://github.com/zurb/foundation-sites/issues/9559.

#### Changes:
- Remove wrong requirements in ResponsiveMenu (these modules do not exists as utils, and are not requirements but plugins).

#### Other changes:
- Remove duplicated event docs in ResponsiveToggle.

For `foundation.responsiveToogle`, it is not a dependency of `foundation.responsiveMenu` and the current docs template support only one file name (see [foundation-docs:templates/partials/javascript-reference.hbs:8](https://github.com/zurb/foundation-docs/blob/da8388b81b48749ea9fb4e9be398fbd11ba2b889/templates/partials/javascript-reference.hbs#L8)).