### PR TITLE
Fix Drilldown from preventing focus trapping by offcanvas.

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -277,8 +277,8 @@ class Drilldown extends Plugin {
         handled: function(preventDefault) {
           if (preventDefault) {
             e.preventDefault();
+            e.stopImmediatePropagation();
           }
-          e.stopImmediatePropagation();
         }
       });
     }); // end keyboardAccess


### PR DESCRIPTION
Addresses #10429.

I found out the issue lies in a `stopImmideatePropagation()` call that prevents the OffCanvas listener from trapping the focus. Moved it so it is not called for the last list item.

[Pen with a fixed version of Foundation](https://codepen.io/Owlbertz/pen/rpBPdY).