### PR TITLE
Linked hoverable dropdown toggle (forceFollow option)

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -127,7 +127,9 @@ class Dropdown extends Positionable {
    * @private
    */
   _events() {
-    var _this = this;
+    var _this = this,
+        hasTouch = 'ontouchstart' in window || (typeof window.ontouchstart !== 'undefined');
+
     this.$element.on({
       'open.zf.trigger': this.open.bind(this),
       'close.zf.trigger': this.close.bind(this),
@@ -135,8 +137,16 @@ class Dropdown extends Positionable {
       'resizeme.zf.trigger': this._setPosition.bind(this)
     });
 
-    this.$anchors.off('click.zf.trigger')
-      .on('click.zf.trigger', function() { _this._setCurrentAnchor(this); });
+    this.$anchors.off('click.zf.trigger').on('click.zf.trigger', function(e) {
+        _this._setCurrentAnchor(this);
+
+        if (_this.options.forceFollow && hasTouch && _this.options.hover) {
+          var hasClicked = $(this).attr('data-is-click') === true;
+          if (hasClicked === false && _this.$element.attr('aria-hidden') === 'true') {
+            e.preventDefault();
+          }
+        }
+    });
 
     if(this.options.hover){
       this.$anchors.off('mouseenter.zf.dropdown mouseleave.zf.dropdown')
@@ -356,7 +366,6 @@ Dropdown.defaults = {
    * @default ''
    */
   positionClass: '',
-
   /**
    * Position of dropdown. Can be left, right, bottom, top, or auto.
    * @option
@@ -407,7 +416,14 @@ Dropdown.defaults = {
    * @type {boolean}
    * @default false
    */
-  closeOnClick: false
-}
+  closeOnClick: false,
+  /**
+   * Boolean to force overide the clicking of toggle link (href) to perform default action, on second touch event for mobile.
+   * @option
+   * @type {boolean}
+   * @default true
+   */
+  forceFollow: true
+};
 
 export {Dropdown};

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -137,7 +137,8 @@ class Dropdown extends Positionable {
       'resizeme.zf.trigger': this._setPosition.bind(this)
     });
 
-    this.$anchors.off('click.zf.trigger').on('click.zf.trigger', function(e) {
+    this.$anchors.off('click.zf.trigger')
+      .on('click.zf.trigger', function(e) {
         _this._setCurrentAnchor(this);
 
         if (_this.options.forceFollow && hasTouch && _this.options.hover) {

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -141,11 +141,13 @@ class Dropdown extends Positionable {
       .on('click.zf.trigger', function(e) {
         _this._setCurrentAnchor(this);
 
-        if (_this.options.forceFollow && hasTouch && _this.options.hover) {
-          var hasClicked = $(this).attr('data-is-click') === true;
-          if (hasClicked === false && _this.$element.attr('aria-hidden') === 'true') {
-            e.preventDefault();
-          }
+        if (_this.options.forceFollow === false) {
+          // if forceFollow false, always prevent default action
+          e.preventDefault();
+        } else if (hasTouch && _this.options.hover && _this.$element.hasClass('is-open') === false) {
+          // if forceFollow true and hover option true, only prevent default action on 1st click
+          // on 2nd click (dropown opened) the default action (e.g. follow a href) gets executed
+          e.preventDefault();
         }
     });
 
@@ -419,7 +421,7 @@ Dropdown.defaults = {
    */
   closeOnClick: false,
   /**
-   * Boolean to force overide the clicking of toggle link (href) to perform default action, on second touch event for mobile.
+   * If true the default action of the toggle (e.g. follow a link with href) gets executed on click. If hover option is also true the default action gets prevented on first click for mobile / touch devices and executed on second click. 
    * @option
    * @type {boolean}
    * @default true

--- a/test/visual/dropdown/linked-dropdown-toggle.html
+++ b/test/visual/dropdown/linked-dropdown-toggle.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en"> <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet">
+  </head>
+  <body>    
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell">
+          <h1>Linked Dropdown Toggle</h1>
+
+          <p>This test is supposed to show a linked dropdown toggle <strong>with enabled hover option</strong>.<br>On desktop mouseover opens the dropdown pane and click opens the link's href.<br>On mobile the first touch opens the dropdown pane and the second touch (while still opened) opens the link's href.</p>
+
+          <div class="button-group">
+            <a href="https://www.google.com" class="button" data-toggle="example-dropdown-1">Linked Hoverable Dropdown</a>
+            <button type="button" class=" secondary button" data-toggle="example-dropdown-2">Hoverable Dropdown</button>
+            <button type="button" class=" secondary button" data-toggle="example-dropdown-3">Clickable Dropdown</button>
+          </div>
+
+          <div class="dropdown-pane" id="example-dropdown-1" data-dropdown data-hover="true" data-hover-pane="true">
+            This is a linked hover dropdown. Try to open me on a mobile screen size and click again on the toggle while opened.
+          </div>
+          <div class="dropdown-pane" id="example-dropdown-2" data-dropdown data-hover="true" data-hover-pane="true">
+            This is a usual hover dropdown.
+          </div>
+          <div class="dropdown-pane" id="example-dropdown-3" data-dropdown data-close-on-click="true">
+            This is a clickable dropdown.
+          </div>
+
+        </div>
+      </div>
+    </div>
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>

--- a/test/visual/dropdown/linked-dropdown-toggle.html
+++ b/test/visual/dropdown/linked-dropdown-toggle.html
@@ -16,7 +16,7 @@
 
           <p>This test is supposed to show a linked dropdown toggle <strong>with enabled hover option</strong>.<br>On desktop mouseover opens the dropdown pane and click opens the link's href.<br>On mobile the first touch opens the dropdown pane and the second touch (while still opened) opens the link's href.</p>
 
-          <div class="button-group">
+          <div class="stacked-for-small button-group">
             <a href="https://www.google.com" class="button" data-toggle="example-dropdown-1">Linked Hoverable Dropdown</a>
             <button type="button" class=" secondary button" data-toggle="example-dropdown-2">Hoverable Dropdown</button>
             <button type="button" class=" secondary button" data-toggle="example-dropdown-3">Clickable Dropdown</button>
@@ -30,6 +30,14 @@
           </div>
           <div class="dropdown-pane" id="example-dropdown-3" data-dropdown data-close-on-click="true">
             This is a clickable dropdown.
+          </div>
+
+          <p>If having set the option <code>forceFollow:false</code> the default action gets always prevented and thus the linked dropdown toggle will never open the link's href.</p>
+
+          <a href="https://www.google.com" class="button" data-toggle="example-dropdown-4">Linked Dropdown with forceFollow false</a>
+
+          <div class="dropdown-pane" id="example-dropdown-4" data-dropdown data-hover="true" data-hover-pane="true" data-force-follow="false">
+            This is a linked hover dropdown with forceFollow set false. The link's href gets never opened no matter how often you click.
           </div>
 
         </div>


### PR DESCRIPTION
I'm sometimes using dropdown toggles that are hoverable and also clickable (direct link).
But this is a huge problem when it comes to touch devices (mostly mobile & tablet but not exclusive).

Thus I've made this PR that adds a new option called `forceFollow` that is inspired by the option from the dropdownMenu component.
If true (default) it supports using linked dropdown toggles that work as described above.

Precisely I've hooked into the click event listener and do a preventDefault if the dropdown is hoverable and not opened yet.
Without my PR the first click opens the dropdown but also immediately opens the link (href).

@kball @IamManchanda would you please review and let me know if it looks good for you?

I've also included a visual test but you can see it working in this codepen as well (make sure you're using a touch devices or touch emulation in dev tools):
https://codepen.io/KaiTheGreat/pen/PJYmXj
