### PR TITLE
Revert "fix: prevent side-effect from .stack-for in media-object"

### DIFF
--- a/scss/components/_media-object.scss
+++ b/scss/components/_media-object.scss
@@ -38,12 +38,6 @@ $mediaobject-image-width-stacked: 100% !default;
       }
     }
   }
-
-  &.stack-for-#{$-zf-zero-breakpoint} .media-object-section {
-    @include breakpoint($-zf-zero-breakpoint only) {
-      @include media-object-stack;
-    }
-  }
 }
 
 /// Adds styles for sections within a media object.
@@ -67,6 +61,12 @@ $mediaobject-image-width-stacked: 100% !default;
 
   > :last-child {
     margin-bottom: 0;
+  }
+
+  .stack-for-#{$-zf-zero-breakpoint} & {
+    @include breakpoint($-zf-zero-breakpoint only) {
+      @include media-object-stack;
+    }
   }
 
   @if $global-flexbox {


### PR DESCRIPTION
This reverts commit 606f16480e0ca8d931adcdf49bcc7d0cef2754c6.

> Prevent a parent component with `.stack-for-*` to have side effects on `.media-object-section`.

Actually, no others component uses `.stack-for-*`.

The commit re-introduce a bug, preventing to create a custom component from `@media media-object-section` (See: https://github.com/zurb/foundation-sites/issues/9038).