### PR TITLE
Remove extraneous reference to 'girl!' in Foundation Zurb Template. Fixes #10663. 

### DIFF
--- a/customizer/index.html
+++ b/customizer/index.html
@@ -155,7 +155,7 @@
           <a href="#" class="alert button">Alert Btn</a><br/>
           <a href="#" class="secondary button">Secondary Btn</a></p>
           <div class="callout">
-            <h5>So many components, girl!</h5>
+            <h5>So many components</h5>
             <p>A whole kitchen sink of goodies comes with Foundation. Check out the docs to see them all, along with details on making them your own.</p>
             <a href="http://foundation.zurb.com/sites/docs/" class="small button">Go to Foundation Docs</a>
           </div>


### PR DESCRIPTION
As per @kball. Thanks!