### PR TITLE
Fix for #9729 : Flexgrid not resetting nested row using 'expanded' class

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -143,7 +143,12 @@
 
     // Expanded row
     &.expanded {
-      @include grid-row-size(expand);
+      @include grid-row-size(expand); 
+      
+      .row {
+        margin-right: auto;
+        margin-left: auto;
+      }
     }
 
     &:not(.expanded) .row {


### PR DESCRIPTION
Fix for #9729 