### PR TITLE
Remove `flex-grid-column()` duplicate `max-width`

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -88,10 +88,6 @@
   @if $columns == expand {
     min-width: 0;
   }
-  // max-width fixes IE 10/11 not respecting the flex-basis property
-  @if $columns != expand and $columns != shrink {
-    max-width: grid-column($columns);
-  }
 }
 
 /// Creates a block grid for a flex grid row.


### PR DESCRIPTION
Very small fix inside `flex-grid-column()` mixin: `max-width` fix is added twice: call to `flex-grid-size()` already import this fix once.

Also, the `min-width` fix should be inside `flex-grid-size()` for really fixing things for any size change.