### PR TITLE
Option to change font-weight of buttons

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -11,8 +11,9 @@
 $button-font-family: inherit !default;
 
 /// Font weight for button elements.
+/// Ignored if null (default)
 /// @type Font-Weight
-$button-font-weight: inherit !default;
+$button-font-weight: null !default;
 
 /// Padding inside buttons.
 /// @type List
@@ -95,9 +96,7 @@ $button-responsive-expanded: false !default;
   vertical-align: middle;
   margin: $button-margin;
   font-family: $button-font-family;
-  @if ($button-font-weight != inherit && $button-font-weight != $global-weight-normal) {
-    font-weight: $button-font-weight;
-  }
+  font-weight: $button-font-weight;
 
   @if (type-of($button-padding) == 'map') {
     @each $size, $padding in $button-padding {

--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -10,6 +10,10 @@
 /// @type Font
 $button-font-family: inherit !default;
 
+/// Font weight for button elements.
+/// @type Font-Weight
+$button-font-weight: inherit !default;
+
 /// Padding inside buttons.
 /// @type List
 $button-padding: 0.85em 1em !default;
@@ -91,6 +95,9 @@ $button-responsive-expanded: false !default;
   vertical-align: middle;
   margin: $button-margin;
   font-family: $button-font-family;
+  @if ($button-font-weight != inherit && $button-font-weight != $global-weight-normal) {
+    font-weight: $button-font-weight;
+  }
 
   @if (type-of($button-padding) == 'map') {
     @each $size, $padding in $button-padding {


### PR DESCRIPTION
Adding option to set the font-weight of buttons. This is useful if the body font weight is set to a lighter font which is to light for buttons with solid background.