### PR TITLE
Allow inline `<cite>` elements

### DIFF
--- a/docs/pages/typography-base.md
+++ b/docs/pages/typography-base.md
@@ -261,6 +261,10 @@ A definition list (`<dl>`) is used to display name-value pairs, like metadata or
 
 Sometimes other people say smart things, and you may want to mention those things with a quote. We've got you covered.
 
+<div class="callout">
+  By default, `<cite>` takes the look of the `.cite-block` component. In Sass, you can customize it with <a href="#sass-variables">`$cite-*` variables</a> or disable it by setting `$enable-cite-block` to false.
+</div>
+
 <div class="docs-codepen-container">
 <a class="codepen-logo-link" href="https://codepen.io/ZURBFoundation/pen/ZKoJMb" target="_blank"><img src="{{root}}assets/img/logos/edit-in-browser.svg" class="" height="" width="" alt="edit on codepen button"></a>
 </div>

--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -215,17 +215,9 @@ $blockquote-padding: rem-calc(9 20 0 19) !default;
 /// @type List
 $blockquote-border: 1px solid $medium-gray !default;
 
-/// Font size for `<cite>` elements.
-/// @type Number
-$cite-font-size: rem-calc(13) !default;
-
 /// Text color for `<cite>` elements.
 /// @type Color
 $cite-color: $dark-gray !default;
-
-/// Pseudo content for `<cite>` elements.
-/// @type String
-$cite-pseudo-content: '\2014 \0020' !default;
 
 /// Font family for `<kbd>` elements.
 /// @type String | List
@@ -458,12 +450,7 @@ $abbr-underline: 1px dotted $black !default;
 
     // Citations
     cite {
-      display: block;
-      font-size: $cite-font-size;
-
-      &:before {
-        content: $cite-pseudo-content;
-      }
+      @include block-citation;
     }
   }
 

--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -79,7 +79,7 @@ $header-styles: (
   @each $size, $headers in $header-sizes {
     $header-map: ();
     @each $header, $font-size in $headers {
-      $header-map: map-merge($header-map, ($header: ('font-size': $font-size)));  
+      $header-map: map-merge($header-map, ($header: ('font-size': $font-size)));
     }
     $header-styles: map-merge($header-styles, ($size: $header-map));
   }
@@ -215,9 +215,9 @@ $blockquote-padding: rem-calc(9 20 0 19) !default;
 /// @type List
 $blockquote-border: 1px solid $medium-gray !default;
 
-/// Text color for `<cite>` elements.
-/// @type Color
-$cite-color: $dark-gray !default;
+/// Use the `.cite-block` component as default for `<cite>` elements.
+/// @type Boolean
+$enable-cite-block: true;
 
 /// Font family for `<kbd>` elements.
 /// @type String | List
@@ -447,16 +447,15 @@ $abbr-underline: 1px dotted $black !default;
       line-height: $paragraph-lineheight;
       color: $blockquote-color;
     }
-
-    // Citations
-    cite {
-      @include block-citation;
-    }
   }
 
   // Inline Citations
-  cite {
-    color: $cite-color;
+  @if ($enable-cite-block == true) {
+    cite {
+      // Extending a class is not recommanded.
+      // TODO: Break the typography-base/typography-helpers separation
+      @extend .cite-block;
+    }
   }
 
   // Abbreviations
@@ -470,7 +469,7 @@ $abbr-underline: 1px dotted $black !default;
   figure {
     margin: 0;
   }
-  
+
   // Code
   code {
     padding: $code-padding;

--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -455,17 +455,21 @@ $abbr-underline: 1px dotted $black !default;
       line-height: $paragraph-lineheight;
       color: $blockquote-color;
     }
+
+    // Citations
+    cite {
+      display: block;
+      font-size: $cite-font-size;
+
+      &:before {
+        content: $cite-pseudo-content;
+      }
+    }
   }
 
-  // Citations
+  // Inline Citations
   cite {
-    display: block;
-    font-size: $cite-font-size;
     color: $cite-color;
-
-    &:before {
-      content: $cite-pseudo-content;
-    }
   }
 
   // Abbreviations

--- a/scss/typography/_helpers.scss
+++ b/scss/typography/_helpers.scss
@@ -6,6 +6,15 @@
 /// @group typography-helpers
 ////
 
+
+/// Font size for `<cite>` elements.
+/// @type Number
+$cite-font-size: rem-calc(13) !default;
+
+/// Pseudo content for `<cite>` elements.
+/// @type String
+$cite-pseudo-content: '\2014 \0020' !default;
+
 /// Default font size for lead paragraphs.
 /// @type Number
 $lead-font-size: $global-font-size * 1.25 !default;
@@ -76,5 +85,15 @@ $stat-font-size: 2.5rem !default;
       margin-#{$global-left}: 0;
       list-style: none;
     }
+  }
+}
+
+@mixin block-citation {
+  // Use to restore the block version of cite elements
+  display: block;
+  font-size: $cite-font-size;
+
+  &:before {
+    content: $cite-pseudo-content;
   }
 }

--- a/scss/typography/_helpers.scss
+++ b/scss/typography/_helpers.scss
@@ -6,15 +6,6 @@
 /// @group typography-helpers
 ////
 
-
-/// Font size for `<cite>` elements.
-/// @type Number
-$cite-font-size: rem-calc(13) !default;
-
-/// Pseudo content for `<cite>` elements.
-/// @type String
-$cite-pseudo-content: '\2014 \0020' !default;
-
 /// Default font size for lead paragraphs.
 /// @type Number
 $lead-font-size: $global-font-size * 1.25 !default;
@@ -46,6 +37,29 @@ $subheader-margin-bottom: 0.5rem !default;
 /// Default font size for statistic numbers.
 /// @type Number
 $stat-font-size: 2.5rem !default;
+
+/// Text color for `.cite-block` component.
+/// @type Color
+$cite-color: $dark-gray !default;
+
+/// Font size for `.cite-block` component.
+/// @type Number
+$cite-font-size: rem-calc(13) !default;
+
+/// Pseudo content for `.cite-block` component.
+/// @type String
+$cite-pseudo-content: '\2014 \0020' !default;
+
+
+@mixin cite-block {
+  display: block;
+  color: $cite-color;
+  font-size: $cite-font-size;
+
+  &:before {
+    content: $cite-pseudo-content;
+  }
+}
 
 @mixin foundation-typography-helpers {
   // Use to create a subheading under a main header
@@ -86,14 +100,8 @@ $stat-font-size: 2.5rem !default;
       list-style: none;
     }
   }
-}
 
-@mixin block-citation {
-  // Use to restore the block version of cite elements
-  display: block;
-  font-size: $cite-font-size;
-
-  &:before {
-    content: $cite-pseudo-content;
+  .cite-block {
+    @include cite-block;
   }
 }


### PR DESCRIPTION
Move the block styling and reduced font size on `<cite>` to only
apply when it is a child of `<blockquote>`.

Fixes issue #10226