### PR TITLE
Fix Interchange when used on images path containing parenthesis

### DIFF
--- a/js/foundation.interchange.js
+++ b/js/foundation.interchange.js
@@ -157,6 +157,7 @@ class Interchange extends Plugin {
     }
     // Replacing background images
     else if (path.match(/\.(gif|jpg|jpeg|png|svg|tiff)([?#].*)?/i)) {
+      path = path.replace(/\(/g, '%28').replace(/\)/g, '%29');
       this.$element.css({ 'background-image': 'url('+path+')' })
           .trigger(trigger);
     }

--- a/test/javascript/components/interchange.js
+++ b/test/javascript/components/interchange.js
@@ -12,7 +12,7 @@ describe('Interchange', function() {
     switch (type) {
       case 'image':
       case 'background':
-        return `_build/assets/img/interchange/${size}.jpg`;
+        return `_build/assets/img/interchange/strip_icc()/${size}.jpg`;
       default:
         return `_build/assets/partials/interchange-${size}.html`;
     }
@@ -79,7 +79,7 @@ describe('Interchange', function() {
 
       plugin.replace(getPath('background', 'large'));
 
-      $html[0].style.backgroundImage.should.contain(getPath('background', 'large'));
+      $html[0].style.backgroundImage.should.contain(getPath('background', 'large').replace(/\(/g, '%28').replace(/\)/g, '%29'));
     });
 
     it('replaces contents of div with templates', function() {
@@ -132,7 +132,7 @@ describe('Interchange', function() {
       plugin.rules.length.should.be.equal(3);
     });
 
-     it('extracts special queries from the plugin element', function() {
+    it('extracts special queries from the plugin element', function() {
       $html = $(generateTemplate('image')).attr('data-interchange', '[image.png, retina]').appendTo('body');
       plugin = new Foundation.Interchange($html, {});
 


### PR DESCRIPTION
Hi,

we faced an issue with Interchange plugin when the Interchange data contain some images with parenthesis in their URL.

The issue happens only for background style replacement.
It comes from the fact that Interchange concatenates the image path with 'url( )' which does already contain some parenthesis:
https://github.com/zurb/foundation-sites/blob/develop/js/foundation.interchange.js#L160

To fix that, i suggest escaping the parenthesis in the image path.

**Example of use case**
We do use Thumbor to manipulate our images.
As shown below, Thumbor's way of applying on-the-fly filter to images is by adding some keywords containing parenthesis on the picture url called:
http://thumbor.readthedocs.io/en/latest/strip_icc.html

**Note for the reviewers**
I've updated the test case to reflect this fix biut i'm not sure whether you prefer having a dedicated test for this case or simply, as I did, having the data used in all Interchange tests using URL containing parenthesis (this ensures that all scenarii work fine with parenthesis). Please let me know if you do prefer a dedicated test.

Cheers