### PR TITLE
Added `margin-left: auto` to top-bar-right & vice versa!

### DIFF
--- a/scss/components/_top-bar.scss
+++ b/scss/components/_top-bar.scss
@@ -101,10 +101,12 @@ $topbar-unstack-breakpoint: medium !default;
 
     .top-bar-left {
       flex: 1 1 auto;
+      margin-right: auto;
     }
 
     .top-bar-right {
       flex: 0 1 auto;
+      margin-left: auto;
     }
   }
   @else {


### PR DESCRIPTION
Fixes #9921 

Bug: http://codepen.io/IamManchanda/pen/PpVZMd
Fix: http://codepen.io/IamManchanda/pen/VpReOb 
Remove top bar left or top bar right and now this will be aligned correctly!

cc @brettsmason for review!

Thanks @bgarrant for reporting!