### PR TITLE
Use calc in button group with single child

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -100,7 +100,7 @@ $buttongroup-radius-on-each: true !default;
     @else {
       // One child
       &:first-child:last-child {
-        width: 100%;
+        width: calc(100% - #{$spacing});
       }
 
       // Two or more childreen


### PR DESCRIPTION
Without calc the single button in a button group would overlap the grid because of set negative margin. This becomes noticeable when the spacing is set to, for example, the grid gutter.
  