### PR TITLE
docs: fix typo in `button-disabled()` params #10783

### DIFF
--- a/scss/components/_button.scss
+++ b/scss/components/_button.scss
@@ -201,8 +201,8 @@ $button-responsive-expanded: false !default;
 }
 
 /// Adds disabled styles to a button by fading the element, reseting the cursor, and disabling pointer events.
-/// @param [Color] $background [$button-background] - Background color of the disabled button.
-/// @param [Color] $color [$button-color] - Text color of the disabled button. Set to `auto` to have the mixin automatically generate a color based on the background color.
+/// @param {Color} $background [$button-background] - Background color of the disabled button.
+/// @param {Color} $color [$button-color] - Text color of the disabled button. Set to `auto` to have the mixin automatically generate a color based on the background color.
 @mixin button-disabled(
   $background: $button-background,
   $color: $button-color


### PR DESCRIPTION
Closes #10783 