### PR TITLE
Fix tabs deeplink history to work with back button within page

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -157,7 +157,7 @@ Add the attribute `data-deep-link="true"` to a tabstrip to:
 - allow users to open a particular tab at page load with a hash-appended URL
 
 ```html_example
-<ul class="tabs" data-deep-link="true" data-tabs id="deeplinked-tabs">
+<ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge="500" data-tabs id="deeplinked-tabs">
   <li class="tabs-title is-active"><a href="#panel1d" aria-selected="true">Tab 1</a></li>
   <li class="tabs-title"><a href="#panel2d">Tab 2</a></li>
   <li class="tabs-title"><a href="#panel3d">Tab 3</a></li>

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -210,6 +210,7 @@ class Tabs {
   /**
    * Opens the tab `$targetContent` defined by `$target`. Collapses active tab.
    * @param {jQuery} $target - Tab to open.
+   * @param {boolean} historyHandled - browser has already handled a history update
    * @fires Tabs#change
    * @function
    */
@@ -302,6 +303,7 @@ class Tabs {
   /**
    * Public method for selecting a content pane to display.
    * @param {jQuery | String} elem - jQuery object or string of the id of the pane to display.
+   * @param {boolean} historyHandled - browser has already handled a history update
    * @function
    */
   selectTab(elem, historyHandled) {

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -77,32 +77,11 @@ class Tabs {
         });
       }
 
-      //use browser to open a tab, if it exists in this tabset
-      if (_this.options.deepLink) {
-        var anchor = window.location.hash;
-        //need a hash and a relevant anchor in this tabset
-        if(anchor.length) {
-          var $link = $elem.find('[href="'+anchor+'"]');
-          if ($link.length) {
-            _this.selectTab($(anchor));
-
-            //roll up a little to show the titles
-            if (_this.options.deepLinkSmudge) {
-              $(window).load(function() {
-                var offset = $elem.offset();
-                $('html, body').animate({ scrollTop: offset.top }, _this.options.deepLinkSmudgeDelay);
-              });
-            }
-
-            /**
-              * Fires when the zplugin has deeplinked at pageload
-              * @event Tabs#deeplink
-              */
-             $elem.trigger('deeplink.zf.tabs', [$link, $(anchor)]);
-           }
-        }
-      }
     });
+    //use browser to open a tab, if it exists in this tabset
+    if (this.options.deepLink) {
+      this._checkDeepLink();
+    }
 
     if(this.options.matchHeight) {
       var $images = this.$tabContent.find('img');
@@ -114,9 +93,32 @@ class Tabs {
       }
     }
 
+    this._checkDeepLink = this._checkDeepLink.bind(this);
     this._events();
   }
 
+  _checkDeepLink() {
+    var anchor = window.location.hash;
+    //need a hash and a relevant anchor in this tabset
+    if(anchor.length) {
+      var $link = this.$element.find('[href="'+anchor+'"]');
+      if ($link.length) {
+        this.selectTab($(anchor));
+
+        //roll up a little to show the titles
+        if (this.options.deepLinkSmudge) {
+          var offset = this.$element.offset();
+          $('html, body').animate({ scrollTop: offset.top }, this.options.deepLinkSmudgeDelay);
+        }
+
+        /**
+          * Fires when the zplugin has deeplinked at pageload
+          * @event Tabs#deeplink
+          */
+         this.$element.trigger('deeplink.zf.tabs', [$link, $(anchor)]);
+       }
+     }
+   }
   /**
    * Adds event handlers for items within the tabs.
    * @private
@@ -130,6 +132,10 @@ class Tabs {
       this._setHeightMqHandler = this._setHeight.bind(this);
 
       $(window).on('changed.zf.mediaquery', this._setHeightMqHandler);
+    }
+
+    if(this.options.deepLink) {
+      $(window).on('popstate', this._checkDeepLink);
     }
   }
 
@@ -365,6 +371,7 @@ class Tabs {
       }
     }
 
+    $(window).off('popstate', this._checkDeepLink);
     Foundation.unregisterPlugin(this);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,16 +1565,16 @@ doiuse@^2.5.0:
     through2 "^0.6.3"
     yargs "^3.5.4"
 
-dom-serializer@0, dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+dom-serializer@0, dom-serializer@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.0.1.tgz#9589827f1e32d22c37c829adabd59b3247af8eaf"
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-serializer@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.0.1.tgz#9589827f1e32d22c37c829adabd59b3247af8eaf"
+dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
@@ -3553,7 +3553,7 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@>=1.7, jquery@^2.2.0:
+jquery@>=1.7, jquery@>=2.2.0, jquery@^2.2.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1565,16 +1565,16 @@ doiuse@^2.5.0:
     through2 "^0.6.3"
     yargs "^3.5.4"
 
-dom-serializer@0, dom-serializer@~0.0.0:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.0.1.tgz#9589827f1e32d22c37c829adabd59b3247af8eaf"
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-serializer@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+dom-serializer@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.0.1.tgz#9589827f1e32d22c37c829adabd59b3247af8eaf"
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
@@ -3553,7 +3553,7 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jquery@>=1.7, jquery@>=2.2.0, jquery@^2.2.0:
+jquery@>=1.7, jquery@^2.2.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
 


### PR DESCRIPTION
I noticed while working on a lesson on tabs deep linking that the history feature was a little flaky - while it added the history to the URL, clicking back did not appropriately open the previous tab.  This fixes this bug by moving the deep link logic into a function and calling it on popstate.