### PR TITLE
Set the min-width value to 0 in order to limit the column width

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -86,7 +86,7 @@
   // fixes recent Chrome version not limiting child width
   // https://stackoverflow.com/questions/34934586/white-space-nowrap-and-flexbox-did-not-work-in-chrome
   @if $columns == expand {
-    min-width: initial;
+    min-width: 0;
   }
   // max-width fixes IE 10/11 not respecting the flex-basis property
   @if $columns != expand and $columns != shrink {


### PR DESCRIPTION
Goal: Fix the columns from expanding outside of the row when using the flex grid. Fixes #9845
The current implementation was using initial instead of 0. The comment above suggests using 0 instead of initial.
Example: http://codepen.io/natewiebe13/pen/YZGaOy