### PR TITLE
[Drilldown] fixes mutateme.zf.trigger fires as often as many submenu you got beca…

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -153,7 +153,6 @@ class Drilldown {
         });
       }
     });
-	  this.$element.on('mutateme.zf.trigger', this._resize.bind(this));
   }
 
   /**
@@ -166,6 +165,7 @@ class Drilldown {
       this._bindHandler = this._scrollTop.bind(this);
       this.$element.on('open.zf.drilldown hide.zf.drilldown closed.zf.drilldown',this._bindHandler);
     }
+    this.$element.on('mutateme.zf.trigger', this._resize.bind(this));
   }
 
   /**


### PR DESCRIPTION
…use it's in the _events($elem) function, and this gets bound as manu times you got submenues.

i'got a menu with 92 submenu's and wondered why the performance is so weak on clicking on the responsiveToggle, so i started searching an found that the mutateme event gets fired as many times as there are submenus, and on the drilldown then 92 times the _getMaxDims was executedthis calcs the heights and so on and is very performant, so i debugged it an moved it to the _registerEvents function

big performance improvement

@zurb/yetinauts 