### PR TITLE
 fixes #10693 stack button group always expanded

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -18,7 +18,7 @@ $buttongroup-spacing: 1px !default;
 /// @type String
 $buttongroup-child-selector: '.button' !default;
 
-/// Maximum number of buttons that can be in an even-width button group.
+/// Maximum number of buttons that can be in an even-width button group. (Only needed when $global-flexbox: false;)
 /// @type Number
 $buttongroup-expand-max: 6 !default;
 

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -255,5 +255,16 @@ $buttongroup-radius-on-each: true !default;
         }
       }
     }
+
+    &.stacked-for-medium.expanded { // sass-lint:disable-line force-element-nesting
+      @include breakpoint(medium down) {
+        display: block;
+
+        #{$buttongroup-child-selector} {
+          display: block;
+          margin-#{$global-right}: 0;
+        }
+      }
+    }
   }
 }

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -168,7 +168,7 @@ $buttongroup-radius-on-each: true !default;
 ) {
   #{$selector} {
     @if $global-flexbox {
-      flex: 1 1 0px; // sass-lint:disable-line zero-unit
+      flex: 0 0 auto;
     }
     @else {
       width: auto;
@@ -204,7 +204,9 @@ $buttongroup-radius-on-each: true !default;
     }
 
     // Even-width Group
-    &.expanded { @include button-group-expand; }
+    &.expanded {
+      @include button-group-expand;
+    }
 
     // Colors
     @each $name, $color in $foundation-palette {
@@ -225,6 +227,10 @@ $buttongroup-radius-on-each: true !default;
     &.stacked-for-small,
     &.stacked-for-medium {
       @include button-group-stack;
+
+      &.expanded {
+        @include button-group-expand;
+      }
     }
 
     &.stacked-for-small {

--- a/test/visual/button/button-group.html
+++ b/test/visual/button/button-group.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="grid-container">
+
+      Buttons should be stacked full-width here
+      <div class="button-group stacked">
+        <a class="button">One</a>
+        <a class="button">Two</a>
+        <a class="button">Three</a>
+      </div>
+
+      Buttons should be auto width here and stack for small
+      <div class="button-group stacked-for-small">
+        <a class="button">One</a>
+        <a class="button">Two</a>
+        <a class="button">Three</a>
+      </div>
+
+      Buttons should be expanded here and stack for medium and small
+      <div class="button-group stacked-for-medium expanded">
+        <a class="button">One</a>
+        <a class="button">Two</a>
+        <a class="button">Three</a>
+        <a class="button">Four</a>
+        <a class="button">Five</a>
+      </div>
+
+    </div>
+
+  <script src="../assets/js/vendor.js"></script>
+  <script src="../assets/js/foundation.js"></script>
+  <script>
+  $(document).foundation();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Ref #10693 

Button Group with `.stacked` class was getting expanded buttons when not stacked. Should be width: auto unless combined with `.expanded`
