### PR TITLE
JSPM can't load npm.js as main

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "exports": false
   },
   "jspm": {
+    "main": "dist/js/foundation.js",
     "format": "global",
     "shim": {
       "dist/js/foundation": {


### PR DESCRIPTION
Loading npm.js as main in browsers leads to an error. So we need to define a different main for JSPM than for NPM.