### PR TITLE
Delete dropdown click event listener on destroy

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -348,6 +348,7 @@ class Dropdown {
   destroy() {
     this.$element.off('.zf.trigger').hide();
     this.$anchor.off('.zf.dropdown');
+    $(document.body).off('click.zf.dropdown');
 
     Foundation.unregisterPlugin(this);
   }


### PR DESCRIPTION
Dropdown element does not delete **`click.zf.dropdown`** body listener when it is destroyed. This event is used to close dropdown on click on some body element.

In a **SPA application**, a dropdown with navigation links will not load a new page on navigation because it will only destroy this element.
For this reason, when old **`click.zf.dropdown`** body listener tries to access destroyed dropdown element, an error happens.
![dropdown-click-listener-error](https://cloud.githubusercontent.com/assets/22997139/24242293/9ee9fe28-0fb7-11e7-8a54-5b51796ba47d.PNG)

*In a non-SPA application this error happens less frequently because browser loads a new page in most navigations.

 