### PR TITLE
[Closes #9708] Added Flex container to responsive variations & Docs update for flexbox helpers classes

### DIFF
--- a/docs/pages/flexbox.md
+++ b/docs/pages/flexbox.md
@@ -185,6 +185,8 @@ For children, there are 3 quick helper classes
 - `.flex-child-grow` (flex child that will grow to take up all possible space)
 - `.flex-child-shrink` (flex child that will shrink to minimum possible space)
 
+Also, adding a breakpoint to the front of these flexbox helper classes will cause it to only be applied on that size screen or larger. For example, `.medium-flex-container` will keep things as default on the smallest screens, but switch itself to a flex container on medium screens and larger.
+
 ```html_example
 <div class="row">
   <div class="column flex-container flex-dir-column">

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -251,6 +251,12 @@
           @include flex-direction($prop);
         }
       }
+      
+      // flex container
+      .flex-container {
+        @include flex;
+      }
+
       // child helper classes
       .#{$-zf-size}-flex-child-auto {
         flex: 1 1 auto;

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -253,7 +253,7 @@
       }
       
       // flex container
-      .flex-container {
+      .#{$-zf-size}-flex-container {
         @include flex;
       }
 


### PR DESCRIPTION
This is a implementation of #9708 

Changes:

1. Discovered that all vanilla flexbox helper classes already have the responsive breakpoint except `flex-container`
2. Added `flex-container` to responsive variations
3. Docs update about the responsive variations 