### PR TITLE
Fixed keyboard navigation for Tabs

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -44,10 +44,12 @@ Put it all together, and we get this:
   <div class="tabs-panel is-active" id="panel1">
     <p>one</p>
     <p>Check me out! I'm a super cool Tab panel with text content!</p>
+    <p><a href="#">I am a link but don't do anything</a></p>
   </div>
   <div class="tabs-panel" id="panel2">
     <p>two</p>
-    <img class="thumbnail" src="assets/img/generic/rectangle-7.jpg">
+    <textarea></textarea>
+    <button class="button">I do nothing!</button>
   </div>
   <div class="tabs-panel" id="panel3">
     <p>three</p>
@@ -89,9 +91,11 @@ Add the `.vertical` class to a tabstrip to stack tabs vertically. You can also p
     <div class="tabs-content vertical" data-tabs-content="example-vert-tabs">
       <div class="tabs-panel is-active" id="panel1v">
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p><a href="#">I am a link but don't do anything</a></p>
       </div>
       <div class="tabs-panel" id="panel2v">
-        <p>Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus.</p>
+        <textarea></textarea>
+        <button class="button">I do nothing!</button>
       </div>
       <div class="tabs-panel" id="panel3v">
         <img class="thumbnail" src="assets/img/generic/rectangle-3.jpg">

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -60,7 +60,8 @@ class Tabs {
         'role': 'tab',
         'aria-controls': hash,
         'aria-selected': isActive,
-        'id': linkId
+        'id': linkId,
+        'tabindex': isActive ? '0' : '-1'
       });
 
       $tabContent.attr({
@@ -276,7 +277,10 @@ class Tabs {
 
       $target.addClass(`${this.options.linkActiveClass}`);
 
-      $tabLink.attr({'aria-selected': 'true'});
+      $tabLink.attr({
+        'aria-selected': 'true',
+        'tabindex': '0'
+      });
 
       $targetContent
         .addClass(`${this.options.panelActiveClass}`)
@@ -292,7 +296,10 @@ class Tabs {
     var $target_anchor = $target
       .removeClass(`${this.options.linkActiveClass}`)
       .find('[role="tab"]')
-      .attr({ 'aria-selected': 'false' });
+      .attr({ 
+        'aria-selected': 'false',
+        'tabindex': -1
+      });
 
     $(`#${$target_anchor.attr('aria-controls')}`)
       .removeClass(`${this.options.panelActiveClass}`)


### PR DESCRIPTION
As discussed in #9767.

Fixed the behavior by setting the `tabindex` accordingly.
I also added some more content to the docs pages to be used as demonstration of both, tabbing and possibility of complex content for Tabs.

Pressing tab while having focus above the tabs will focus the active tab link.
Pressing tab again will follow the normal flow and not focus the next tab link as it has now `tabindex` set to `-1`. Using arrow keys to switch tabs works as intended.
Tabbing back from inside the tab panel will focus the active tab link as it has `tabindex` set to `0`.