### PR TITLE
use https as protocol

### DIFF
--- a/docs/layout/default.html
+++ b/docs/layout/default.html
@@ -9,7 +9,7 @@
   <link rel="icon" href="assets/img/icons/foundation-favicon.ico" type="image/x-icon">
   <title>{{#unlesspage 'index'}}{{title}} | {{/unlesspage}}Foundation for Sites 6 Docs</title>
   <link href="assets/css/docs.css?t=1" rel="stylesheet" />
-  <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
   <!-- <link rel="stylesheet" href="./node_modules/motion-ui/dist/motion-ui.css" /> -->
   <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>

--- a/docs/pages/equalizer.md
+++ b/docs/pages/equalizer.md
@@ -125,7 +125,7 @@ If you have a gallery of items that wrap multiple times, Equalizer can be config
 <div class="row small-up-1 medium-up-2 large-up-4" data-equalizer data-equalize-by-row="true">
   <div class="column">
     <div class="callout" data-equalizer-watch>
-      <img src="//placehold.it/180x200" class="thumbnail" alt="">
+      <img src="https://placehold.it/180x200" class="thumbnail" alt="">
       <p>Lorem ipsum dolor sit amet<p>
     </div>
   </div>
@@ -141,7 +141,7 @@ If you have a gallery of items that wrap multiple times, Equalizer can be config
   </div>
   <div class="column">
     <div class="callout" data-equalizer-watch>
-      <img src="//placehold.it/180x180" class="thumbnail" alt="">
+      <img src="https://placehold.it/180x180" class="thumbnail" alt="">
     </div>
   </div>
   <div class="column">
@@ -156,12 +156,12 @@ If you have a gallery of items that wrap multiple times, Equalizer can be config
   </div>
   <div class="column">
     <div class="callout" data-equalizer-watch>
-      <img src="//placehold.it/180x400" class="thumbnail" alt="">
+      <img src="https://placehold.it/180x400" class="thumbnail" alt="">
     </div>
   </div>
   <div class="column">
     <div class="callout" data-equalizer-watch>
-      <img src="//placehold.it/180x200" class="thumbnail" alt="">
+      <img src="https://placehold.it/180x200" class="thumbnail" alt="">
       <p>Lorem ipsum dolor sit amet<p>
     </div>
   </div>
@@ -177,22 +177,7 @@ If you have a gallery of items that wrap multiple times, Equalizer can be config
   </div>
   <div class="column">
     <div class="callout" data-equalizer-watch>
-      <img src="//placehold.it/180x180" class="thumbnail" alt="">
-    </div>
-  </div>
-  <div class="column">
-    <div class="callout" data-equalizer-watch>
-      <p>Lorem ipsum dolor sit amet<p>
-    </div>
-  </div>
-  <div class="column">
-    <div class="callout" data-equalizer-watch>
-      <p>Lorem ipsum dolor sit amet<p>
-    </div>
-  </div>
-  <div class="column">
-    <div class="callout" data-equalizer-watch>
-      <p>Lorem ipsum dolor sit amet<p>
+      <img src="https://placehold.it/180x180" class="thumbnail" alt="">
     </div>
   </div>
   <div class="column">
@@ -212,7 +197,22 @@ If you have a gallery of items that wrap multiple times, Equalizer can be config
   </div>
   <div class="column">
     <div class="callout" data-equalizer-watch>
-      <img src="//placehold.it/180x400" class="thumbnail" alt="">
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <p>Lorem ipsum dolor sit amet<p>
+    </div>
+  </div>
+  <div class="column">
+    <div class="callout" data-equalizer-watch>
+      <img src="https://placehold.it/180x400" class="thumbnail" alt="">
     </div>
   </div>
 </div>

--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -541,22 +541,22 @@ Block grids are a shorthand way to create equally-sized columns. Add a class of 
 ```html_example
 <div class="row small-up-2 medium-up-3 large-up-4">
   <div class="column column-block">
-    <img src="//placehold.it/600x600" class="thumbnail" alt="">
+    <img src="https://placehold.it/600x600" class="thumbnail" alt="">
   </div>
   <div class="column column-block">
-    <img src="//placehold.it/600x600" class="thumbnail" alt="">
+    <img src="https://placehold.it/600x600" class="thumbnail" alt="">
   </div>
   <div class="column column-block">
-    <img src="//placehold.it/600x600" class="thumbnail" alt="">
+    <img src="https://placehold.it/600x600" class="thumbnail" alt="">
   </div>
   <div class="column column-block">
-    <img src="//placehold.it/600x600" class="thumbnail" alt="">
+    <img src="https://placehold.it/600x600" class="thumbnail" alt="">
   </div>
   <div class="column column-block">
-    <img src="//placehold.it/600x600" class="thumbnail" alt="">
+    <img src="https://placehold.it/600x600" class="thumbnail" alt="">
   </div>
   <div class="column column-block">
-    <img src="//placehold.it/600x600" class="thumbnail" alt="">
+    <img src="https://placehold.it/600x600" class="thumbnail" alt="">
   </div>
 </div>
 ```

--- a/docs/pages/starter-projects.md
+++ b/docs/pages/starter-projects.md
@@ -28,7 +28,7 @@ It's also possible to download the template files directly from GitHub. Run `npm
 ## ZURB Template
 
 <div class="responsive-embed widescreen mb1">
-  <iframe id="zurb-template-starter" data-linkable-video='3Uj74uJ3GSQ' width="500" height="315" src="//www.youtube.com/embed/3Uj74uJ3GSQ?enablejsapi=1" enablejsapi="1" frameborder="0" allowfullscreen ></iframe>
+  <iframe id="zurb-template-starter" data-linkable-video='3Uj74uJ3GSQ' width="500" height="315" src="https://www.youtube.com/embed/3Uj74uJ3GSQ?enablejsapi=1" enablejsapi="1" frameborder="0" allowfullscreen ></iframe>
   <a id="docs-mobile-video-link" class="docs-mobile-video" target="_blank" href="https://www.youtube.com/watch?v=3Uj74uJ3GSQ"></a>
 </div>
 

--- a/test/visual/accordion-menu/accordionmenu.html
+++ b/test/visual/accordion-menu/accordionmenu.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/active-menu-flex.html
+++ b/test/visual/menu/active-menu-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
     <style>

--- a/test/visual/menu/active-menu-float.html
+++ b/test/visual/menu/active-menu-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/basic-menu-flex.html
+++ b/test/visual/menu/basic-menu-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/basic-menu-float.html
+++ b/test/visual/menu/basic-menu-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/expanded-menu-flex.html
+++ b/test/visual/menu/expanded-menu-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/expanded-menu-float.html
+++ b/test/visual/menu/expanded-menu-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-dropdownmenu-alignment-flex.html
+++ b/test/visual/menu/horizontal-dropdownmenu-alignment-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-dropdownmenu-alignment-float.html
+++ b/test/visual/menu/horizontal-dropdownmenu-alignment-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-menu-alignment-flex.html
+++ b/test/visual/menu/horizontal-menu-alignment-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-menu-alignment-float.html
+++ b/test/visual/menu/horizontal-menu-alignment-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-centered-flex.html
+++ b/test/visual/menu/menu-centered-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-centered-float.html
+++ b/test/visual/menu/menu-centered-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-form-flex.html
+++ b/test/visual/menu/menu-form-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-form-float.html
+++ b/test/visual/menu/menu-form-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-icons-flex.html
+++ b/test/visual/menu/menu-icons-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-icons-float.html
+++ b/test/visual/menu/menu-icons-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-text-flex.html
+++ b/test/visual/menu/menu-text-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-text-float.html
+++ b/test/visual/menu/menu-text-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/nested-menu-flex.html
+++ b/test/visual/menu/nested-menu-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/nested-menu-float.html
+++ b/test/visual/menu/nested-menu-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/responsive-menu-flex.html
+++ b/test/visual/menu/responsive-menu-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/responsive-menu-float.html
+++ b/test/visual/menu/responsive-menu-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/simple-menu-flex.html
+++ b/test/visual/menu/simple-menu-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/simple-menu-float.html
+++ b/test/visual/menu/simple-menu-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-accordionmenu-alignment-flex.html
+++ b/test/visual/menu/vertical-accordionmenu-alignment-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-accordionmenu-alignment-float.html
+++ b/test/visual/menu/vertical-accordionmenu-alignment-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-drilldownmenu-alignment-flex.html
+++ b/test/visual/menu/vertical-drilldownmenu-alignment-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-drilldownmenu-alignment-float.html
+++ b/test/visual/menu/vertical-drilldownmenu-alignment-float.html
@@ -8,7 +8,7 @@
     <title>Vertical Drillodwn</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-dropdownmenu-alignment-flex.html
+++ b/test/visual/menu/vertical-dropdownmenu-alignment-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-dropdownmenu-alignment-float.html
+++ b/test/visual/menu/vertical-dropdownmenu-alignment-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-menu-alignment-flex.html
+++ b/test/visual/menu/vertical-menu-alignment-flex.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-menu-alignment-float.html
+++ b/test/visual/menu/vertical-menu-alignment-float.html
@@ -8,7 +8,7 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {


### PR DESCRIPTION
This PR adds https to the protocol relative URLs so https is enforced.

This solves different issues:
* testing locally works (does not use the file protocol anymore)
* enforces https and so can use http/2 (faster)
* prevents MitM attacks
* protocol relative URLs are an anti-pattern for a few years
* ...

https://jeremywagner.me/blog/stop-using-the-protocol-relative-url
https://www.paulirish.com/2010/the-protocol-relative-url/