### PR TITLE
Fixed wrong case in code sample.

### DIFF
--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -137,13 +137,13 @@ Here's a complete example that can be pasted into the `<body>` tag of your page.
 Foundation's Off-canvas is set to `position: fixed` by default using the `.off-canvas` class. This makes the off-canvas panel sit in relation to the viewport, and is the desired behavior for most users. However you can also set an off-canvas container to `position: absolute` by using the alternative class `.off-canvas-absolute`. Also be sure to use the `.off-canvas-wrapper` when using this method.
 
 ```html_example
-<button type="button" class="button" data-toggle="offCanvasLeftSPlit1">Open Left</button>
+<button type="button" class="button" data-toggle="offCanvasLeftSplit1">Open Left</button>
 <button type="button" class="button" data-toggle="offCanvasRightSplit2">Open Right</button>
 
 <div class="row">
   <div class="small-6 columns">
     <div class="off-canvas-wrapper">
-      <div class="off-canvas-absolute position-left" id="offCanvasLeftSPlit1" data-off-canvas>
+      <div class="off-canvas-absolute position-left" id="offCanvasLeftSplit1" data-off-canvas>
         <!-- Your menu or Off-canvas content goes here -->
       </div>
       <div class="off-canvas-content" style="min-height: 300px;" data-off-canvas-content>


### PR DESCRIPTION
There were two instances where the wrong case was used in the "Off-canvas Position" section of the documentation. Instead of **"Split"** the example had **"SPlit"** which would still work, but is unclean. It is also an official Off-canvas example, so it could be spreading through test code for people learning Foundation and lead to confusion. I simply made the **"P"** lowercase on lines 140 and 146. I quoted the code below.

Before Fix line 140:
`<button type="button" class="button" data-toggle="offCanvasLeftSPlit1">Open Left</button>`

Before Fix 146:
`<div class="off-canvas-absolute position-left" id="offCanvasLeftSPlit1" data-off-canvas>`