### PR TITLE
Update _responsive-embed.scss

### DIFF
--- a/scss/components/_responsive-embed.scss
+++ b/scss/components/_responsive-embed.scss
@@ -60,7 +60,7 @@ $responsive-embed-ratios: (
   @include foundation-responsive-embed;
 }
 
-@mixin flex-video($ratio: $responsive-embed-ratio) {
+@mixin flex-video($ratio: default) {
   @warn 'This mixin is being replaced by responsive-embed(). flex-video() will be removed in Foundation 6.4.';
   @include responsive-embed;
 }

--- a/scss/components/_responsive-embed.scss
+++ b/scss/components/_responsive-embed.scss
@@ -62,5 +62,5 @@ $responsive-embed-ratios: (
 
 @mixin flex-video($ratio: $responsive-embed-ratio) {
   @warn 'This mixin is being replaced by responsive-embed(). flex-video() will be removed in Foundation 6.4.';
-  @include responsive-embed;
+  @include responsive-embed($ratio);
 }

--- a/scss/components/_responsive-embed.scss
+++ b/scss/components/_responsive-embed.scss
@@ -60,7 +60,7 @@ $responsive-embed-ratios: (
   @include foundation-responsive-embed;
 }
 
-@mixin flex-video($ratio: default) {
+@mixin flex-video($ratio: $responsive-embed-ratio) {
   @warn 'This mixin is being replaced by responsive-embed(). flex-video() will be removed in Foundation 6.4.';
   @include responsive-embed;
 }

--- a/scss/components/_responsive-embed.scss
+++ b/scss/components/_responsive-embed.scss
@@ -17,6 +17,9 @@ $responsive-embed-ratios: (
   widescreen: 16 by 9,
 ) !default;
 
+// WARNING: Will be removed in version 6.4
+$responsive-embed-ratio: default;
+
 /// Creates a responsive embed container.
 /// @param {String|List} $ratio [default] - Ratio of the container. Can be a key from the `$responsive-embed-ratios` map or a list formatted as `x by y`.
 @mixin responsive-embed($ratio: default) {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -494,6 +494,8 @@ $responsive-embed-ratios: (
   default: 4 by 3,
   widescreen: 16 by 9,
 );
+// WARNING: Will be removed in version 6.4
+$responsive-embed-ratio: default;
 
 // 29. Reveal
 // ----------

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -494,8 +494,6 @@ $responsive-embed-ratios: (
   default: 4 by 3,
   widescreen: 16 by 9,
 );
-// WARNING: Will be removed in version 6.4
-$responsive-embed-ratio: default;
 
 // 29. Reveal
 // ----------


### PR DESCRIPTION
The var in the mixin currently doesn't exist and as such including it without a set $ratio var results in build failure.