### PR TITLE
.progress-meter should use $progress-radius instead of $global-radius - Issue 10184

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-load-plugins": "^1.5.0",
     "gulp-newer": "^1.1.0",
     "gulp-plumber": "^1.0.1",
-    "gulp-postcss": "^7.0.0",
+    "gulp-postcss": "^6.4.1",
     "gulp-prompt": "^0.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-load-plugins": "^1.5.0",
     "gulp-newer": "^1.1.0",
     "gulp-plumber": "^1.0.1",
-    "gulp-postcss": "^6.4.1",
+    "gulp-postcss": "^7.0.0",
     "gulp-prompt": "^0.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",

--- a/scss/components/_progress-bar.scss
+++ b/scss/components/_progress-bar.scss
@@ -19,7 +19,7 @@
   background-color: $progress-meter-background;
 
   @if has-value($progress-radius) {
-    border-radius: $global-radius;
+    border-radius: $progress-radius;
   }
 }
 


### PR DESCRIPTION
As-per issue 10184, _progress-bar.scss should use $progress-radius on line 22, rather than $global-radius.