### PR TITLE
Correcting include list!

### DIFF
--- a/docs/pages/prototyping-utilities.md
+++ b/docs/pages/prototyping-utilities.md
@@ -65,7 +65,7 @@ You can instead import only the specific utility classes that you need. To make 
 @include foundation-prototype-rounded;
 @include foundation-prototype-bordered;
 @include foundation-prototype-shadow;
-@include foundation-prototype-titlebar;
+@include foundation-prototype-separator;
 @include foundation-prototype-overflow;
 @include foundation-prototype-display;
 @include foundation-prototype-position;


### PR DESCRIPTION
Actually at the time of development ... I named it titlebar ... but as we have `title-bar` in top bar changed the name to separator.
By mistakenly ... didn't changed in the docs - include list ... 
Changing now ... and merging!