### PR TITLE
Minor bug fix in the card-container mixin

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -67,7 +67,7 @@ $card-margin: $global-margin !default;
   box-shadow: $shadow;
 
   overflow: hidden;
-  color: $card-font-color;
+  color: $color;
 
   & > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
The font color parameter to the mixin was ignored and the $card-font-color variable was always used.
