### PR TITLE
Further fix for off-canvas content classes

### DIFF
--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -175,12 +175,14 @@ class OffCanvas extends Plugin {
   /**
    * Removes the CSS transition/position classes of the off-canvas content container.
    * Removing the classes is important when another off-canvas gets opened that uses the same content container.
+   * @param {Boolean} hasReveal - true if related off-canvas element is revealed.
    * @private
    */
   _removeContentClasses(hasReveal) {
-    this.$content.removeClass(this.contentClasses.base.join(' '));
-    if (hasReveal === true) {
-      this.$content.removeClass(this.contentClasses.reveal.join(' '));
+    if (typeof hasReveal !== 'boolean') {
+      this.$content.removeClass(this.contentClasses.base.join(' '));
+    } else if (hasReveal === false) {
+      this.$content.removeClass(`has-reveal-${this.position}`);
     }
   }
 
@@ -192,8 +194,9 @@ class OffCanvas extends Plugin {
    */
   _addContentClasses(hasReveal) {
     this._removeContentClasses(hasReveal);
-    this.$content.addClass(`has-transition-${this.options.transition} has-position-${this.position}`);
-    if (hasReveal === true) {
+    if (typeof hasReveal !== 'boolean') {
+      this.$content.addClass(`has-transition-${this.options.transition} has-position-${this.position}`);
+    } else if (hasReveal === true) {
       this.$content.addClass(`has-reveal-${this.position}`);
     }
   }


### PR DESCRIPTION
This PR is a further fix for the off-canvas classes that didn't get toggled correctly if several revealed elements had been included. It is related to this PR: https://github.com/zurb/foundation-sites/pull/10421

There have been two problems:

1. each revealed element did remove all `has-reveal-x` classes before adding its own what is a problem because several revealed elements may share the same content container. I've now limited the removal to the single class that got added before.
2. the `has-transition-x` and `has-position-x` classes got added even if the element is revealed. That may cause issues because the related styles shouldn't be active if the element is revealed and no other element is opened. I'm now adding these classes only if the reveal feature is not included (`hasReveal` neither true nor false)

@brettsmason @IamManchanda thanks for spotting this issue!
My fix may be reviewed in your recently added visual test (offcanvas-reveal-modal-large.html)
