### PR TITLE
Feature Add attribute for auto focus within off canvas

### DIFF
--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -196,7 +196,12 @@ class OffCanvas {
 
     if (this.options.autoFocus === true) {
       this.$element.one(Foundation.transitionend(this.$element), function() {
-        _this.$element.find('a, button').eq(0).focus();
+        var canvasFocus = _this.$element.find('[data-autofocus]');
+        if (canvasFocus.length) {
+            canvasFocus.eq(0).focus();
+        } else {
+            _this.$element.find('a, button').eq(0).focus();
+        }
       });
     }
 


### PR DESCRIPTION
Checks for the attribute [data-autofocus] within the toggled off canvas
and focuses on the first occurrence if available.  Otherwise reverts to
standard behaviour.