### PR TITLE
Set border-width variable on button-base mixin

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -44,7 +44,8 @@ $button-radius: $global-radius !default;
 
 /// Border width for hollow outline buttons
 /// @type Number
-$button-hollow-border-width: 1px !default;
+$button-border-width: 1px !default;
+$button-hollow-border-width: $button-border-width;
 
 /// Sizes for buttons.
 /// @type Map
@@ -100,7 +101,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   }
 
   -webkit-appearance: none;
-  border: $button-hollow-border-width solid transparent;
+  border: $button-border-width solid transparent;
   border-radius: $button-radius;
   transition: $button-transition;
 

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -100,7 +100,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   }
 
   -webkit-appearance: none;
-  border: 1px solid transparent;
+  border: $button-hollow-border-width solid transparent;
   border-radius: $button-radius;
   transition: $button-transition;
 

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -42,10 +42,13 @@ $button-color-alt: $black !default;
 /// @type Number
 $button-radius: $global-radius !default;
 
+/// Border for buttons, transparent by default
+/// @type List
+$button-border: 1px solid transparent !default;
+
 /// Border width for hollow outline buttons
 /// @type Number
-$button-border-width: 1px !default;
-$button-hollow-border-width: $button-border-width !default;
+$button-hollow-border-width: 1px !default;
 
 /// Sizes for buttons.
 /// @type Map
@@ -101,7 +104,7 @@ $button-transition: background-color 0.25s ease-out, color 0.25s ease-out !defau
   }
 
   -webkit-appearance: none;
-  border: $button-border-width solid transparent;
+  border: $button-border;
   border-radius: $button-radius;
   transition: $button-transition;
 

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -45,7 +45,7 @@ $button-radius: $global-radius !default;
 /// Border width for hollow outline buttons
 /// @type Number
 $button-border-width: 1px !default;
-$button-hollow-border-width: $button-border-width;
+$button-hollow-border-width: $button-border-width !default;
 
 /// Sizes for buttons.
 /// @type Map


### PR DESCRIPTION
When using a modified hollow button width (i.e. 2px instead of default 1px), 
non-hollow buttons could have the same border-width as set on $button-hollow-border-width