### PR TITLE
fix: remove events handler when ResponsiveAccordionTabs is destroyed #10901

### DIFF
--- a/js/foundation.responsiveAccordionTabs.js
+++ b/js/foundation.responsiveAccordionTabs.js
@@ -119,11 +119,8 @@ class ResponsiveAccordionTabs extends Plugin{
    * @private
    */
   _events() {
-    var _this = this;
-
-    $(window).on('changed.zf.mediaquery', function() {
-      _this._checkMediaQueries();
-    });
+    this._changedZfMediaQueryHandler = this._checkMediaQueries.bind(this);
+    $(window).on('changed.zf.mediaquery', this._changedZfMediaQueryHandler);
   }
 
   /**
@@ -234,7 +231,7 @@ class ResponsiveAccordionTabs extends Plugin{
    */
   _destroy() {
     if (this.currentPlugin) this.currentPlugin.destroy();
-    $(window).off('.zf.ResponsiveAccordionTabs');
+    $(window).off('changed.zf.mediaquery', this._changedZfMediaQueryHandler);
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/zurb/foundation-sites/issues/10901
