### PR TITLE
Fix duplicate CSS property on slider-handle mixin

### DIFF
--- a/scss/components/_slider.scss
+++ b/scss/components/_slider.scss
@@ -52,7 +52,6 @@ $slider-transition: all 0.2s ease-in-out !default;
 @mixin slider-handle {
   @include disable-mouse-outline;
   @include vertical-center;
-  position: absolute;
   left: 0;
   z-index: 1;
 


### PR DESCRIPTION
Hi, 

We don't need to have the CSS positon property here:
https://github.com/zurb/foundation-sites/blob/41137b01455b73c217e1cf23b353bed363c0da29/scss/components/_slider.scss#L55

as it is already done in the vertical-center mixin:
https://github.com/zurb/foundation-sites/blob/6606bfdf7c28eaa1234559a636698be5fb97055d/scss/util/_mixins.scss#L239

as a result, we get a duplicate CSS position property in the CSS generated:
https://github.com/zurb/foundation-sites/blob/d2926e29e6ac3854ce105e7a64494286d7e7537b/dist/css/foundation.css#L4439-L4444
