### PR TITLE
The gimbal mixin maintains semantic property of flex mixin attributes

### DIFF
--- a/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
+++ b/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
@@ -424,7 +424,7 @@
     optgroup,
     select,
     textarea {
-      font-family: inherit; /* 1 */
+      font-family: $base-font-family; /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
         line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */

--- a/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
+++ b/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
@@ -424,7 +424,7 @@
     optgroup,
     select,
     textarea {
-      font-family: $base-font-family; /* 1 */
+      font-family: inherit; /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
         line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -27,7 +27,7 @@
   @include -zf-each-breakpoint {
     @for $i from 1 through 6 {
       .#{$-zf-size}-order-#{$i} {
-	@include flex-order($i);
+        @include flex-order($i);
       }
     }
   }
@@ -35,12 +35,12 @@
 
 @mixin flex-gimbal($o: row, $x: left, $y: top) {
   $map-xy: (
-  bottom: right,
-  center: middle,
-  left: top,
-  middle: center,
-  right: bottom,
-  top: left
+    bottom: right,
+    center: middle,
+    left: top,
+    middle: center,
+    right: bottom,
+    top: left
 );
   $x1: $x;
   $y1: $y;

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -62,11 +62,3 @@
 .gimbal-test {
   @include flex-gimbal($o: column, $x: justify, $y: middle);
 }
-
-// @include flex-gimbal($o:column,$x:left,$y:top) yields...
-// .gimbal-test {
-//   display: flex;
-//   flex-direction: column;
-//   justify-content: flex-start;
-//   align-items: flex-start;
-// }

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -27,35 +27,49 @@
   @include -zf-each-breakpoint {
     @for $i from 1 through 6 {
       .#{$-zf-size}-order-#{$i} {
-        @include flex-order($i);
+	@include flex-order($i);
       }
     }
   }
 }
 
-@mixin gimbal($o:row,$x:left,$y:top) {
-  //columns
+@mixin flex-gimbal($o: row, $x: left, $y: top) {
   $map-xy: (
-  right: bottom,
-  left: top,
-  top: left,
-  bottom: right,
-  center: middle,
-  middle: center
+    right: bottom,
+    left: top,
+    top: left,
+    bottom: right,
+    center: middle,
+    middle: center
 );
   $x1: $x;
   $y1: $y;
   @if $o == column {
-    $x1: map-get($map-xy,$y);
-    $y1: map-get($map-xy,$x);
+    $x1: map-get($map-xy, $y);
+    $y1: map-get($map-xy, $x);
   }
 
   @include flex;
   @include flex-direction($o);
-  @include flex-align($x:$x1,$y:$y1);
+  @include flex-align($x: $x1, $y: $y1);
 }
 
 ///////
 .gimbal-test {
-  @include gimbal($o:column,$x:left,$y:top);
+  @include flex-gimbal($o: row, $x: right, $y: bottom);
 }
+
+// @include flex-gimbal($o:column,$x:left,$y:top) yields...
+// .gimbal-test {
+//   display: flex;
+//   flex-direction: column;
+//   justify-content: flex-start;
+//   align-items: flex-start;
+// }
+//  @include flex-gimbal($o:row,$x:right,$y:bottom) yields...
+// .gimbal-test {
+//   display: flex;
+//   flex-direction: row;
+//   justify-content: flex-end;
+//   align-items: flex-end;
+// }

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -35,18 +35,21 @@
 
 @mixin flex-gimbal($o: row, $x: left, $y: top) {
   $map-xy: (
-    right: bottom,
-    left: top,
-    top: left,
     bottom: right,
     center: middle,
-    middle: center
+    left: top,
+    middle: center,
+    right: bottom,
+    top: left
 );
   $x1: $x;
   $y1: $y;
+
   @if $o == column {
-    $x1: map-get($map-xy, $y);
-    $y1: map-get($map-xy, $x);
+    @if map-has-key($map-xy, $y) and map-has-key($map-xy, $x) {
+      $x1: map-get($map-xy, $y);
+      $y1: map-get($map-xy, $x);
+    }
   }
 
   @include flex;
@@ -56,7 +59,7 @@
 
 ///////
 .gimbal-test {
-  @include flex-gimbal($o: row, $x: right, $y: bottom);
+  @include flex-gimbal($o: column, $x: justify, $y: middle);
 }
 
 // @include flex-gimbal($o:column,$x:left,$y:top) yields...

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -32,3 +32,30 @@
     }
   }
 }
