### PR TITLE
util.GetOffsets with offsets

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -143,8 +143,8 @@ class Tooltip {
         $tipDims = Foundation.Box.GetDimensions(this.template),
         $anchorDims = Foundation.Box.GetDimensions(this.$element),
         direction = (position === 'left' ? 'left' : ((position === 'right') ? 'left' : 'top')),
-        param = (direction === 'top') ? 'height' : 'width',
-        offset = (param === 'height') ? this.options.vOffset : this.options.hOffset,
+        // param = (direction === 'top') ? 'height' : 'width',
+        // offset = (param === 'height') ? this.options.vOffset : this.options.hOffset,
         _this = this;
 
     if (($tipDims.width >= $tipDims.windowDims.width) || (!this.counter && !Foundation.Box.ImNotTouchingYou(this.template))) {

--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -133,7 +133,7 @@ function GetOffsets(element, anchor, position, vOffset, hOffset, isOverflow) {
       break;
     case 'center top':
       return {
-        left: ($anchorDims.offset.left + ($anchorDims.width / 2)) - ($eleDims.width / 2),
+        left: ($anchorDims.offset.left + (($anchorDims.width / 2)) - ($eleDims.width / 2) + hOffset),
         top: $anchorDims.offset.top - ($eleDims.height + vOffset)
       }
       break;
@@ -146,7 +146,7 @@ function GetOffsets(element, anchor, position, vOffset, hOffset, isOverflow) {
     case 'center left':
       return {
         left: $anchorDims.offset.left - ($eleDims.width + hOffset),
-        top: ($anchorDims.offset.top + ($anchorDims.height / 2)) - ($eleDims.height / 2)
+        top: ($anchorDims.offset.top + (($anchorDims.height / 2)) - ($eleDims.height / 2) + vOffset)
       }
       break;
     case 'center right':


### PR DESCRIPTION
I wasn't able to position the tooltip as I wanted because it was only accepting either `vOffset` or `hOffset` based on the tooltip's direction.

the lines I have commented out weren't even used.
I'm not sure if this will break other plugins.

Feedback is welcome.