### PR TITLE
7548 prevent reveal scroll on iOS using position:fixed on html element

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -123,6 +123,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   html.is-reveal-open body {
     min-height: 100%;
     overflow: hidden;
+    position: fixed;
     user-select: none;
   }
 


### PR DESCRIPTION
Quick fix to address #7548, reveal scrolling on mobile, by adding `position:fixed`

Tested on iOS 10.2