### PR TITLE
fix: prevent "space" on input to open dropdown

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -178,7 +178,7 @@ class Dropdown extends Positionable {
 
       Keyboard.handleKey(e, 'Dropdown', {
         open: function() {
-          if ($target.is(_this.$anchors) && !$target.is('input')) {
+          if ($target.is(_this.$anchors) && !$target.is('input, textarea')) {
             _this.open();
             _this.$element.attr('tabindex', -1).focus();
             e.preventDefault();

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -178,7 +178,7 @@ class Dropdown extends Positionable {
 
       Keyboard.handleKey(e, 'Dropdown', {
         open: function() {
-          if ($target.is(_this.$anchors)) {
+          if ($target.is(_this.$anchors) && !$target.is('input')) {
             _this.open();
             _this.$element.attr('tabindex', -1).focus();
             e.preventDefault();

--- a/test/javascript/components/dropdown.js
+++ b/test/javascript/components/dropdown.js
@@ -97,4 +97,34 @@ describe('Dropdown', function() {
       }, 2);
     });
   });
+
+  describe('keyboard events', function () {
+    it('opens Dropdown on SPACE', function() {
+      $dropdownController = $(getDropdownController()).appendTo('body');
+      $dropdownContainer = $(getDropdownContainer()).appendTo('body');
+      plugin = new Foundation.Dropdown($dropdownContainer, {});
+      $dropdownController.focus()
+        .trigger(window.mockKeyboardEvent('SPACE'));
+
+      $dropdownContainer.should.be.visible;
+    });
+    it('focuses Dropdown on SPACE', function() {
+      $dropdownController = $(getDropdownController()).appendTo('body');
+      $dropdownContainer = $(getDropdownContainer()).appendTo('body');
+      plugin = new Foundation.Dropdown($dropdownContainer, {});
+      $dropdownController.focus()
+        .trigger(window.mockKeyboardEvent('SPACE'));
+
+      document.activeElement.should.be.equal($dropdownContainer[0]);
+    });
+    it('does not focus Dropdown when anchor is an input', function() {
+      $dropdownController = $('<input type="text" data-toggle="my-dropdown">').appendTo('body');
+      $dropdownContainer = $(getDropdownContainer()).appendTo('body');
+      plugin = new Foundation.Dropdown($dropdownContainer, {});
+      $dropdownController.focus()
+        .trigger(window.mockKeyboardEvent('SPACE'));
+
+      document.activeElement.should.be.equal($dropdownController[0]);
+    });
+  })
 });

--- a/test/visual/dropdown/dropdown-on-input.html
+++ b/test/visual/dropdown/dropdown-on-input.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell">
+          <h1>Dropdown: Attached to an input</h1>
+
+          <p>When the Dropdown is attached to an input element, it should not receive focus when a space is entered into the input..</p>
+          
+          <div class="row">
+            <div class="column">
+              <input type="text" data-toggle="dropdown" aria-describedby="dropdown" placeholder="Click to open Dropdown">
+              <div class="dropdown-pane" id="dropdown" data-dropdown data-close-on-click="true">
+                <p>Now press space to see if I receive focus. This should not be the case.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>
+


### PR DESCRIPTION
I had the usecase where I used a Dropdown as a auto-completion/suggestion feature. The Dropdown was attached to an input element and shows when the input has focus. Issue was then, that everytime a space was entered into the input, the Dropdown would receive focus and prevent the typing within the input.

I am not sure, whether this is too specific or not to become part of the code base.