### PR TITLE
Add missing word 'using' into sass.md

### DIFF
--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -32,7 +32,7 @@ autoprefixer({
 
 ## Loading the Framework
 
-If you're the CLI to create a project, the Sass compilation process is already set up for you. If not, you can compile our Sass files yourself, or drop in a pre-built CSS file.
+If you're using the CLI to create a project, the Sass compilation process is already set up for you. If not, you can compile our Sass files yourself, or drop in a pre-built CSS file.
 
 To get started, first install the framework files using Bower or npm.
 


### PR DESCRIPTION
Adding a missing word 'using' into line 35 of sass.md, so it makes sense.