### PR TITLE
fixes #8404 hollow button dropdown arrow

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -306,6 +306,20 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
           border-top-color: $button-background;
         }
       }
+
+      &.hollow {
+        &::after {
+          border-top-color: $button-background;
+        }
+
+        @each $name, $color in $button-palette {
+          &.#{$name} {
+            &::after {
+              border-top-color: $color;
+            }
+          }
+        }
+      }
     }
 
     // Button with dropdown arrow only

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -618,4 +618,3 @@ $topbar-submenu-background: $topbar-background;
 $topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
 $topbar-input-width: 200px;
 $topbar-unstack-breakpoint: medium;
-

--- a/test/visual/button/button.html
+++ b/test/visual/button/button.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+<h4>These hollow buttons should have arrow color that matches border.</h4>
+  <button class="dropdown hollow button tiny ">Dropdown Button</button>
+  <button class="dropdown hollow secondary button small ">Dropdown Button</button>
+  <button class="dropdown hollow alert button">Dropdown Button</button>
+  <button class="dropdown hollow success button large ">Dropdown Button</button>
+  <button class="dropdown hollow warning button expanded ">Dropdown Button</button>
+
+  <script src="../assets/js/vendor.js"></script>
+  <script src="../assets/js/foundation.js"></script>
+  <script>
+  $(document).foundation();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
hollow button dropdown arrows were always white. this fixes the arrow with the appropriate dropdown arrow color