### PR TITLE
Fix slider data-start float bug 

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -153,7 +153,7 @@ class Slider extends Plugin {
       pctOfBar = this._logTransform(pctOfBar);
       break;
     }
-    var value = (this.options.end - this.options.start) * pctOfBar + this.options.start;
+    var value = (this.options.end - this.options.start) * pctOfBar + parseFloat(this.options.start);
 
     return value
   }

--- a/test/visual/slider/parseFloat.html
+++ b/test/visual/slider/parseFloat.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell">
+          <div class="slider" data-start="5.0" data-slider data-initial-start="50" data-end="200">
+            <span class="slider-handle"  data-slider-handle role="slider" tabindex="1"></span>
+            <span class="slider-fill" data-slider-fill></span>
+            <input type="hidden">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
@IamManchanda  per your request

data-start float with a trailing 0 is typed as a string. This causes an undesired concatenation breaking the slider. 

[#10579](https://github.com/zurb/foundation-sites/issues/10579)