### PR TITLE
Specificity first in titles on docs pages

### DIFF
--- a/docs/layout/default.html
+++ b/docs/layout/default.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{description}}">
   <link rel="icon" href="assets/img/icons/foundation-favicon.ico" type="image/x-icon">
-  <title>Foundation for Sites 6 Docs{{#unlesspage 'index'}} | {{title}}{{/unlesspage}}</title>
+  <title>{{#unlesspage 'index'}}{{title}} | {{/unlesspage}}Foundation for Sites 6 Docs</title>
   <link href="assets/css/docs.css" rel="stylesheet" />
   <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
   <!-- <link rel="stylesheet" href="./node_modules/motion-ui/dist/motion-ui.css" /> -->


### PR DESCRIPTION
As @MattWilcox pointed out, for usability docs page titles should have the more specific part first, global/branding last.