### PR TITLE
Fixed flex horizontal alignment. Issue #10125

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -121,6 +121,9 @@ $global-button-cursor: auto !default;
 $global-left: if($global-text-direction == rtl, right, left);
 $global-right: if($global-text-direction == rtl, left, right);
 
+// Internal variable that contains the flex justifying options
+$-zf-flex-justify: -zf-flex-justify($global-text-direction);
+
 /// Global tolerance for color pick contrast.
 /// @type Number
 $global-color-pick-contrast-tolerance: 0 !default;

--- a/scss/components/_flex.scss
+++ b/scss/components/_flex.scss
@@ -71,14 +71,14 @@ $flexbox-responsive-breakpoints: true !default;
 
 @mixin foundation-flex-classes {
   // Horizontal alignment using justify-content
-  @each $hdir, $prop in map-remove($-zf-flex-justify, 'left') {
+  @each $hdir, $prop in $-zf-flex-justify {
     .align-#{$hdir} {
       @include flex-align($x: $hdir);
     }
   }
   
   // Horizontal alignment Specifically for Vertical Menu
-  @each $hdir, $prop in map-remove($-zf-flex-justify, 'left', 'justify', 'spaced') {
+  @each $hdir, $prop in map-remove($-zf-flex-justify, 'justify', 'spaced') {
     .align-#{$hdir} {
       &.vertical.menu > li > a { 
         @include flex-align($x: $hdir);

--- a/scss/util/_flex.scss
+++ b/scss/util/_flex.scss
@@ -1,10 +1,15 @@
-$-zf-flex-justify: (
-  'left': flex-start,
-  'right': flex-end,
-  'center': center,
-  'justify': space-between,
-  'spaced': space-around,
-);
+@function -zf-flex-justify($text-direction){
+  $-zf-flex-justify: (
+    'left': if($text-direction == rtl, flex-end, flex-start),
+    'right': if($text-direction == rtl, flex-start, flex-end),
+    'center': center,
+    'justify': space-between,
+    'spaced': space-around,
+  );
+
+  @return $-zf-flex-justify;
+}
+
 
 $-zf-flex-align: (
   'top': flex-start,


### PR DESCRIPTION
This PR fixes this issue #10125

The variable `$-zf-flex-justify` in `scss/util/_flex.scss` contains static values for the two properties **left** and **right**, but they should be set depending on the current direction context that is stored in `$global-text-direction`. 
Technically, we cannot use the variable `$global-text-direction` in any Scss utility because `$global-text-direction` lives in `_global.scss` which is called after `_util.scss`, therefore I changed that variable -`$-zf-flex-justify`- to a function (`zf-flex-justify($text-direction)`) that takes the direction as an argument, as well as I defined an internal global variable with the origin name `$-zf-flex-justify`  in `_global.scss`to void changing in any Scss component that was using that variable name.