### PR TITLE
Fix missing `.` with class names with xy grid

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -53,9 +53,9 @@
     // https://github.com/zurb/foundation-sites/pull/10222 and
     // https://github.com/zurb/foundation-sites/pull/10164
     .grid-x {
-      $str: "> #{$-zf-size}-shrink, > #{$-zf-size}-full";
+      $str: "> .#{$-zf-size}-shrink, > .#{$-zf-size}-full";
       @for $i from 1 through $grid-columns {
-        $str: $str + ", > #{$-zf-size}-#{$i}"
+        $str: $str + ", > .#{$-zf-size}-#{$i}"
       }
       #{$str} {
         flex-basis: auto;


### PR DESCRIPTION
Noticed a bug when reworking grid container that a lot of the base classes (without margin/padding) were missing `.` in their class names and as a result weren't working.
