### PR TITLE
Add back aria-hidden true to tabs for consistency. 

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -69,6 +69,10 @@ class Tabs {
         'aria-labelledby': linkId
       });
 
+      if(!isActive) {
+        $tabContent.attr('aria-hidden', 'true');
+      }
+
       if(isActive && _this.options.autoFocus){
         $(window).load(function() {
           $('html, body').animate({ scrollTop: $elem.offset().top }, _this.options.deepLinkSmudgeDelay, () => {
@@ -282,7 +286,7 @@ class Tabs {
       });
 
       $targetContent
-        .addClass(`${this.options.panelActiveClass}`)
+        .addClass(`${this.options.panelActiveClass}`).removeAttr('aria-hidden');
   }
 
   /**
@@ -294,13 +298,14 @@ class Tabs {
     var $target_anchor = $target
       .removeClass(`${this.options.linkActiveClass}`)
       .find('[role="tab"]')
-      .attr({ 
+      .attr({
         'aria-selected': 'false',
         'tabindex': -1
       });
 
     $(`#${$target_anchor.attr('aria-controls')}`)
       .removeClass(`${this.options.panelActiveClass}`)
+      .attr({ 'aria-hidden': 'true' })
   }
 
   /**

--- a/test/javascript/components/tabs.js
+++ b/test/javascript/components/tabs.js
@@ -44,11 +44,11 @@ describe('Tabs', function() {
     it('sets ARIA attributes', function() {
       $html = $(template).appendTo('body');
       plugin = new Foundation.Tabs($html.find('[data-tabs]'), {});
-            
+
       // Panels
       $html.find('#panel1').should.have.attr('role', 'tabpanel');
       $html.find('#panel1').should.have.attr('aria-labelledby', $html.find('[href="#panel1"]').attr('id'));
-      $html.find('#panel1').should.have.attr('aria-hidden', 'false');
+      $html.find('#panel1').should.not.have.attr('aria-hidden');
       $html.find('#panel2').should.have.attr('aria-hidden', 'true');
 
       // Links
@@ -102,7 +102,7 @@ describe('Tabs', function() {
       plugin = new Foundation.Tabs($html.find('[data-tabs]'), {});
 
       plugin.selectTab('#panel2');
-      $html.find('#panel2').should.have.attr('aria-hidden', 'false');
+      $html.find('#panel2').should.have.not.attr('aria-hidden');
       $html.find('[href="#panel2"]').should.have.attr('aria-selected', 'true');
     });
 


### PR DESCRIPTION
Also updates tests to understand correct attribute removal

Addresses the consistency and testing issues raised in https://github.com/zurb/foundation-sites/pull/9916