### PR TITLE
Fix typo in anchor-text-decoration docs

### DIFF
--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -147,7 +147,7 @@ $anchor-color: $primary-color !default;
 /// @type Color
 $anchor-color-hover: scale-color($anchor-color, $lightness: -14%) !default;
 
-/// Default text deocration for links.
+/// Default text decoration for links.
 /// @type String
 $anchor-text-decoration: none !default;
 


### PR DESCRIPTION
Just a minor documentation fix: typo in `anchor-text-decoration` description.