### PR TITLE
Update dependency `fourseven:scss`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
   	"transform-es2015-destructuring",
   	"transform-es2015-template-literals",
   	"transform-es2015-parameters",
-		"transform-es2015-shorthand-properties",
-  	"transform-es2015-spread",
+  	"transform-es2015-shorthand-properties",
+  	"transform-es2015-spread"
   ]
 }

--- a/.versions
+++ b/.versions
@@ -3,7 +3,7 @@ babel-runtime@0.1.8
 caching-compiler@1.0.4
 ecmascript@0.4.3
 ecmascript-runtime@0.2.10
-fourseven:scss@3.4.1
+fourseven:scss@4.5.4
 jquery@1.11.8
 meteor@1.1.14
 modules@0.6.1

--- a/package.js
+++ b/package.js
@@ -8,8 +8,8 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.2.1');
-  api.imply('fourseven:scss@3.4.1');
-  api.use(['ecmascript', 'jquery', 'fourseven:scss@3.4.1'], 'client');
+  api.imply('fourseven:scss@4.5.4');
+  api.use(['ecmascript', 'jquery', 'fourseven:scss@4.5.4'], 'client');
   api.addFiles('dist/js/foundation.js', 'client');
   api.addFiles([
 


### PR DESCRIPTION
Fixes https://github.com/zurb/foundation-sites/issues/10606 by updating the version of `fourseven:scss` implied in `package.js`.

Also fixed a syntax error that was throwing an error when including this into a meteor project:
```
=> Started proxy.                             
=> Errors prevented startup:                  
   
   While processing files with ecmascript (for target web.browser):
   <anonymous>: .babelrc is not a valid JSON file: Unexpected token ] in JSON at position 356
   at JSON.parse (<anonymous>)
   at BabelCompiler.BCp._inferFromBabelRc (packages/babel-compiler.js:255:16)
   at BabelCompiler.BCp.inferExtraBabelOptions (packages/babel-compiler.js:244:10)
   at BabelCompiler.BCp.processOneFileForTarget (packages/babel-compiler.js:174:10)
   at BabelCompiler.<anonymous> (packages/babel-compiler.js:111:26)
   at Array.forEach (<anonymous>)
   at BabelCompiler.BCp.processFilesForTarget (packages/babel-compiler.js:110:14)
```

I also noted that Node 8 was required to get this running properly, which I was unaware of but is probably common knowledge.