### PR TITLE
[XY-Grid] propose swapping wrap logic to nowrap

### DIFF
--- a/scss/xy-grid/_grid.scss
+++ b/scss/xy-grid/_grid.scss
@@ -19,10 +19,10 @@
 /// Creates a container for your flex cells.
 ///
 /// @param {Keyword} $direction [horizontal] - Either horizontal or vertical direction of cells within.
-/// @param {Boolean} $wrap [true] - If the cells within should wrap or not.
+/// @param {Boolean} $wrap [false] - If the cells within should wrap or not.
 @mixin xy-grid(
   $direction: horizontal,
-  $wrap: true
+  $wrap: false
 ) {
   $direction: if($direction == 'horizontal', row, column);
   $wrap: if($wrap, wrap, nowrap);

--- a/test/visual/xy-grid/margin-grid.html
+++ b/test/visual/xy-grid/margin-grid.html
@@ -90,6 +90,18 @@
       <div class="cell medium-4"><div class="demo">4</div></div>
     </div>
 
+    <div class="grid-x margin-gutters">
+      <div class="medium-auto cell">
+        <img src="http://placehold.it/400" alt="" />
+      </div>
+      <div class="medium-auto cell">
+        <img src="http://placehold.it/400" alt="" />
+      </div>
+      <div class="medium-auto cell">
+        <img src="http://placehold.it/400" alt="" />
+      </div>
+    </div>
+
     <script src="../assets/js/vendor.js"></script>
     <script src="../assets/js/foundation.js"></script>
     <script>


### PR DESCRIPTION
Just setting a basic `.grid-x` revealed an unexpected behavior. 

Using this markup
```
<div class="grid-x margin-gutters">
  <div class="medium-auto cell">
    <img src="http://placehold.it/300" alt="" />
  </div>
  <div class="medium-auto cell">
    <img src="http://placehold.it/300" alt="" />
  </div>
  <div class="medium-auto cell">
    <img src="http://placehold.it/300" alt="" />
  </div>
</div>
```
Results in this
![5ydznka4ce](https://cloud.githubusercontent.com/assets/5652085/26770397/68caf20a-496b-11e7-8907-92926c947a90.gif)

But what is expected is 
![aowda3ez6s](https://cloud.githubusercontent.com/assets/5652085/26770432/ac52307e-496b-11e7-9603-99c0071d90a1.gif)

Since it's a mixin option - this PR proposes we default to nowrap which means the grid follows prior convention. 

The opposite allows more than 12 cells per `.grid` but results can be inconsistent.