### PR TITLE
Keyboard mock

### DIFF
--- a/test/javascript/components/drilldown.js
+++ b/test/javascript/components/drilldown.js
@@ -212,4 +212,103 @@ describe('Drilldown Menu', function() {
   });
 
 
+  describe('keyboard events', function() {
+    // Currently not testable, as triggered event won't move on focus
+    it.skip('does not trap focus on root element going down', function() {
+      $html = $(template).appendTo('body');
+      let $dummyElement = $('<a tabindex="0">Dummy</a>').appendTo('body'); // Dummy target to see if focus is not trapped
+      plugin = new Foundation.Drilldown($html, {});
+
+      // Focus last element
+      $dummyElement.focus();
+      $html.find('> li:last-child > a').trigger(window.mockKeyboardEvent('TAB'));
+
+      document.activeElement.should.not.be.equal($html.find('> li:last-child > a')[0]);
+
+      $dummyElement.remove();
+    });
+    // Currently not testable, as triggered event won't move on focus
+    it.skip('does not trap focus on root element going up', function() {
+      let $dummyElement = $('<a tabindex="0">Dummy</a>').appendTo('body'); // Dummy target to see if focus is not trapped
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      // Focus first element
+      $dummyElement.focus();
+      $html.find('> li:first-child > a').trigger(window.mockKeyboardEvent('TAB', {shift: true}));
+
+      document.activeElement.should.not.be.equal($html.find('> li:first-child > a')[0]);
+
+      $dummyElement.remove();
+    });
+    it('closes current sub menu using ESC', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      // Open it first
+      plugin._show($html.find('> li:nth-child(1)'))
+
+      $html.find('> li:nth-child(1) > ul > li:first-child > a').focus()
+        .trigger(window.mockKeyboardEvent('ESCAPE'));
+
+      $html.find('> li:nth-child(1) > ul').should.have.class('is-closing');
+    });
+    it('moves focus to next element on TAB', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      $html.find('> li:nth-child(1) > a').focus()
+        .trigger(window.mockKeyboardEvent('TAB'));
+
+      document.activeElement.should.be.equal($html.find('> li:nth-child(2) > a')[0]);
+    });
+    it('moves focus to previous element on TAB', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      $html.find('> li:nth-child(2) > a').focus()
+        .trigger(window.mockKeyboardEvent('TAB', {shift: true}));
+
+      document.activeElement.should.be.equal($html.find('> li:nth-child(1) > a')[0]);
+    });
+    it('moves focus to next element on ARROW_DOWN', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      $html.find('> li:nth-child(1) > a').focus()
+        .trigger(window.mockKeyboardEvent('ARROW_DOWN'));
+
+      document.activeElement.should.be.equal($html.find('> li:nth-child(2) > a')[0]);
+    });
+    it('moves focus to previous element on ARROW_UP', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      $html.find('> li:nth-child(2) > a').focus()
+        .trigger(window.mockKeyboardEvent('ARROW_UP'));
+
+      document.activeElement.should.be.equal($html.find('> li:nth-child(1) > a')[0]);
+    });
+    it('opens child element on ARROW_RIGHT', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      $html.find('> li:nth-child(1) > a').focus()
+        .trigger(window.mockKeyboardEvent('ARROW_RIGHT'));
+
+      $html.find('> li:nth-child(1) > ul').should.have.class('is-active');
+    });
+    it('closes child element on ARROW_LEFT', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Drilldown($html, {});
+
+      // Open it first
+      plugin._show($html.find('> li:nth-child(1)'))
+
+      $html.find('> li:nth-child(1) > ul > li:first-child > a').focus()
+        .trigger(window.mockKeyboardEvent('ARROW_LEFT'));
+
+      $html.find('> li:nth-child(1) > ul').should.have.class('is-closing');
+    });
+  });
 });

