### PR TITLE
Fix for Responsive Accordion Lost Event Bindings 

### DIFF
--- a/js/foundation.responsiveAccordionTabs.js
+++ b/js/foundation.responsiveAccordionTabs.js
@@ -189,7 +189,7 @@ class ResponsiveAccordionTabs extends Plugin{
     if (toSet === 'accordion') {
       $panels.each(function(key,value){
         $(value).appendTo($liHeads.get(key)).addClass('accordion-content').attr('data-tab-content','').removeClass('is-active').css({height:''});
-        $('[data-tabs-content='+_this.$element.attr('id')+']').after('<div id="tabs-placeholder-'+_this.$element.attr('id')+'"></div>').remove();
+        $('[data-tabs-content='+_this.$element.attr('id')+']').after('<div id="tabs-placeholder-'+_this.$element.attr('id')+'"></div>').detach();
         $liHeads.addClass('accordion-item').attr('data-accordion-item','');
         $liHeadsA.addClass('accordion-title');
       });


### PR DESCRIPTION
Fixed a bug in the responsive accordion plugin where event bindings were getting lost when switching from tabs to accordion.

You can see an example of it here:
f6test.herokuapp.com

It's a simple fix. `detach` should be used instead of `remove`. The two methods are identical with the exception that `detach` keeps the jQuery event bindings in tact. 