### PR TITLE
Fix autoprefixer documentation for Sass setup

### DIFF
--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -30,7 +30,7 @@ To get the proper browser support, use these Autoprefixer settings:
 
 ```js
 autoprefixer({
-  browsers: ['last 2 versions', 'ie >= 9', 'and_chr >= 2.3']
+  browsers: ['last 2 versions', 'ie >= 9', 'Android >= 2.3', 'ios >= 7']
 });
 ```
 


### PR DESCRIPTION
The documentation for configuring gulp-autoprefixer does not match the actual configuration used in the build scripts.  This updates the documentation to match.
