### PR TITLE
Fix slider data-start float bug

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -153,7 +153,7 @@ class Slider extends Plugin {
       pctOfBar = this._logTransform(pctOfBar);
       break;
     }
-    var value = (this.options.end - this.options.start) * pctOfBar + this.options.start;
+    var value = (this.options.end - this.options.start) * pctOfBar + parseFloat(this.options.start);
 
     return value
   }


### PR DESCRIPTION
data-start float with a trailing 0 is typed as a string. This causes an undesired concatenation breaking the slider. 

[#10579](https://github.com/zurb/foundation-sites/issues/10579)