### PR TITLE
removes bower install from manual installation

### DIFF
--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -47,7 +47,6 @@ Then open the folder in your command line, and install the needed dependencies:
 ```bash
 cd projectname
 npm install
-bower install
 ```
 
 Finally, run `npm start` to run the Sass compiler. It will re-run every time you save a Sass file.
@@ -65,7 +64,6 @@ Then open the folder in your command line, and install the needed dependencies:
 ```bash
 cd projectname
 npm install
-bower install
 ```
 
 Finally, run `npm start` to run Gulp. Your finished site will be created in a folder called `dist`, viewable at this URL:


### PR DESCRIPTION
As the new version of foundation do not use bower and the zurb and basic template do not have a bower.json file, the documentation should also get updated and the bower install command should get removed