### PR TITLE
Original dropdown position & alignment and CSS classes

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -105,7 +105,9 @@ class Dropdown extends Positionable {
    * @private
    */
   _setPosition() {
+    this.$element.removeClass(`has-position-${this.position} has-alignment-${this.alignment}`);
     super._setPosition(this.$currentAnchor, this.$element, this.$parent);
+    this.$element.addClass(`has-position-${this.position} has-alignment-${this.alignment}`);
   }
 
   /**

--- a/js/foundation.positionable.js
+++ b/js/foundation.positionable.js
@@ -40,6 +40,8 @@ class Positionable extends Plugin {
     this.triedPositions = {};
     this.position  = this.options.position === 'auto' ? this._getDefaultPosition() : this.options.position;
     this.alignment = this.options.alignment === 'auto' ? this._getDefaultAlignment() : this.options.alignment;
+    this.originalPosition = this.position;
+    this.originalAlignment = this.alignment;
   }
 
   _getDefaultPosition () {
@@ -121,6 +123,12 @@ class Positionable extends Plugin {
     var $eleDims = Box.GetDimensions($element),
         $anchorDims = Box.GetDimensions($anchor);
 
+
+    if (!this.options.allowOverlap) {
+      // restore original position & alignment before checking overlap
+      this.position = this.originalPosition;
+      this.alignment = this.originalAlignment;
+    }
 
     $element.offset(Box.GetExplicitOffsets($element, $anchor, this.position, this.alignment, this._getVOffset(), this._getHOffset()));
 


### PR DESCRIPTION
I've used the dropdown component to build a custom tooltip.
While working on it I've got two problems:

1. the original position & alignment gets changed if an overlap is detected but doesn't get restored once the overlap case isn't taking effect anymore
2. there are no CSS classes set that provide the current position & alignment what is a huge problem if you need to adjust the styling according to the current value (in my case a tooltip arrow whose direction is dependent on the dropdown pane's position)

This PR fixes both of these problems by saving the original values and restoring them before the overlap check. Same for the missing CSS classes that get set & updated every time the position is set.

@kball what do you think about this? Any objections?
