### PR TITLE
Fixed: I made the option posible recursively merge.

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -19,7 +19,7 @@ class Abide extends Plugin {
    */
   _setup(element, options = {}) {
     this.$element = element;
-    this.options  = $.extend({}, Abide.defaults, this.$element.data(), options);
+    this.options  = $.extend(true, {}, Abide.defaults, this.$element.data(), options);
 
     this.className = 'Abide'; // ie9 back compat
     this._init();

--- a/test/javascript/components/abide.js
+++ b/test/javascript/components/abide.js
@@ -18,6 +18,22 @@ describe('Abide', function() {
       plugin.$element.should.be.an('object');
       plugin.options.should.be.an('object');
     });
+
+    it('the options are recursively merged', function() {
+      $html = $('<form data-abide novalidate></form>').appendTo('body');
+
+      var options = {
+        validators: {
+          notEqualTo: function (el, required, parent) {
+            return $(`#${el.attr('data-equalto')}`).val() !== el.val();
+          }
+        }
+      };
+
+      plugin = new Foundation.Abide($html, options);
+
+      plugin.options.validators.should.includes.keys('equalTo', 'notEqualTo');
+    });
   });
 
   describe('validateInput()', function() {


### PR DESCRIPTION
I made the option posible recursively merge for Abide component.
Only Abide component.

## Before

`Foundation.Abide.defaults.validators` was overwritten.

```js
var options = {
  validators: {
    notEqualTo: function (el, required, parent) {
      return $(`#${el.attr('data-equalto')}`).val() !== el.val();
    }
  }
};

plugin = new Foundation.Abide($html, options);

Foundation.Abide.defaults.validators //=> { equalTo: function }
plugin.options.validators //=> { notEqualTo: function }
```

## After

```js
...

plugin = new Foundation.Abide($html, options);

Foundation.Abide.defaults.validators //=> { equalTo: function }
plugin.options.validators //=> {  equalTo: function, notEqualTo: function }
```

## Why did you correspond only to Abide?

There was only Abide component which included the object in the option.

```js
for (var name in Foundation._plugins) {
  var defaults = Foundation._plugins[name].defaults
  for (var key in defaults) {
    if (defaults[key] instanceof Object) {
      console.log(name);
    }
  }
}
```
=> `abide`
