### PR TITLE
[Fixes #9721] Added a variable: breadcrumb slash color

### DIFF
--- a/scss/components/_breadcrumbs.scss
+++ b/scss/components/_breadcrumbs.scss
@@ -68,7 +68,6 @@ $breadcrumbs-item-slash-color: $medium-gray !default;
         position: relative;
         top: 1px;
         margin: 0 $breadcrumbs-item-margin;
-
         opacity: 1;
         content: $slash;
         color: $breadcrumbs-item-slash-color;

--- a/scss/components/_breadcrumbs.scss
+++ b/scss/components/_breadcrumbs.scss
@@ -38,6 +38,10 @@ $breadcrumbs-item-uppercase: true !default;
 /// @type Boolean
 $breadcrumbs-item-slash: true !default;
 
+/// Color of breadcrumb slash.
+/// @type Color
+$breadcrumbs-item-slash-color: $medium-gray !default;
+
 /// Adds styles for a breadcrumbs container, along with the styles for the `<li>` and `<a>` elements inside of it.
 @mixin breadcrumbs-container {
   @include clearfix;
@@ -67,7 +71,7 @@ $breadcrumbs-item-slash: true !default;
 
         opacity: 1;
         content: $slash;
-        color: $medium-gray;
+        color: $breadcrumbs-item-slash-color;
       }
     }
     @else {


### PR DESCRIPTION
Fixes #9721 as this looks logical to me!
Thanks a lot @stefan2 for reporting! 

@kball @brettsmason : I have one issue though 
=> `$breadcrumbs-item-color-disabled` and `$breadcrumbs-item-slash-color` share the same color. Is this meant to happen like this? 

----------------------------------------------------------------------------------------------------------------

Also please close the issue on merge as i forgot to add it on commit message.