### PR TITLE
Fixed ESC button on drilldown menus.

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -234,8 +234,11 @@ class Drilldown {
           return true;
         },
         close: function() {
-          _this._back();
-          //_this.$menuItems.first().focus(); // focus to first element
+          // Don't close on element in root ul
+          if (!$element.is(_this.$element.find('> li > a'))) {
+            _this._hide($element.parent().parent());
+            $element.parent().parent().siblings('a').focus();
+          }
         },
         open: function() {
           if (!$element.is(_this.$menuItems)) { // not menu item means back button


### PR DESCRIPTION
Previously, _back was being called without a parameter which is both a wrong ca$
ESC is now using _hide and will place focus on the anchor that was used to open$

TBD: If hideAll should be called so all sub menus are closed using ESC.