### PR TITLE
fix: fix dropdown anchor attributes #10627

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -66,12 +66,18 @@ class Dropdown extends Positionable {
       this.$parent = null;
     }
 
+    // Do not change the `labelledby` if it is defined
+    var labelledby = this.$element.attr('aria-labelledby')
+      || this.$currentAnchor.attr('id')
+      || GetYoDigits(6, 'dd-anchor');
+
     this.$element.attr({
       'aria-hidden': 'true',
       'data-yeti-box': $id,
       'data-resize': $id,
-      'aria-labelledby': this.$currentAnchor.id || GetYoDigits(6, 'dd-anchor')
+      'aria-labelledby': labelledby
     });
+
     super._init();
     this._events();
   }

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -94,7 +94,7 @@ class Dropdown extends Positionable {
 
   _getDefaultAlignment() {
     // handle legacy float approach
-    var horizontalPosition = /float-(\S+)/.exec(this.$currentAnchor.className);
+    var horizontalPosition = /float-(\S+)/.exec(this.$currentAnchor.attr('class'));
     if(horizontalPosition) {
       return horizontalPosition[1];
     }


### PR DESCRIPTION
Changes:
* fix dropdown aria-labelledby based on its anchor id (bug introduced in #10360 - 36521fb)
    Tested with WAVE, the dropdown is no longer considered as invalid.
* fix dropdown default alignement based on its anchor `float-*` class

Closes #10627
  