### PR TITLE
Now preserves the existing querystring questionmark if there already …

### DIFF
--- a/js/foundation.util.timerAndImageLoader.js
+++ b/js/foundation.util.timerAndImageLoader.js
@@ -67,7 +67,7 @@ function onImagesLoaded(images, callback){
     else {
       // fix for IE. See https://css-tricks.com/snippets/jquery/fixing-load-in-ie-for-cached-images/
       var src = $(this).attr('src');
-      $(this).attr('src', src + '?' + (new Date().getTime()));
+      $(this).attr('src', src + (src.indexOf('?') >= 0 ? '&' : '?') + (new Date().getTime()));
       $(this).one('load', function() {
         singleImageLoaded();
       });


### PR DESCRIPTION
…is one present, and uses an ampersand instead in that case.