### PR TITLE
fix Travis build / npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-load-plugins": "^1.5.0",
     "gulp-newer": "^1.1.0",
     "gulp-plumber": "^1.0.1",
-    "gulp-postcss": "^6.4.1",
+    "gulp-postcss": "^6.4.0",
     "gulp-prompt": "^0.2.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",


### PR DESCRIPTION
This would also affect users of older npm versions.
npm can not find gulp-postcss 6.4.1 and so it fails.

https://github.com/postcss/gulp-postcss/releases

See the [log](https://s3.amazonaws.com/archive.travis-ci.org/jobs/252964124/log.txt?X-Amz-Expires=30&X-Amz-Date=20170712T212949Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20170712/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=10152e4ec35485aab4efc26452e96a40a0488b53e332e5f4b26e7356f26df561) of the last Travis build. 

It was caused / introduced by the deploy task:

https://github.com/zurb/foundation-sites/commit/414f1b82f763d0062f627a322a65a86a10890f90#diff-b9cfc7f2cdf78a7f4b91a753d10865a

https://github.com/zurb/foundation-sites/blob/d9ff0c0e2f3d82bf525cd4b9091b28632b17b087/gulp/tasks/deploy.js#L432

PS: The [lock file](https://raw.githubusercontent.com/zurb/foundation-sites/cd932445bfbedb42de25318bbb22b401eec92d7f/package-lock.json) still has 6.3.1 at the top.