+
+@mixin gimbal($o:row,$x:left,$y:top) {
+  //columns
+  $map-xy: (
+  right: bottom,
+  left: top,
+  top: left,
+  bottom: right,
+  center: middle,
+  middle: center
+);
+  $x1: $x;
+  $y1: $y;
+  @if $o == column {
+    $x1: map-get($map-xy,$y);
+    $y1: map-get($map-xy,$x);
+  }
+
+  @include flex;
+  @include flex-direction($o);
+  @include flex-align($x:$x1,$y:$y1);
+}
+
+///////
+.gimbal-test {
+  @include gimbal($o:column,$x:left,$y:top);
+}

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -35,15 +35,16 @@
 
 @mixin flex-gimbal($o: row, $x: left, $y: top) {
   $map-xy: (
-    bottom: right,
-    center: middle,
-    left: top,
-    middle: center,
-    right: bottom,
-    top: left
+  bottom: right,
+  center: middle,
+  left: top,
+  middle: center,
+  right: bottom,
+  top: left
 );
   $x1: $x;
   $y1: $y;
+
 
   @if $o == column {
     @if map-has-key($map-xy, $y) and map-has-key($map-xy, $x) {
@@ -68,11 +69,4 @@
 //   flex-direction: column;
 //   justify-content: flex-start;
 //   align-items: flex-start;
-// }
-//  @include flex-gimbal($o:row,$x:right,$y:bottom) yields...
-// .gimbal-test {
-//   display: flex;
-//   flex-direction: row;
-//   justify-content: flex-end;
-//   align-items: flex-end;
 // }

--- a/test/visual/flex-grid/flex-gimbal.html
+++ b/test/visual/flex-grid/flex-gimbal.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+ <head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Foundation for Sites Testing</title>
+  <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+  <link href="../assets/css/foundation-flex.css" rel="stylesheet" />
+
+  <style>
+    html {
+     height: 100%;
+    }
+    body {
+     min-height: 100%;
+    }
+
+    .gimbal-test {
+     background-color: green;
+     margin:5px;
+    }
+
+    .child {
+     background-color: pink;
+     margin:5px;
+     min-height:20px;
+     min-width:20px;
+    }
+
+  </style>
+
+ </head>
+ <body class="gimbal-test">
+  <div class="child"></div>
+  <div class="child"></div>
+  <div class="child"></div>
+
+  <script src="../assets/js/vendor.js"></script>
+  <script src="../assets/js/foundation.js"></script>
+  <script>
+    $(document).foundation();
+  </script>
+ </body>
+</html>


### PR DESCRIPTION
So, how to explain this?

As indicated in issue  #9837, the new and handy flex mixins -- though helpful -- become difficult to use with, for instance, `flex-direction: column`. Because the mixin argument-value pairs for `@mixin flex-align(...)` are biased in favor of `flex-direction: row`, the semantic meaning is lost/confused with `flex-direction: column`.

I put together a rough cut of what I am calling the "gimbal" mixin. It allows for the 'top', 'bottom', 'left', 'right', etc attribute values to retain their semantic value irrespective of flex direction.

This is just a draft and I would like some input on how "justify" and "spaced" should relate to "stretch". [linky](http://foundation.zurb.com/sites/docs/flexbox.html#flex-align).

EDIT: fixed incorrect reference