### PR TITLE
Remove calculated width for scrollable tables

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -323,8 +323,5 @@ $table-stack-breakpoint: medium !default;
   .table-scroll {
     overflow-x: auto;
 
-    table {
-      width: auto;
-    }
   }
 }


### PR DESCRIPTION
Setting`width: auto` on a table reverts to default where browsers calculate a width. It overrides stylesheets that declare a table width (without `!important` that is) For example: I have `table{width:100%}` and control widths using containers. A table that needs scrolling somewhere between medium and large breakpoints will collapse because the column width is set by the widest unbreakable content in the cells.
![image](https://user-images.githubusercontent.com/9751044/35643398-c51dcae0-068b-11e8-9b5e-ccf6e5c01834.png)
