### PR TITLE
fix: fix duplicate id's on accordion when id is already set on <li> elements

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -47,7 +47,7 @@ class Accordion extends Plugin {
       var $el = $(el),
           $content = $el.children('[data-tab-content]'),
           id = $content[0].id || GetYoDigits(6, 'accordion'),
-          linkId = el.id || `${id}-label`;
+          linkId = (el.id) ? `${el.id}-label` : `${id}-label`;
 
       $el.find('a:first').attr({
         'aria-controls': id,


### PR DESCRIPTION
Problem described in #10870.

Added `-label` to the end of the id on the `<a>` element when the id is previously set on its parent `<li>` element to avoid duplicate id's.