### PR TITLE
Prevent keyboard trap in drilldown menu.

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -227,11 +227,13 @@ class Drilldown {
         },
         up: function() {
           $prevElement.focus();
-          return true;
+          // Don't tap focus on first element in root ul
+          return !$element.is(_this.$element.find('> li:first-child > a'));
         },
         down: function() {
           $nextElement.focus();
-          return true;
+          // Don't tap focus on last element in root ul
+          return !$element.is(_this.$element.find('> li:last-child > a'));
         },
         close: function() {
           _this._back();


### PR DESCRIPTION
Added check if current element is first/last element in root ul of drilldown.
Only prevents default if this is not the case now.

Fixes #9597