### PR TITLE
RTL support for text alignment classes!

### DIFF
--- a/scss/typography/_alignment.scss
+++ b/scss/typography/_alignment.scss
@@ -5,15 +5,29 @@
 @mixin foundation-text-alignment {
   @each $size in $breakpoint-classes {
     @include breakpoint($size) {
-      @each $align in (left, right, center, justify) {
-        @if $size != $-zf-zero-breakpoint {
+      @if $size != $-zf-zero-breakpoint {
+        @each $align in (center, justify) {
           .#{$size}-text-#{$align} {
             text-align: $align;
           }
         }
-        @else {
+        @each $align-ltr, $align-rtl in (left: start, right: end) {
+          .#{$size}-text-#{$align-ltr} {
+            text-align: $align-ltr;
+            text-align: $align-rtl;
+          }
+        }
+      }
+      @else {
+        @each $align in (center, justify) {
           .text-#{$align} {
             text-align: $align;
+          }
+        }
+        @each $align-ltr, $align-rtl in (left: start, right: end) {
+          .text-#{$align-ltr} {
+            text-align: $align-ltr;
+            text-align: $align-rtl;
           }
         }
       }


### PR DESCRIPTION
Inspiration => https://davidwalsh.name/text-align-start

What changes,

```scss
.text-left {
  text-align: left; // Fallback, where `start` is not supported
  text-align: start; }

.text-right {
  text-align: right; // Fallback, where `end` is not supported
  text-align: end; }
```