### PR TITLE
Shouldnt we Exclude Node Modules folder

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
       // Compiles ES6 and ES7 into ES5 code
       {
         test: /\.js$/,
+        exclude: /node_modules/,
         use: [
           {
             loader: 'babel-loader',


### PR DESCRIPTION
Taken from official babel docs 
https://github.com/babel/babel-loader#usage

> **babel-loader is slow!**
> 
> Make sure you are transforming as few files as possible. Because you are probably
> matching `/\.js$/`, you might be transforming the `node_modules` folder or other unwanted
> source.
> To exclude `node_modules`, see the `exclude` option in the `loaders` config as documented above.
> You can also speed up babel-loader by as much as 2x by using the `cacheDirectory` option.
> This will cache transformations to the filesystem.

