### PR TITLE
Fix bug in foundation.util.touch

### DIFF
--- a/js/foundation.util.touch.js
+++ b/js/foundation.util.touch.js
@@ -102,7 +102,7 @@ Touch.setupSpotSwipe = function($) {
 Touch.setupTouchHandler = function($) {
   $.fn.addTouch = function(){
     this.each(function(i,el){
-      $(el).bind('touchstart touchmove touchend touchcancel',function(){
+      $(el).bind('touchstart touchmove touchend touchcancel', function(event)  {
         //we pass the original event object because the jQuery event
         //object is normalized to w3c specs and does not provide the TouchList
         handleTouch(event);


### PR DESCRIPTION
Hello! I found a bug with foundation Slider - it's works incorrectly on Firefox Mobile for Android - I can't move the slider and I'm getting an error in console that `event` variable is not defined.
After adding `event` param error was fixed and a slider works fine from my mobile browser finally.