### PR TITLE
fix: fix off-canvas option `revealOn` when used without classes #10867 

### DIFF
--- a/dist/js/npm.js
+++ b/dist/js/npm.js
@@ -6,10 +6,11 @@ Foundation.addToJquery($);
 // Add Foundation Utils to Foundation global namespace for backwards
 // compatibility.
 
-import { rtl, GetYoDigits, transitionend } from '../../js/foundation.util.core';
+import { rtl, GetYoDigits, transitionend, RegExpEscape } from '../../js/foundation.util.core';
 Foundation.rtl = rtl;
 Foundation.GetYoDigits = GetYoDigits;
 Foundation.transitionend = transitionend;
+Foundation.RegExpEscape = RegExpEscape;
 
 import { Box } from '../../js/foundation.util.box'
 import { onImagesLoaded } from '../../js/foundation.util.imageLoader';

--- a/js/entries/foundation.js
+++ b/js/entries/foundation.js
@@ -6,10 +6,11 @@ Foundation.addToJquery($);
 // Add Foundation Utils to Foundation global namespace for backwards
 // compatibility.
 
-import { rtl, GetYoDigits, transitionend } from '../foundation.util.core';
+import { rtl, GetYoDigits, transitionend, RegExpEscape } from '../foundation.util.core';
 Foundation.rtl = rtl;
 Foundation.GetYoDigits = GetYoDigits;
 Foundation.transitionend = transitionend;
+Foundation.RegExpEscape = RegExpEscape;
 
 import { Box } from '../foundation.util.box'
 import { onImagesLoaded } from '../foundation.util.imageLoader';

--- a/js/entries/plugins/foundation.core.js
+++ b/js/entries/plugins/foundation.core.js
@@ -6,10 +6,11 @@ Foundation.addToJquery($);
 // These are now separated out, but historically were a part of this module,
 // and since this is here for backwards compatibility we include them in
 // this entry.
-import {rtl, GetYoDigits, transitionend} from '../../foundation.util.core';
+import {rtl, GetYoDigits, transitionend, RegExpEscape} from '../../foundation.util.core';
 Foundation.rtl = rtl;
 Foundation.GetYoDigits = GetYoDigits;
 Foundation.transitionend = transitionend;
+Foundation.RegExpEscape = RegExpEscape;
 
 // Every plugin depends on plugin now, we can include that on the core for the
 // script inclusion path.

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -3,7 +3,7 @@
 import $ from 'jquery';
 import { Keyboard } from './foundation.util.keyboard';
 import { MediaQuery } from './foundation.util.mediaQuery';
-import { transitionend } from './foundation.util.core';
+import { transitionend, RegExpEscape } from './foundation.util.core';
 import { Plugin } from './foundation.plugin';
 
 import { Triggers } from './foundation.util.triggers';
@@ -118,12 +118,16 @@ class OffCanvas extends Plugin {
       }
     }
 
-    this.options.isRevealed = this.options.isRevealed || new RegExp(this.options.revealClass, 'g').test(this.$element[0].className);
+    // Get the revealOn option from the class.
+    var revealOnClass = this.$element[0].className.match(RegExpEscape(this.options.revealClass) + '([^\s])+', 'g');
+    if (revealOnClass) {
+      this.options.isRevealed = true;
+      this.options.revealOn = this.options.revealOn || revealOnClass[1];
+    }
 
