### PR TITLE
Home end slider

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -34,7 +34,9 @@ class Slider {
         'SHIFT_ARROW_RIGHT': 'increase_fast',
         'SHIFT_ARROW_UP': 'increase_fast',
         'SHIFT_ARROW_DOWN': 'decrease_fast',
-        'SHIFT_ARROW_LEFT': 'decrease_fast'
+        'SHIFT_ARROW_LEFT': 'decrease_fast',
+        'HOME': 'min',
+        'END': 'max'
       },
       'rtl': {
         'ARROW_LEFT': 'increase',
@@ -516,6 +518,12 @@ class Slider {
         },
         increase_fast: function() {
           newValue = oldValue + _this.options.step * 10;
+        },
+        min: function() {
+          newValue = _this.options.start;
+        },
+        max: function() {
+          newValue = _this.options.end;
         },
         handled: function() { // only set handle pos when event was handled specially
           e.preventDefault();

--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -15,6 +15,8 @@ const keyCodes = {
   13: 'ENTER',
   27: 'ESCAPE',
   32: 'SPACE',
+  35: 'END',
+  36: 'HOME',
   37: 'ARROW_LEFT',
   38: 'ARROW_UP',
   39: 'ARROW_RIGHT',

--- a/test/javascript/components/slider.js
+++ b/test/javascript/components/slider.js
@@ -153,4 +153,24 @@ describe('Slider', function() {
     });
   });
 
+  describe('keyboard events', function() {
+    it('sets value to minimum using HOME', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Slider($html, {});
+
+      plugin.$handle.focus()
+        .trigger(window.mockKeyboardEvent('HOME'));
+
+      plugin.$handle.should.have.attr('aria-valuenow', plugin.$handle.attr('aria-valuemin'));
+    });
+    it('sets value to maximum using END', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Slider($html, {});
+
+      plugin.$handle.focus()
+        .trigger(window.mockKeyboardEvent('END'));
+
+      plugin.$handle.should.have.attr('aria-valuenow', plugin.$handle.attr('aria-valuemax'));
+    });
+  });
 });

--- a/test/javascript/lib/keyboard-event-mock.js
+++ b/test/javascript/lib/keyboard-event-mock.js
@@ -5,6 +5,8 @@
     'ENTER': 13,
     'ESCAPE': 27,
     'SPACE': 32,
+    'END': 35,
+    'HOME': 36,
     'ARROW_LEFT': 37,
     'ARROW_UP': 38,
     'ARROW_RIGHT': 39,


### PR DESCRIPTION
Implemented home and end keyboard events according to the specs I gathered [here](https://github.com/Owlbertz/a11y-collection/blob/master/components/slider.md#examples).

Home sets slider to minimum value.
End sets slider to maximum value.

Tests will likely fail because of #9916, but the tests I added for this specific feature should work fine.