### PR TITLE
Remove text-decoration from link buttons

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -377,7 +377,8 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
     }
   }
   a.button {
-    &:hover {
+    &:hover,
+    &:focus {
       text-decoration: none;
     }
   }

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -376,4 +376,9 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
       margin-#{$global-left}: 0;
     }
   }
+  a.button {
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }


### PR DESCRIPTION
Remove text-decoration from link buttons. If text-decoration is set in global settings we don't want this to apply on button.