### PR TITLE
Fix units on input and select heights

### DIFF
--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -19,7 +19,7 @@ $select-triangle-color: $dark-gray !default;
 $select-radius: $global-radius !default;
 
 @mixin form-select {
-  $height: ($input-font-size * $input-line-height) + (get-side($input-padding, 'top') + get-side($input-padding, 'bottom')) - rem-calc(1);
+  $height: ($input-font-size * unitless-calc($input-line-height)) + (get-side($input-padding, 'top') + get-side($input-padding, 'bottom')) - rem-calc(1);
 
   height: $height;
   margin: 0 0 $form-spacing;

--- a/scss/forms/_text.scss
+++ b/scss/forms/_text.scss
@@ -83,7 +83,7 @@ $input-radius: $global-radius !default;
 $form-button-radius: $global-radius !default;
 
 @mixin form-element {
-  $height: ($input-font-size * $input-line-height) + (get-side($input-padding, 'top') + get-side($input-padding, 'bottom')) - rem-calc(1);
+  $height: ($input-font-size * unitless-calc($input-line-height)) + (get-side($input-padding, 'top') + get-side($input-padding, 'bottom')) - rem-calc(1);
 
   display: block;
   box-sizing: border-box;


### PR DESCRIPTION
Fixes an issue introduced with https://github.com/zurb/foundation-sites/pull/9681 where the scss will break if $input-line-height has units other than %.