### PR TITLE
Change cursor for accordion submenu toggle

### DIFF
--- a/scss/components/_accordion-menu.scss
+++ b/scss/components/_accordion-menu.scss
@@ -129,6 +129,7 @@ $accordionmenu-arrow-size: 6px !default;
     position: absolute;
     top: 0;
     #{$global-right}: 0;
+    cursor: pointer;
 
     width: $accordionmenu-submenu-toggle-width;
     height: $accordionmenu-submenu-toggle-height;


### PR DESCRIPTION
Noticed while testing that we don't get a pointer cursor when hovering over a new submenu toggle within accordion menu, but I think it should to give feedback to the user.