### PR TITLE
Add grow to xy-cell-base

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -44,7 +44,7 @@
 
 /// Sets base flex properties for cells.
 ///
-/// @param {Keyword} $size [full] - The size of your cell. Accepts `full`, `auto` or `shrink`.
+/// @param {Keyword} $size [full] - The size of your cell. Accepts `full`, `auto`, `shrink` or `grow`.
 @mixin xy-cell-base($size: full) {
   @if($size == 'full') {
     // This is the base style, all others inherit from it

--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -58,6 +58,9 @@
   @elseif ($size == 'shrink') {
     flex: 0 0 auto;
   }
+  @elseif ($size == 'grow') {
+    flex: 1 0 auto;
+  }
 }
 
 /// Resets a cells width (or height if vertical is true) as well as strips its gutters.


### PR DESCRIPTION
Add the ability to use the xy-cell-base mixin to grow the flex item to take up all available space.

This is effectively the same as: `.flex-child-grow`, found @ https://foundation.zurb.com/sites/docs/flexbox-utilities.html#vanilla-flexbox-helper-classes - But there isn't a way to do this through the current SASS mixins.