### PR TITLE
New function: font-stack

### DIFF
--- a/scss/util/_typography.scss
+++ b/scss/util/_typography.scss
@@ -1,0 +1,34 @@
+// Foundation for Sites by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+////
+/// @group functions
+////
+
+$-zf-font-stack: (
+  'georgia': (Georgia, "URW Bookman L", serif),
+  'helvetica': (Helvetica, Arial, "Nimbus Sans L", sans-serif),
+  'lucida-grande': ("Lucida Grande", "Lucida Sans Unicode", "Bitstream Vera Sans", sans-serif),
+  'monospace': ("Courier New", Courier, "Nimbus Sans L", monospace),
+  'system': (-apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif),
+  'verdana': (Verdana, Geneva, "DejaVu Sans", sans-serif),
+);
+
+/// Retrieve a font stack string from a map.
+/// @param {String} $stack - The key of the font stack from the map.
+/// @param {Map} $map - A map of font stacks to retrieve a string from.
+/// @return {List} A font stack list.
+@function font-stack($stack, $map: $-zf-font-stack) {
+  @if (type-of($map) == 'map') {
+    @if (map-has-key($map, $stack)) {
+      @return map-get($map, $stack);
+    }
+    @else {
+      @error 'Font stack $key is not available in $map';
+    }
+  }
+  @else {
+    @error '$map is not a map';
+  }
+}

--- a/scss/util/_typography.scss
+++ b/scss/util/_typography.scss
@@ -25,10 +25,10 @@ $-zf-font-stack: (
       @return map-get($map, $stack);
     }
     @else {
-      @error 'Font stack $key is not available in $map';
+      @error 'Font stack `#{$stack}` is not available in `#{$map}`';
     }
   }
   @else {
-    @error '$map is not a map';
+    @error '`#{$map}` is not a valid map';
   }
 }

--- a/scss/util/_typography.scss
+++ b/scss/util/_typography.scss
@@ -15,17 +15,19 @@ $-zf-font-stack: (
   'verdana': (Verdana, Geneva, "DejaVu Sans", sans-serif),
 );
 
