### PR TITLE
[Advancement] Responsive variation for float classes

### DIFF
--- a/scss/components/_float.scss
+++ b/scss/components/_float.scss
@@ -6,22 +6,45 @@
 /// @group float
 ////
 
+@mixin float-center {
+  display: block;
+  margin-right: auto;
+  margin-left: auto;
+}
+
 @mixin foundation-float-classes {
-  .float-left {
-    float: left !important;
-  }
-
-  .float-right {
-    float: right !important;
-  }
-
-  .float-center {
-    display: block;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
-  .clearfix {
-    @include clearfix;
+  @each $size in $breakpoint-classes {
+    @include breakpoint($size) {
+      // Float left and right
+      @each $float in (left, right) {
+        @if $size != $-zf-zero-breakpoint {
+          .#{$size}-float-#{$float} {
+            float: $float !important;
+          }
+        }
+        @else {
+          .float-#{$float} {
+            float: $float !important;
+          }
+        }
+      }
+      // Float center and clearfix
+      @if $size != $-zf-zero-breakpoint {
+        .#{$size}-float-center {
+          @include float-center;
+        }
+        .#{$size}-clearfix {
+          @include clearfix;
+        }
+      }
+      @else {
+        .float-center {
+          @include float-center;
+        }
+        .clearfix {
+          @include clearfix;
+        }
+      }
+    }
   }
 }

--- a/scss/components/_float.scss
+++ b/scss/components/_float.scss
@@ -28,6 +28,7 @@
           }
         }
       }
+      
       // Float center and clearfix
       @if $size != $-zf-zero-breakpoint {
         .#{$size}-float-center {


### PR DESCRIPTION
Hello there once again!!

=> http://foundation.zurb.com/sites/docs/float-classes.html

I Would like to add **responsive variations** to float classes,
In short, would like to add 

```scss
.medium-float-left { }
.medium-float-right { }
.medium-float-center { }
.medium-clearfix { /* Before and after */ }

.large-float-left { }
.large-float-right { }
.large-float-center { }
.large-clearfix { /* Before and after */ }
```

**Reasons for which me straight pushed it instead of posting an issue**
- It doesn't make the css bulky, not too much of the final generated css.
- Responsive helpers for things like floats are very helpful for responsive web design.
- This should be added as **default** instead of things like non-default mixins !!!