### PR TITLE
Make reset inherit font-family instead of settings sans-serif

### DIFF
--- a/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
+++ b/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
@@ -424,7 +424,7 @@
     optgroup,
     select,
     textarea {
-      font-family: $base-font-family; /* 1 */
+      font-family: inherit; /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
         line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */


### PR DESCRIPTION
Goal: Make reset less opinionated. Fixes #9668
- Reset was setting the font-family of buttons to be sans-serif, instead of inheriting. This was causing buttons to not use the font specified in the body.