### PR TITLE
New SmoothScroll module based on Magellan scrollToLoc code. 

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -167,6 +167,7 @@ Get to know the pieces of Foundation.
         <li><a href="equalizer.html">Equalizer</a></li>
         <li><a href="interchange.html">Interchange</a></li>
         <li><a href="toggler.html">Toggler</a></li>
+        <li><a href="smooth-scroll.html">Smooth Scroll</a></li>
         <li><a href="sticky.html">Sticky</a></li>
       </ul>
     </section>

--- a/docs/pages/magellan.md
+++ b/docs/pages/magellan.md
@@ -8,7 +8,7 @@ tags:
 
 <div data-sticky-container>
   <div class="sticky" id="sticky-magellan" style="width:100%;" data-sticky data-margin-top="0" data-margin-bottom="0" data-top-anchor="setup" data-btm-anchor="destroy:bottom" data-sticky-on="small">
-    <nav data-magellan class="sticky-mag" data-bar-offset="25">
+    <nav data-magellan class="sticky-mag" data-offset="25">
       <ul class="horizontal menu expanded">
         <li><a href="#setup">Setup</a></li>
         <li><a href="#sticky-navigation">Sticky Navigation</a></li>

--- a/docs/pages/smooth-scroll.md
+++ b/docs/pages/smooth-scroll.md
@@ -1,0 +1,40 @@
+---
+title: Smooth Scroll
+description: Allows internal links smooth scrolling.
+js: js/foundation.smoothScroll.js
+tags:
+  - navigation
+---
+
+<ul class="menu vertical" data-smooth-scroll>
+  <li><a href="#setup">Setup</a></li>
+  <li><a href="#javascript-reference">Javascript Reference</a></li>
+</ul>
+
+<br>
+
+## Setup
+
+To enable SmoothScroll on internal links, just add the attribute `data-smooth-scroll` to the parent container like our [Menu](menu.html). Each section needs a unique ID
+
+```html
+<ul class="horizontal menu" data-smooth-scroll>
+  <li><a href="#first">First Arrival</a></li>
+  <li><a href="#second">Second Arrival</a></li>
+  <li><a href="#third">Third Arrival</a></li>
+</ul>
+<div class="sections">
+  <section id="first">First Section</section>
+  <section id="second">Second Section</section>
+  <section id="third">Third Section</section>
+</div>
+```
+
+You can also setup SmoothScroll directly via indiviual link.
+
+```html
+<a href="#exclusive" data-smooth-scroll>Exclusive Section</a>
+<section id="exclusive">The Exclusive Section</section>
+```
+
+---

--- a/docs/pages/smooth-scroll.md
+++ b/docs/pages/smooth-scroll.md
@@ -6,9 +6,16 @@ tags:
   - navigation
 ---
 
-## Usage
+<ul class="menu vertical" data-smooth-scroll>
+  <li><a href="#setup">Setup</a></li>
+  <li><a href="#javascript-reference">Javascript Reference</a></li>
+</ul>
 
-To enable smooth scrolling on internal links add the attribute `data-smooth-scroll` to the parent container like our [Menu](menu.html). Each section needs a unique ID
+<br>
+
+## Setup
+
+To enable SmoothScroll on internal links, just add the attribute `data-smooth-scroll` to the parent container like our [Menu](menu.html). Each section needs a unique ID
 
 ```html
 <ul class="horizontal menu" data-smooth-scroll>
@@ -23,7 +30,7 @@ To enable smooth scrolling on internal links add the attribute `data-smooth-scro
 </div>
 ```
 
-You can also apply `data-smooth-scroll` attribute directly to the link.
+You can also setup SmoothScroll directly via indiviual link.
 
 ```html
 <a href="#exclusive" data-smooth-scroll>Exclusive Section</a>

--- a/docs/pages/smooth-scroll.md
+++ b/docs/pages/smooth-scroll.md
@@ -6,16 +6,9 @@ tags:
   - navigation
 ---
 
-<ul class="menu vertical" data-smooth-scroll>
-  <li><a href="#setup">Setup</a></li>
-  <li><a href="#javascript-reference">Javascript Reference</a></li>
-</ul>
+## Usage
 
