### PR TITLE
Make hidden parts of submenus inaccessible without creating tab trap

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -100,10 +100,11 @@ class Drilldown {
       _this._back($menu);
     });
 
+    this.$submenus.addClass('invisible');
     if(!this.options.autoHeight) {
       this.$submenus.addClass('drilldown-submenu-cover-previous');
     }
-    
+
     // create a wrapper on element if it doesn't exist.
     if(!this.$element.parent().hasClass('is-drilldown')){
       this.$wrapper = $(this.options.wrapper).addClass('is-drilldown');
@@ -336,7 +337,7 @@ class Drilldown {
   _show($elem) {
     if(this.options.autoHeight) this.$wrapper.css({height:$elem.children('[data-submenu]').data('calcHeight')});
     $elem.attr('aria-expanded', true);
-    $elem.children('[data-submenu]').addClass('is-active').attr('aria-hidden', false);
+    $elem.children('[data-submenu]').addClass('is-active').removeClass('invisible').attr('aria-hidden', false);
     /**
      * Fires when the submenu has opened.
      * @event Drilldown#open
@@ -358,7 +359,7 @@ class Drilldown {
     $elem.addClass('is-closing')
          .one(Foundation.transitionend($elem), function(){
            $elem.removeClass('is-active is-closing');
-           $elem.blur();
+           $elem.blur().addClass('invisible');
          });
     /**
      * Fires when the submenu has closed.

--- a/test/visual/drilldown/drilldown-menu-auto-height.html
+++ b/test/visual/drilldown/drilldown-menu-auto-height.html
@@ -27,6 +27,7 @@
       <li><a href="#">Item</a></li>
     </ul>
   </li>
+  <li><a href="#">Item</a></li>
   <li> <a href="#">Item</a>
     <ul class="vertical menu">
       <li><a href="#">Item</a></li>
@@ -67,7 +68,6 @@
       </li>
     </ul>
   </li>
-  <li><a href="#">Item</a></li>
 </ul>
       </div>
     </div>


### PR DESCRIPTION
Discovered during QA, the change to prevent tab trapping implemented by @Owlbertz in https://github.com/zurb/foundation-sites/pull/9634 had the side effect that if your last element on the top level menu of a drilldown had a submenu, tab would open that submenu rather than exiting the drilldown.

The reason: on the last element we dont' prevent default (to prevent tab trap), but the result is that we'd tab into the submenu.

The solution: Make the submenus actually inaccessible to the tab index when they are hidden (e.g. only open them using our JS). Use `visibility:hidden` to do this so that their heights are still available for calculation.