### PR TITLE
#10416 input group buttons sizing 

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -107,6 +107,7 @@ $input-prefix-padding: 1rem !default;
 
     @if $global-flexbox {
       flex: 0 0 auto;
+      display: flex;
     }
     @else {
       width: 1%;
@@ -118,10 +119,15 @@ $input-prefix-padding: 1rem !default;
     button,
     label {
       @extend %input-group-child;
-      height: $height;
+      @if $global-flexbox {
+        height: auto;
+        align-self: stretch;
+      }
+      @else {
+        height: $height;
+      }
       padding-top: 0;
       padding-bottom: 0;
-
       font-size: $input-font-size;
     }
   }


### PR DESCRIPTION
This is a recreation of https://github.com/zurb/foundation-sites/pull/10453 sinds @gskaplan didn't respond anymore. This time based on the `develop` branch. Original comment:

> This fix resolve the issue where input-group-buttons aren't filling up the entire space of the parent container. Thanks to @rafibomb for helping with the code. This relates to issue #10416.
> 
> Please review as necessary. @IamManchanda.