### PR TITLE
Push, pull, & offset optional for foundation-grid

### DIFF
--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -163,20 +163,13 @@
     }
 
     // Gutter adjustment
-    @if $uncenter {
-      .#{$-zf-size}-#{$uncenter} {
-        @include grid-col-unpos;
-      }
-    }
-
-    @if $push {
-      .#{$-zf-size}-#{$push}-0 {
-        @include grid-col-unpos;
-      }
-    }
-
-    @if $pull {
-      .#{$-zf-size}-#{$pull}-0 {
+    $-gutter-unpos-selector: (
+      if($uncenter, '.#{$-zf-size}-#{$uncenter}', null),
+      if($push, '.#{$-zf-size}-#{$push}-0', null),
+      if($pull, '.#{$-zf-size}-#{$pull}-0', null),
+    );
+    @if ($uncenter or $push or $pull) {
+      #{$-gutter-unpos-selector} {
         @include grid-col-unpos;
       }
     }

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -161,7 +161,7 @@
     }
 
     // Gutter adjustment
-    #{$-zf-size}-#{$uncenter} {
+    .#{$-zf-size}-#{$uncenter} {
       @include grid-col-unpos;
     }
 

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -161,10 +161,20 @@
     }
 
     // Gutter adjustment
-    .#{$-zf-size}-#{$uncenter},
-    .#{$-zf-size}-#{$push}-0,
-    .#{$-zf-size}-#{$pull}-0 {
+    #{$-zf-size}-#{$uncenter} {
       @include grid-col-unpos;
+    }
+
+    @if $push {
+      .#{$-zf-size}-#{$push}-0 {
+        @include grid-col-unpos;
+      }
+    }
+
+    @if $pull {
+      .#{$-zf-size}-#{$pull}-0 {
+        @include grid-col-unpos;
+      }
     }
   }
 

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -106,20 +106,26 @@
 
       // Source ordering
       @if $i < $grid-column-count {
-        .#{$-zf-size}-#{$push}-#{$i} {
-          @include grid-col-pos($i);
+        @if $push {
+          .#{$-zf-size}-#{$push}-#{$i} {
+            @include grid-col-pos($i);
+          }
         }
 
-        .#{$-zf-size}-#{$pull}-#{$i} {
-          @include grid-col-pos(-$i);
+        @if $pull {
+          .#{$-zf-size}-#{$pull}-#{$i} {
+            @include grid-col-pos(-$i);
+          }
         }
       }
 
       // Offsets
       $o: $i - 1;
 
-      .#{$-zf-size}-#{$offset}-#{$o} {
-        @include grid-col-off($o);
+      @if $offset {
+        .#{$-zf-size}-#{$offset}-#{$o} {
+          @include grid-col-off($o);
+        }
       }
     }
 

--- a/scss/grid/_classes.scss
+++ b/scss/grid/_classes.scss
@@ -156,13 +156,17 @@
     }
 
     // Positioning
-    .#{$-zf-size}-#{$center} {
-      @include grid-col-pos(center);
+    @if $center {
+      .#{$-zf-size}-#{$center} {
+        @include grid-col-pos(center);
+      }
     }
 
     // Gutter adjustment
-    .#{$-zf-size}-#{$uncenter} {
-      @include grid-col-unpos;
+    @if $uncenter {
+      .#{$-zf-size}-#{$uncenter} {
+        @include grid-col-unpos;
+      }
     }
 
     @if $push {


### PR DESCRIPTION
Allowing push, pull, offset, center, and uncenter to be optional for foundation-grid

Fixes issue #10701