### PR TITLE
Forms-reset by normalize-scss overwrite button font-family

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -6,9 +6,9 @@
 /// @group button
 ////
 
-/// Font family for button elements.
-/// @type String | List
-$button-font-family: $body-font-family !default;
+/// Font family of text inputs.
+/// @type Font
+$button-font-family: inherit !default;
 
 /// Padding inside buttons.
 /// @type List

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -6,7 +6,7 @@
 /// @group button
 ////
 
-/// Font family of text inputs.
+/// Font family for button elements.
 /// @type Font
 $button-font-family: inherit !default;
 

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -6,6 +6,10 @@
 /// @group button
 ////
 
+/// Font family for button elements.
+/// @type String | List
+$button-font-family: $body-font-family !default;
+
 /// Padding inside buttons.
 /// @type List
 $button-padding: 0.85em 1em !default;
@@ -82,6 +86,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   display: inline-block;
   vertical-align: middle;
   margin: $button-margin;
+  font-family: $button-font-family;
 
   @if (type-of($button-padding) == 'map') {
     @each $size, $padding in $button-padding {
@@ -158,7 +163,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
 
 @mixin button-hollow-style(
   $color: $primary-color,
-  $hover-lightness: $button-hollow-hover-lightness, 
+  $hover-lightness: $button-hollow-hover-lightness,
   $border-width: $button-hollow-border-width
 ) {
   $color-hover: scale-color($color, $lightness: $hover-lightness);

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -240,6 +240,7 @@ $breadcrumbs-item-slash: true;
 // 11. Button
 // ----------
 
+$button-font-family: $body-font-family;
 $button-padding: 0.85em 1em;
 $button-margin: 0 0 $global-margin 0;
 $button-fill: solid;


### PR DESCRIPTION
**Problem:**
Forms-reset by normalize-scss overwrite button font-family. See on line 422, /_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss.

**Example:**
`$body-font-family: Verdana;`
`<button>Example Button</button>`
Result: Button's font-family is sans-serif.

**Solution:**
Adding $button-font-family as similar to /scss/forms/_text.scss.