### PR TITLE
Adds flex to card-divider and fixes card width for narrow content

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -56,6 +56,7 @@ $card-margin: $global-margin !default;
   @if $global-flexbox {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
   }
 
   margin-bottom: $margin;
@@ -81,6 +82,7 @@ $card-margin: $global-margin !default;
 ) {
   @if $global-flexbox {
     flex: 0 1 auto;
+    display: flex;
   }
 
   padding: $padding;

--- a/test/visual/card/card.html
+++ b/test/visual/card/card.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation-flex.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="row small-up-2 medium-up-3">
+      <div class="column flex-container">
+        <div class="card">
+          <img src="http://placehold.it/300x100">
+          <div class="card-section">
+            <h4>Making sure</h4>
+            <p>card doesnt shrink</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="column flex-container">
+        <div class="card">
+          <img src="http://placehold.it/300x100">
+          <div class="card-section">
+            <h4>Making sure</h4>
+            <p>images below are spread apart and vertically centered</p>
+          </div>
+          <div class="card-divider align-justify align-middle">
+            <img src="http://placehold.it/15">
+            <img src="http://placehold.it/15">
+            <img src="http://placehold.it/15">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- Adds display: flex; to .card-divider so that flex-utilities can be applied (ref #9533)
- Adds flex-grow: 1; to .card to fix issue with card width collapsing when in display: flex parent. (ref #9533)

Also adds test case for both
