### PR TITLE
Add support for responsive button padding

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -78,7 +78,17 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   display: inline-block;
   vertical-align: middle;
   margin: $button-margin;
-  padding: $button-padding;
+
+  @if (type-of($button-padding) == 'map') {
+    @each $size, $padding in $button-padding {
+      @include breakpoint($size) {
+        padding: $padding;
+      }
+    }
+  }
+  @else {
+    padding: $button-padding;
+  }
 
   -webkit-appearance: none;
   border: 1px solid transparent;


### PR DESCRIPTION
Goal: To support responsive button padding and support a single value as well.
`$button-padding` can be set to one of the following:
```scss
$button-padding: 0.85em 1em;
// or
$button-padding: (
  small: 0.85em 1em,
  medium: 1.25em 1.5em
);
```