### PR TITLE
XY grid fixes

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -40,7 +40,6 @@
     > .shrink {
       @include xy-cell-static(shrink, false);
     }
-
   }
 
   // Auto width
@@ -228,7 +227,7 @@
   }
 
   .grid-y {
-    @include xy-grid(vertical);
+    @include xy-grid(vertical, false);
 
 
     > .cell {

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -58,13 +58,11 @@
         @include xy-cell-base(shrink);
         @include xy-cell-static(shrink, false);
       }
-
     }
-
 
     @for $i from 1 through $grid-columns {
       // Sizing (percentage)
-      .#{$-zf-size}-#{$i} {
+      .grid-x > .#{$-zf-size}-#{$i} {
         @include xy-cell-static($i, false, $gutter-type: padding);
       }
     }

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -66,6 +66,16 @@
       }
     }
   }
+
+  // Reset width when using `.grid-margin-x` not on `.grid-x`
+  .grid-margin-x:not(.grid-x) > .cell {
+    width: auto;
+  }
+
+  // Reset height when using `.grid-margin-y` not on `.grid-y`
+  .grid-margin-y:not(.grid-y) > .cell {
+    height: auto;
+  }
 }
 
 @mixin -xy-breakpoint-cell-classes($class-breakpoint, $gutter-breakpoint, $vertical) {


### PR DESCRIPTION
This is an attempt to fix multiple XY grid issues I've discovered whilst constructing visual tests as well as other outstanding issues.

This fixes:
- `[size]-auto/shrink` classes overriding sizing classes with a bigger breakpoint widths
- Vertical padding grid wrapping issue (closes #10174 
- `align-stretch` not applying to `grid-margin-y` as that class was overwriting the height (closes #10180)