### PR TITLE
Fixed typo in 'reveal-modal-width' mixin, now uses '$max-width' argument

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -92,7 +92,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   @include breakpoint(medium) {
     @extend %reveal-centered;
     width: $width;
-    max-width: $reveal-max-width;
+    max-width: $max-width;
   }
 }
 


### PR DESCRIPTION
Fixed typo in 'reveal-modal-width' mixin where default value for argument '$max-width' was being assigned to the property instead of the actual value.