### PR TITLE
Fix table border rendering by including border-collapse declaration

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -192,6 +192,7 @@ $table-stack-breakpoint: medium !default;
   $stripe: $table-stripe,
   $nest: false
 ) {
+  border-collapse: collapse;
   width: 100%;
   margin-bottom: $global-margin;
   border-radius: $global-radius;


### PR DESCRIPTION
Fixes the core table element CSS by adding:
`border-collapse: collapse;`

This fixes #10004 and allows the settings file table border declaration to render correctly.