### PR TITLE
[Reveal] Fix closing when Motion UI is used

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -368,18 +368,17 @@ class Reveal {
 
     // Motion UI method of hiding
     if (this.options.animationOut) {
-      if (this.options.overlay) {
-        Foundation.Motion.animateOut(this.$overlay, 'fade-out', finishUp);
-      }
-      else {
-        finishUp();
-      }
-
-      Foundation.Motion.animateOut(this.$element, this.options.animationOut);
+      Foundation.Motion.animateOut(this.$element, this.options.animationOut, () => {
+        if (this.options.overlay) {
+          Foundation.Motion.animateOut(this.$overlay, 'fade-out', finishUp);
+        }
+        else {
+          finishUp();
+        }
+      });
     }
     // jQuery method of hiding
     else {
-
       this.$element.hide(this.options.hideDelay);
 
       if (this.options.overlay) {

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -368,14 +368,11 @@ class Reveal {
 
     // Motion UI method of hiding
     if (this.options.animationOut) {
-      Foundation.Motion.animateOut(this.$element, this.options.animationOut, () => {
-        if (this.options.overlay) {
-          Foundation.Motion.animateOut(this.$overlay, 'fade-out', finishUp);
-        }
-        else {
-          finishUp();
-        }
-      });
+      if (this.options.overlay) {
+        Foundation.Motion.animateOut(this.$overlay, 'fade-out');
+      }
+
+      Foundation.Motion.animateOut(this.$element, this.options.animationOut, finishUp);
     }
     // jQuery method of hiding
     else {


### PR DESCRIPTION
Thanks to #9653, when closing a modal, it now checks if there is another opened one before removing the `is-reveal-open` class from `body`. It works when jQuery is used to hide the elements - since its behavior has been modified - but no longer with Motion UI.

As the `finishUp` function is called before the modal is actually closed, the `is-reveal-open` class is never removed - since `$('.reveal:visible').length === 0` [here](https://github.com/zurb/foundation-sites/blob/develop/js/foundation.reveal.js#L415) will always be false.

This PR purpose one way to fix it by hiding the modal first then the overlay. Nevertheless, it will change the current closing behavior - the overlay and the modal are hidden at the same time. If it should remain like that, there are other ways to fix it, fortunately!

I believe that a unit or visual test should also be given, but I didn't learn how to write that yet...