### PR TITLE
Reveal mobileScrollTop option

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -380,7 +380,7 @@ class Reveal extends Plugin {
           $('html, body').removeClass('is-reveal-open');
         }
         if(_this.originalScrollPos) {
-          $('body').scrollTop(_this.originalScrollPos);
+          $('html, body').scrollTop(_this.originalScrollPos);
           _this.originalScrollPos = null;
         }
       }

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -241,7 +241,7 @@ class Reveal extends Plugin {
     var _this = this;
 
     function addRevealOpenClasses() {
-      if (_this.isMobile) {
+      if (_this.isMobile && _this.options.mobileScrollTop === true) {
         if(!_this.originalScrollPos) {
           _this.originalScrollPos = window.pageYOffset;
         }
@@ -375,7 +375,7 @@ class Reveal extends Plugin {
     this.$element.off('keydown.zf.reveal');
 
     function finishUp() {
-      if (_this.isMobile) {
+      if (_this.isMobile && _this.options.mobileScrollTop === true) {
         if ($('.reveal:visible').length === 0) {
           $('html, body').removeClass('is-reveal-open');
         }
@@ -567,7 +567,14 @@ Reveal.defaults = {
    * @type {string}
    * @default ''
    */
-  additionalOverlayClasses: ''
+  additionalOverlayClasses: '',
+  /**
+   * Define if scrollTop should be set to 0 for mobile devices while the reveal is opened.
+   * Mobile devices get identified by user agent.
+   * @type {boolean}
+   * @default  true
+   */
+  mobileScrollTop: true
 };
 
 function iPhoneSniff() {

--- a/test/visual/reveal/mobile.html
+++ b/test/visual/reveal/mobile.html
@@ -11,6 +11,7 @@
     <style>
       .force-great-height { max-width: 150px; }
       .test-callout { position: absolute; left: 0; top: 0; z-index: 1500; width: 100%; display: none; }
+      .auto.reveal { height: auto; min-height: 0; max-height: 100vh; }
     </style>
   </head>
   <body>
@@ -30,7 +31,7 @@
             <p>By default the reveal sets scrollTop to 0 if getting opened on a mobile device (indentified via user agent) and restores the original scrollTop after being closed.</p>
             <p><button class="alert button" data-open="exampleModal1">Open Default</button></p>
 
-            <div class="reveal" id="exampleModal1" data-reveal>
+            <div class="auto reveal" id="exampleModal1" data-reveal>
               <p>I'm a default reveal on a mobile device</p>
               <p><button class="button" data-close>Close</button></p>
             </div>
@@ -41,7 +42,7 @@
             <p>This reveal uses has set the option `mobileScrollTop: false` and thus doesn't affect the scrollTop if opened.</p>
             <p><button class="success button" data-open="exampleModal2">Open without scrollTop</button></p>
 
-            <div class="reveal" id="exampleModal2" data-reveal data-mobile-scroll-top="false">
+            <div class="auto reveal" id="exampleModal2" data-reveal data-mobile-scroll-top="false">
               <p>I'm a reveal with the option mobileScrollTop set to false.</p>
               <p><button class="button" data-close>Close</button></p>
             </div>

--- a/test/visual/reveal/mobile.html
+++ b/test/visual/reveal/mobile.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+    <style>
+      .force-great-height { max-width: 150px; }
+      .test-callout { position: absolute; left: 0; top: 0; z-index: 1500; width: 100%; display: none; }
+    </style>
+  </head>
+  <body>
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell">
+          <h1>Reveal</h1>
+
+          <div class="test-callout alert callout">
+            If you see this, scrollTop got set to 0 by the reveal plugin
+          </div>
+
+          <p class="force-great-height">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod placeat repellendus architecto, obcaecati in. Similique necessitatibus dolore repellendus modi perspiciatis dolorum, possimus pariatur sapiente eaque voluptatem rerum commodi ipsum a! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod placeat repellendus architecto, obcaecati in. Similique necessitatibus dolore repellendus modi perspiciatis dolorum, possimus pariatur sapiente eaque voluptatem rerum commodi ipsum a! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod placeat repellendus architecto, obcaecati in. Similique necessitatibus dolore repellendus modi perspiciatis dolorum, possimus pariatur sapiente eaque voluptatem rerum commodi</p>
+          
+          <section>
+            <h2>Mobile (default)</h2>
+            <p>By default the reveal sets scrollTop to 0 if getting opened on a mobile device (indentified via user agent) and restores the original scrollTop after being closed.</p>
+            <p><button class="alert button" data-open="exampleModal1">Open Default</button></p>
+
+            <div class="reveal" id="exampleModal1" data-reveal>
+              <p>I'm a default reveal on a mobile device</p>
+              <p><button class="button" data-close>Close</button></p>
+            </div>
+          </section>
+
+          <section>
+            <h2>Mobile (disabled mobile scrollTop)</h2>
+            <p>This reveal uses has set the option `mobileScrollTop: false` and thus doesn't affect the scrollTop if opened.</p>
+            <p><button class="success button" data-open="exampleModal2">Open without scrollTop</button></p>
+
+            <div class="reveal" id="exampleModal2" data-reveal data-mobile-scroll-top="false">
+              <p>I'm a reveal with the option mobileScrollTop set to false.</p>
+              <p><button class="button" data-close>Close</button></p>
+            </div>
+          </section>
+
+          <p class="force-great-height">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod placeat repellendus architecto, obcaecati in. Similique necessitatibus dolore repellendus modi perspiciatis dolorum, possimus pariatur sapiente eaque voluptatem rerum commodi ipsum a! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod placeat repellendus architecto, obcaecati in. Similique necessitatibus dolore repellendus modi perspiciatis dolorum, possimus pariatur sapiente eaque voluptatem rerum commodi ipsum a! Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quod placeat repellendus architecto, obcaecati in. Similique necessitatibus dolore repellendus modi perspiciatis dolorum, possimus pariatur sapiente eaque voluptatem rerum commodi</p>
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+    <script>
+
+      $('[data-reveal]').on('open.zf.reveal', function(){
+        $('.test-callout').show();
+      });
+
+      $('[data-reveal]').on('closed.zf.reveal', function(){
+        $('.test-callout').hide();
+      });
+
+      // Alert if no mobile device since it's required for this test
+      var UA = window.navigator.userAgent;
+      if (!UA.match(/iP(ad|hone|od).*OS/) && !UA.match(/Android/)) {
+        alert('ERROR: you have to view this test on a mobile device or an emulator with mobile user agent!');
+      }
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a new option to the reveal plugin called 'mobileScrollTop'.
The purpose of this option is to provide a possibility for disabling the mobile scrollTop behavior that I've spotted in this issue: https://github.com/zurb/foundation-sites/issues/10543

As described in the issue report I still don't know why the scrollTop value gets set to 0 while the reveal is opened on a mobile device (identified by user agent instead of media query) at all.
But since this PR adds a new option to disable this behavior it definitely doesn't cause any issues at existing projects.

I'va also added a visual test so you can easily see the benefit of this option.
http://localhost:3000/reveal/mobile.html

@kball **would be great to get your feedback on this!**

If this behavior isn't necessary I would adjust my PR and simply remove it instead of adding a new option.