### PR TITLE
Fixes #9344

### DIFF
--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -22,7 +22,7 @@ $input-prefix-border: 1px solid $medium-gray !default;
 $input-prefix-padding: 1rem !default;
 
 @mixin foundation-form-prepostfix {
-  $height: ($input-font-size + $form-spacing * 1.5);
+  $height: ($input-font-size * $input-line-height) + (get-side($input-padding, 'top') + get-side($input-padding, 'bottom')) - rem-calc(1);;
 
   .input-group {
     display: if($global-flexbox, flex, table);
@@ -91,11 +91,7 @@ $input-prefix-padding: 1rem !default;
 
     @if $global-flexbox {
       flex: 1 1 0px; // sass-lint:disable-line zero-unit
-      height: auto;
       min-width: 0;
-    }
-    @else {
-      height: $height;
     }
   }
 
@@ -135,8 +131,8 @@ $input-prefix-padding: 1rem !default;
 
   // Specificity bump needed to prevent override by buttons
   @if not $global-flexbox {
-      .input-group .input-group-button {
-          display: table-cell;
-      }
+    .input-group .input-group-button {
+      display: table-cell;
+    }
   }
 }


### PR DESCRIPTION
Implements the newer input height formula from #9681 for input groups.

# Note 1:
I think it would be nice if the input height formula was moved to a single location so this issue can't reoccur in the future if the formula were to change again. The same formula is now in `_input-group.scss`, `_text.scss`, and `_select.scss`. However, I'm not sure of the best way to do this. Maybe a new file `scss/forms/_vars.scss` that `_input-group.scss`, `_text.scss`, and `_select.scss` can all use?

# Note 2:
I removed the hardcoded height on `.input-group-field` in non-flexbox-mode so that the input/select/textarea element would just inherit its normal height. There shouldn't be any reason to override the height on `.input-group-field` unless it's being used on a non input/select/textarea element. I guess this could be considered a breaking change in that scenario. Should I revert?
