### PR TITLE
Set toggle button "title" to submenuToggleText

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -64,7 +64,7 @@ class AccordionMenu {
 
       if(_this.options.submenuToggle) {
         $elem.addClass('has-submenu-toggle');
-        $elem.children('a').after('<button id="' + linkId + '" class="submenu-toggle" aria-controls="' + subId + '" aria-expanded="' + isActive + '"><span class="submenu-toggle-text">' + _this.options.submenuToggleText + '</span></button>');
+        $elem.children('a').after('<button id="' + linkId + '" class="submenu-toggle" aria-controls="' + subId + '" aria-expanded="' + isActive + '" title="' + _this.options.submenuToggleText + '"><span class="submenu-toggle-text">' + _this.options.submenuToggleText + '</span></button>');
       } else {
         $elem.attr({
           'aria-controls': subId,


### PR DESCRIPTION
When a user hovers over the toggle button, there should be a title attribute to indicate what will happen if they click the button. Adds a "title" attribute to the toggle button set to "_this.options.submenuToggleText"