### PR TITLE
Grid Container Rework

### DIFF
--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -90,11 +90,24 @@ To define a grid type, simple set `.grid-margin-x` or `.grid-padding-x` on the g
 
 ## Grid Container
 
-The grid defaults to the full width of its container. In order to contain the grid, use the `.grid-container` class.
+The grid defaults to the full width of the available space. To contain it use the `grid-container` class. The container will be centered and have a max-width equal to your `$grid-container` setting (1200px by default), along with padding on the left/right equal to half your `$grid-container-padding` setting.
 
 ```html
 <div class="grid-container">
-  <div class="grid-x">
+  <div class="grid-x grid-margin-x">
+    <div class="cell small-4">cell</div>
+    <div class="cell small-4">cell</div>
+    <div class="cell small-4">cell</div>
+  </div>
+</div>
+```
+### Grid Container Fluid
+
+To stretch the content to the full width of the available space, simply use the class `grid-container-fluid` instead.
+
+```html
+<div class="grid-container-fluid">
+  <div class="grid-x grid-margin-x">
     <div class="cell small-4">cell</div>
     <div class="cell small-4">cell</div>
     <div class="cell small-4">cell</div>
@@ -102,14 +115,24 @@ The grid defaults to the full width of its container. In order to contain the gr
 </div>
 ```
 
-By default, the container will be centered and have a max-width equal to your
-`$max-width` setting (1200px by default), and be flush to the screen for widths
-below that. If you want to add padding below the `$max-width`, simply add the
-`.grid-container-padded` class to your grid container.
+### Grid Container Full
+
+To stretch the content to the full width of the available space and remove grid container padding, simply use the class `grid-container-full`. Note that this is primarily for use with `grid-margin-x` - it works with `grid-padding-x` too, but will work the same as `grid-container-fluid`.
+
+<div class="callout alert">
+  <p>Please note when using the `grid-container-full` and `grid-margin-x` you will also need to hide the horizontal overflow in order for this to work correctly if your content is going to touch the sides of the viewport.</p>
+  <p>The best way to do this is:
+  ```
+  body {
+    overflow-x: hidden;
+  }
+  ```
+  </p>
+</div>
 
 ```html
-<div class="grid-container grid-container-padded">
-  <div class="grid-x">
+<div class="grid-container-full">
+  <div class="grid-x grid-margin-x">
     <div class="cell small-4">cell</div>
     <div class="cell small-4">cell</div>
     <div class="cell small-4">cell</div>

--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -103,10 +103,10 @@ The grid defaults to the full width of the available space. To contain it use th
 ```
 ### Grid Container Fluid
 
-To stretch the content to the full width of the available space, simply use the class `grid-container-fluid` instead.
+To stretch the content to the full width of the available space, simply add the class `fluid` to your `grid-container`.
 
 ```html
-<div class="grid-container-fluid">
+<div class="grid-container fluid">
   <div class="grid-x grid-margin-x">
     <div class="cell small-4">cell</div>
     <div class="cell small-4">cell</div>
@@ -117,21 +117,15 @@ To stretch the content to the full width of the available space, simply use the 
 
 ### Grid Container Full
 
-To stretch the content to the full width of the available space and remove grid container padding, simply use the class `grid-container-full`. Note that this is primarily for use with `grid-margin-x` - it works with `grid-padding-x` too, but will work the same as `grid-container-fluid`.
+To stretch the content to the full width of the available space and remove grid container padding, simply add the class `full` to your `grid-container`. Note that this variation is primarily for use for the `grid-margin-x` - it works with `grid-padding-x` too, but will work the same as `.grid-container.fluid`.
 
 <div class="callout alert">
-  <p>Please note when using the `grid-container-full` and `grid-margin-x` you will also need to hide the horizontal overflow in order for this to work correctly if your content is going to touch the sides of the viewport.</p>
-  <p>The best way to do this is:
-  ```
-  body {
-    overflow-x: hidden;
-  }
-  ```
-  </p>
+  <p>Please note that when you are using `grid-margin-x` on a `grid-container` with `full` class you will also need to hide the horizontal overflow in order for this to work correctly if your content is going to touch the sides of the viewport.</p>
+  <p>The best way to do this is:&nbsp; `body {overflow-x: hidden;}`</p>
 </div>
 
 ```html
