### PR TITLE
Add else statement inside of ifequal example

### DIFF
--- a/docs/pages/panini.md
+++ b/docs/pages/panini.md
@@ -126,6 +126,8 @@ Displays the HTML inside the helper if the two values are equal.
 ```handlebars
 {{#ifequal foo bar}}
   <p>foo and bar are equal</p>
+{{else}}
+  <p>foo and bar are not equal}}  
 {{/ifequal}}
 ```
 


### PR DESCRIPTION
It is unclear that `{{else}}` statements are possible inside of `{{#ifequal}}` helpers to show HTML if the two values are not equal. Because there are `{{#ifpage}}` and `{{#unlesspage}}` as separate equal/not equal helpers, users may be confused that there is no equivalent "unlessequal" helper or "!" syntax.

I have successfully used the `{{else}}` Handlebars helper inside if the `{{#ifequal}}` Paini helper to achieve the desired "not equal" condition, but only thought to try this as a guess after a lot of unsuccessful searching through documentation on both Handlebars and Panini.
