### PR TITLE
Fix #10229 - Add align item center to `.menu.simple`!

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -189,6 +189,10 @@ $menu-item-background-hover: $light-gray !default;
 /// @param {Keyword} $dir [$global-left] - Direction of the menu. This effects the side of the <li> that receives the margin.
 /// @param {Number} $margin [$menu-simple-margin] - The margin to apply to each <li>.
 @mixin menu-simple($dir: $global-left, $margin: $menu-simple-margin) {
+  @if $global-flexbox {
+    align-items: center;
+  }
+  
   li + li {
     margin-#{$dir}: $margin;
   }


### PR DESCRIPTION
This fixes #10229