### PR TITLE
Scripts in HTML Starter Template linked wrong

### DIFF
--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -101,9 +101,9 @@ Start with this HTML template and adapt it to your needs. Be sure to include the
   <body>
     <h1>Hello, world!</h1>
 
-    <script src="js/vendor/jquery.min.js"></script>
-    <script src="js/vendor/what-input.min.js"></script>
-    <script src="js/foundation.min.js"></script>
+    <script src="js/vendor/jquery.js"></script>
+    <script src="js/vendor/what-input.js"></script>
+    <script src="js/vendor/foundation.min.js"></script>
     <script>
       $(document).foundation();
     </script>


### PR DESCRIPTION
The links in the starter template were linked wrong, jquery.min.js doesn't exist in the CSS only download, but jquery.js does, same with the what-input script, it does not have a min version in the CSS download, only a version without min. The file foundation.min.js exists but it is in the vendor folder, not directly in the js folder. After fixing these three links in the starter template, everything I try is now working as expected. 

Without these linked properly you cannot totally use Foundation.

The starter template should link everything correctly so everything works as shown in the tutorials. I actually was looking at other frameworks because I couldn't get all that I wanted to run working, and the wrong linking was why. I went back to my old Foundation code and everything is working perfectly. This template may just be old code from a previous version of Foundation when the file structure was different.

This fix will help new people to this framework learn and stay with Foundation.
