### PR TITLE
fix: enforce `show-for-sr` and others visibility classes with important #10850

### DIFF
--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -207,27 +207,38 @@
 /// Makes an element visually hidden, but still accessible to keyboards and assistive devices.
 /// @link http://snook.ca/archives/html_and_css/hiding-content-for-accessibility Hiding Content for Accessibility
 /// @link http://hugogiraudel.com/2016/10/13/css-hide-and-seek/
-@mixin element-invisible {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0,0,0,0);
-  white-space: nowrap;
-  clip-path: inset(50%);
-  border: 0;
+///
+/// @param {Boolean} $enforce - If `true`, use `!important` on applied properties
+@mixin element-invisible(
+  $enforce: true
+) {
+  $important: if($enforce, '!important', null);
+
+  position: absolute #{$important};
+  width: 1px #{$important};
+  height: 1px #{$important};
+  padding: 0 #{$important};
+  overflow: hidden #{$important};
+  clip: rect(0,0,0,0) #{$important};
+  white-space: nowrap #{$important};
+  clip-path: inset(50%) #{$important};
+  border: 0 #{$important};
 }
 
 /// Reverses the CSS output created by the `element-invisible()` mixin.
-@mixin element-invisible-off {
-  position: static !important;
-  width: auto;
-  height: auto;
-  overflow: visible;
-  clip: auto;
-  white-space: normal;
-  clip-path: none;
+/// @param {Boolean} $enforce - If `true`, use `!important` on applied properties
+@mixin element-invisible-off(
+  $enforce: true
+) {
+  $important: if($enforce, '!important', null);
+
+  position: static #{$important};
+  width: auto #{$important};
+  height: auto #{$important};
+  overflow: visible #{$important};
+  clip: auto #{$important};
+  white-space: normal #{$important};
+  clip-path: none #{$important};
 }
 
 /// Vertically centers the element inside of its first non-static parent,


### PR DESCRIPTION
> Most of our classes should depends on cascade. Our components must be customizable (in Sass AND in CSS) so their properties must be overridable without having to increase the specificity.
>
> However, I agree that some classes can have a "deterministic and uncustomizable behavior", and so can use !important on their properties to ensure that. But we should be careful about this, explicit in the documentation, and not begin to use !important everywhere to make things "work" quickly.
>
> In a perfect CSS architecture, this would be an entirely separated type of classes. A sort of "stand-alone state" with a particular prefix.
-- https://github.com/zurb/foundation-sites/issues/10850#issuecomment-356741458

See: https://hugogiraudel.com/2016/10/13/css-hide-and-seek/ (cc @HugoGiraudel)

Closes: https://github.com/zurb/foundation-sites/issues/10850
