### PR TITLE
[QA] Remove `nowrap` from a menu anchor/button

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -73,7 +73,6 @@ $menu-icons-back-compat: true !default;
   .button {
     line-height: 1;
     text-decoration: none;
-    white-space: nowrap;
     display: block;
     padding: $menu-items-padding;
   }


### PR DESCRIPTION
This addresses a bug found during QA that was causing a drilldown menu with a long title to not wrap and get cut off.

Having looked over the history of the menu I'm not sure why this was introduced (even though it was me that added it!). I can't see any logical reason for it to be included, but it should probably be tested with the visual tests before merge just in case.