### PR TITLE
Fixes #10892 - Foundation.toggler.js is causing: `TypeError: Cannot read property '0' of undefined` when using ES6 modules

### DIFF
--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -51,8 +51,10 @@ class Toggler extends Plugin {
     // Otherwise, parse toggle class
     else {
       input = this.$element.data('toggler');
-      // Allow for a . at the beginning of the string
-      this.className = input[0] === '.' ? input.slice(1) : input;
+      if (input) {
+        // Allow for a . at the beginning of the string
+        this.className = input[0] === '.' ? input.slice(1) : input;
+      }
     }
 
     // Add ARIA attributes to triggers


### PR DESCRIPTION
Foundation.toggler.js is causing: `TypeError: Cannot read property '0' of undefined` when using ES6 modules

See here: https://github.com/zurb/foundation-sites/issues/10892