### PR TITLE
[Button] Simplify .clear

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -46,10 +46,6 @@ $button-radius: $global-radius !default;
 /// @type Number
 $button-hollow-border-width: 1px !default;
 
-/// Border width for hollow outline buttons
-/// @type Number
-$button-clear-border-width: 1px !default;
-
 /// Sizes for buttons.
 /// @type Map
 $button-sizes: (
@@ -74,10 +70,6 @@ $button-background-hover-lightness: -20% !default;
 /// Color lightness on hover for hollow buttons.
 /// @type Number
 $button-hollow-hover-lightness: -50% !default;
-
-/// Color lightness on hover for clear buttons.
-/// @type Number
-$button-clear-hover-lightness: -50% !default;
 
 // Internal: flip from margin-right to margin-left for defaults
 @if $global-text-direction == 'rtl' {
@@ -195,30 +187,6 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
       border: $border-width solid $color;
       color: $color;
     }
-  }
-}
-
-/// Removes background fill on hover and focus for hollow buttons.
-@mixin button-clear {
-  &,
-  &:hover, &:focus {
-    background-color: transparent;
-  }
-}
-
-@mixin button-clear-style(
-  $color: $primary-color,
-  $hover-lightness: $button-clear-hover-lightness,
-  $border-width: $button-clear-border-width
-) {
-  $color-hover: scale-color($color, $lightness: $hover-lightness);
-
-  border: $border-width solid transparent;
-  color: $color;
-
-  &:hover, &:focus {
-    border-color: transparent;
-    color: $color-hover;
   }
 }
 
@@ -350,12 +318,24 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
     // Clear style
     @if $button-fill != clear {
       &.clear {
-        @include button-clear;
-        @include button-clear-style;
+        @include button-hollow;
+        @include button-hollow-style;
+
+        &, &:hover, &:focus {
+          &, &.disabled, &[disabled] {
+            border-color: transparent;
+          }
+        }
 
         @each $name, $color in $button-palette {
           &.#{$name} {
-            @include button-clear-style($color);
+            @include button-hollow-style($color);
+
+            &, &:hover, &:focus {
+              &, &.disabled, &[disabled] {
+                border-color: transparent;
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR refactors the `.clear` button class to leverage the `button-hollow-style()` mixin. 

Closes #9961, which references @rafibomb's #9739. 
