### PR TITLE
Update docs layout to remove unnecessary menu

### DIFF
--- a/docs/assets/scss/_component-list.scss
+++ b/docs/assets/scss/_component-list.scss
@@ -1,9 +1,9 @@
-.docs-nav.menu {
+.docs-nav {
   padding-top: 1rem;
   border-right: 1px solid #efefef;
 }
 
-.menu .docs-nav-category {
+.docs-nav .docs-nav-category {
   background: none;
 
   .accordion-title {
@@ -42,15 +42,15 @@
   }
 }
 
-.docs-nav.menu a:hover {
+.docs-nav a:hover {
   background: none;
 }
 
-.docs-nav.menu a:focus {
+.docs-nav a:focus {
   background: none;
 }
 
-.docs-nav.menu .current a {
+.docs-nav .current a {
   background: none;
   color: $primary-color;
 }
@@ -64,7 +64,6 @@
   }
 
   li a {
-    font-size: 1rem;
     color: #717171;
     line-height: 1.5;
     transition: color 0.3s ease;

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -327,7 +327,7 @@ $global-nav-hover-color: lighten($global-nav-bg, 10%);
   background: url("../img/icons/youtube.png") no-repeat center 0;
 }
 
-.menu li.docs-nav-version {
+.docs-nav li.docs-nav-version {
   display: flex;
   align-items: center;
 
@@ -423,7 +423,7 @@ a[data-open-video] {
   position: relative;
 }
 
-.docs-nav.menu {
+.docs-nav {
   .docs-expand-all {
     font-size: 0.6rem;
     position: absolute;

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -1,4 +1,4 @@
-<div class="vertical menu docs-nav" id="docs-menu">
+<div class="docs-nav" id="docs-menu">
 
 <!--
   <ul class="docs-nav-version-container">

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clipboard": "^1.7.1",
     "corejs-typeahead": "^1.1.1",
     "doiuse": "^2.6.0",
-    "foundation-docs": "zurb/foundation-docs#v0.2.0",
+    "foundation-docs": "zurb/foundation-docs#v0.2.1",
     "gulp": "^3.8.10",
     "gulp-add-src": "^0.2.0",
     "gulp-babel": "^6.1.1",


### PR DESCRIPTION
The new menu stylings highlights that the current docs nav is using the menu class incorrectly, and it causes conflicts. Update to resolve.  Targeted at develop as this is only relevant for 6.4+, though we can probably cherry-pick this change back to 6.3