### PR TITLE
Add new `xy-cell-breakpoints` mixin. This allows you to pass a map of…

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -93,7 +93,7 @@
 /// @param {Keyword|Number} $size [full] - The size of your cell. Can be `full` (default) for 100% width, `auto` to use up available space and `shrink` to use up only required space.
 /// @param {Boolean} $gutter-output [true] - Whether or not to output gutters
 /// @param {Number|Map} $gutters [$grid-margin-gutters] - Map or single value for gutters.
-/// @param {Keyword} $gutter-type [margin] - Map or single value for gutters.
+/// @param {Keyword} $gutter-type [margin] - Gutter type of the cell. Accepts `margin` or `padding`.
 /// @param {List} $gutter-position [right left] - The position to apply gutters to. Accepts `top`, `bottom`, `left`, `right` in any combination.
 /// @param {String} $breakpoint [null] - The name of the breakpoint size in your gutters map to get the size from. If using with the `breakpoint()` mixin this will be set automatically unless manually entered.
 /// @param {Boolean} $vertical [false] - Set to true to output vertical (height) styles rather than widths.
@@ -144,12 +144,64 @@
   }
 }
 
+///  Creates a cell for your grid along with responsive sizes for the cell. A shorthand version of using `xy-cell` within the breakpoint mixin.
+///
+/// @param {Map} $sizes [null] - Accepts a map of breakpoint size : cell size key value pairs, eg (small: 12, medium: 6, large: 4).
+/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters
+/// @param {Number|Map} $gutters [$grid-margin-gutters] - Map or single value for gutters.
+/// @param {Keyword} $gutter-type [margin] - Gutter type of the cell. Accepts `margin` or `padding`.
+/// @param {List} $gutter-position [right left] - The position to apply gutters to. Accepts `top`, `bottom`, `left`, `right` in any combination.
+/// @param {Boolean} $vertical [false] - Set to true to output vertical (height) styles rather than widths.
+@mixin xy-cell-breakpoints(
+  $sizes: null,
+  $gutter-output: true,
+  $gutters: $grid-margin-gutters,
+  $gutter-type: margin,
+  $gutter-position: right left,
+  $vertical: false
+) {
+
+  @each $breakpoint, $size in $sizes {
+
+    @include breakpoint($breakpoint) {
+
+      // Get our gutters from map if available, if not map just return the value.
+      $gutter: -zf-get-bp-val($gutters, $breakpoint);
+
+      // Base flex properties
+      @include xy-cell-base($size);
+
+      @if($gutter-type == 'margin') {
+        @include -xy-cell-properties($size, $gutter, $vertical);
+      }
+      @else {
+        @include -xy-cell-properties($size, 0, $vertical);
+      }
+
+      @if $gutter-output {
+        // If gutters = map
+        @if(type-of($gutters) == 'map') {
+          // If $gutters map has a key = $breakpoint, output the value
+          @if (map-has-key($gutters, $breakpoint)) {
+            @include xy-gutters($gutter, $gutter-type, $gutter-position);
+          }
+        }
+        // If not a map
+        @else {
+          @include xy-gutters($gutter, $gutter-type, $gutter-position);
+        }
+      }
+
+    }
+  }
+}
+
 /// Creates a single breakpoint sized grid. Used to generate our grid classes.
 ///
 /// @param {Keyword|Number} $size [full] - The size of your cell. Can be `full` (default) for 100% width, `auto` to use up available space and `shrink` to use up only required space.
 /// @param {Boolean} $gutter-output [true] - Whether or not to output gutters
 /// @param {Number|Map} $gutters [$grid-margin-gutters] - Map or single value for gutters.
-/// @param {Keyword} $gutter-type [margin] - Map or single value for gutters.
+/// @param {Keyword} $gutter-type [margin] - Gutter type of the cell. Accepts `margin` or `padding`.
 /// @param {String} $breakpoint [null] - The name of the breakpoint size in your gutters map to get the size from. If using with the `breakpoint()` mixin this will be set automatically unless manually entered.
 /// @param {Boolean} $vertical [false] - Set to true to output vertical (height) styles rather than widths.
 @mixin xy-cell-static(


### PR DESCRIPTION
… breakpoint:cell size pairs to generate styles for multiple breakpoints.

This was suggested [in this thread](https://github.com/zurb/foundation-sites/issues/10141#issuecomment-307596031) and I thought it was a great suggestion.

Rather than confuse logic in the `xy-cell` mixin though I chose to add it as a new mixin (the right decision?).
Example use case:

```
.my-cell {
    @include xy-cell-breakpoints($sizes: (small: 12, medium: 6, large: 4));
}
```

Generates this:
```
.my-cell {
  width: calc(100% - 1.25rem);
  margin-right: 0.625rem;
  margin-left: 0.625rem; }
  @media print, screen and (min-width: 40em) {
    .my-cell {
      width: calc(50% - 1.875rem);
      margin-right: 0.9375rem;
      margin-left: 0.9375rem; } }
  @media print, screen and (min-width: 64em) {
    .my-cell {
      width: calc(33.33333% - 1.875rem); } }
```

Works OK from my testing but would appreciate feedback!
