### PR TITLE
[Abide] Add Form Error attribute

### DIFF
--- a/docs/pages/abide.md
+++ b/docs/pages/abide.md
@@ -8,7 +8,7 @@ tags:
   - validation
 ---
 
-### Abide Demo
+## Abide Demo
 
 These input types create a text field: `text`, `date`, `datetime`, `datetime-local`, `email`, `month`, `number`, `password`, `search`, `tel`, `time`, `url`, and `week`.
 

--- a/docs/pages/abide.md
+++ b/docs/pages/abide.md
@@ -115,6 +115,29 @@ These input types create a text field: `text`, `date`, `datetime`, `datetime-loc
   <textarea type="text" class="is-invalid-input"></textarea>
 </label>
 
+---
+
+### Form Errors
+
+Abide automatically detects Form Errors of an input by their class (`.form-error` by default, see the `formErrorSelector` option) when they are siblings of the input or inside the same parent.
+
+When the Form Errors cannot be placed next to its field, like in an Input Group, the relation can be declared with `[data-form-error-for]` attribute.
+
+```html_example
+<form data-abide novalidate>
+  <label>
+    Amount
+    <div class="input-group">
+      <span class="input-group-label">$</span>
+      <input class="input-group-field" id="exampleNumberInput" type="number" required pattern="number"/>
+    </div>
+    <span class="form-error" data-form-error-for="exampleNumberInput">Amount is required.</span>
+  </label>
+  <button class="button" type="submit" value="Submit">Submit</button>
+</form>
+```
+
+
 ## Initial State
 
 ```html

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -110,9 +110,11 @@ class Abide {
   }
 
   /**
-   * Based on $el, get the first element with selector in this order:
-   * 1. The element's direct sibling('s).
-   * 3. The element's parent's children.
+   * Get:
+   * - Based on $el, the first element(s) corresponding to `formErrorSelector` in this order:
+   *   1. The element's direct sibling('s).
+   *   2. The element's parent's children.
+   * - Element(s) with the attribute `[data-form-error-for]` set with the element's id.
    *
    * This allows for multiple form errors per input, though if none are found, no form errors will be shown.
    *
@@ -120,11 +122,14 @@ class Abide {
    * @returns {Object} jQuery object with the selector.
    */
   findFormError($el) {
+    var id = $el[0].id;
     var $error = $el.siblings(this.options.formErrorSelector);
 
     if (!$error.length) {
       $error = $el.parent().find(this.options.formErrorSelector);
     }
+
+    $error = $error.add(this.$element.find(`[data-form-error-for="${id}"]`));
 
     return $error;
   }


### PR DESCRIPTION
Closes #9600.

#### Changes:
- Add `[data-form-error-for=someId]` attribute to declare a relation between a form error and the related field.
- Add docs in Abide with explanation about the way Form Errors are found and an example for `[data-form-error-for]`

#### Other changes:
- Fix docs title in Abide (was `###` instead of `##`)