### PR TITLE
[Tabs] Allow the target tab's id to be specified through another attribute

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -7,12 +7,12 @@ js: js/foundation.tabs.js
 
 ## Basics
 
-There are two pieces to a tabbed interface: the tabs themselves, and the content for each tab. The tabs are an element with the class `.tabs`, and each item has the class `.tabs-title`. Each tab contains a link to a tab. The `href` of each link should match the ID of a tab.
+There are two pieces to a tabbed interface: the tabs themselves, and the content for each tab. The tabs are an element with the class `.tabs`, and each item has the class `.tabs-title`. Each tab contains a link to a tab. The `href` of each link should match the ID of a tab. Alternatively, the ID can be specified with the attribute `data-tabs-target`.
 
 ```html
 <ul class="tabs" data-tabs id="example-tabs">
   <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">Tab 1</a></li>
-  <li class="tabs-title"><a href="#panel2">Tab 2</a></li>
+  <li class="tabs-title"><a data-tabs-target="#panel2" href="#/tabs/panel2">Tab 2</a></li>
 </ul>
 ```
 

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -50,7 +50,7 @@ class Tabs {
       var $elem = $(this),
           $link = $elem.find('a'),
           isActive = $elem.hasClass(`${_this.options.linkActiveClass}`),
-          hash = $link[0].hash.slice(1),
+          hash = $link.attr('data-tabs-target') || $link[0].hash.slice(1),
           linkId = $link[0].id ? $link[0].id : `${hash}-label`,
           $tabContent = $(`#${hash}`);
 
@@ -234,8 +234,8 @@ class Tabs {
     var $oldTab = this.$element.
           find(`.${this.options.linkClass}.${this.options.linkActiveClass}`),
           $tabLink = $target.find('[role="tab"]'),
-          hash = $tabLink[0].hash,
-          $targetContent = this.$tabContent.find(hash);
+          hash = $tabLink.attr('data-tabs-target') || $tabLink[0].hash.slice(1),
+          $targetContent = this.$tabContent.find(`#${hash}`);
 
     //close old tab
     this._collapseTab($oldTab);
@@ -271,8 +271,8 @@ class Tabs {
    */
   _openTab($target) {
       var $tabLink = $target.find('[role="tab"]'),
-          hash = $tabLink[0].hash,
-          $targetContent = this.$tabContent.find(hash);
+          hash = $tabLink.attr('data-tabs-target') || $tabLink[0].hash.slice(1),
+          $targetContent = this.$tabContent.find(`#${hash}`);
 
       $target.addClass(`${this.options.linkActiveClass}`);
 

--- a/test/javascript/components/tabs.js
+++ b/test/javascript/components/tabs.js
@@ -6,7 +6,7 @@ describe('Tabs', function() {
       <ul class="tabs" data-tabs id="example-tabs">
         <li class="tabs-title is-active"><a href="#panel1" aria-selected="true">Tab 1</a></li>
         <li class="tabs-title"><a href="#panel2">Tab 2</a></li>
-        <li class="tabs-title"><a href="#panel3">Tab 3</a></li>
+        <li class="tabs-title"><a data-tabs-target="panel3" href="#/panel3">Tab 3</a></li>
       </ul>
 
       <div class="tabs-content" data-tabs-content="example-tabs">
@@ -77,6 +77,13 @@ describe('Tabs', function() {
 
       plugin.selectTab('#panel2');
       $html.find('#panel2').should.be.visible;
+    });
+    it('opens the selected tab with data-tabs-target attribute', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Tabs($html.find('[data-tabs]'), {});
+
+      plugin.selectTab('#/panel3');
+      $html.find('#panel3').should.be.visible;
     });
   });
 


### PR DESCRIPTION
I faced to some limits with tabs while building a one-page website. I'd like to explain a bit more what I'm trying to do in order to understand the goal of this PR - and maybe there is an easier solution...
So, the document is composed of sections. Each section is accessible through a hash like `#/section1` to produce some kind of navigation. In one of them, there are some tabs which I would like to access through `#/section1/panel1`. Unfortunately, it will not works if I use this hash as the `href` attribute of the link - and as the id of the panel - since it needs to be escaped to be [selected with jQuery](https://api.jquery.com/id-selector/).

This PR allows one to specify in the link the ID of the tab through a `data-tabs-target` attribute. It will be retrieved first, falling back to `href` if it's empty. What do you think about that? Thanks in advance!