### PR TITLE
Fixes #9913: Removed aria-hidden and using is-active for targeting active tabs

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -280,7 +280,7 @@ class Tabs {
 
       $targetContent
         .addClass(`${this.options.panelActiveClass}`)
-        .attr({'aria-hidden': 'false'});
+        .attr({'aria-hidden': ''});
   }
 
   /**

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -65,7 +65,6 @@ class Tabs {
 
       $tabContent.attr({
         'role': 'tabpanel',
-        'aria-hidden': !isActive,
         'aria-labelledby': linkId
       });
 
@@ -280,7 +279,6 @@ class Tabs {
 
       $targetContent
         .addClass(`${this.options.panelActiveClass}`)
-        .attr({'aria-hidden': ''});
   }
 
   /**
@@ -296,7 +294,6 @@ class Tabs {
 
     $(`#${$target_anchor.attr('aria-controls')}`)
       .removeClass(`${this.options.panelActiveClass}`)
-      .attr({ 'aria-hidden': 'true' });
   }
 
   /**

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -138,7 +138,7 @@ $tab-content-padding: 1rem !default;
   display: none;
   padding: $padding;
 
-  &[aria-hidden=""] {
+  &.is-active {
     display: block;
   }
 }

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -138,7 +138,7 @@ $tab-content-padding: 1rem !default;
   display: none;
   padding: $padding;
 
-  &[aria-hidden="false"] {
+  &[aria-hidden=""] {
     display: block;
   }
 }


### PR DESCRIPTION
Hey Good evening guys
I am looking to fix #9913 

But at the moment its partial fix, 
As by default no content is showing up 
When i click on a tabs , the content get showed up and flow gets normal

Reason:
1. By default, the active content still has `aria-hidden="false"`
2. When i click on a tabs, things work normally as now the active content div has `aria-hidden` as null instead of false 

Can anyone tell me what i need to do more to solve this ??
What i want is that `aria-hidden` should be null by default too for the active content div by default!