### PR TITLE
Set correct auto flex properties

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -53,7 +53,7 @@
     min-width: 0px;
   }
   @elseif ($size == 'auto') {
-    flex: 1 1 auto;
+    flex: 1 1 0px; // sass-lint:disable-line zero-unit
   }
   @elseif ($size == 'shrink') {
     flex: 0 0 auto;


### PR DESCRIPTION
Fixes #10138
See https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored - must include `px`.