### PR TITLE
.align-center-middle as new alignment class

### DIFF
--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -164,23 +164,6 @@ To align an individual child, use the below classes. They use the same alignment
 </div>
 ```
 
----
-
-## Central Alignment
-
-Central alignment can be applied to a flex parent&mdash;which will centrally align all children automatically.
-
-To set parent alignment, use this class:
-
-- `.align-center-middle`
-
-```html_example
-<div class="row align-center-middle">
-  <div class="columns">I am in the center-middle&mdash; that is, I am centrally located!</div>
-  <div class="columns">As above, though I share the center-middle with my siblings.
-</div>
-```
-
 ## Vanilla Flexbox Helper Classes
 
 Foundation also includes some helper classes for quickly applying flex

--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -164,6 +164,23 @@ To align an individual child, use the below classes. They use the same alignment
 </div>
 ```
 
+---
+
+## Central Alignment
+
+Central alignment can be applied to a flex parent&mdash;which will centrally align all children automatically.
+
+To set parent alignment, use this class:
+
+- `.align-center-middle`
+
+```html_example
+<div class="row align-center-middle">
+  <div class="columns">I am in the center-middle&mdash; that is, I am centrally located!</div>
+  <div class="columns">As above, though I share the center-middle with my siblings.
+</div>
+```
+
 ## Vanilla Flexbox Helper Classes
 
 Foundation also includes some helper classes for quickly applying flex

--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -164,6 +164,25 @@ To align an individual child, use the below classes. They use the same alignment
 </div>
 ```
 
+---
+
+### Central Alignment
+
+Central alignment can be applied to a flex parent, which will centrally align all children's automatically. To set this to your layout, simply use the class: `.align-center-middle`.
+
+<div class="primary callout">
+  <p>We are using `.text-center` class just for demo purposes here.</p>
+</div>
+
+```html_example
+<div class="row align-center-middle text-center">
+  <div class="columns small-4">I am in the center-middle</div>
+  <div class="columns small-4">I am also centrally located</div>
+</div>
+```
+
+---
+
 ## Vanilla Flexbox Helper Classes
 
 Foundation also includes some helper classes for quickly applying flex

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -17,12 +17,11 @@
     }
   }
 
-  .align-central {
+  // Central alignment of content
+  .align-center-middle {
+    @include flex-align($x: center, $y: middle);
     align-content: center;
-    @include flex-align($x: 'center');
-    @include flex-align($y: 'middle');
   }
-
 
   // Source ordering
   @include -zf-each-breakpoint {

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -17,6 +17,13 @@
     }
   }
 
+  .align-central {
+    align-content: center;
+    @include flex-align($x: 'center');
+    @include flex-align($y: 'middle');
+  }
+
+
   // Source ordering
   @include -zf-each-breakpoint {
     @for $i from 1 through 6 {


### PR DESCRIPTION
Hello,

I've written a new class named `.align-center-middle` for the flex-grid. It does both vertical centering -- `.align-middle` -- and horizontal centering -- `.align-center`.

I made sure to leverage extant mixins.

EDIT: I've changed the language of the OP to reflect the ensuing discussion.
EDIT2: This new class also causes immediate descendants to "gravitate" towards the parent's center (see `.align-contents: center` on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content)).
