### PR TITLE
Fix off-canvas sizes iteration for reveal

### DIFF
--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -397,6 +397,28 @@ Advanced off-canvas users may use the new `contentId` option to bind an element 
 
 ---
 
+## Off-canvas Sizes
+
+In v6.4.2 the type of the off-canvas size variables has changed from number to map. This lets you define breakpoint specific sizes instead of one value for all.
+The map may contain every key that is defined in `$breakpoint-classes`.
+
+<div class="warning callout">
+  Please note the sizes maps do currently not work perfectly for the reveal classes. If sizes are defined for medium and large, `.reveal-for-medium` will only consider the medium value. This is going to get fixed in a future release.
+</div>
+
+```scss
+$offcanvas-sizes: (
+  small: 250px,
+  medium: 350px,
+);
+$offcanvas-vertical-sizes: (
+  small: 250px,
+  medium: 350px,
+);
+```
+
+---
+
 ## Migrating from versions prior to v6.4
 
 If you're upgrading from v6.3 there's nothing to do unless you haven't changed the default value of `$offcanvas-shadow`. Prior to v6.4 this variable was used for both, overlap and push off-canvas elements. Now it's only used for the overlap element whereas the push element uses two new variables:

--- a/scss/components/_off-canvas.scss
+++ b/scss/components/_off-canvas.scss
@@ -380,7 +380,8 @@ $maincontent-class: 'off-canvas-content' !default;
 @mixin off-canvas-reveal(
 $position: left,
 $zindex: $offcanvas-reveal-zindex,
-$content: $maincontent-class
+$content: $maincontent-class,
+$breakpoint: small
 ) {
   transform: none;
   z-index: $zindex;
@@ -401,20 +402,12 @@ $content: $maincontent-class
   }
 
   @at-root .#{$content}.has-reveal-#{$position} {
-    @each $name, $size in $offcanvas-sizes {
-      @include breakpoint($name) {
-        margin-#{$position}: $size;
-      }
-    }
+    margin-#{$position}: -zf-get-bp-val($offcanvas-sizes, $breakpoint);
   }
 
   // backwards compatibility (prior to v6.4)
   & ~ .#{$content} {
-    @each $name, $size in $offcanvas-sizes {
-      @include breakpoint($name) {
-        margin-#{$position}: $size;
-      }
-    }
+    margin-#{$position}: -zf-get-bp-val($offcanvas-sizes, $breakpoint);
   }
 }
 
@@ -481,19 +474,19 @@ $content: $maincontent-class
     @if $name != $-zf-zero-breakpoint {
       @include breakpoint($name) {
         .position-left.reveal-for-#{$name} {
-          @include off-canvas-reveal(left);
+          @include off-canvas-reveal(left, $offcanvas-reveal-zindex, $maincontent-class, $name);
         }
 
         .position-right.reveal-for-#{$name} {
-          @include off-canvas-reveal(right);
+          @include off-canvas-reveal(right, $offcanvas-reveal-zindex, $maincontent-class, $name);
         }
 
         .position-top.reveal-for-#{$name} {
-          @include off-canvas-reveal(top);
+          @include off-canvas-reveal(top, $offcanvas-reveal-zindex, $maincontent-class, $name);
         }
 
         .position-bottom.reveal-for-#{$name} {
-          @include off-canvas-reveal(bottom);
+          @include off-canvas-reveal(bottom, $offcanvas-reveal-zindex, $maincontent-class, $name);
         }
       }
     }


### PR DESCRIPTION
This is a bugfix of the off-canvas-sizes map iteration in the off-canvas-reveal mixin that showed up during QA and was reported in my closed PR:
https://github.com/zurb/foundation-sites/pull/10451

There have been a problematic CSS output because the iteration includes the breakpoint mixin while it gets included by another breakpoint mixin.
I've fixed this now by piping through the breakpoint name as 4th param what lets me get rid of the iteration within the reveal mixin.

@kball please let me know if it looks good from your side, too
