### PR TITLE
Rewrote onImagesLoaded to prevent loading images multiple times. Fixes #9932

### DIFF
--- a/js/foundation.util.timerAndImageLoader.js
+++ b/js/foundation.util.timerAndImageLoader.js
@@ -58,19 +58,22 @@ function onImagesLoaded(images, callback){
     callback();
   }
 
-  images.each(function() {
+  images.each(function(){
     // Check if image is loaded
-    if (this.complete || (this.readyState === 4) || (this.readyState === 'complete')) {
+    if (this.complete && this.naturalWidth !== undefined) {
       singleImageLoaded();
     }
-    // Force load the image
     else {
-      // fix for IE. See https://css-tricks.com/snippets/jquery/fixing-load-in-ie-for-cached-images/
-      var src = $(this).attr('src');
-      $(this).attr('src', src + (src.indexOf('?') >= 0 ? '&' : '?') + (new Date().getTime()));
-      $(this).one('load', function() {
+      // If the above check failed, simulate loading on detached element.
+      var image = new Image();
+      // Still count image as loaded if it finalizes with an error.
+      var events = "load.zf.images error.zf.images";
+      $(image).one(events, function me(event){
+        // Unbind the event listeners. We're using 'one' but only one of the two events will have fired.
+        $(this).off(events, me);
         singleImageLoaded();
       });
+      image.src = $(this).attr('src');
     }
   });
 


### PR DESCRIPTION
Changed onImagesLoaded function to use load and error events on a detached image element to detect when images are loaded rather than changing the source on existing elements which would cause images to be loaded multiple times as described in #9932.

The method I've implemented is used in https://github.com/alexanderdickson/waitForImages and https://github.com/desandro/imagesloaded/, both popular libraries for doing this.

My version can be viewed and tested at http://codepen.io/rlhawk1/pen/OmbvGw