### PR TITLE
Update to #9711 in a way that doesn't modify underlying dependency

### DIFF
--- a/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
+++ b/_vendor/normalize-scss/sass/normalize/_normalize-mixin.scss
@@ -424,7 +424,7 @@
     optgroup,
     select,
     textarea {
-      font-family: inherit; /* 1 */
+      font-family: $base-font-family; /* 1 */
       font-size: 100%; /* 1 */
       @if $normalize-vertical-rhythm {
         line-height: ($base-line-height / $base-font-size) * 1em; /* 1 */

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -206,6 +206,15 @@ $alert-color: get-color(alert);
     overflow: auto;
   }
 
+  // Make reset inherit font-family instead of settings sans-serif
+  button,
+  input,
+  optgroup,
+  select,
+  textarea {
+    font-family: inherit;
+  }
+
   // Internal classes to show/hide elements in JavaScript
   .is-visible {
     display: block !important;


### PR DESCRIPTION
Addresses an issue we've been seeing where the _vendor file keeps showing diffs... the underlying issue is `_vendor` files encapsulate dependencies and should not be changed. To achieve the same effect we can utilize the cascade.