### PR TITLE
Update fourseven:scss version for Meteor 1.6 #10606

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,3 @@
 {
-	"plugins": [
-  	"transform-es2015-arrow-functions",
-  	"transform-es2015-block-scoped-functions",
-  	"transform-es2015-block-scoping",
-  	"transform-es2015-classes",
-  	"transform-es2015-destructuring",
-  	"transform-es2015-template-literals",
-  	"transform-es2015-parameters",
-  	"transform-es2015-shorthand-properties",
-  	"transform-es2015-spread"
-  ]
+
 }

--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
   	"transform-es2015-destructuring",
   	"transform-es2015-template-literals",
   	"transform-es2015-parameters",
-		"transform-es2015-shorthand-properties",
-  	"transform-es2015-spread",
+  	"transform-es2015-shorthand-properties",
+  	"transform-es2015-spread"
   ]
 }

--- a/package.js
+++ b/package.js
@@ -8,8 +8,7 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.2.1');
-  api.imply('fourseven:scss@3.4.1');
-  api.use(['ecmascript', 'jquery', 'fourseven:scss@3.4.1'], 'client');
+  api.use(['ecmascript', 'jquery', 'fourseven:scss'], 'client');
   api.addFiles('dist/js/foundation.js', 'client');
   api.addFiles([
 


### PR DESCRIPTION
Fixes the bug in #10606 where foundation-sites cannot be used under Meteor 1.6 as fourseven:scss@3.4.1 is no longer supported (due to Node upgrade).  This PR allows using the newer versions of fourseven:scss that are supported by Meteor 1.6 and Node 8.
