### PR TITLE
[docs] Fix title on deprecation notices

### DIFF
--- a/docs/pages/flexbox-utilities.md
+++ b/docs/pages/flexbox-utilities.md
@@ -219,7 +219,7 @@ For children, there are 3 quick helper classes to apply the flex property. These
 ### Responsive Classes 
 
 <div class="callout alert">
-  <p><strong>Depreciation Notice:</strong> From v6.5.x, we are disabling responsive classes by default. You would be able to re-enable it though, with setting that <code>$flexbox-responsive-breakpoints</code> to <code>true</code> .</p>
+  <p><strong>Deprecation Notice:</strong> From v6.5.x, we are disabling responsive classes by default. You would be able to re-enable it though, with setting that <code>$flexbox-responsive-breakpoints</code> to <code>true</code> .</p>
 </div>
 
 All of these helper classes come in responsive varieties, prefixed with all of your named breakpoints.

--- a/docs/pages/float-classes.md
+++ b/docs/pages/float-classes.md
@@ -17,7 +17,7 @@ You can change the float behavior of an element by adding the `.float-left` or `
 </div>
 
 <div class="callout alert">
-  <p><strong>Depreciation Notice:</strong> From v6.5.x, we are moving Float classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus Float classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
+  <p><strong>Deprecation Notice:</strong> From v6.5.x, we are moving Float classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus Float classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
 </div>
 
 ```html_example

--- a/docs/pages/typography-helpers.md
+++ b/docs/pages/typography-helpers.md
@@ -15,7 +15,7 @@ tags:
 ## Text Alignment
 
 <div class="callout alert">
-  <p><strong>Depreciation Notice:</strong> From v6.5.x, we are moving text alignment classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus text alignment classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
+  <p><strong>Deprecation Notice:</strong> From v6.5.x, we are moving text alignment classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus text alignment classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
 </div>
 
 You can change the text alignment of an element by adding `.text-left`, `.text-right`, `.text-center` or `.text-justify` to an element.

--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -17,7 +17,7 @@ tags:
 </div>
 
 <div class="callout alert">
-  <p><strong>Depreciation Notice:</strong> From v6.5.x, we are moving visibility classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus visibility classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
+  <p><strong>Deprecation Notice:</strong> From v6.5.x, we are moving visibility classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus visibility classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
 </div>
 
 ## Show by Screen Size


### PR DESCRIPTION
It's a common mistake to use "depreciated" where "[deprecated](https://en.wikipedia.org/wiki/Deprecation)" is meant so I assume this is a mistake. If it was an intentional choice please close this PR. 😃 