### PR TITLE
Rename duplicate $block-grid-max` to `$xy-block-grid-max` ...

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -185,7 +185,7 @@
 @mixin xy-block-grid-classes($margin-grid: true, $padding-grid: true) {
   @if $padding-grid {
     @include -zf-each-breakpoint {
-      @for $i from 1 through $block-grid-max {
+      @for $i from 1 through $xy-block-grid-max {
         .#{$-zf-size}-up-#{$i} {
           @include xy-grid-layout($i, '.cell', false, $gutter-type: padding);
         }
@@ -195,7 +195,7 @@
 
   @if $margin-grid {
     @include -zf-each-breakpoint {
-      @for $i from 1 through $block-grid-max {
+      @for $i from 1 through $xy-block-grid-max {
         // This is purely for responsive gutters - the margin grid has to go back and adjust widths (or heights)
         // for prior breakpoints based on the responsive gutter.
         @if(type-of($grid-margin-gutters) == 'map' and map-has-key($grid-margin-gutters, $-zf-size)) {
@@ -208,7 +208,7 @@
           }
         }
       }
-      @for $i from 1 through $block-grid-max {
+      @for $i from 1 through $xy-block-grid-max {
         .grid-margin-x.#{$-zf-size}-up-#{$i} {
           @include xy-grid-layout($i, '.cell', false, $gutter-type: margin, $breakpoint: $-zf-size);
         }

--- a/scss/xy-grid/_xy-grid.scss
+++ b/scss/xy-grid/_xy-grid.scss
@@ -33,14 +33,13 @@ $grid-padding-gutters: $grid-margin-gutters !default;
 /// @type Map | Length
 $grid-container-padding: $grid-padding-gutters !default;
 
-
-/// The maximum width to apply padding to a grid container
+/// The maximum width to apply to a grid container
 /// @type Number
 $grid-container-max: $global-width !default;
 
-/// The maximum number of cells in a block grid.
+/// The maximum number of cells in an XY block grid.
 /// @type Number
-$block-grid-max: 8 !default;
+$xy-block-grid-max: 8 !default;
 
 @import 'gutters';
 @import 'grid';


### PR DESCRIPTION
Allow for both types of block grids.
Closes #10432 