--- a/test/javascript/components/orbit.js
+++ b/test/javascript/components/orbit.js
@@ -194,4 +194,27 @@ describe('Orbit', function() {
       }, 201);
     });
   });
+
+  describe('keyboard events', function() {
+    it('moves switches to next slide using ARROW_RIGHT', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Orbit($html, {});
+      let spy = sinon.spy(plugin, 'changeSlide');
+
+      plugin.$wrapper.focus()
+        .trigger(window.mockKeyboardEvent('ARROW_RIGHT'));
+
+      sinon.assert.calledWith(spy, true);
+    });
+    it('moves switches to previous slide using ARROW_LEFT', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Orbit($html, {});
+      let spy = sinon.spy(plugin, 'changeSlide');
+
+      plugin.$wrapper.focus()
+        .trigger(window.mockKeyboardEvent('ARROW_LEFT'));
+
+      sinon.assert.calledWith(spy, false);
+    });
+  });
 });

--- a/test/javascript/index.html
+++ b/test/javascript/index.html
@@ -20,6 +20,7 @@
       mocha.setup('bdd');
       chai.should();
     </script>
+    <script src="lib/keyboard-event-mock.js"></script>
     <script src="js-tests.js"></script>
     <script>
       mocha.run();

--- a/test/javascript/lib/keyboard-event-mock.js
+++ b/test/javascript/lib/keyboard-event-mock.js
@@ -1,0 +1,38 @@
+(function(global) {
+  var keyCodes = {
+    'A': 65,
+    'TAB': 9,
+    'ENTER': 13,
+    'ESCAPE': 27,
+    'SPACE': 32,
+    'ARROW_LEFT': 37,
+    'ARROW_UP': 38,
+    'ARROW_RIGHT': 39,
+    'ARROW_DOWN': 40
+  };
+
+  /**
+   * Creates a dummy event to parse.
+   * Uses jQuery Event class constructor.
+   * @param  {number} keyCode Key code of the key that is simulated.
+   * @param  {object} opts    Options that say if modifiers are pressed.
+   * @return {Event}          Event to use.
+   */
+  global.mockKeyboardEvent =  mockKeyboardEvent = function(keyCode, opts) {
+    var options = opts || {},
+        isCtrl = !!options.ctrl,
+        isAlt = !!options.alt,
+        isShift = !!options.shift,
+        isMeta = !!options.meta,
+        keyCode = typeof keyCode === 'number' ? keyCode : keyCodes[keyCode],
+        event = {
+          shiftKey: isShift,
+          altKey: isAlt,
+          ctrlKey: isCtrl,
+          metaKey: isMeta,
+          keyCode: keyCode,
+          which: keyCode
+        };
+    return new $.Event('keydown', event);
+  };
+})(window);

--- a/test/javascript/util/keyboard.js
+++ b/test/javascript/util/keyboard.js
@@ -6,22 +6,7 @@ describe('Keyboard util', function() {
    * @param  {object} opts    Options that say if modifiers are pressed.
    * @return {Event}          Event to use.
    */
-  const createEvent = function(keyCode, opts) {
-    let options = opts || {},
-        isCtrl = !!options.ctrl,
-        isAlt = !!options.alt,
-        isShift = !!options.shift,
-        isMeta = !!options.meta,
-        event = {
-          shiftKey: isShift,
-          altKey: isAlt,
-          ctrlKey: isCtrl,
-          metaKey: isMeta,
-          keyCode: keyCode,
-          which: keyCode
-        };
-    return new $.Event('keydown', event);
-  };
+  const createEvent = window.mockKeyboardEvent;
   const keyCodes = {
     'A': 65,
     'TAB': 9,


### PR DESCRIPTION
Added a util class for easier testing of keyboard events in Mocha.
This class generates mocked events that can be parsed by the Keyboard util.

Currently implemented as a proof of concept in Drilldown and Orbit.

@zurb/yetinauts Please have a look and give me some feedback about this idea in general. I'll then eventually implement it into further components as well.