### PR TITLE
Fixed Accordion Menu scrolling when using space.

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -152,6 +152,7 @@ class AccordionMenu {
         toggle: function() {
           if ($element.children('[data-submenu]').length) {
             _this.toggle($element.children('[data-submenu]'));
+            return true;
           }
         },
         closeAll: function() {


### PR DESCRIPTION
Addresses #9953.

Keyboard handler should return true for the space event so the scrolling is prevented properly.
