### PR TITLE
use on() to listen for the load event

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -82,7 +82,7 @@ class Accordion extends Plugin {
           //roll up a little to show the titles
           if (this.options.deepLinkSmudge) {
             var _this = this;
-            $(window).load(function() {
+            $(window).on('load', function() {
               var offset = _this.$element.offset();
               $('html, body').animate({ scrollTop: offset.top }, _this.options.deepLinkSmudgeDelay);
             });

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -77,7 +77,7 @@ class Tabs extends Plugin {
       }
 
       if(isActive && _this.options.autoFocus){
-        $(window).load(function() {
+        $(window).on('load', function() {
           $('html, body').animate({ scrollTop: $elem.offset().top }, _this.options.deepLinkSmudgeDelay, () => {
             $link.focus();
           });


### PR DESCRIPTION
`.load()` is deprecated since jQuery 1.8 and the event can only be fetched with `.on('load')`

> Note: Prior to jQuery 3.0, the event handling suite also had a method named .load(). Older versions of jQuery determined which method to fire based on the set of arguments passed to it.

https://api.jquery.com/load/
https://api.jquery.com/load-event/