### PR TITLE
Fix flex-grid nested row alignment

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -55,6 +55,10 @@
       }
     }
 
+    &:not(.#{$expanded}) .#{$row} {
+      @include grid-row-size(expand);
+    }
+
     @if type-of($grid-column-gutter) == 'map' {
       // Static (unresponsive) row gutters
       //

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -134,6 +134,11 @@
     // Nesting behavior
     & .row {
       @include flex-grid-row(nest, $base: false);
+
+      &.collapse {
+        margin-right: 0;
+        margin-left: 0;
+      }
     }
 
     // Expanded row

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -141,6 +141,10 @@
       @include grid-row-size(expand);
     }
 
+    &:not(.expanded) .row {
+      @include grid-row-size(expand);
+    }
+
     &.collapse {
       > .column {
         @include grid-col-collapse;

--- a/test/visual/grid/collapse-nesting.html
+++ b/test/visual/grid/collapse-nesting.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation-flex.css" rel="stylesheet" />
+    <style>
+      .bred {
+        border: 3px solid red;
+      }
+
+      .bgreen {
+        border: 3px solid green;
+      }
+
+      .byellow {
+        border: 3px solid orange;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="row">
+      <div class="column">
+        <h1>Grid and Flex Grid: Nesting in collapsed row</h1>
+
+        <p>These are nested standard and collapsed rows. All rows should be aligned on the right and left.</p>
+      </div>
+    </div>
+
+    <div class="row collapse" >
+      <div class="column small-12" >
+        <div class="bred" >Single column in a Collapsed Row
+            <div class="row" >
+              <div class="column small-12" >
+                <div class="bgreen" >Single column in a Row
+                  <div class="row" >
+                      <div class="column small-6" >
+                        <div class="bred" >Two columns in a Row
+
+                        </div>
+                      </div>
+                      <div class="column small-6" >
+                        <div class="bred" >Two columns in a Row
+
+                        </div>
+                      </div>
+                    </div>
+
+                    <div class="row collapse" >
+                      <div class="column small-6" >
+                        <div class="byellow" >Two columns in a Collapsed Row
+
+                        </div>
+                      </div>
+                      <div class="column small-6" >
+                        <div class="byellow" >Two columns in a Collapsed Row
+
+                        </div>
+                      </div>
+                    </div>
+
+                </div>
+              </div>
+            </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Partially fix #9557

### Bugs:
See: https://github.com/zurb/foundation-sites/issues/9557#issuecomment-269123378.
1. > Every row has a max width (`75rem`, [scss/grid/_row.scss:62](https://github.com/ncoden/foundation-sites/blob/develop/scss/grid/_row.scss#L62)), so when nested, it can't be enlarged with negative margins: the left negative margin has an effect and not the right one. See: https://codepen.io/ncoden/pen/xRNzyL.
2. > Collapsed rows have negative margins when nested, but columns inside it do not have paddings. This is related to https://github.com/zurb/foundation-sites/issues/9082.
3. > Rows nested inside expanded rows are smaller and so should be centred, like classic rows. Negative margins prevent the row to be centered.

### Fixes:
1. Fix size of row nested inside collapsed (flex-)grid row: expand the size of all row nested in a non-expanded row.
2. Fix nested collapsed flex-grid row: apply the same path than for classic grids.

### Other changes:
- Add visual tests for nesting in collapsed rows.

### Unresolved:
3. Currently, there is no way to center the rows nested inside expanded rows without breaking the deep rows or precisely assuming the structure of the grid. 

### ⚠️  Note:
THIS IS A TEMPORARY FIX. Grids and flex-grids have a lot of bugs like this one and should be refactorized. Removing the "container" role of the row would allow to provide better fixes for 1st and 2nd problems and to fix the 3rd.