-<div class="grid-container-full">
+<div class="grid-container full">
   <div class="grid-x grid-margin-x">
     <div class="cell small-4">cell</div>
     <div class="cell small-4">cell</div>

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -14,8 +14,12 @@
     @include xy-grid-container;
   }
 
-  .grid-container-padded {
-    @include xy-grid-container-padding;
+  .grid-container-fluid {
+    @include xy-grid-container(100%);
+  }
+
+  .grid-container-full {
+    @include xy-grid-container(100%, 0);
   }
 
   // Base grid styles
@@ -161,6 +165,13 @@
 
     // Negative margin for nested grids
     .grid-padding-x {
+      @include xy-gutters($negative: true);
+    }
+
+    // Negative margin for grids within `grid-container/grid-container-fluid`
+    // This allows margin and padding grids to line up with eachother
+    .grid-container > &,
+    .grid-container-fluid > & {
       @include xy-gutters($negative: true);
     }
 

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -12,14 +12,14 @@
   // Grid Container
   .grid-container {
     @include xy-grid-container;
-  }
 
-  .grid-container-fluid {
-    @include xy-grid-container(100%);
-  }
+    &.fluid {
+      @include xy-grid-container(100%);
+    }
 
-  .grid-container-full {
-    @include xy-grid-container(100%, 0);
+    &.full {
+      @include xy-grid-container(100%, 0);
+    }
   }
 
   // Base grid styles
@@ -168,10 +168,9 @@
       @include xy-gutters($negative: true);
     }
 
-    // Negative margin for grids within `grid-container/grid-container-fluid`
+    // Negative margin for grids within `grid-container/grid-container.fluid`
     // This allows margin and padding grids to line up with eachother