-<br>
-
-## Setup
-
-To enable SmoothScroll on internal links, just add the attribute `data-smooth-scroll` to the parent container like our [Menu](menu.html). Each section needs a unique ID
+To enable smooth scrolling on internal links add the attribute `data-smooth-scroll` to the parent container like our [Menu](menu.html). Each section needs a unique ID
 
 ```html
 <ul class="horizontal menu" data-smooth-scroll>
@@ -30,7 +23,7 @@ To enable SmoothScroll on internal links, just add the attribute `data-smooth-sc
 </div>
 ```
 
-You can also setup SmoothScroll directly via indiviual link.
+You can also apply `data-smooth-scroll` attribute directly to the link.
 
 ```html
 <a href="#exclusive" data-smooth-scroll>Exclusive Section</a>

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -76,6 +76,7 @@
   <li{{#ifpage 'equalizer'}} class="current"{{/ifpage}}><a href="equalizer.html">Equalizer <small>Column Alignment</small></a></li>
   <li{{#ifpage 'interchange'}} class="current"{{/ifpage}}><a href="interchange.html">Interchange <small>Responsive Content</small></a></li>
   <li{{#ifpage 'toggler'}} class="current"{{/ifpage}}><a href="toggler.html">Toggler <small>CSS Helper</small></a></li>
+  <li{{#ifpage 'smooth-scroll'}} class="current"{{/ifpage}}><a href="smooth-scroll.html">Smooth Scroll <small>Navigation</small></a></li>
   <li{{#ifpage 'sticky'}} class="current"{{/ifpage}}><a href="sticky.html">Sticky <small>Header/Sidebar</small></a></li>
 
   <li class="docs-nav-title">Sass</li>

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -113,7 +113,14 @@ class Magellan {
     this._inTransition = true;
     var _this = this;
 
-    Foundation.SmoothScroll.scrollToLoc(loc, this.options, function() {
+    var options = {
+      animationEasing: this.options.animationEasing,
+      animationDuration: this.options.animationDuration,
+      threshold: this.options.threshold,
+      offset: this.options.offset
+    };
+
+    Foundation.SmoothScroll.scrollToLoc(loc, options, function() {
       _this._inTransition = false; 
       _this._updateActive();
     })
@@ -145,7 +152,7 @@ class Magellan {
       var isDown = this.scrollPos < winPos,
           _this = this,
           curVisible = this.points.filter(function(p, i){
-            return isDown ? p - _this.options.barOffset <= winPos : p - _this.options.barOffset - _this.options.threshold <= winPos;
+            return isDown ? p - _this.options.offset <= winPos : p - _this.options.offset - _this.options.threshold <= winPos;
           });
       curIdx = curVisible.length ? curVisible.length - 1 : 0;
     }
@@ -238,7 +245,7 @@ Magellan.defaults = {
    * @type {number}
    * @default 0
    */
-  barOffset: 0
+  offset: 0
 }
 
 // Window exports

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -5,6 +5,7 @@
 /**
  * Magellan module.
  * @module foundation.magellan
+ * @requires foundation.smoothScroll
  */
 
 class Magellan {
@@ -109,18 +110,13 @@ class Magellan {
    * @function
    */
   scrollToLoc(loc) {
-    // Do nothing if target does not exist to prevent errors
-    if (!$(loc).length) {return false;}
     this._inTransition = true;
-    var _this = this,
-        scrollPos = Math.round($(loc).offset().top - this.options.threshold / 2 - this.options.barOffset);
+    var _this = this;
 
-    $('html, body').stop(true).animate(
-      { scrollTop: scrollPos },
-      this.options.animationDuration,
-      this.options.animationEasing,
-      function() {_this._inTransition = false; _this._updateActive()}
-    );
+    Foundation.SmoothScroll.scrollToLoc(loc, this.options, function() {
+      _this._inTransition = false; 
+      _this._updateActive();
+    })
   }
 
   /**

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -1,0 +1,123 @@
+'use strict';
+
+!function($) {
+
+/**
+ * SmoothScroll module.
+ * @module foundation.smooth-scroll
+ */
+class SmoothScroll {
+    constructor(element, options) {
+        this.$element = element;
+        this.options = $.extend({}, SmoothScroll.defaults, this.$element.data(), options);
+
+        this._init();
+
+        Foundation.registerPlugin(this, 'SmoothScroll');
+    }
+
+    /**
+     * Initialize the SmoothScroll plugin 
+     */
+    _init() {
+        var id = this.$element[0].id || Foundation.GetYoDigits(6, 'smooth-scroll');
+        var _this = this;
+        this.$element.attr({
+            'id': id
+        });
+
+        this._events();
+    }
+
+    _events() {
+        var _this = this;
+
+        this.$element.on('click.zf.smoothScroll', 'a[href^="#"]', function(e) {
+            e.preventDefault();
+            var arrival   = this.getAttribute('href');
+            _this.scrollToLoc(arrival);
+        });
+    }
+
+    /**
+     * Function to scroll to a given location on the page.
+     * @param {String} loc - a properly formatted jQuery id selector. Example: '#foo'
+     * @function
+     */
+    scrollToLoc(loc) {
+        this._inTransition = true;
+        var _this = this;
+        this.constructor.scrollToLoc(loc, this.options, function() {
+            _this._inTransition = false;
+        });
+    }
+
+    /**
+     * Function to scroll to a given location on the page.
+     * @param {String} loc - a properly formatted jQuery id selector. Example: '#foo'
+     * @static
+     * @function
+     */
+    static scrollToLoc(loc, options, callback) {
+        // Do nothing if target does not exist to prevent errors
+        if (!$(loc).length) {
+            return false;
+        }
+
+        var scrollPos = Math.round($(loc).offset().top - options.threshold / 2 - options.barOffset);
+
+        $('html, body').stop(true).animate(
+            { scrollTop: scrollPos },
+            options.animationDuration,
+            options.animationEasing,
+            function() {
+                if(callback && typeof callback == "function"){
+                    callback();
+                }
+            }
+        );
+    }
+
+    destory() {
+        Foundation.unregisterPlugin(this);
+    }
+}
+
+/**
+ * Default settings for plugin.
+ */
+SmoothScroll.defaults = {
+  /**
+   * Amount of time, in ms, the animated scrolling should take between locations.
+   * @option
+   * @type {number}
+   * @default 500
+   */
+  animationDuration: 500,
+  /**
+   * Animation style to use when scrolling between locations. Can be `'swing'` or `'linear'`.
+   * @option
+   * @type {string}
+   * @default 'linear'
+   * @see {@link https://api.jquery.com/animate|Jquery animate}
+   */
+  animationEasing: 'linear',
+  /**
+   * Number of pixels to use as a marker for location changes.
+   * @option
+   * @type {number}
+   * @default 50
+   */
+  threshold: 50,
+  /**
+   * Number of pixels to offset the scroll of the page on item click if using a sticky nav bar.
+   * @option
+   * @type {number}
+   * @default 0
+   */
+  barOffset: 0
+}
+
+// Window exports
+Foundation.plugin(SmoothScroll, 'SmoothScroll');
+}(jQuery);

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -62,16 +62,18 @@ class SmoothScroll {
     /**
      * Function to scroll to a given location on the page.
      * @param {String} loc - A properly formatted jQuery id selector. Example: '#foo'
-     * @param {Object} options - The options to use.
-     * @param {Function} callback - The callback function.
+     * @param {Object} options - Overrides to the default plugin settings.
+     * @param {Function} callback - The callback function when scroll animation is finished.
      * @static
      * @function
      */
-    static scrollToLoc(loc, options = SmoothScroll.defaults, callback) {
+    static scrollToLoc(loc, options, callback) {
         // Do nothing if target does not exist to prevent errors
         if (!$(loc).length) {
             return false;
         }
+
+        options = $.extend({}, SmoothScroll.defaults, options);
 
         var scrollPos = Math.round($(loc).offset().top - options.threshold / 2 - options.offset);
 

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -17,7 +17,8 @@ class SmoothScroll {
     }
 
     /**
-     * Initialize the SmoothScroll plugin 
+     * Initialize the SmoothScroll plugin
+     * @private
      */
     _init() {
         var id = this.$element[0].id || Foundation.GetYoDigits(6, 'smooth-scroll');
@@ -29,42 +30,50 @@ class SmoothScroll {
         this._events();
     }
 
+    /**
+     * Initializes events for SmoothScroll.
+     * @private
+     */
     _events() {
         var _this = this;
 
-        this.$element.on('click.zf.smoothScroll', 'a[href^="#"]', function(e) {
+        // click handler function.
+        var handleLinkClick = function(e) {
+            // exit function if the event source isn't coming from an anchor with href attribute starts with '#'
+            if(!$(this).is('a[href^="#"]'))  {
+                return false;
+            }
+            
+            var arrival = this.getAttribute('href');
+            
+            _this._inTransition = true;
+
+            SmoothScroll.scrollToLoc(arrival, _this.options, function() {
+                _this._inTransition = false;
+            });
+            
             e.preventDefault();
-            var arrival   = this.getAttribute('href');
-            _this.scrollToLoc(arrival);
-        });
+        };
+
+        this.$element.on('click.zf.smoothScroll', handleLinkClick)
+        this.$element.on('click.zf.smoothScroll', 'a[href^="#"]', handleLinkClick);
     }
 
     /**
      * Function to scroll to a given location on the page.
-     * @param {String} loc - a properly formatted jQuery id selector. Example: '#foo'
-     * @function
-     */
-    scrollToLoc(loc) {
-        this._inTransition = true;
-        var _this = this;
-        this.constructor.scrollToLoc(loc, this.options, function() {
-            _this._inTransition = false;
-        });
-    }
-
-    /**
-     * Function to scroll to a given location on the page.
-     * @param {String} loc - a properly formatted jQuery id selector. Example: '#foo'
+     * @param {String} loc - A properly formatted jQuery id selector. Example: '#foo'
+     * @param {Object} options - The options to use.
+     * @param {Function} callback - The callback function.
      * @static
      * @function
      */
-    static scrollToLoc(loc, options, callback) {
+    static scrollToLoc(loc, options = SmoothScroll.defaults, callback) {
         // Do nothing if target does not exist to prevent errors
         if (!$(loc).length) {
             return false;
         }
 
-        var scrollPos = Math.round($(loc).offset().top - options.threshold / 2 - options.barOffset);
+        var scrollPos = Math.round($(loc).offset().top - options.threshold / 2 - options.offset);
 
         $('html, body').stop(true).animate(
             { scrollTop: scrollPos },
@@ -78,6 +87,10 @@ class SmoothScroll {
         );
     }
 
+   /**
+    * Destroys an instance of SmoothScroll.
+    * @function
+    */
     destory() {
         Foundation.unregisterPlugin(this);
     }
@@ -115,7 +128,7 @@ SmoothScroll.defaults = {
    * @type {number}
    * @default 0
    */
-  barOffset: 0
+  offset: 0
 }
 
 // Window exports

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -62,18 +62,16 @@ class SmoothScroll {
     /**
      * Function to scroll to a given location on the page.
      * @param {String} loc - A properly formatted jQuery id selector. Example: '#foo'
-     * @param {Object} options - Overrides to the default plugin settings.
-     * @param {Function} callback - The callback function when scroll animation is finished.
+     * @param {Object} options - The options to use.
+     * @param {Function} callback - The callback function.
      * @static
      * @function
      */
-    static scrollToLoc(loc, options, callback) {
+    static scrollToLoc(loc, options = SmoothScroll.defaults, callback) {
         // Do nothing if target does not exist to prevent errors
         if (!$(loc).length) {
             return false;
         }
-
-        options = $.extend({}, SmoothScroll.defaults, options);
 
         var scrollPos = Math.round($(loc).offset().top - options.threshold / 2 - options.offset);
 


### PR DESCRIPTION
Implementation for #9587 

To enable smooth scroll on the internal links just add the **data-smooth-scroll** attribute to the parent container, sample code below, or via javascript initialization.

```html
<ul data-smooth-scroll data-threshold="0" data-animation-easing="swing" >
    <li><a href="#section1">Section 1</a></li>
</ul>
```

The **Magellan** module now depends on the **SmoothScroll** module for the scrolling animation functionality.

