### PR TITLE
Adding additional classes to reveal-overlay element

### DIFF
--- a/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
+++ b/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
@@ -424,7 +424,7 @@
     optgroup,
     select,
     textarea {
-      font-family: inherit; /* 1 */
+      font-family: $base-font-family; /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
         line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */

--- a/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
+++ b/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
@@ -424,7 +424,7 @@
     optgroup,
     select,
     textarea {
-      font-family: $base-font-family; /* 1 */
+      font-family: inherit; /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
         line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -81,8 +81,14 @@ class Reveal {
    * @private
    */
   _makeOverlay() {
+    var additionalOverlayClasses = '';
+
+    if (this.options.additionalOverlayClasses) {
+      additionalOverlayClasses = ' ' + this.options.additionalOverlayClasses;
+    }
+
     return $('<div></div>')
-      .addClass('reveal-overlay' + ' ' + this.options.additionalOverlayClassNames)
+      .addClass('reveal-overlay' + additionalOverlayClasses)
       .appendTo(this.options.appendTo);
   }
 
@@ -583,12 +589,12 @@ Reveal.defaults = {
    */
   appendTo: "body",
   /**
-   * Allows adding additional class names to the reveal overlay
+   * Allows adding additional class names to the reveal overlay.
    * @option
    * @type {string}
    * @default ''
    */
-  additionalOverlayClassNames: ''
+  additionalOverlayClasses: ''
 };
 
 // Window exports

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -82,7 +82,7 @@ class Reveal {
    */
   _makeOverlay() {
     return $('<div></div>')
-      .addClass('reveal-overlay')
+      .addClass('reveal-overlay' + ' ' + this.options.additionalOverlayClassNames)
       .appendTo(this.options.appendTo);
   }
 
@@ -581,8 +581,14 @@ Reveal.defaults = {
    * @type {string}
    * @default "body"
    */
-  appendTo: "body"
-
+  appendTo: "body",
+  /**
+   * Allows adding additional class names to the reveal overlay
+   * @option
+   * @type {string}
+   * @default ''
+   */
+  additionalOverlayClassNames: ''
 };
 
 // Window exports

--- a/test/javascript/components/reveal.js
+++ b/test/javascript/components/reveal.js
@@ -99,8 +99,16 @@ describe('Reveal', function() {
 
       $('body').should.have.class('is-reveal-open');
     });
+    it('adds optional overlay classes overlay element', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Reveal($html, {additionalOverlayClasses: 'default'});
+
+      plugin.open();
+
+      $('.reveal-overlay').should.have.class('default');
+    });
     // TODO: Check if  this.$element.trigger('closeme.zf.reveal', this.id) is correctly used.
-    
+
     // it('closes previously opened modal if multipleOpened option is false', function(done) {
     //   $html = $(template).appendTo('body');
     //   $html2 = $(template).attr('id', 'exampleModal2').appendTo('body');
@@ -187,7 +195,7 @@ describe('Reveal', function() {
         $('body').should.not.have.class('is-reveal-open');
         done();
       });
-      
+
       plugin.close();
     });
     it('does not remove class from body if another reveal is open', function(done) {
@@ -223,7 +231,7 @@ describe('Reveal', function() {
       	$html.should.be.hidden;
       	done();
       });
-      
+
       plugin.close();
     });
 


### PR DESCRIPTION
As requested in #9822. Adding additional classes to `reveal-overlay`
element.

Not the possibility to replace the class, since many styling and some JS
handles react on this class.