-    // Get the revealOn option from the class / ensure the `reveal-on-*` class is set.
-    if (this.options.isRevealed === true) {
-      this.options.revealOn = this.options.revealOn || this.$element[0].className.match(/(reveal-for-medium|reveal-for-large)/g)[0].split('-')[2];
-      if (this.options.revealOn) this.$element.first().addClass(`reveal-for-${this.options.revealOn}`);
+    // Ensure the `reveal-on-*` class is set.
+    if (this.options.isRevealed === true && this.options.revealOn) {
+      this.$element.first().addClass(`${this.options.revealClass}${this.options.revealOn}`);
       this._setMQChecker();
     }
 

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -122,9 +122,8 @@ class OffCanvas extends Plugin {
 
     // Get the revealOn option from the class / ensure the `reveal-on-*` class is set.
     if (this.options.isRevealed === true) {
-      if (this.options.revealOn)
       this.options.revealOn = this.options.revealOn || this.$element[0].className.match(/(reveal-for-medium|reveal-for-large)/g)[0].split('-')[2];
-      this.$element.first().addClass(`reveal-for-${this.options.revealOn}`);
+      if (this.options.revealOn) this.$element.first().addClass(`reveal-for-${this.options.revealOn}`);
       this._setMQChecker();
     }
 

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -119,7 +119,8 @@ class OffCanvas extends Plugin {
     }
 
     // Get the revealOn option from the class.
-    var revealOnClass = this.$element[0].className.match(RegExpEscape(this.options.revealClass) + '([^\s])+', 'g');
+    var revealOnRegExp = new RegExp(RegExpEscape(this.options.revealClass) + '([^\\s]+)', 'g');
+    var revealOnClass = revealOnRegExp.exec(this.$element[0].className);
     if (revealOnClass) {
       this.options.isRevealed = true;
       this.options.revealOn = this.options.revealOn || revealOnClass[1];

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -120,8 +120,11 @@ class OffCanvas extends Plugin {
 
     this.options.isRevealed = this.options.isRevealed || new RegExp(this.options.revealClass, 'g').test(this.$element[0].className);
 
+    // Get the revealOn option from the class / ensure the `reveal-on-*` class is set.
     if (this.options.isRevealed === true) {
+      if (this.options.revealOn)
       this.options.revealOn = this.options.revealOn || this.$element[0].className.match(/(reveal-for-medium|reveal-for-large)/g)[0].split('-')[2];
+      this.$element.first().addClass(`reveal-for-${this.options.revealOn}`);
       this._setMQChecker();
     }
 

--- a/js/foundation.util.core.js
+++ b/js/foundation.util.core.js
@@ -24,6 +24,18 @@ function GetYoDigits(length, namespace){
   return Math.round((Math.pow(36, length + 1) - Math.random() * Math.pow(36, length))).toString(36).slice(1) + (namespace ? `-${namespace}` : '');
 }
 
+/**
+ * Escape a string so it can be used as a regexp pattern
+ * @function
+ * @see https://stackoverflow.com/a/9310752/4317384
+ *
+ * @param {String} str - string to escape.
+ * @returns {String} - escaped string
+ */
+function RegExpEscape(str){
+  return str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
 function transitionend($elem){
   var transitions = {
     'transition': 'transitionend',
@@ -49,4 +61,4 @@ function transitionend($elem){
   }
 }
 
-export {rtl, GetYoDigits, transitionend};
+export {rtl, GetYoDigits, RegExpEscape, transitionend};

--- a/test/javascript/util/core.js
+++ b/test/javascript/util/core.js
@@ -69,6 +69,17 @@ describe('Foundation core', function() {
     });
   });
 
+  describe('RegExpEscape()', function() {
+    it('escape all special characters in a string for RegExp', function () {
+      const str = 'abc012-[]{}()*+?.,\\^$|#\s\t\r\n';
+      const notstr = 'abc012-[]{}not-the-escaped-string';
+      const reg = new RegExp(Foundation.RegExpEscape(str), 'g');
+
+      reg.test(str).should.be.true;
+      reg.test(notstr).should.be.false;
+    });
+  });
+
   describe('reflow()', function() {
   });
 

--- a/test/visual/offcanvas/reveal-on-option.html
+++ b/test/visual/offcanvas/reveal-on-option.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>Off canvas reveal classes</title>
+    <title>Off canvas revealOn option</title>
     <link href="../assets/css/foundation.css" rel="stylesheet" />
   </head>
   <body>
@@ -13,18 +13,18 @@
       <div class="cell">
         <div class="off-canvas-wrapper">
 
-          <div class="off-canvas position-left reveal-for-large" id="offCanvasLeft" data-off-canvas>
+          <div class="off-canvas position-left" id="offCanvasLeft" data-off-canvas data-is-revealed="true" data-reveal-on="large">
             <button class="close-button" aria-label="Close panel" type="button" data-close>
               <span aria-hidden="true">&times;</span>
             </button>
-            <h3>This is a left off-canvas panel with a <code>reveal-for-large</code> class. It should reveal on large and up screens.</h3>
+            <h3>This is a left off-canvas panel with <code>[data-reveal-on="large"]</code>. It should reveal on large and up screens.</h3>
           </div>
 
-          <div class="off-canvas position-right reveal-for-medium" id="offCanvasRight" data-off-canvas>
+          <div class="off-canvas position-right" id="offCanvasRight" data-off-canvas data-is-revealed="true" data-reveal-on="medium">
             <button class="close-button" aria-label="Close panel" type="button" data-close>
               <span aria-hidden="true">&times;</span>
             </button>
-            <h3>This is a right off-canvas panel with a <code>reveal-for-medium</code> class. It should reveal on medium and up screens.</h3>
+            <h3>This is a right off-canvas panel with a <code>[data-reveal-on="medium"]</code> class. It should reveal on medium and up screens.</h3>
           </div>
 
           <div class="off-canvas-content" data-off-canvas-content>
@@ -35,7 +35,7 @@
                 <button type="button" class="button" data-toggle="offCanvasRight">Right Push</button>
               </div>
 
-              <h1>This test demonstrates the reveal-for-x classes.</h1>
+              <h1>This test demonstrates the [reveal-on] option.</h1>
 
               <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eros massa, lacinia sed rutrum non, sodales quis urna. In hac habitasse platea dictumst. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vivamus in rutrum magna, a varius lorem. Suspendisse nec nisi massa. Sed id lacus feugiat, commodo risus id, vulputate odio. Quisque aliquam lacus id mi euismod, ut sodales odio porttitor. Donec finibus dui vitae odio ultricies, sit amet volutpat risus bibendum. Nulla sagittis rhoncus fermentum. Nulla nisi mi, cursus posuere mollis in, faucibus ut lacus.
 


### PR DESCRIPTION
Closes https://github.com/zurb/foundation-sites/issues/10867

Other changes:
* fix Off-canvas `revealOn` option when used with `revealClass` option
* add a visual test for off-canvas `revealOn` option