### PR TITLE
Reveal ajax keydown

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -148,16 +148,6 @@ class Reveal extends Plugin {
       }
     });
 
-    if (this.$anchor.length) {
-      this.$anchor.on('keydown.zf.reveal', function(e) {
-        if (e.which === 13 || e.which === 32) {
-          e.stopPropagation();
-          e.preventDefault();
-          _this.open();
-        }
-      });
-    }
-
     if (this.options.closeOnClick && this.options.overlay) {
       this.$overlay.off('.zf.reveal').on('click.zf.reveal', function(e) {
         if (e.target === _this.$element[0] ||

--- a/test/visual/reveal/basic.html
+++ b/test/visual/reveal/basic.html
@@ -87,12 +87,31 @@
           <p><button class="button" data-close>Close modal</button></p>
         </div>
       </section>
+
+      <section>
+        <h2>Eventlistener for anchor</h2>
+        <p>When triggering the modal with the keyboard (space or enter) it should change content.</p>
+        <p><button class="button" data-open="exampleModal8" id="exampleAnchor18-1">Open modal</button></p>
+        <p><a href="#" data-open="exampleModal8" id="exampleAnchor18-2">Open modal</a></p>
+        <div class="reveal" id="exampleModal8" data-reveal>
+          <p>Something went wrong</p>
+          <p><button class="button" data-close>Close modal</button></p>
+        </div>
+      </section>
     </div>
 
     <script src="../assets/js/vendor.js"></script>
     <script src="../assets/js/foundation.js"></script>
     <script>
       $(document).foundation();
+    </script>
+    <script>
+      // Additional script related to "Eventlistener for anchor"
+      $('#exampleAnchor18-1, #exampleAnchor18-2').on('click', function() {
+        $('#exampleModal8 p').first().html('If you see this, everything works out.');
+      }).on('closed.zf.reveal', function() {
+        $('#exampleModal8 p').first().html('Something went wrong');
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
Removed keydown handler that used to trigger open.
Will still trigger for space and enter automatically for buttons as Reveal anchors (i.e. triggers).
However, space will not trigger the click event for links (which is the default behavior).
As buttons should be used as anchors, this follows the specs.

Relevant for issue #10019.