### PR TITLE
Xy grid gutter class fix

### DIFF
--- a/docs/assets/scss/examples/_grid.scss
+++ b/docs/assets/scss/examples/_grid.scss
@@ -78,11 +78,15 @@
 [id^="docs-xy"].docs-component .docs-code-live {
   @include foundation-xy-grid-classes;
 
-  .grid {
+  .grid-x,
+  .grid-y {
     font-size: 12px;
-    margin-bottom: 10px;
     line-height: 2rem;
     margin-bottom: 1.5rem;
+  }
+
+  .grid-y .grid-x {
+    margin-bottom: 0;
   }
 
   .cell {

--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -71,18 +71,18 @@ The structure of XY grid uses `.grid-x`, `.grid-y`, and `.cell` as its base. Wit
 ## Gutters
 
 The defining feature of the XY grid is the ability to use margin AND padding grids in harmony.
-To define a grid type, simple set `.margin-gutters` or `.padding-gutters` on the grid.
+To define a grid type, simple set `.grid-margin-x` or `.grid-padding-x` on the grid.
 
 <div class="docs-codepen-container">
 <a class="codepen-logo-link" href="https://codepen.io/ZURBFoundation/pen/owvqYp?editors=1000" target="_blank"><img src="{{root}}assets/img/logos/edit-in-browser.svg" class="" height="" width="" alt="edit on codepen button"></a>
 </div>
 
 ```html_example
-<div class="grid-x margin-gutters">
+<div class="grid-x grid-margin-x">
   <div class="medium-6 large-4 cell">12/6/4 cells</div>
   <div class="medium-6 large-8 cell">12/6/8 cells</div>
 </div>
-<div class="grid-x padding-gutters">
+<div class="grid-x grid-padding-x">
   <div class="medium-6 large-4 cell">12/6/4 cells</div>
   <div class="medium-6 large-8 cell">12/6/8 cells</div>
 </div>
@@ -109,7 +109,7 @@ The grid defaults to the full width of its container. In order to contain the gr
 If the class `.auto` or `.[size]-auto` is added to the cell, it will take up the remaining space.
 
 ```html_example
-<div class="grid-x margin-gutters">
+<div class="grid-x grid-margin-x">
   <div class="small-4 cell">4 cells</div>
   <div class="auto cell">Whatever's left!</div>
 </div>
@@ -120,7 +120,7 @@ If the class `.auto` or `.[size]-auto` is added to the cell, it will take up the
 Multiple expanding cells will share the leftover space equally.
 
 ```html_example
-<div class="grid-x margin-gutters">
+<div class="grid-x grid-margin-x">
   <div class="small-4 cell">4 cells</div>
   <div class="auto cell">Whatever's left!</div>
   <div class="auto cell">Whatever's left!</div>
@@ -132,7 +132,7 @@ Multiple expanding cells will share the leftover space equally.
 A cell can also be made to *shrink*, by adding the `.shrink` or `.[size]-shrink` class. This means it will only take up the space its contents need.
 
 ```html_example
-<div class="grid-x margin-gutters">
+<div class="grid-x grid-margin-x">
   <div class="shrink cell">Shrink!</div>
   <div class="auto cell">Expand!</div>
 </div>
@@ -159,12 +159,12 @@ To switch back to the auto behavior from a percentage or shrink behavior, use th
 
 ## Collapse Cells
 
-The `.[size]-[margin-type]-collapse` class lets you remove cell gutters.
+The `.[size]-[gutter-type]-collapse` class lets you remove cell gutters.
 
 There are times when you won't want each media query to be collapsed. In this case, use the media query size you want and collapse and add that to your grid element. Example shows gutters at small and no gutters on medium and up.
 
 ```html_example
-<div class="grid-x margin-gutters medium-margin-collapse">
+<div class="grid-x grid-margin-x medium-margin-collapse">
   <div class="small-6 cell">
     Gutters at small no gutters at medium.
   </div>
@@ -181,7 +181,7 @@ There are times when you won't want each media query to be collapsed. In this ca
 Offsets work by applying `margin-left` (or `margin-top` for a vertical grid) to a grid.
 
 ```html_example
-<div class="grid-x margin-gutters">
+<div class="grid-x grid-margin-x">
   <div class="small-4 large-offset-2 cell">Offset 2 on large</div>
   <div class="small-4 cell">4 cells</div>
 </div>
@@ -192,7 +192,9 @@ Offsets work by applying `margin-left` (or `margin-top` for a vertical grid) to 
 ## Vertical Grids
 
 The XY grid also supports vertical grids. Simply apply `.grid-y` instead of `.grid-x`.
-The internal cells will shift automatically to provide spacing vertically rather than horizontally
+The internal cells will shift automatically to provide spacing vertically rather than horizontally.
+
+You can also apply margin or padding with `.grid-margin-y` and `.grid-padding-y` to apply spacing to the top and bottom of cells.
 
 <div class="callout">
   <p>Please note for vertical grids to work, the grid needs a height. You can also use [grid frame](#grid-frame) to create a 100 vertical height grid (or 100% height if nested).</p>
@@ -230,7 +232,7 @@ Here's an example of what you can do:
 <div class="grid-y medium-grid-frame">
   <div class="cell shrink header cell-block-container">
     <h1>Grid Frame Header</h1>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell medium-4">
         A medium 4 cell
       </div>
@@ -243,7 +245,7 @@ Here's an example of what you can do:
     </div>
   </div>
   <div class="cell auto cell-block-container">
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell medium-4 medium-cell-block-y">
         <h2>Independent scrolling sidebar</h2>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer lacus odio, accumsan id ullamcorper eget, varius nec erat. Nulla facilisi. Donec dui felis, euismod nec finibus vitae, dapibus quis arcu. Maecenas tempor et ipsum quis venenatis. Ut posuere sed augue sit amet efficitur. Sed imperdiet, justo id tempus rhoncus, est est viverra turpis, non vulputate magna lectus et nisl. Pellentesque ultrices porttitor vehicula. Ut aliquet efficitur ligula, a consectetur felis. Proin tristique ut augue nec luctus. Curabitur a sapien pretium, auctor elit a, efficitur erat. Donec tincidunt dui vel velit bibendum euismod. Cras vitae nibh dui. Aliquam erat volutpat. Etiam sit amet arcu a erat efficitur facilisis. Ut viverra dapibus turpis, et ornare justo. Integer in dui cursus, dignissim tortor a, hendrerit risus.</p>

--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -65,12 +65,7 @@
 /// @param {Boolean} $vertical [false] - Set to true to output vertical (height) styles rather than widths.
 @mixin xy-cell-reset($vertical: true) {
   $direction: if($vertical == true, width, height);
-  $sides: if($vertical == true, left right, top bottom);
   #{$direction}: auto;
-  @each $side in $sides {
-    margin-#{$side}: 0;
-    padding-#{$side}: 0;
-  }
 }
 
 // Sets our cell widths or heights depending on gutter type.

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -90,7 +90,7 @@
 @mixin xy-margin-grid-classes(
   $gutter-position: left right,
   $vertical: false,
-  $wrapping-selector: '.margin-gutters'
+  $wrapping-selector: '.grid-margin-x'
 ){
   #{$wrapping-selector} {
     @include xy-gutters($negative: true, $gutter-position: $gutter-position);
@@ -128,10 +128,10 @@
 
 // Padding Grid classes
 @mixin xy-padding-grid-classes {
-  .padding-gutters {
+  .grid-padding-x {
 
     // Negative margin for nested grids
-    .padding-gutters {
+    .grid-padding-x {
       @include xy-gutters($negative: true);
     }
 
@@ -144,6 +144,16 @@
 
 // Block Grid classes
 @mixin xy-block-grid-classes($margin-grid: true, $padding-grid: true) {
+  @if $padding-grid {
+    @include -zf-each-breakpoint {
+      @for $i from 1 through $block-grid-max {
+        .#{$-zf-size}-up-#{$i} {
+          @include xy-grid-layout($i, '.cell', false, $gutter-type: padding);
+        }
+      }
+    }
+  }
+
   @if $margin-grid {
     @include -zf-each-breakpoint {
       @for $i from 1 through $block-grid-max {
@@ -152,7 +162,7 @@
         @if(type-of($grid-margin-gutters) == 'map' and map-has-key($grid-margin-gutters, $-zf-size)) {
           @each $bp in -zf-breakpoints-less-than($-zf-size) {
             @if(map-has-key($grid-margin-gutters, $bp)) {
-              .margin-gutters.#{$bp}-up-#{$i} {
+              .grid-margin-x.#{$bp}-up-#{$i} {
                 @include xy-grid-layout($i, '.cell', false, $gutter-type: margin, $breakpoint: $bp);
               }
             }
@@ -160,18 +170,8 @@
         }
       }
       @for $i from 1 through $block-grid-max {
-        .margin-gutters.#{$-zf-size}-up-#{$i} {
+        .grid-margin-x.#{$-zf-size}-up-#{$i} {
           @include xy-grid-layout($i, '.cell', false, $gutter-type: margin, $breakpoint: $-zf-size);
-        }
-      }
-    }
-  }
-
-  @if $padding-grid {
-    @include -zf-each-breakpoint {
-      @for $i from 1 through $block-grid-max {
-        .padding-gutters.#{$-zf-size}-up-#{$i} {
-          @include xy-grid-layout($i, '.cell', false, $gutter-type: padding);
         }
       }
     }
@@ -206,7 +206,7 @@
         @include xy-cell-offset($o, $gutters: $grid-padding-gutters, $gutter-type: padding, $breakpoint: $-zf-size);
       }
 
-      .margin-gutters > .#{$-zf-size}-offset-#{$o} {
+      .grid-margin-x > .#{$-zf-size}-offset-#{$o} {
         @include xy-cell-offset($o, $breakpoint: $-zf-size);
       }
     }
@@ -260,24 +260,24 @@
         }
       }
     }
+  }
 
-    @if $padding-grid {
-      &.padding-gutters {
-        // Negative margin for nested grids
-        .padding-gutters {
-          @include xy-gutters($negative: true, $gutter-position: top bottom);
-        }
+  @if $padding-grid {
+    &.grid-padding-y {
+      // Negative margin for nested grids
+      .grid-padding-y {
+        @include xy-gutters($negative: true, $gutter-position: top bottom);
+      }
 
-        // Base cell styles
-        > .cell {
-          @include xy-gutters($gutters: $grid-padding-gutters, $gutter-type: padding, $gutter-position: top bottom);
-        }
+      // Base cell styles
+      > .cell {
+        @include xy-gutters($gutters: $grid-padding-gutters, $gutter-type: padding, $gutter-position: top bottom);
       }
     }
   }
 
   @if $margin-grid {
-    @include xy-margin-grid-classes(top bottom, true, '.grid-y.margin-gutters')
+    @include xy-margin-grid-classes(top bottom, true, '.grid-margin-y')
   }
 }
 

--- a/test/visual/xy-grid/block-grid.html
+++ b/test/visual/xy-grid/block-grid.html
@@ -31,7 +31,7 @@
     <h2>Margin Block Grid</h2>
     <p>small 2, medium 4, large 6</p>
 
-    <div class="grid-x margin-gutters small-up-2 medium-up-4 large-up-6">
+    <div class="grid-x grid-margin-x small-up-2 medium-up-4 large-up-6">
       <div class="cell"><div class="demo">cell</div></div>
       <div class="cell"><div class="demo">cell</div></div>
       <div class="cell"><div class="demo">cell</div></div>
@@ -49,7 +49,7 @@
     <h2>Padding Block Grid</h2>
     <p>small 1, medium 3, large 5</p>
 
-    <div class="grid-x padding-gutters small-up-1 medium-up-3 large-up-5">
+    <div class="grid-x grid-padding-x small-up-1 medium-up-3 large-up-5">
       <div class="cell"><div class="demo">cell</div></div>
       <div class="cell"><div class="demo">cell</div></div>
       <div class="cell"><div class="demo">cell</div></div>

--- a/test/visual/xy-grid/collapse.html
+++ b/test/visual/xy-grid/collapse.html
@@ -31,7 +31,7 @@
     <h2>Margin Grid Collapse</h2>
     <p>Gutters should collapse on large.</p>
 
-    <div class="grid-x margin-gutters large-margin-collapse">
+    <div class="grid-x grid-margin-x large-margin-collapse">
       <div class="cell medium-12"><div class="demo">12</div></div>
       <div class="cell medium-11"><div class="demo">11</div></div>
       <div class="cell medium-1"><div class="demo">1</div></div>
@@ -52,7 +52,7 @@
     <h2>Padding Grid Collapse</h2>
     <p>Gutters should collapse on medium.</p>
 
-    <div class="grid-x padding-gutters medium-padding-collapse">
+    <div class="grid-x grid-padding-x medium-padding-collapse">
       <div class="cell medium-12"><div class="demo">12</div></div>
       <div class="cell medium-11"><div class="demo">11</div></div>
       <div class="cell medium-1"><div class="demo">1</div></div>

--- a/test/visual/xy-grid/combo-grids.html
+++ b/test/visual/xy-grid/combo-grids.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>xy margin grid</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+    <style>
+      body {
+        padding: 30px;
+      }
+
+      .demo {
+        background: #1779ba;
+      }
+
+      h2 {
+        margin: 0;
+      }
+
+      .cell {
+        /*background: dodgerblue;*/
+        background: tomato;
+        line-height: 50px;
+        color: white;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Combo Grid</h1>
+
+    <h2>Sizing Classes, margin x, padding x & y</h2>
+
+    <div class="grid-x grid-margin-x grid-padding-x grid-padding-y">
+      <div class="cell medium-12"><div class="demo">12</div></div>
+      <div class="cell medium-11"><div class="demo">11</div></div>
+      <div class="cell medium-1"><div class="demo">1</div></div>
+      <div class="cell medium-10"><div class="demo">10</div></div>
+      <div class="cell medium-2"><div class="demo">2</div></div>
+      <div class="cell medium-9"><div class="demo">9</div></div>
+      <div class="cell medium-3"><div class="demo">3</div></div>
+      <div class="cell medium-8"><div class="demo">8</div></div>
+      <div class="cell medium-4"><div class="demo">4</div></div>
+      <div class="cell medium-7"><div class="demo">7</div></div>
+      <div class="cell medium-5"><div class="demo">5</div></div>
+      <div class="cell medium-6"><div class="demo">6</div></div>
+      <div class="cell medium-4"><div class="demo">4</div></div>
+    </div>
+
+    <h2>Block Grid With Margin xy and padding x</h2>
+
+    <div class="grid-x grid-margin-x grid-margin-y grid-padding-x small-up-2 medium-up-3 large-up-4">
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+      <div class="cell"><div class="demo">6/4/3</div></div>
+    </div>
+
+    <h2>Auto and Shrink</h2>
+
+    <div class="grid-x grid-margin-x">
+      <div class="cell medium-shrink"><div class="demo">Shrink on medium</div></div>
+      <div class="cell medium-auto"><div class="demo">Auto on medium</div></div>
+    </div>
+
+    <h2>Collapse</h2>
+
+    <div class="grid-x grid-margin-x large-margin-collapse">
+      <div class="cell medium-12"><div class="demo">12</div></div>
+      <div class="cell medium-11"><div class="demo">11</div></div>
+      <div class="cell medium-1"><div class="demo">1</div></div>
+      <div class="cell medium-10"><div class="demo">10</div></div>
+      <div class="cell medium-2"><div class="demo">2</div></div>
+      <div class="cell medium-9"><div class="demo">9</div></div>
+      <div class="cell medium-3"><div class="demo">3</div></div>
+      <div class="cell medium-8"><div class="demo">8</div></div>
+      <div class="cell medium-4"><div class="demo">4</div></div>
+      <div class="cell medium-7"><div class="demo">7</div></div>
+      <div class="cell medium-5"><div class="demo">5</div></div>
+      <div class="cell medium-6"><div class="demo">6</div></div>
+      <div class="cell medium-4"><div class="demo">4</div></div>
+    </div>
+
+    <h2>Offset</h2>
+
+    <div class="grid-x grid-margin-x">
+      <div class="cell medium-3 medium-offset-2"><div class="demo">3</div></div>
+      <div class="cell medium-4"><div class="demo">4</div></div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>
+

--- a/test/visual/xy-grid/frame-grid.html
+++ b/test/visual/xy-grid/frame-grid.html
@@ -23,7 +23,7 @@
     <div class="grid-y medium-grid-frame">
       <div class="cell shrink header cell-block-container">
         <h1>Grid Frame Header</h1>
-        <div class="grid-x padding-gutters">
+        <div class="grid-x grid-padding-x">
           <div class="cell medium-4">
             A medium 4 cell
           </div>
@@ -36,7 +36,7 @@
         </div>
       </div>
       <div class="cell auto cell-block-container">
-        <div class="grid-x padding-gutters">
+        <div class="grid-x grid-padding-x">
           <div class="cell medium-4 medium-cell-block-y">
             <h2>Independent scrolling sidebar</h2>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer lacus odio, accumsan id ullamcorper eget, varius nec erat. Nulla facilisi. Donec dui felis, euismod nec finibus vitae, dapibus quis arcu. Maecenas tempor et ipsum quis venenatis. Ut posuere sed augue sit amet efficitur. Sed imperdiet, justo id tempus rhoncus, est est viverra turpis, non vulputate magna lectus et nisl. Pellentesque ultrices porttitor vehicula. Ut aliquet efficitur ligula, a consectetur felis. Proin tristique ut augue nec luctus. Curabitur a sapien pretium, auctor elit a, efficitur erat. Donec tincidunt dui vel velit bibendum euismod. Cras vitae nibh dui. Aliquam erat volutpat. Etiam sit amet arcu a erat efficitur facilisis. Ut viverra dapibus turpis, et ornare justo. Integer in dui cursus, dignissim tortor a, hendrerit risus.</p>

--- a/test/visual/xy-grid/margin-grid.html
+++ b/test/visual/xy-grid/margin-grid.html
@@ -30,7 +30,7 @@
 
     <h2>Sizing Classes</h2>
 
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell medium-12"><div class="demo">12</div></div>
       <div class="cell medium-11"><div class="demo">11</div></div>
       <div class="cell medium-1"><div class="demo">1</div></div>
@@ -48,9 +48,9 @@
 
     <h2>Nesting</h2>
 
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell medium-6">
-        <div class="grid-x margin-gutters">
+        <div class="grid-x grid-margin-x">
           <div class="cell medium-9"><div class="demo">9 nested</div></div>
           <div class="cell medium-3"><div class="demo">3 nested</div></div>
         </div>
@@ -60,14 +60,14 @@
 
     <h2>Auto and Shrink</h2>
 
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell medium-shrink"><div class="demo">Shrink on medium</div></div>
       <div class="cell medium-auto"><div class="demo">Auto on medium</div></div>
     </div>
 
     <h2>Collapse</h2>
 
-    <div class="grid-x margin-gutters large-margin-collapse">
+    <div class="grid-x grid-margin-x large-margin-collapse">
       <div class="cell medium-12"><div class="demo">12</div></div>
       <div class="cell medium-11"><div class="demo">11</div></div>
       <div class="cell medium-1"><div class="demo">1</div></div>
@@ -85,7 +85,7 @@
 
     <h2>Offset</h2>
 
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell medium-3 medium-offset-2"><div class="demo">3</div></div>
       <div class="cell medium-4"><div class="demo">4</div></div>
     </div>

--- a/test/visual/xy-grid/offset.html
+++ b/test/visual/xy-grid/offset.html
@@ -30,73 +30,73 @@
 
     <h2>Margin Grid Offset</h2>
 
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-1"><div class="demo">1</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-2"><div class="demo">2</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-3"><div class="demo">3</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-4"><div class="demo">4</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-5"><div class="demo">5</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-6"><div class="demo">6</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-7"><div class="demo">7</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-8"><div class="demo">8</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-9"><div class="demo">95</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-10"><div class="demo">10</div></div>
     </div>
-    <div class="grid-x margin-gutters">
+    <div class="grid-x grid-margin-x">
       <div class="cell small-1 small-offset-11"><div class="demo">11</div></div>
     </div>
 
     <h2>Padding Grid Offset</h2>
 
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-1"><div class="demo">1</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-2"><div class="demo">2</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-3"><div class="demo">3</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-4"><div class="demo">4</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-5"><div class="demo">5</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-6"><div class="demo">6</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-7"><div class="demo">7</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-8"><div class="demo">8</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-9"><div class="demo">95</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-10"><div class="demo">10</div></div>
     </div>
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell small-1 small-offset-11"><div class="demo">11</div></div>
     </div>
 

--- a/test/visual/xy-grid/padding-grid.html
+++ b/test/visual/xy-grid/padding-grid.html
@@ -30,7 +30,7 @@
 
     <h2>Sizing Classes</h2>
 
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell medium-12"><div class="demo">12</div></div>
       <div class="cell medium-11"><div class="demo">11</div></div>
       <div class="cell medium-1"><div class="demo">1</div></div>
@@ -48,9 +48,9 @@
 
     <h2>Nesting</h2>
 
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell medium-6">
-        <div class="grid-x padding-gutters">
+        <div class="grid-x grid-padding-x">
           <div class="cell medium-9"><div class="demo">9 nested</div></div>
           <div class="cell medium-3"><div class="demo">3 nested</div></div>
         </div>
@@ -60,14 +60,14 @@
 
     <h2>Auto and Shrink</h2>
 
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell medium-shrink"><div class="demo">Shrink on medium</div></div>
       <div class="cell medium-auto"><div class="demo">Auto on medium</div></div>
     </div>
 
     <h2>Collapse</h2>
 
-    <div class="grid-x padding-gutters large-padding-collapse">
+    <div class="grid-x grid-padding-x large-padding-collapse">
       <div class="cell medium-12"><div class="demo">12</div></div>
       <div class="cell medium-11"><div class="demo">11</div></div>
       <div class="cell medium-1"><div class="demo">1</div></div>
@@ -85,7 +85,7 @@
 
     <h2>Offset</h2>
 
-    <div class="grid-x padding-gutters">
+    <div class="grid-x grid-padding-x">
       <div class="cell medium-3 medium-offset-2"><div class="demo">3</div></div>
       <div class="cell medium-4"><div class="demo">4</div></div>
     </div>

--- a/test/visual/xy-grid/vertical-grid.html
+++ b/test/visual/xy-grid/vertical-grid.html
@@ -1,4 +1,4 @@
-6<!doctype html>
+<!doctype html>
 <!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
 <html class="no-js" lang="en" dir="ltr">
   <head>
@@ -28,7 +28,7 @@
 
     <h2>Margin Grid</h2>
 
-    <div class="grid-y margin-gutters" style="height: 800px;">
+    <div class="grid-y grid-margin-y" style="height: 800px;">
       <div class="cell auto medium-3 large-1"><div class="demo">auto/3/1</div></div>
       <div class="cell auto medium-3 large-2"><div class="demo">auto/3/2</div></div>
       <div class="cell auto medium-3 large-4"><div class="demo">auto/3/4</div></div>
@@ -37,7 +37,7 @@
 
     <h2>Padding Grid</h2>
 
-    <div class="grid-y grid-frame padding-gutters" style="height: 800px;">
+    <div class="grid-y grid-frame grid-padding-y" style="height: 800px;">
       <div class="cell auto medium-3 large-1"><div class="demo">auto/3/1</div></div>
       <div class="cell auto medium-3 large-2"><div class="demo">auto/3/2</div></div>
       <div class="cell auto medium-3 large-4"><div class="demo">auto/3/4</div></div>


### PR DESCRIPTION
This changes the old margin/padding gutter classes to the new `.grid-margin/padding-x/y` syntax.
This allows margin/padding to be applied to all 4 sides, regardless of the grid direction.

One remaining issue that I can think of with this. The base `.cell` class is linked to `.grid-margin-x/y` - specifically their width/height whish is outputted at 100% (minus the margin). Could this cause issues in certain configurations?