### PR TITLE
Off-canvas with sticky / fixed elements [old]

### DIFF
--- a/docs/layout/default.html
+++ b/docs/layout/default.html
@@ -41,7 +41,7 @@
         </div>
       </a> -->
 
-      <div class="docs-sticky-top-bar">
+      <div class="docs-sticky-top-bar" data-off-canvas-sticky>
         {{> navigation}}
         {{> mobile-navigation}}
         {{> search-bar}}
@@ -54,7 +54,7 @@
 {{> body}}
         </div>
         <div class="medium-3 large-2 medium-pull-9 large-pull-10 hide-for-small-only columns" data-sticky-container>
-          <div class="docs-nav-container" data-sticky data-anchor="body-container" data-margin-top="6">
+          <div class="docs-nav-container" data-sticky data-anchor="body-container" data-margin-top="6" data-off-canvas-sticky>
             {{> component-list}}
           </div>
         </div>

--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -389,6 +389,25 @@ Advanced off-canvas users may use the new `contentId` option to bind an element 
 
 ---
 
+## Sticky
+
+By default an element with `position: fixed` disappears when opening an off-canvas with push transition. The reason for this is the transform property of the off-canvas content container what causes a `position: absolute` behavior for the fixed element.
+
+The good news: we've added the possibility to preserve the fixed appearance!
+You only have to add the attribute `data-off-canvas-sticky` to every sticky / fixed element that is supposed to remain fixed after opening the off-canvas.
+
+<div class="callout warning">
+  Please note that using this attribute will force the option `contentScroll: false`
+</div>
+
+```html
+<div class="top-bar sticky" data-sticky data-off-canvas-sticky>
+  Sticky top bar that will remain sticky after having opened an off-canvas
+</div>
+```
+
+---
+
 ## Migrating from versions prior to v6.4
 
 If you're upgrading from v6.3 there's nothing to do unless you haven't changed the default value of `$offcanvas-shadow`. Prior to v6.4 this variable was used for both, overlap and push off-canvas elements. Now it's only used for the overlap element whereas the push element uses two new variables:

--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -300,8 +300,13 @@ $maincontent-class: 'off-canvas-content' !default;
 /// Sets the styles for the content container.
 @mixin off-canvas-content() {
   transform: none;
-  transition: transform $offcanvas-transition-length $offcanvas-transition-timing;
   backface-visibility: hidden;
+
+  // Bind to has-transition-X class to prevent transition for transform:none
+  &.has-transition-overlap,
+  &.has-transition-push {
+    transition: transform $offcanvas-transition-length $offcanvas-transition-timing;
+  }
 
   // Transform scope until the element is closed (makes sure transitionend gets triggered)
   &.has-transition-push {

--- a/test/visual/offcanvas/sticky.html
+++ b/test/visual/offcanvas/sticky.html
@@ -100,7 +100,7 @@
           <div id="content" class="off-canvas-content" data-off-canvas-content>
 
             <div class="top-bar-container" data-sticky-container>
-              <div class="sticky" data-sticky data-options="anchor: page; marginTop: 0; stickyOn: small;" style="width: 100%;">
+              <div class="sticky" data-sticky data-off-canvas-sticky data-options="anchor: page; marginTop: 0; stickyOn: small;" style="width: 100%;">
                 <div class="top-bar">
                   <div class="">
                     <div class="top-bar-left">


### PR DESCRIPTION
Guess I've come out as an off-canvas power user with my prior PR :wink: 
So it's probably no suprise I'm facing a new off-canvas problem (apart from the support of push transition for nested off-canvas elements).

I'm often using a sticky top bar for medium down to open an off-canvas navi.
What really bothers me then is the loss of the fixed state while the off-canvas with push transition is opened.
This is caused by the transform scope of the content container and as far as I know Brett, discarding the transform setup is not an option for him (I agree to this because performance is definitely important).

That's why I've created the possibility to preserve the fixed state anyway.
I'm pseudo fixing the sticky elements by setting inline CSS when opening the off-canvas (position absolute values) and restoring the original values after having closed the off-canvas again.

This PR adds the new attribute `data-off-canvas-sticky` that has to be added to each sticky / fixed element that is supposed to get pseudo fixed on opening an off-canvas with push transition.
Besides I've introduced the new event `closedEnd.zf.offcanvas` that gets triggered once the close transition has finished.

@brettsmason @kball **what do you think? Looking forward to getting you feedback on this!**

You can easily see my changes in action when you open the off-canvas docs page, scroll down a bit and open a push off-canvas.
Currently (live) the fixed navi disappears. In my fork it remains sticky (pseudo fixed).
