### PR TITLE
Nest accordion arrows block within `.accordion-menu`!

### DIFF
--- a/scss/components/_accordion-menu.scss
+++ b/scss/components/_accordion-menu.scss
@@ -107,6 +107,15 @@ $accordionmenu-arrow-size: 6px !default;
         @include menu-nested($accordionmenu-nested-margin, right);
       }
     }
+
+    @if $accordionmenu-arrows {
+      @include zf-accordion-menu-left-right-arrows;
+
+      .is-accordion-submenu-parent[aria-expanded='true'] > a::after {
+        transform: rotate(180deg);
+        transform-origin: 50% 50%;
+      }
+    }
   }
 
   .is-accordion-submenu li {
@@ -158,14 +167,5 @@ $accordionmenu-arrow-size: 6px !default;
 
   .submenu-toggle-text {
     @include element-invisible;
-  }
-
-  @if $accordionmenu-arrows {
-    @include zf-accordion-menu-left-right-arrows;
-
-    .is-accordion-submenu-parent[aria-expanded='true'] > a::after {
-      transform: rotate(180deg);
-      transform-origin: 50% 50%;
-    }
   }
 }


### PR DESCRIPTION
This fixes one of the issues raised in #10279 
This just the dropdown arrow block within `accordion-menu`

For visual tests,
http://localhost:3000/menu/vertical-accordionmenu-alignment-flex.html
http://localhost:3000/menu/vertical-accordionmenu-alignment-float.html