### PR TITLE
Fixed tooltip positioning for SVG elements

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -72,8 +72,13 @@ class Tooltip {
    */
   _getPositionClass(element) {
     if (!element) { return ''; }
-    // var position = element.attr('class').match(/top|left|right/g);
-    var position = element[0].className.match(/\b(top|left|right)\b/g);
+
+    var elementClassName = element[0].className;
+    if (element[0] instanceof SVGElement) {
+        elementClassName = elementClassName.baseVal;
+    }
+
+    var position = elementClassName.match(/\b(top|left|right)\b/g);
         position = position ? position[0] : '';
     return position;
   };


### PR DESCRIPTION
Prior to this change, tooltips would not position correctly if I tried to create a tooltip on an SVG element. The tooltip plugin attempts to read the position to place the tooltip based on the `className` attribute of the target element. This change makes it so that the tooltip references the `className.baseVal` attribute for SVG elements, enabling tooltips to position properly.
