### PR TITLE
issue-10628: Define variables before use in _breakpoint.scss

### DIFF
--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -323,25 +323,39 @@ $breakpoint-classes: (small medium large) !default;
   }
 }
 
+$small-up: '';
+$small-only: '';
+
 @if map-has-key($breakpoints, small) {
   $small-up: screen;
   $small-only: unquote('screen and #{breakpoint(small only)}');
 }
+
+$medium-up: '';
+$medium-only: '';
 
 @if map-has-key($breakpoints, medium) {
   $medium-up: unquote('screen and #{breakpoint(medium)}');
   $medium-only: unquote('screen and #{breakpoint(medium only)}');
 }
 
+$large-up: '';
+$large-only: '';
+
 @if map-has-key($breakpoints, large) {
   $large-up: unquote('screen and #{breakpoint(large)}');
   $large-only: unquote('screen and #{breakpoint(large only)}');
 }
 
+$xlarge-up: '';
+$xlarge-only: '';
+
 @if map-has-key($breakpoints, xlarge) {
   $xlarge-up: unquote('screen and #{breakpoint(xlarge)}');
   $xlarge-only: unquote('screen and #{breakpoint(xlarge only)}');
 }
+
+$xxlarge-up: '';
 
 @if map-has-key($breakpoints, xxlarge) {
   $xxlarge-up: unquote('screen and #{breakpoint(xxlarge)}');


### PR DESCRIPTION
Fixes #10628

When using the `$small-up`, etc variables we were getting `Undefined variable: "$small-up"` because those variables need to be defined outside the if-statements. Went with empty strings for parity with the data type that is expected for these variables.

This is rather urgent of a fix for our organization since we are in the process of upgrading from Foundation 5 to Foundation 6 and use these variables to create @media CSS.

Thanks for taking a look!
