### PR TITLE
Update to abbreviation specificity to overwrite normalize

### DIFF
--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -469,10 +469,11 @@ $abbr-underline: 1px dotted $black !default;
   }
 
   // Abbreviations
-  abbr {
+  abbr, abbr[title] {
     border-bottom: $abbr-underline;
     color: $body-font-color;
     cursor: help;
+    text-decoration: none;
   }
 
   // Figures


### PR DESCRIPTION
Normalize's abbr[title] styling was overwriting this style. Adding this specificity promotes foundation abbr above normalize.
