### PR TITLE
Fix SASS Deprecations

### DIFF
--- a/scss/xy-grid/_gutters.scss
+++ b/scss/xy-grid/_gutters.scss
@@ -30,7 +30,7 @@
 
       // Loop through each gutter position
       @each $value in $gutter-position {
-        #{$gutter-type}-#{$value}: #{$operator}$gutter;
+        #{$gutter-type}-#{$value}: unquote("#{$operator}#{$gutter}");
       }
     }
   }
@@ -39,7 +39,7 @@
 
     // Loop through each gutter position
     @each $value in $gutter-position {
-      #{$gutter-type}-#{$value}: #{$operator}$gutter;
+      #{$gutter-type}-#{$value}: unquote("#{$operator}#{$gutter}");
     }
   }
 }


### PR DESCRIPTION
Hi!

I recently noticed that `foundation-rails` was generating a deprecation warning with `sass` >= `3.4.20`.

Here's the warning I was noticing:

```
DEPRECATION WARNING on line 33 of /Users/me/src/app/vendor/bundle/ruby/2.4.0/gems/foundation-rails-6.4.1.2/vendor/assets/scss/xy-grid/_gutters.scss:
#{} interpolation near operators will be simplified in a future version of Sass.
To preserve the current behavior, use quotes:

  unquote("#{$operator}#{$gutter}")

You can use the sass-convert command to automatically fix most cases.
```

As suggested by the SASS compiler, I've squelched the deprecation by using the `unquote` function.

This fixes https://github.com/zurb/foundation-sites/issues/10534.

SEE: https://github.com/sass/sass/issues/1778