### PR TITLE
Fix #9866 - Hack to disable `-webkit-appearance` from getting prefixed

### DIFF
--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -37,8 +37,13 @@ $meter-fill-bad: $alert-color !default;
     height: $meter-height;
     margin-bottom: 1rem;
 
-    -webkit-appearance: -hack-; // Hack to disable `-webkit-appearance: none` from getting prefixed
-    appearance: none;
+    // Specific Hack to disable `-webkit-appearance: none` from getting prefixed,
+    // We have disabled autoprefixer first and are just using `-moz-appearance: none` 
+    // as a prefix and neglecting `-webkit-appearance: none`
+    
+    /*! autoprefixer: off */
+    -moz-appearance: none;
+         appearance: none;
 
     @if has-value($meter-radius) {
       border-radius: $meter-radius;

--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -37,7 +37,7 @@ $meter-fill-bad: $alert-color !default;
     height: $meter-height;
     margin-bottom: 1rem;
 
-    -webkit-appearance: text; // Hack to disable `-webkit-appearance` from getting prefixed
+    -webkit-appearance: text; // Hack to disable `-webkit-appearance: none` from getting prefixed
     appearance: none;
 
     @if has-value($meter-radius) {

--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -37,7 +37,7 @@ $meter-fill-bad: $alert-color !default;
     height: $meter-height;
     margin-bottom: 1rem;
 
-    -webkit-appearance: text; // Hack to disable `-webkit-appearance: none` from getting prefixed
+    -webkit-appearance: -hack-; // Hack to disable `-webkit-appearance: none` from getting prefixed
     appearance: none;
 
     @if has-value($meter-radius) {

--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -37,9 +37,9 @@ $meter-fill-bad: $alert-color !default;
     height: $meter-height;
     margin-bottom: 1rem;
 
-    // Specific Hack to disable `-webkit-appearance: none` from getting prefixed,
-    // We have disabled autoprefixer first and are just using `-moz-appearance: none` 
-    // as a prefix and neglecting `-webkit-appearance: none`
+    // Disable `-webkit-appearance: none` from getting prefixed,
+    // We have disabled autoprefixer first and are just only using 
+    // `-moz-appearance: none` as a prefix and neglecting the webkit.
     
     /*! autoprefixer: off */
     -moz-appearance: none;

--- a/scss/forms/_meter.scss
+++ b/scss/forms/_meter.scss
@@ -37,6 +37,7 @@ $meter-fill-bad: $alert-color !default;
     height: $meter-height;
     margin-bottom: 1rem;
 
+    -webkit-appearance: text; // Hack to disable `-webkit-appearance` from getting prefixed
     appearance: none;
 
     @if has-value($meter-radius) {


### PR DESCRIPTION
Closes #9866 
Reference => http://stackoverflow.com/a/38892123/3301436

Please note that my solution is a bit of a **hack** to basically not let autoprefixer prefix `-webkit-appearance`
If somebody got a better way, then please tell and i will change!