### PR TITLE
Fixes quotes in xy-cell-size comment

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -8,7 +8,7 @@
 
 /// Calculate the percentage size of a cell.
 ///
-/// @param {Number|List} $size [$grid-columns] - Size to make the cell. You can pass a value in multiple formats, such as `6`, `50%`, `1 of 2 or 1/3.
+/// @param {Number|List} $size [$grid-columns] - Size to make the cell. You can pass a value in multiple formats, such as `6`, `50%`, `1 of 2` or `1/3`.
 @function xy-cell-size(
   $size: $grid-columns
 ) {


### PR DESCRIPTION
Targeting `master` since it is a documentation fix.
