### PR TITLE
Add missing arguement for xy-grid-layout mixin

### DIFF
--- a/scss/xy-grid/_layout.scss
+++ b/scss/xy-grid/_layout.scss
@@ -28,6 +28,6 @@
   $size: percentage(1/$n);
 
   & > #{$selector} {
-    @include xy-cell($size, $gutter-output, $gutter-type: $gutter-type, $gutter-position: $gutter-position, $vertical: $vertical);
+    @include xy-cell($size, $gutter-output, $gutters, $gutter-type, $gutter-position, $breakpoint, $vertical);
   }
 }


### PR DESCRIPTION
Add missing 7th arguement to the `xy-cell` mixin within the `xy-grid-layout` mixin.
Closes #10401