### PR TITLE
the cb is missed in this._setWrapperHeight() so the current cb logic is never used in foundation.orbit.js

### DIFF
--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -48,7 +48,7 @@ $card-margin-bottom: $global-margin !default;
 @mixin card-container(
   $background: $card-background,
   $color: $card-font-color,
-  $margin: $card-margin,
+  $margin: $card-margin-bottom,
   $border: $card-border,
   $radius: $card-border-radius,
   $shadow: $card-shadow

--- a/scss/components/_card.scss
+++ b/scss/components/_card.scss
@@ -36,7 +36,7 @@ $card-padding: $global-padding !default;
 
 /// Default bottom margin.
 /// @type number
-$card-margin: $global-margin !default;
+$card-margin-bottom: $global-margin !default;
 
 /// Adds styles for a card container.
 /// @param {Color} $background - Background color of the card.

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -292,7 +292,7 @@ $card-border: 1px solid $light-gray;
 $card-shadow: none;
 $card-border-radius: $global-radius;
 $card-padding: $global-padding;
-$card-margin: $global-margin;
+$card-margin-bottom: $global-margin;
 
 // 15. Close Button
 // ----------------


### PR DESCRIPTION
...

``` javascript

/**
  * Sets wrapper and slide heights for the orbit.
  * @function
  * @private
  */
  _prepareForOrbit() {
    var _this = this;
    var cb = _this.options.callback || function(){};
    this._setWrapperHeight( cb );
  }
```

...