### PR TITLE
TASK: extend docs with hint for a single cell in the xy grid

### DIFF
--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -117,6 +117,19 @@ below that. If you want to add padding below the `$max-width`, simply add the
   </div>
 </div>
 ```
+
+If you have just a single cell for a padding grid, you can save some markup by combining the `.grid-container`, `.grid-x` and `.grid-padding-x` classes together on the same element. You can still nest more grids inside this container like usual.
+
+<div class="warning callout">
+  <p>For a margin grid it needs to stay separated.</p>
+</div>
+
+```html
+<div class="grid-container grid-x grid-padding-x">
+  <div class="cell">cell</div>
+</div>
+```
+
 ---
 
 ## Auto Sizing


### PR DESCRIPTION
This PR extends the docs with a hint for a single cell in the xy grid. 

Based on the question here: https://github.com/zurb/foundation-sites/issues/10141#issuecomment-311686892

This could be helpful for others , if they search for something similar.