-/// Retrieve a font stack string from a map.
-/// @param {String} $stack - The key of the font stack from the map.
-/// @param {Map} $map - A map of font stacks to retrieve a string from.
-/// @return {List} A font stack list.
-@function font-stack($stack, $map: $-zf-font-stack) {
+/// Return a font stack list from a map. Equivalent to `map-safe-get($name, $-zf-font-stack)`.
+///
+/// @param {String} $name - Name of the font stack.
+/// @param {Map} $map [$-zf-font-stack] - Map of font stacks to retrieve a list from.
+///
+/// @returns {List} Found font stack.
+@function font-stack($name, $map: $-zf-font-stack) {
   @if (type-of($map) == 'map') {
-    @if (map-has-key($map, $stack)) {
-      @return map-get($map, $stack);
+    @if (map-has-key($map, $name)) {
+      @return map-get($map, $name);
     }
     @else {
-      @error 'Font stack `#{$stack}` is not available in `#{$map}`';
+      @error 'Font stack `#{$name}` is not available in `#{$map}`';
     }
   }
   @else {

--- a/scss/util/_typography.scss
+++ b/scss/util/_typography.scss
@@ -17,20 +17,10 @@ $-zf-font-stack: (
 
 /// Return a font stack list from a map. Equivalent to `map-safe-get($name, $-zf-font-stack)`.
 ///
-/// @param {String} $name - Name of the font stack.
+/// @param {String} $stack - Name of the font stack.
 /// @param {Map} $map [$-zf-font-stack] - Map of font stacks to retrieve a list from.
 ///
 /// @returns {List} Found font stack.
-@function font-stack($name, $map: $-zf-font-stack) {
-  @if (type-of($map) == 'map') {
-    @if (map-has-key($map, $name)) {
-      @return map-get($map, $name);
-    }
-    @else {
-      @error 'Font stack `#{$name}` is not available in `#{$map}`';
-    }
-  }
-  @else {
-    @error '`#{$map}` is not a valid map';
-  }
+@function font-stack($stack, $map: $-zf-font-stack) {
+  @return map-safe-get($map, $stack);
 }

--- a/scss/util/_util.scss
+++ b/scss/util/_util.scss
@@ -11,3 +11,4 @@
 @import 'flex';
 @import 'breakpoint';
 @import 'mixins';
+@import 'typography';

--- a/scss/util/_value.scss
+++ b/scss/util/_value.scss
@@ -142,16 +142,16 @@
 /// Safely return a value from a map.
 ///
 /// @param {Map} $map - Map to retrieve a value from.
-/// @param {String} $name - Name of the map key.
+/// @param {String} $key - Name of the map key.
 ///
 /// @returns {List} Found value.
-@function map-safe-get($map, $name) {
-  @if (type-of($map) == 'map') {
-    @if (map-has-key($map, $name)) {
-      @return map-get($map, $name);
+@function map-safe-get($map, $key) {
+  @if (type-of($map) == 'map' or (type-of($map) == 'list' and length($map) == 0)) {
+    @if (map-has-key($map, $key)) {
+      @return map-get($map, $key);
     }
     @else {
-      @error 'Key: `#{$name}` is not available in `#{$map}`';
+      @error 'Key: `#{$key}` is not available in `#{$map}`';
     }
   }
   @else {

--- a/scss/util/_value.scss
+++ b/scss/util/_value.scss
@@ -138,3 +138,23 @@
   @return if(type-of($map) != 'list', ($value,), $map);
 
 }
+
+/// Safely return a value from a map.
+///
+/// @param {String} $name - Name of the map key.
+/// @param {Map} $map - Map to retrieve a value from.
+///
+/// @returns {List} Found value.
+@function map-safe-get($name, $map) {
+  @if (type-of($map) == 'map') {
+    @if (map-has-key($map, $name)) {
+      @return map-get($map, $name);
+    }
+    @else {
+      @error 'Key: `#{$name}` is not available in `#{$map}`';
+    }
+  }
+  @else {
+    @error '`#{$map}` is not a valid map';
+  }
+}

--- a/scss/util/_value.scss
+++ b/scss/util/_value.scss
@@ -141,11 +141,11 @@
 
 /// Safely return a value from a map.
 ///
-/// @param {String} $name - Name of the map key.
 /// @param {Map} $map - Map to retrieve a value from.
+/// @param {String} $name - Name of the map key.
 ///
 /// @returns {List} Found value.
-@function map-safe-get($name, $map) {
+@function map-safe-get($map, $name) {
   @if (type-of($map) == 'map') {
     @if (map-has-key($map, $name)) {
       @return map-get($map, $name);

--- a/test/sass/_value.scss
+++ b/test/sass/_value.scss
@@ -114,5 +114,16 @@
       'Gets a value from a nested map');
   }
 
+  @include test('Map Safe Get [function]') {
+    $map: (
+      one: 'two',
+      ),
+    );
+    $expect: 'two';
+    
+    @include assert-equal(map-safe-get($map, one), $expect,
+      'Safely return a value from a map');
+  }
+
   // TODO: Add spec for pow()
 }

--- a/test/sass/_value.scss
+++ b/test/sass/_value.scss
@@ -116,8 +116,7 @@
 
   @include test('Map Safe Get [function]') {
     $map: (
-      one: 'two',
-      ),
+      one: 'two'
     );
     $expect: 'two';
     


### PR DESCRIPTION
This PR adds some carefully selected font stacks to an internal map variable `$-zf-font-stack`.
A helper function has also been added `font-stack` to allow you to use one of these stacks. Simply pass in the stack key, eg `font-family: font-stack(system);` to use the system font stack.

This ensures a consistent way to use some quality font stacks, but also the ability to add your own map with stacks in too, simply pass it as the second parameter to the function.

This was the result of a discussion with @ncoden about how to sort out #9596.