### PR TITLE
Pin panini dependency while waiting for bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "normalize-scss": "6.0.0",
     "octophant": "^1.0.0",
     "opener": "^1.4.3",
-    "panini": "^1.4.0",
+    "panini": "1.4.0",
     "parker": "^1.0.0-alpha.0",
     "prettyjson": "^1.1.3",
     "require-dir": "^0.3.2",


### PR DESCRIPTION
The latest version of panini (1.5.0) introduces a breakage for our usecase in generating the docs. I've filed an issue here: https://github.com/zurb/panini/issues/132

But for now lets pin the dependency to 1.4.0