### PR TITLE
Custom Pattern and Validator code fix

### DIFF
--- a/docs/pages/abide.md
+++ b/docs/pages/abide.md
@@ -344,9 +344,14 @@ website: {
 * Add new patterns and validators before or after foundation is initialized
 
 ```javascript
-$(document).foundation();
+
+// Set paramaters
 Foundation.Abide.defaults.patterns['dashes_only'] = /^[0-9-]*$/;
 Foundation.Abide.defaults.validators['greater_than'] =
+
+// Init Foundation
+$(document).foundation();
+
 function($el,required,parent) {
   // parameter 1 is jQuery selector
   if (!required) return true;


### PR DESCRIPTION
In `Adding Custom Pattern and Validator` the JS example is broken.

Foundation is initialized before the defaults are set.

Changed code example to set params first, then init Foundation.