### PR TITLE
Fixes issue with cell block height pinning in Safari

### DIFF
--- a/scss/xy-grid/_frame.scss
+++ b/scss/xy-grid/_frame.scss
@@ -61,7 +61,7 @@
   @if $vertical == true {
     overflow-y: auto;
     max-height: 100%;
-    height: 100%;
+    min-height: 100%;
   } @else {
     overflow-x: auto;
     max-width: 100%;


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/zurb/foundation-sites/pull/10649 and turned up while doing QA on 6.4.4-rc1, which results in cell blocks not functioning properly in Safari
