### PR TITLE
Revert "Fix bug #9361"

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -173,7 +173,8 @@
   // Column row
   // The double .row class is needed to bump up the specificity
   .column.row.row {
-    display: flex;
+    float: none;
+    display: block;
   }
 
   // To properly nest a column row, padding and margin is removed


### PR DESCRIPTION
This reverts #9362, which was done (and merged) based on a misunderstanding of the flex grid.

This was my bad for merging, apparently I either didn't look deeply enough into it or I wasn't yet understanding the grid well enough.

The misunderstanding was: a combined row/column *by nature* is full with, and items inside of it should be treated as if they are inside a column (block by default). If you want to create sub-columns inside, you need a new row.

This fixes a regression that was introduced in 6.3.0 and re-highlighted during QA for 6.3.1.
