### PR TITLE
tweak card borders

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -18,6 +18,8 @@ $card-font-color: $body-font-color !default;
 /// @type Color
 $card-divider-background: $light-gray !default;
 
+$card-divider-border-right: inset #e1e1e1 1px;
+
 /// Default border style.
 /// @type List
 //$card-border: 1px solid $light-gray !default;
@@ -84,9 +86,7 @@ $card-margin: $global-margin !default;
     flex: 0 1 auto;
   }
 
-  border-width: 0 1px 0 0;
-  border-style: solid;
-  border-color: $white;
+  border-right: $card-divider-border-right;
 
   padding: $padding;
   background: $background;
@@ -104,8 +104,8 @@ $card-margin: $global-margin !default;
     flex: 1 0 auto;
   }
 
-  border-width: 0 1px 0 0;
-  border-style: solid;
+  border-width: 1px;
+  border-style: none inset solid outset;
   border-color: $light-gray;
 
   padding: $padding;

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -20,7 +20,8 @@ $card-divider-background: $light-gray !default;
 
 /// Default border style.
 /// @type List
-$card-border: 1px solid $light-gray !default;
+//$card-border: 1px solid $light-gray !default;
+$card-border: none !default;
 
 /// Default card shadow.
 /// @type List
@@ -83,6 +84,10 @@ $card-margin: $global-margin !default;
     flex: 0 1 auto;
   }
 
+  border-width: 0 1px 0 0;
+  border-style: solid;
+  border-color: $white;
+
   padding: $padding;
   background: $background;
 
@@ -98,6 +103,10 @@ $card-margin: $global-margin !default;
   @if $global-flexbox {
     flex: 1 0 auto;
   }
+
+  border-width: 0 1px 0 0;
+  border-style: solid;
+  border-color: $light-gray;
 
   padding: $padding;
 


### PR DESCRIPTION
Before submitting a pull request, make sure it's targeting the right branch:


This is a tweak to card borders. With the current default, one cannot easily distinguish the boundaries of adjacent cards without margins.

This PR removes the default border of the card element and adds asymmetric borders to `.card-section` and `.card-divider`.