### PR TITLE
[Fixes #9705] Add menu-centered to flexbox mode.

### DIFF
--- a/docs/pages/menu.md
+++ b/docs/pages/menu.md
@@ -52,7 +52,7 @@ By default, each item in the menu aligns to the left. They can also be aligned t
 To align items in the middle, add a wrapping element with the class `.menu-centered`.
 
 <div class="primary callout">
-  <p>If you're using <a href="flexbox.html">Flexbox mode</a>, you don't need the wrapper class. Instead, you can just add the class <code>.align-center</code> to the menu.</p>
+  <p>If you're using <a href="flexbox.html">Flexbox mode</a>, you have the option of either using <code>.align-center</code> to the menu like this <a href="http://codepen.io/IamManchanda/pen/jyGjmV">codepen</a> or instead you can use the default wrapper class below.</p>
 </div>
 
 ```html_example

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -359,8 +359,13 @@ $menu-border: $light-gray !default;
     text-align: center;
 
     > .menu {
-      display: inline-block;
-      vertical-align: top;
+      @if $global-flexbox {
+        @include flex-align($x: center, $y: top);
+      }
+      @else {
+        display: inline-block;
+        vertical-align: top;
+      }
     }
   }
 


### PR DESCRIPTION
Implementation for #9705 

This adds `menu-centered` class to flexbox mode to keep the similarity beetween both modes. 
Can confirm you that i have done the testing ( both modes, flexbox and non flexbox )

Thanks for posting the issue: @LaurelBCodin 
but it was not so a bug... but instead a missing css class on flexbox mode.

--------------------------------------------------------------------------------------------------------------

@kball for merge or review.
Also please close the issue on merge as i forgot to add it on commit message.