### PR TITLE
Show all th for $show-header-for-stacked

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -275,12 +275,8 @@ $table-stack-breakpoint: medium !default;
 @mixin table-stack($header: $show-header-for-stacked) {
   @if $header {
     thead {
-      th:first-child {
-        display: block;
-      }
-
       th {
-        display: none;
+        display: block;
       }
     }
   }


### PR DESCRIPTION
Fixes #8512.

Show all `th` tags (not just the first one) for `table.stack` when `$show-header-for-stacked` is `true`.

With this markup and `$show-header-for-stacked: true;` we will now show all `th` tags when the screen size is small. Previously only the first `th` tag was shown.

```
<table class="stack">
   <thead>
   <tr><th>Title</th><th>Author</th><th>Posts</th><th>Date</th></tr>
   </thead>
   <tbody>
   <tr>
      <td><a href="/">Some title</a></td>
      <td>Author</td>
      <td>42</td>
      <td>August 11, 1967</td>
   </tr>
   </tbody>
</table>
```

