### PR TITLE
Changes align-self-center for align-self-middle

### DIFF
--- a/docs/pages/media-object.md
+++ b/docs/pages/media-object.md
@@ -88,7 +88,7 @@ In flexbox mode, you can use the <a href="flexbox.html#helper-classes">flexbox h
 
 ```html
 <div class="media-object">
-  <div class="media-object-section align-self-center">
+  <div class="media-object-section align-self-middle">
     <div class="thumbnail">
       <img src= "assets/img/media-object/avatar-2.jpg">
     </div>


### PR DESCRIPTION
The example shows how to vertically align parts of media object. There is no class “self-align-center”.