### PR TITLE
Fix #9565 - prevent `<pre>` overflow

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -196,6 +196,11 @@ $alert-color: get-color(alert);
     line-height: 1;
   }
 
+  // Prevent text overflow on pre
+  pre {
+    overflow: auto;
+  }
+
   // Internal classes to show/hide elements in JavaScript
   .is-visible {
     display: block !important;


### PR DESCRIPTION
Fix: https://github.com/zurb/foundation-sites/issues/9565

There is no case where we would expect the `<pre>` content to overflow.
