### PR TITLE
Fixing magellan is-active issue  ||  adding traversing to magelan $active

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -165,8 +165,10 @@ class Magellan extends Plugin {
     }
 
     this.$active.removeClass(this.options.activeClass);
-    this.$active = this.$links.filter('[href="#' + this.$targets.eq(curIdx).data('magellan-target') + '"]').addClass(this.options.activeClass);
-
+    this.$active = this.$links.filter('[href="#' + this.$targets.eq(curIdx).data('magellan-target') + '"]').parents()[this.options.activeParents]
+  	               ? $( this.$links.filter('[href="#' + this.$targets.eq(curIdx).data('magellan-target') + '"]').parents()[this.options.activeParents] ).addClass(this.options.activeClass)
+  	               : this.$links.filter('[href="#' + this.$targets.eq(curIdx).data('magellan-target') + '"]').addClass(this.options.activeClass);
+    
     if(this.options.deepLinking){
       var hash = "";
       if(curIdx != undefined){
@@ -238,6 +240,13 @@ Magellan.defaults = {
    * @default 'is-active'
    */
   activeClass: 'is-active',
+    /**
+  * If >= 0 index of parents of active link, where activeClass is added/removed
+  * @option
+  * @type {number}
+  * @default -1
+  */
+ activeParents: -1,
   /**
    * Allows the script to manipulate the url of the current page, and if supported, alter the history.
    * @option

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -37,8 +37,17 @@ class Magellan extends Plugin {
   _init() {
     var id = this.$element[0].id || GetYoDigits(6, 'magellan');
     var _this = this;
-    this.$targets = $('[data-magellan-target]');
-    this.$links = this.$element.find('a');
+    
+    _this.lnks = $();
+    _this.tgts = $();
+    this.$element.find('a').each(function(index,elem) {
+            _this.lnks = _this.lnks.add(elem);
+            _this.tgts = _this.tgts.add($('[data-magellan-target="'+  elem.hash.slice(1) +'"]'));
+    });
+
+        this.$links = _this.lnks;
+        this.$targets = _this.tgts;    
+
     this.$element.attr({
       'data-resize': id,
       'data-scroll': id,

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -152,7 +152,7 @@ $dropdown-menu-item-background-active: transparent !default;
     }
 
     // Active state
-    .is-active {
+    .is-active > a {
       background: $dropdown-menu-item-background-active;
       color: $dropdown-menu-item-color-active;
     }

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -152,7 +152,7 @@ $dropdown-menu-item-background-active: transparent !default;
     }
 
     // Active state
-    .is-active > a {
+    .is-active {
       background: $dropdown-menu-item-background-active;
       color: $dropdown-menu-item-color-active;
     }

--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -441,7 +441,7 @@ $menu-icons-back-compat: true !default;
     }
 
     // Active state
-    .is-active > a {
+    .is-active {
       @include menu-state-active;
     }
     


### PR DESCRIPTION
[https://github.com/zurb/foundation-sites/issues/10470#issuecomment-319499782](https://github.com/zurb/foundation-sites/issues/10470#issuecomment-319499782)

__menu.scss_ &&  __dropdown-menu.scss_:
Fixing: '_**is-active**_' class is added to a-tag but all scss is for parent element to receive  is-active class.
Making _**is-active**_ class general => see changes in magellan.js

_magellan.js_:
Adding option _**activeParents**_ for traversing $active element.
