### PR TITLE
remove useless lines for padding props

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -244,8 +244,6 @@ $menu-border: $light-gray !default;
 }
 
 @mixin menu-text {
-  padding-top: 0;
-  padding-bottom: 0;
   padding: $menu-item-padding;
 
   font-weight: bold;


### PR DESCRIPTION
We did a css selector performance test which suggest us to remove the padding-top and bottom declarations, as they are overwritten by the padding shorthand property.
