### PR TITLE
[QA] Fix vertical grid classes

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -285,9 +285,9 @@
       // https://github.com/zurb/foundation-sites/issues/10244
       // https://github.com/zurb/foundation-sites/pull/10222 and
       // https://github.com/zurb/foundation-sites/pull/10164
-      $str: "> #{$-zf-size}-shrink, > #{$-zf-size}-full";
+      $str: "> .#{$-zf-size}-shrink, > .#{$-zf-size}-full";
       @for $i from 1 through $grid-columns {
-        $str: $str + ", > #{$-zf-size}-#{$i}"
+        $str: $str + ", > .#{$-zf-size}-#{$i}"
       }
       #{$str} {
         flex-basis: auto;


### PR DESCRIPTION
This fixes the vertical grid issue identified during QA where by `auto` and `shrink` flex properties were trumping the size class flex properties. The issue turned out to be a few missing `.` on the selectors.

This seems to now be working perfectly in visual tests but please confirm.