### PR TITLE
Add inclusion of mixins for scss installation

### DIFF
--- a/docs/pages/motion-ui.md
+++ b/docs/pages/motion-ui.md
@@ -60,10 +60,12 @@ gulp.src('./src/scss/app.scss')
   }));
 ```
 
-Finally, import the library into your Sass file.
+Finally, import the library into your Sass file and include the mixins.
 
 ```scss
 @import 'motion-ui'
+@include motion-ui-transitions;
+@include motion-ui-animations;
 ```
 
 Or, another way to start using Motion UI is through a CDN.


### PR DESCRIPTION
Orbit will not work with simply importing `motion-ui`, the mixins must be included as well. This updates the documentation and adds to the code sample.