### PR TITLE
docs: add missing doc for parameters in XY Grid mixins #10904

### DIFF
--- a/scss/xy-grid/_collapse.scss
+++ b/scss/xy-grid/_collapse.scss
@@ -11,6 +11,7 @@
 /// @param {String} $selector [.cell] - The child element to remove the gutter from.
 /// @param {Keyword} $gutter-type [margin] - The type of gutter to remove.
 /// @param {List} $gutter-position [right left] - The positions to remove gutters from. Accepts `top`, `bottom`, `left`, `right` in any combination.
+/// @param {Keyword} $min-breakpoint [$-zf-zero-breakpoint] - Minimum breakpoint in `$breakpoint-classes` for which to collapse the gutter.
 @mixin xy-grid-collapse(
   $selector: '.cell',
   $gutter-type: margin,
@@ -54,7 +55,7 @@
             }
           }
         }
-      } 
+      }
     }
   }
   @else {

--- a/scss/xy-grid/_grid.scss
+++ b/scss/xy-grid/_grid.scss
@@ -9,6 +9,7 @@
 /// Creates a max width container, designed to house your grid content.
 ///
 /// @param {Number} $width [$grid-container] - a width to limit the container to.
+/// @param {Number} $padding [$grid-container-padding] - paddings of the container.
 @mixin xy-grid-container(
   $width: $grid-container,
   $padding: $grid-container-padding

--- a/scss/xy-grid/_position.scss
+++ b/scss/xy-grid/_position.scss
@@ -9,6 +9,9 @@
 /// Offsets a column to the right/bottom by `$n` columns.
 ///
 /// @param {Number|List} $n - Size to offset by. You can pass in any value accepted by the `zf-cell()` mixin, such as `6`, `50%`, or `1 of 2`.
+/// @param {Number|Map} $gutters [$grid-margin-gutters] Map of gutters or single value to use for responsive gutters.
+/// @param {Keyword} $gutter-type [margin] The type of gutter to use. Can be `margin` or `padding`
+/// @param {Number|Array|Keyword} $breakpoint [$-zf-zero-breakpoint] - Single value, breakpoint name, or list of breakpoint names to use for `$gutters`. See `-zf-breakpoint-value()`.
 /// @param {Boolean} $vertical [false] Sets the direction of the offset. If set to true will apply margin-top instead.
 @mixin xy-cell-offset(
  $n,


### PR DESCRIPTION
Adds doc for:
* `xy-grid-collapse`
* `xy-grid-container`
* `xy-cell-offset`

Closes https://github.com/zurb/foundation-sites/issues/10904