### PR TITLE
Add testcase and add qualifiers on basis overrides

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -44,6 +44,9 @@
 
   // Auto width
   @include -zf-each-breakpoint() {
+    // This is a bit of a hack/workaround, see these PRs for the backstory:
+    // https://github.com/zurb/foundation-sites/pull/10222 and
+    // https://github.com/zurb/foundation-sites/pull/10164
     .grid-x > [class*="#{$-zf-size}-"]:not([class*="#{$-zf-size}-order"]):not([class*="#{$-zf-size}-offset"]) {
       flex-basis: auto;
     }
@@ -254,6 +257,9 @@
 
 
     @include -zf-each-breakpoint() {
+      // This is a bit of a hack/workaround, see these PRs for the backstory:
+      // https://github.com/zurb/foundation-sites/pull/10222 and
+      // https://github.com/zurb/foundation-sites/pull/10164
       > [class*="#{$-zf-size}-"]:not([class*="#{$-zf-size}-order"]):not([class*="#{$-zf-size}-offset"]) {
         flex-basis: auto;
       }

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -44,7 +44,7 @@
 
   // Auto width
   @include -zf-each-breakpoint() {
-    .grid-x > [class*="#{$-zf-size}-"] {
+    .grid-x > [class*="#{$-zf-size}-"]:not([class*="#{$-zf-size}-order"]):not([class*="#{$-zf-size}-offset"]) {
       flex-basis: auto;
     }
     @if not($-zf-size == small) {
@@ -254,7 +254,7 @@
 
 
     @include -zf-each-breakpoint() {
-      > [class*="#{$-zf-size}-"] {
+      > [class*="#{$-zf-size}-"]:not([class*="#{$-zf-size}-order"]):not([class*="#{$-zf-size}-offset"]) {
         flex-basis: auto;
       }
 

--- a/test/visual/xy-grid/kitchen-sink.html
+++ b/test/visual/xy-grid/kitchen-sink.html
@@ -446,7 +446,25 @@
         <h3>Here's my footer</h3>
       </div>
     </div>
-    
+
+  <h3>Test case from <a href="https://github.com/zurb/foundation-sites/issues/10141#issuecomment-308679657">Issue #10141</a></h3>
+  <div class="grid-x grid-padding-x grid-demo">
+    <div class="small-4 medium-4 large-4 cell">
+      <div class="grid-x grid-padding-x grid-padding-y align-middle">
+        <div class="shrink cell small-order-2 medium-order-2 large-order-1">
+          <img src="http://lorempixel.com/75/75/nature" alt="">
+        </div>
+        <div class="auto cell small-order-1 medium-order-1 large-order-2">
+          <h2>source second</h2>
+          <p>This should wrap around nicely... but seems to don't when there's a longer text...</p>
+        </div>
+      </div>
+    </div>
+    <div class="small-8 medium-8 large-8 cell">
+      <h1>filler</h1>
+    </div>
+  </div>
+
     <script src="../assets/js/vendor.js"></script>
     <script src="../assets/js/foundation.js"></script>
     <script>


### PR DESCRIPTION
This is a little bit of a hackfix, but we're running into a situation where the wildcard-style flex-basis resets we introduced in https://github.com/zurb/foundation-sites/pull/10164 collide with other responsive flex or grid classes like `[size]-order-*` and `[size]-offset-*`.

The "pure" fix would be to go back to having every size class reset its flex basis, but that generates truly absurd amounts of HTML. Other fixes explored prior to #10164 ran into various browser flexbugs that broke different browsers.  Thus, I propose this workaround which explicitly excludes the 2 sets of responsive classes we generate that make sense to apply to cells and are not grid sizing classes.