### PR TITLE
Add $contrast-warnings variable to facilitate suppressing color contrast warning output

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -73,7 +73,7 @@ $global-radius: 0;
 $global-text-direction: ltr;
 $global-flexbox: false;
 $print-transparent-backgrounds: true;
-$contrast-warnings-enabled: true;
+$contrast-warnings: true;
 
 @include add-foundation-colors;
 

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -73,6 +73,7 @@ $global-radius: 0;
 $global-text-direction: ltr;
 $global-flexbox: false;
 $print-transparent-backgrounds: true;
+$contrast-warnings-enabled: true;
 
 @include add-foundation-colors;
 

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -73,7 +73,6 @@ $global-radius: 0;
 $global-text-direction: ltr;
 $global-flexbox: false;
 $print-transparent-backgrounds: true;
-$contrast-warnings: true;
 
 @include add-foundation-colors;
 

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -4,6 +4,8 @@
 
 @import 'math';
 
+$contrast-warnings-enabled: true !default;
+
 ////
 /// @group functions
 ////
@@ -71,7 +73,7 @@
     }
   }
 
-  @if ($contrast < 3) {
+  @if ($contrast-warnings-enabled and $contrast < 3) {
     @warn "Contrast ratio of #{$best} on #{$base} is pretty bad, just #{$contrast}";
   }
 

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -4,7 +4,7 @@
 
 @import 'math';
 
-$contrast-warnings-enabled: true !default;
+$contrast-warnings: true !default;
 
 ////
 /// @group functions
@@ -73,7 +73,7 @@ $contrast-warnings-enabled: true !default;
     }
   }
 
-  @if ($contrast-warnings-enabled and $contrast < 3) {
+  @if ($contrast-warnings and $contrast < 3) {
     @warn "Contrast ratio of #{$best} on #{$base} is pretty bad, just #{$contrast}";
   }
 


### PR DESCRIPTION
In many cases, developers don't get to choose the colors that are used in their application. The color contrast warning output can be a bit overwhelming when compiling Foundation's Sass. It also creates a lot of potentially unnecessary noise in deploy/CI console output, dev logs, etc. 

This PR resolves #9843 by adding a variable `$contrast-warnings-enabled` to the *_settings.scss* file for use within the [_color.scss file](https://github.com/zurb/foundation-sites/blob/develop/scss/util/_color.scss#L74)

**Adds**
- `$contrast-warnings-enabled` variable (boolean) to *_settings.scss* (used in *_color.scss*)