### PR TITLE
Issue 10416 - input-group buttons not sized properly

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -106,8 +106,8 @@ $input-prefix-padding: 1rem !default;
     text-align: center;
 
     @if $global-flexbox {
-      flex: 0 0 auto;
       display: flex;
+      flex: 0 0 auto;
     }
     @else {
       width: 1%;

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -107,6 +107,7 @@ $input-prefix-padding: 1rem !default;
 
     @if $global-flexbox {
       flex: 0 0 auto;
+      display: flex;
     }
     @else {
       width: 1%;
@@ -118,10 +119,16 @@ $input-prefix-padding: 1rem !default;
     button,
     label {
       @extend %input-group-child;
-      height: $height;
+
+      @if $global-flexbox {
+        height: auto;
+        align-self: stretch;
+      }
+      @else {
+        height: $height;
+      }
       padding-top: 0;
       padding-bottom: 0;
-
       font-size: $input-font-size;
     }
   }

--- a/test/visual/form/input-group-float.html
+++ b/test/visual/form/input-group-float.html
@@ -12,7 +12,7 @@
   <body>
 
     <div class="row column">
-      <h3>FLOW Control Group: input-group height &amp; vertical alignment.</h3>
+      <h3>FLOAT Control Group: input-group height &amp; vertical alignment.</h3>
       <p>Assure that all controls are flush at the top and bottom. Pay special
         attention to the Submit button.</p>
     </div>

--- a/test/visual/form/input-group-flow.html
+++ b/test/visual/form/input-group-flow.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+    <link href="../assets/css/foundation-float.css" rel="stylesheet" />
+  </head>
+  <body>
+
+    <div class="row column">
+      <h3>FLOW Control Group: input-group height &amp; vertical alignment.</h3>
+      <p>Assure that all controls are flush at the top and bottom. Pay special
+        attention to the Submit button.</p>
+    </div>
+    <div class="medium-4 column">
+      <div class="input-group">
+        <span class="input-group-label">$</span>
+        <input class="input-group-field" type="number">
+        <div class="input-group-button">
+          <input type="submit" class="button" value="Submit">
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>

--- a/test/visual/form/input-group-xygrid.html
+++ b/test/visual/form/input-group-xygrid.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+
+  </head>
+  <body>
+
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="medium-12 cell">
+          <h3>XY Grid-Control Group: input-group height &amp; vertical alignment.</h3>
+          <p>Assure that all controls are flush at the top and bottom. Pay special
+            attention to the Submit button.</p>
+        </div>
+        <div class="medium-4 cell">
+          <div class="input-group">
+            <span class="input-group-label">$</span>
+            <input class="input-group-field" type="number">
+            <div class="input-group-button">
+              <input type="submit" class="button" value="Submit">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This fix resolve the issue where input-group-buttons aren't filling up the entire space of the parent container. Thanks to @rafibomb for helping with the code. This relates to issue #10416.

Please review as necessary. @IamManchanda.