### PR TITLE
Fix reveal enableScroll calculation of scrollTop

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -186,7 +186,8 @@ class Reveal extends Plugin {
   * Disables the scroll when Reveal is shown to prevent the background from shifting
   * @param {number} scrollTop
   */
-  _disableScroll(scrollTop){
+  _disableScroll(scrollTop) {
+    scrollTop = scrollTop || $(window).scrollTop();
     if ($(document).height() > $(window).height()) {
       $("html")
         .css("top", -scrollTop);
@@ -197,7 +198,8 @@ class Reveal extends Plugin {
   * Reenables the scroll when Reveal closes
   * @param {number} scrollTop
   */
-  _enableScroll(scrollTop){
+  _enableScroll(scrollTop) {
+    scrollTop = scrollTop || parseInt($("html").css("top"));
     if ($(document).height() > $(window).height()) {
       $("html")
         .css("top", "");
@@ -264,9 +266,7 @@ class Reveal extends Plugin {
       this.$element.trigger('closeme.zf.reveal', this.id);
     }
 
-    var scrollTop = $(window).scrollTop();
-
-    this._disableScroll(scrollTop);
+    this._disableScroll();
 
     var _this = this;
 

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -184,7 +184,7 @@ class Reveal extends Plugin {
 
   /**
   * Disables the scroll when Reveal is shown to prevent the background from shifting
-  * @param {number} scrollTop
+  * @param {number} scrollTop - Scroll to visually apply, window current scroll by default
   */
   _disableScroll(scrollTop) {
     scrollTop = scrollTop || $(window).scrollTop();
@@ -196,7 +196,7 @@ class Reveal extends Plugin {
 
   /**
   * Reenables the scroll when Reveal closes
-  * @param {number} scrollTop
+  * @param {number} scrollTop - Scroll to restore, html "top" property by default (as set by `_disableScroll`)
   */
   _enableScroll(scrollTop) {
     scrollTop = scrollTop || parseInt($("html").css("top"));
@@ -400,6 +400,9 @@ class Reveal extends Plugin {
 
     function finishUp() {
 
+      // Get the current top before the modal is closed and restore the scroll after.
+      // TODO: use component properties instead of HTML properties
+      // See https://github.com/zurb/foundation-sites/pull/10786
       var scrollTop = parseInt($("html").css("top"));
 
       if ($('.reveal:visible').length  === 0) {

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -184,10 +184,10 @@ class Reveal extends Plugin {
 
   /**
   * Disables the scroll when Reveal is shown to prevent the background from shifting
+  * @param {number} scrollTop
   */
-  _disableScroll(){
+  _disableScroll(scrollTop){
     if ($(document).height() > $(window).height()) {
-      var scrollTop = $(window).scrollTop();
       $("html")
         .css("top", -scrollTop);
     }
@@ -195,10 +195,10 @@ class Reveal extends Plugin {
 
   /**
   * Reenables the scroll when Reveal closes
+  * @param {number} scrollTop
   */
-  _enableScroll(){
+  _enableScroll(scrollTop){
     if ($(document).height() > $(window).height()) {
-      var scrollTop = parseInt($("html").css("top"));
       $("html")
         .css("top", "");
       $(window).scrollTop(-scrollTop);
@@ -264,7 +264,9 @@ class Reveal extends Plugin {
       this.$element.trigger('closeme.zf.reveal', this.id);
     }
 
-    this._disableScroll();
+    var scrollTop = $(window).scrollTop();
+
+    this._disableScroll(scrollTop);
 
     var _this = this;
 
@@ -398,6 +400,8 @@ class Reveal extends Plugin {
 
     function finishUp() {
 
+      var scrollTop = parseInt($("html").css("top"));
+
       if ($('.reveal:visible').length  === 0) {
         $('html').removeClass('is-reveal-open');
       }
@@ -406,7 +410,7 @@ class Reveal extends Plugin {
 
       _this.$element.attr('aria-hidden', true);
 
-      _this._enableScroll();
+      _this._enableScroll(scrollTop);
 
       /**
       * Fires when the modal is done closing.


### PR DESCRIPTION
This PR fixes an issue with the scrollTop calculation of the `_enableScroll` method in the reveal component.
Precisely the issue occurred for me on iOS / iPhone.

After some debugging I found out the line `parseInt($("html").css("top"))` doesn't work as expected in this scenario because the class `.is-reveal-open` got removed before.
Therefore the html element got `position:static` again an returns `auto` as top-value on iOS.

To fix this I've moved the scrollTop calculation from the disabledScroll/enableScroll methods to the place they get called and pipe them through as param.
So now the top value gets calculated before `.is-reveal-open` is removed.

@IamManchanda @kball would you review?
