### PR TITLE
Fix for .grid-y.align-justify -> .cell .cell.auto .cell configuration

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -77,6 +77,9 @@
   }
   @elseif ($size == 'auto') {
     #{$direction}: auto;
+    @if ($vertical) {
+      flex-basis: auto;
+    }
     $val: if($margin-gutter == 0, 100%, calc(100% - #{rem-calc($margin-gutter)}));
   }
   @elseif ($size == 'shrink') {


### PR DESCRIPTION
Given the following DOM
```lang:html
<div class="grid-y align-justify" style="min-height: 100vh">
  <div class="cell"></div>
  <div class="cell auto"></div>
  <div class="cell"></div>
</div>
```
The current setup with leads to overlapping of the middle cell.

Seams to be a Chrome Bug. Codepen Example (shrink the window so that the middle content doesn't fit completely): https://s.codepen.io/DaSch/debug/OxVxaP/RBMOJexjGzgk