### PR TITLE
fix: do not generate invalid xy-cell when breakpoint is not found

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -120,21 +120,26 @@
     }
   }
 
-  // Get our gutters from map if available, if not map just return the value.
+  // Get the gutter for the passed breakpoint/value.
   $gutter: -zf-get-bp-val($gutters, $breakpoint);
 
-  // Base flex properties
-  @include xy-cell-base($size);
+  @if($gutter != null) {
+    // Base flex properties
+    @include xy-cell-base($size);
 
-  @if($gutter-type == 'margin') {
-    @include -xy-cell-properties($size, $gutter, $vertical);
+    @if($gutter-type == 'margin') {
+      @include -xy-cell-properties($size, $gutter, $vertical);
+    }
+    @else {
+      @include -xy-cell-properties($size, 0, $vertical);
+    }
+
+    @if $gutter-output {
+      @include xy-gutters($gutter, $gutter-type, $gutter-position);
+    }
   }
   @else {
-    @include -xy-cell-properties($size, 0, $vertical);
-  }
-
-  @if $gutter-output {
-    @include xy-gutters($gutter, $gutter-type, $gutter-position);
+    @warn 'xy-cell: no gutters were found in `$gutters` for "$breakpoint: #{$breakpoint}", cell was not generated`'
   }
 }
 


### PR DESCRIPTION
For the following code:
```scss
.test {
  @include xy-cell(12, $breakpoint: small);
  @include xy-cell(12, $breakpoint: xxx-invalid-breakpoint-xxx);
}
```

Generate the following code:
```css
.test {
  width: calc(100% - 1.25rem);
  margin-right: 0.625rem;
  margin-left: 0.625rem;
}
```

And gives this warning:
```
WARNING: xy-cell: no gutters were found in `$gutters` for "$breakpoint: xxx-invalid-breakpoint-xxx", cell was not generated`
Backtrace:
	../foundation-sites/scss/xy-grid/_cell.scss:142, in mixin `xy-cell`
	...
```

Not: a refactor of breakpoints seems necessary to ensure we have this behavior across the whole framework.