### PR TITLE
Remove `rem-calc` use for `xy-grid-container`

### DIFF
--- a/scss/xy-grid/_grid.scss
+++ b/scss/xy-grid/_grid.scss
@@ -12,7 +12,7 @@
 @mixin xy-grid-container(
   $width: $grid-container
 ) {
-  max-width: rem-calc($width);
+  max-width: $width;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
This allows for more flexible widths, eg `vw`. See https://github.com/zurb/foundation-sites/issues/10141#issuecomment-310682672 for details.