-    .grid-container > &,
-    .grid-container-fluid > & {
+    .grid-container:not(.full) > & {
       @include xy-gutters($negative: true);
     }
 

--- a/scss/xy-grid/_grid.scss
+++ b/scss/xy-grid/_grid.scss
@@ -10,34 +10,13 @@
 ///
 /// @param {Number} $width [$grid-container] - a width to limit the container to.
 @mixin xy-grid-container(
-  $width: $grid-container
+  $width: $grid-container,
+  $padding: $grid-container-padding
 ) {
+  @include xy-gutters($gutters: $padding, $gutter-type: padding);
+
   max-width: $width;
   margin: 0 auto;
-}
-
-/// Add padding to your container, up to a particular size
-///
-/// @param {Number} $width [$grid-container] - a width to limit the container to.
-@mixin xy-grid-container-padding(
-  $padding: $grid-container-padding,
-  $max: $grid-container-max
-) {
-  // Output our margin gutters.
-  @if (type-of($padding) == 'map') {
-    @include -zf-breakpoint-value(auto, $padding) {
-      padding-left: rem-calc($-zf-bp-value / 2);
-      padding-right: rem-calc($-zf-bp-value / 2);
-    }
-  }
-  @elseif (type-of($padding) == 'number') {
-    padding-left: rem-calc($padding) / 2;
-    padding-right: rem-calc($padding) / 2;
-  }
-  @include breakpoint($max) {
-    padding-left: 0;
-    padding-right: 0;
-  }
 }
 
 /// Creates a container for your flex cells.

--- a/test/visual/xy-grid/containers.html
+++ b/test/visual/xy-grid/containers.html
@@ -8,6 +8,11 @@
     <title>xy margin grid</title>
     <link href="../assets/css/foundation.css" rel="stylesheet" />
     <style>
+      body {
+        overflow-x: hidden;
+        text-align: center;
+      }
+
       .demo {
         background: #1779ba;
         color: white;
@@ -23,36 +28,66 @@
     </style>
   </head>
   <body>
+
+    <h1>Grid Container</h1>
+    <p>The below 2 examples should line up with each other.</p>
+
     <div class="grid-container">
-      <div class="grid-x grid-padding-x">
-        <div class="cell">
-          <h1>Grid Container</h1>
-
-          <div class="primary callout">
-            <p>Resize the window to know the difference!</p>
-          </div>
-
-          <h4>With no `grid-container-padding` should be flush below 1200px, and bounded and centered above</h4>
-
-          <div class="grid-container">
-            <div class="grid-x grid-margin-x">
-              <div class="cell medium-12"><div class="demo">12/12</div></div>
-            </div>
-          </div>
-
-          <h4>With `grid-container-padded` should have padding below 1200px, corresponding to responsive gutters</h4>
-
-          <div class="grid-container grid-container-padded">
-            <div class="grid-x grid-margin-x">
-              <div class="cell medium-12"><div class="demo">12/12</div></div>
-            </div>
-          </div>
-        </div>
-        
-
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
       </div>
     </div>
-    
+
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+      </div>
+    </div>
+
+    <hr>
+
+    <h1>Grid Container Fluid</h1>
+    <p>The below 2 examples should line up with each other.</p>
+
+    <div class="grid-container-fluid">
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+      </div>
+    </div>
+
+    <div class="grid-container-fluid">
+      <div class="grid-x grid-padding-x">
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+      </div>
+    </div>
+
+    <hr>
+
+    <h1>Grid Container Full</h1>
+    <p>The below 2 examples should <strong>NOT</strong> line up with each other.<br>
+    This is because we don't want to cut off the padding on the padding version, but we want the margin version to be flush with the edge.</p>
+
+    <div class="callout alert">
+      <p>Also note the use of `overflow-x: hidden;` on the `body`. This is required for this to work correctly, but is noted in the docs.</p>
+    </div>
+
+    <div class="grid-container-full">
+      <div class="grid-x grid-margin-x">
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+      </div>
+    </div>
+
+    <div class="grid-container-full">
+      <div class="grid-x grid-padding-x">
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+        <div class="cell medium-6"><div class="demo">Cell</div></div>
+      </div>
+    </div>
 
     <script src="../assets/js/vendor.js"></script>
     <script src="../assets/js/foundation.js"></script>

--- a/test/visual/xy-grid/containers.html
+++ b/test/visual/xy-grid/containers.html
@@ -51,14 +51,14 @@
     <h1>Grid Container Fluid</h1>
     <p>The below 2 examples should line up with each other.</p>
 
-    <div class="grid-container-fluid">
+    <div class="grid-container fluid">
       <div class="grid-x grid-margin-x">
         <div class="cell medium-6"><div class="demo">Cell</div></div>
         <div class="cell medium-6"><div class="demo">Cell</div></div>
       </div>
     </div>
 
-    <div class="grid-container-fluid">
+    <div class="grid-container fluid">
       <div class="grid-x grid-padding-x">
         <div class="cell medium-6"><div class="demo">Cell</div></div>
         <div class="cell medium-6"><div class="demo">Cell</div></div>
@@ -75,14 +75,14 @@
       <p>Also note the use of `overflow-x: hidden;` on the `body`. This is required for this to work correctly, but is noted in the docs.</p>
     </div>
 
-    <div class="grid-container-full">
+    <div class="grid-container full">
       <div class="grid-x grid-margin-x">
         <div class="cell medium-6"><div class="demo">Cell</div></div>
         <div class="cell medium-6"><div class="demo">Cell</div></div>
       </div>
     </div>
 
-    <div class="grid-container-full">
+    <div class="grid-container full">
       <div class="grid-x grid-padding-x">
         <div class="cell medium-6"><div class="demo">Cell</div></div>
         <div class="cell medium-6"><div class="demo">Cell</div></div>


### PR DESCRIPTION
First take on the reworked grid container. Updates docs to show usage as well as modified visual test to show this visually.

To confirm what this does:

- reworks `grid-container` to have padding by default
- removes `grid-container-padded` but use its variables for the container padding
- adds `grid-container-fluid` and `grid-container-full`
- Makes `grid-padding-x` have negative margins if within `grid-container/grid-container-fluid` to properly line up with margin grids

This should get some solid testing before merging just to make sure this is the behaviour we want, but from the visual tests it works great.