### PR TITLE
Fix typo in javascript docs page

### DIFF
--- a/docs/pages/javascript.md
+++ b/docs/pages/javascript.md
@@ -63,7 +63,7 @@ The `.foundation()` function on the jQuery object will kick off every Foundation
 $(document).foundation();
 ```
 
-You can also selectively initialize plugins by call the `.foundation();` method on one or more elements with a plugin.
+You can also selectively initialize plugins by calling the `.foundation();` method on one or more elements with a plugin.
 
 ```js
 $('#foo').foundation(); // initialize all plugins within the element `#foo`


### PR DESCRIPTION
Instead of "call the ...", "calling the ..." sounds much better.