### PR TITLE
Iterates over $button-palette

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -207,7 +207,7 @@ $buttongroup-radius-on-each: true !default;
     &.expanded { @include button-group-expand; }
 
     // Colors
-    @each $name, $color in $foundation-palette {
+    @each $name, $color in $button-palette {
       @if $button-fill != hollow {
         &.#{$name} #{$buttongroup-child-selector} {
           @include button-style($color, auto, auto);


### PR DESCRIPTION
To generate .button-group colors variations, iteration should be over $button-palette instead of $foundation-palette. It fixes issue #10576.