### PR TITLE
Make xy grid styles accessible everywhere within the docs

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -12,6 +12,7 @@
 @import 'motion-ui';
 
 @include foundation-everything($flex: false);
+@include foundation-xy-grid-classes;
 @include foundation-flex-classes;
 @include foundation-prototype-classes;
 @include foundation-range-input;


### PR DESCRIPTION
Since XY is orthogonal to the other grids, there should be no side effects (didn't see any in testing), and this lets us incrementally merge XY grid examples into every part of the docs.