### PR TITLE
Prototype update (Rounded Switches, Remove Visibility Depreciation, and Separate Utility Section) 

### DIFF
--- a/docs/pages/prototyping-utilities.md
+++ b/docs/pages/prototyping-utilities.md
@@ -121,6 +121,19 @@ These `.radius`, `.rounded`, `.bordered` & `.shadow` classes can be used indepen
 <button type="button" class="button radius bordered shadow warning">Warning</button>
 ```
 
+#### Switches
+
+Please note that you need to add `rounded` class with `switch-paddle` and not `switch`.
+
+```html_example
+<div class="switch">
+  <input class="switch-input" id="exampleSwitch" type="checkbox" name="exampleSwitch">
+  <label class="switch-paddle rounded" for="exampleSwitch">
+    <span class="show-for-sr">Download Kittens</span>
+  </label>
+</div>
+```
+
 #### Cards
 
 ```html

--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -16,10 +16,6 @@ tags:
   <p>There are no classes to detect touchscreen devices, as both desktop and mobile browsers inconsistently report touch support. Learn more here: <a href="http://www.stucox.com/blog/you-cant-detect-a-touchscreen/">You Can't Detect a Touchscreen</a></p>
 </div>
 
-<div class="callout alert">
-  <p><strong>Depreciation Notice:</strong> From v6.5.x, we are moving visibility classes to <a href="prototyping-utilities.html">Prototype specific mode</a> and thus visibility classes will be disabled by default. You can re-enable it though, with a simple `@include`.</p>
-</div>
-
 ## Show by Screen Size
 
 In this example, we use the `.show` visibility classes to show certain strings of text based on the device on which users view a page. If their browser meets the class's conditions, the element will be shown. If not, it will be hidden.

--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -39,14 +39,22 @@
       </div>
     </li>
 
-    <li class="accordion-item {{#ifpage 'xy-grid' 'grid' 'flex-grid' 'forms' 'visibility' 'float-classes'}}is-active{{/ifpage}}" data-accordion-item>
+    <li class="accordion-item {{#ifpage 'xy-grid' 'grid' 'flex-grid' 'forms'}}is-active{{/ifpage}}" data-accordion-item>
       <a href="#" class="accordion-title">General</a>
-      <div class="accordion-content {{#ifpage 'xy-grid' 'grid' 'flex-grid' 'forms' 'visibility' 'float-classes'}}is-active{{/ifpage}}" data-tab-content>
+      <div class="accordion-content {{#ifpage 'xy-grid' 'grid' 'flex-grid' 'forms'}}is-active{{/ifpage}}" data-tab-content>
         <ul class="docs-nav-subcategory">
           <li{{#ifpage 'xy-grid'}} class="current"{{/ifpage}}><a href="xy-grid.html">XY Grid <span class="label">New</span></a></li>
           <li{{#ifpage 'grid'}} class="current"{{/ifpage}}><a href="grid.html">Float Grid<span class="label">Legacy</span></a></li>
           <li{{#ifpage 'flex-grid'}} class="current"{{/ifpage}}><a href="flex-grid.html">Flex Grid<span class="label">Legacy</span></a></li>
           <li{{#ifpage 'forms'}} class="current"{{/ifpage}}><a href="forms.html">Forms</a></li>
+        </ul>
+      </div>
+    </li>
+
+    <li class="accordion-item {{#ifpage 'prototyping-utilities' 'flexbox-utilities' 'visibility' 'float-classes'}}is-active{{/ifpage}}" data-accordion-item>
+      <a href="#" class="accordion-title">Utilities</a>
+      <div class="accordion-content {{#ifpage 'prototyping-utilities' 'flexbox-utilities' 'visibility' 'float-classes'}}is-active{{/ifpage}}" data-tab-content>
+        <ul class="docs-nav-subcategory">
           <li{{#ifpage 'prototyping-utilities'}} class="current"{{/ifpage}}><a href="prototyping-utilities.html">Prototyping Utilities</a></li>
           <li{{#ifpage 'flexbox-utilities'}} class="current"{{/ifpage}}><a href="flexbox-utilities.html">Flexbox Utilities</a></li>
           <li{{#ifpage 'visibility'}} class="current"{{/ifpage}}><a href="visibility.html">Visibility Classes</a></li>

--- a/scss/prototype/_rounded.scss
+++ b/scss/prototype/_rounded.scss
@@ -30,6 +30,9 @@ $prototype-border-radius: rem-calc(3) !default;
 @mixin foundation-prototype-rounded {
   .rounded {
     @include border-rounded;
+    &:after {
+      border-radius: 50%; // For switches
+    }
   }
 
   .radius {


### PR DESCRIPTION
This takes care of 3 things

- [x] Support for Rounded Switches within optional prototypes ( #10460 )
- [x] Remove Visibility Depreciation ( #10540 )
- [x] Separate Utility Section :arrow_double_down: 

![utility](https://user-images.githubusercontent.com/4970624/30241487-f94e24d2-95a1-11e7-95c5-c6d594b60b0d.png)
