### PR TITLE
Sass fix for util import in settings

### DIFF
--- a/docs/layout/default.html
+++ b/docs/layout/default.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="{{description}}">
   <link rel="icon" href="assets/img/icons/foundation-favicon.ico" type="image/x-icon">
-  <title>Foundation for Sites 6 Docs{{#unlesspage 'index'}} | {{title}}{{/unlesspage}}</title>
+  <title>{{#unlesspage 'index'}}{{title}} | {{/unlesspage}}Foundation for Sites 6 Docs</title>
   <link href="assets/css/docs.css" rel="stylesheet" />
   <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
   <!-- <link rel="stylesheet" href="./node_modules/motion-ui/dist/motion-ui.css" /> -->

--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -135,7 +135,7 @@ It's possible to use both the JavaScript slider and the native slider in the sam
 
 ## Non-linear value translation
 
-Sometimes not every value is of equal importance. In the example below, the slider focusses on the higher numbers by adding a `log`-type position value funtion.
+Sometimes not every value is of equal importance. In the example below, the slider focusses on the higher numbers by adding a `log`-type position value function.
 Alternatively there is also a `pow`-type position value function available, making the reverse possible.
 
 ```html_example

--- a/js/foundation.responsiveMenu.js
+++ b/js/foundation.responsiveMenu.js
@@ -7,9 +7,6 @@
  * @module foundation.responsiveMenu
  * @requires foundation.util.triggers
  * @requires foundation.util.mediaQuery
- * @requires foundation.util.accordionMenu
- * @requires foundation.util.drilldown
- * @requires foundation.util.dropdown-menu
  */
 
 class ResponsiveMenu {

--- a/js/foundation.responsiveToggle.js
+++ b/js/foundation.responsiveToggle.js
@@ -93,23 +93,19 @@ class ResponsiveToggle {
    */
   toggleMenu() {
     if (!Foundation.MediaQuery.atLeast(this.options.hideFor)) {
+      /**
+       * Fires when the element attached to the tab bar toggles.
+       * @event ResponsiveToggle#toggled
+       */
       if(this.options.animate) {
         if (this.$targetMenu.is(':hidden')) {
           Foundation.Motion.animateIn(this.$targetMenu, this.animationIn, () => {
-            /**
-             * Fires when the element attached to the tab bar toggles.
-             * @event ResponsiveToggle#toggled
-             */
             this.$element.trigger('toggled.zf.responsiveToggle');
             this.$targetMenu.find('[data-mutate]').triggerHandler('mutateme.zf.trigger');
           });
         }
         else {
           Foundation.Motion.animateOut(this.$targetMenu, this.animationOut, () => {
-            /**
-             * Fires when the element attached to the tab bar toggles.
-             * @event ResponsiveToggle#toggled
-             */
             this.$element.trigger('toggled.zf.responsiveToggle');
           });
         }
@@ -117,11 +113,6 @@ class ResponsiveToggle {
       else {
         this.$targetMenu.toggle(0);
         this.$targetMenu.find('[data-mutate]').trigger('mutateme.zf.trigger');
-
-        /**
-         * Fires when the element attached to the tab bar toggles.
-         * @event ResponsiveToggle#toggled
-         */
         this.$element.trigger('toggled.zf.responsiveToggle');
       }
     }

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -41,7 +41,7 @@
 //  36. Tooltip
 //  37. Top Bar
 
-@import 'util/util';
+@import '../util/util';
 
 // 1. Global
 // ---------


### PR DESCRIPTION
Hi! Great work!

Noticed in 6.3.0 that the file path reference for importing `util/util` in `foundation-sites/scss/settings/_settings.scss` on ine 44  

> @import 'util/util';

led to the erorr while compiling the Sass:

>  Error: File to import not found or unreadable: util/util.

Updated line 44 to

> @import '../util/util';

Thanks

