### PR TITLE
fix: remove tab outline when not using keyboard 10798

### DIFF
--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -91,6 +91,7 @@ $tab-content-padding: 1rem !default;
   float: #{$global-left};
 
   > a {
+    @include disable-mouse-outline;
     display: block;
     padding: $padding;
     font-size: $font-size;


### PR DESCRIPTION
> No `outline` should be show when it is not for accessibility reasons, since it is not part of the Foundation design. So when `what-input` detect a mouse, we should have `outline: 0;` on the tab links

Closes #10798