### PR TITLE
Force 'width' css attribute for sticky element (when 'is-stuck')

### DIFF
--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -310,6 +310,7 @@ class Sticky {
     }
 
     this.$element.css({
+      'width': `${newElemWidth - pdngl - pdngr}px`,
       'max-width': `${newElemWidth - pdngl - pdngr}px`
     });
 


### PR DESCRIPTION
The "**max-width**" attribute for a '_is-stuck_' DOM element is already forced by the Zurb Foundation Sticky library.
But the '**width**' attribute is not set, causing the element to be smaller than its original width, as it acquires the '_position:fixed_' attribute.
Forcing the '**width**' attribute ensures that the element remains visually the same in width.

### 1. The actual Foundation UNSTUCK :
![1-sticky-unstuck](https://cloud.githubusercontent.com/assets/8602659/24318445/bf56e1fe-1105-11e7-8131-50682d596cd0.png)

### 2. The actual Foundation STUCK :
![2-sticky-stuck-actual-foundation](https://cloud.githubusercontent.com/assets/8602659/24318446/c1e62c86-1105-11e7-81e6-42c4c35341bf.png)

### 3. The Proposal STUCK :
![3-sticky-stuck-actual-proposal](https://cloud.githubusercontent.com/assets/8602659/24318449/c57bd896-1105-11e7-9440-14caa918587a.png)

