### PR TITLE
Fix reset for y-grid to clear max-width as well

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -66,6 +66,7 @@
 @mixin xy-cell-reset($vertical: true) {
   $direction: if($vertical == true, width, height);
   #{$direction}: auto;
+  max-#{$direction}: none;
 }
 
 // Sets our cell widths or heights depending on gutter type.


### PR DESCRIPTION
Fixes issue where grid-y cells are still constrained by the width set by grid-x cells.

Fixes 
<img width="1106" alt="xy grid foundation for sites 6 docs" src="https://user-images.githubusercontent.com/44007/30444465-f05b30ec-9937-11e7-9a43-393da60a0ad2.png">

To 
<img width="1119" alt="xy grid foundation for sites 6 docs-1" src="https://user-images.githubusercontent.com/44007/30444477-fdc18024-9937-11e7-8785-67c190863aa7.png">

