### PR TITLE
[Button] Adds option to fill hollow button backgrounds on hover

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -67,6 +67,10 @@ $button-background-hover-lightness: -20% !default;
 /// @type Number
 $button-hollow-hover-lightness: -50% !default;
 
+/// Default fill for hollow buttons on hover. Can either be `solid` or `hollow`.
+/// @type Keyword
+$button-hollow-hover-fill: hollow !default;
+
 // Internal: flip from margin-right to margin-left for defaults
 @if $global-text-direction == 'rtl' {
   $button-margin: 0 0 $global-margin $global-margin !default;
@@ -158,7 +162,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
 
 @mixin button-hollow-style(
   $color: $primary-color,
-  $hover-lightness: $button-hollow-hover-lightness, 
+  $hover-lightness: $button-hollow-hover-lightness,
   $border-width: $button-hollow-border-width
 ) {
   $color-hover: scale-color($color, $lightness: $hover-lightness);
@@ -167,10 +171,18 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   color: $color;
 
   &:hover, &:focus {
-    border-color: $color-hover;
-    color: $color-hover;
+    @if $button-hollow-hover-fill == solid {
+        border-color: $color-hover;
+        color: $button-color;
+        background-color: $color-hover;
+      }
+      @else {
+        background-color: transparent;
+        border-color: $color-hover;
+        color: $color-hover;
+      }
+    }
   }
-}
 
 /// Adds disabled styles to a button by fading the element, reseting the cursor, and disabling pointer events.
 /// @param [Color] $background [$primary-color] - Background color of the disabled button.

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -99,6 +99,7 @@ $grid-column-gutter: (
   medium: 30px,
 );
 $grid-column-align-edge: true;
+$grid-column-alias: 'columns';
 $block-grid-max: 8;
 
 // 4. Base Typography
@@ -236,6 +237,7 @@ $breadcrumbs-item-color-disabled: $medium-gray;
 $breadcrumbs-item-margin: 0.75rem;
 $breadcrumbs-item-uppercase: true;
 $breadcrumbs-item-slash: true;
+$breadcrumbs-item-slash-color: $medium-gray;
 
 // 11. Button
 // ----------
@@ -248,6 +250,7 @@ $button-background-hover: scale-color($button-background, $lightness: -15%);
 $button-color: $white;
 $button-color-alt: $black;
 $button-radius: $global-radius;
+$button-hollow-border-width: 1px;
 $button-sizes: (
   tiny: 0.6rem,
   small: 0.75rem,
@@ -258,6 +261,7 @@ $button-palette: $foundation-palette;
 $button-opacity-disabled: 0.25;
 $button-background-hover-lightness: -20%;
 $button-hollow-hover-lightness: -50%;
+$button-hollow-hover-fill: hollow; // Can either be `solid` or `hollow`.
 $button-transition: background-color 0.25s ease-out, color 0.25s ease-out;
 
 // 12. Button Group


### PR DESCRIPTION
Currently, overriding hollow button backgrounds to fill in CSS is challenging, especially when coupled with color classes.

Adds option through variable in settings file to change hover background behavior:

```
$button-hollow-hover-fill: hollow; // Can either be `solid` or `hollow`
```
