### PR TITLE
Remove transition for `.reveal-for-*` classes

### DIFF
--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -265,6 +265,7 @@ $content: $maincontent-class
 ) {
   transform: none;
   z-index: $zindex;
+  transition: none;
 
   @if not $offcanvas-fixed-reveal {
     position: absolute;


### PR DESCRIPTION
Hopefully fixes #9713

This only applies when an off canvas is revealed, but the transition is still present when going from the revealed state to a smaller screen, but I personally think that's fine.