### PR TITLE
feat: add `code-inline` and `code-block` typography helpers #9614

### DIFF
--- a/docs/pages/typography-base.md
+++ b/docs/pages/typography-base.md
@@ -306,6 +306,29 @@ Remember to escape angle brackets when printing HTML: <code>&lt;div&gt;</code>
 
 ---
 
+Use `.code-inline` component to apply the code style when you want.
+
+```html_example
+<span class="code-inline">I am not code, but I am displayed as if.</span>
+```
+
+---
+
+Use the `.code-block` component to create a block of code.
+
+```html_example
+<code class="code-block">{
+    "What I am": "I am a big chunk of code. I can have very long lines, I will not break and show a scrollbar instead.",
+    ...
+}</code>
+```
+
+<div class="callout info">
+  <p>It is recommanded to use the appropriate semantic markup for your content (`<code>` for code, `<pre>` for pre-formatted text). Styling classes `.code-inline` and `.code-block` should be used without semantic markup only if the content is NOT code/pre-formatted text but should be displayed as if.</p>
+</div>
+
+---
+
 ## Keystrokes
 
 Use the `<kbd>` element to annotate a key stroke or combination.

--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -115,29 +115,9 @@ $paragraph-margin-bottom: 1rem !default;
 /// @type String
 $paragraph-text-rendering: optimizeLegibility !default;
 
-/// Text color of code samples.
-/// @type Color
-$code-color: $black !default;
-
-/// Font family of code samples.
-/// @type String | List
-$code-font-family: $font-family-monospace !default;
-
-/// Font weight of text in code samples.
-/// @type String
-$code-font-weight: $global-weight-normal !default;
-
-/// Background color of code samples.
-/// @type Color
-$code-background: $light-gray !default;
-
-/// Border around code samples.
-/// @type List
-$code-border: 1px solid $medium-gray !default;
-
-/// Padding around text of code samples.
-/// @type Number | List
-$code-padding: rem-calc(2 5 1) !default;
+/// Use the `.code-inline` component as default for `<code>` elements.
+/// @type Boolean
+$enable-code-inline: true;
 
 /// Default color for links.
 /// @type Color
@@ -471,15 +451,10 @@ $abbr-underline: 1px dotted $black !default;
   }
 
   // Code
-  code {
-    padding: $code-padding;
-
-    border: $code-border;
-    background-color: $code-background;
-
-    font-family: $code-font-family;
-    font-weight: $code-font-weight;
-    color: $code-color;
+  @if ($enable-code-inline == true) {
+    code {
+      @extend .code-inline;
+    }
   }
 
   // Keystrokes

--- a/scss/typography/_helpers.scss
+++ b/scss/typography/_helpers.scss
@@ -50,6 +50,30 @@ $cite-font-size: rem-calc(13) !default;
 /// @type String
 $cite-pseudo-content: '\2014 \0020' !default;
 
+/// Text color of `.code-inline` and `.code-block` components.
+/// @type Color
+$code-color: $black !default;
+
+/// Font family of `.code-inline` and `.code-block` components.
+/// @type String | List
+$code-font-family: $font-family-monospace !default;
+
+/// Font weight of text in `.code-inline` and `.code-block` components.
+/// @type String
+$code-font-weight: $global-weight-normal !default;
+
+/// Background color of `.code-inline` and `.code-block` components.
+/// @type Color
+$code-background: $light-gray !default;
+
+/// Border around `.code-inline` and `.code-block` components.
+/// @type List
+$code-border: 1px solid $medium-gray !default;
+
+/// Padding around text of `.code-inline` and `.code-block` components.
+/// @type Number | List
+$code-padding: rem-calc(2 5 1) !default;
+
 
 @mixin cite-block {
   display: block;
@@ -59,6 +83,29 @@ $cite-pseudo-content: '\2014 \0020' !default;
   &:before {
     content: $cite-pseudo-content;
   }
+}
+
+@mixin code-base {
+  padding: $code-padding;
+
+  border: $code-border;
+  background-color: $code-background;
+
+  font-family: $code-font-family;
+  font-weight: $code-font-weight;
+  color: $code-color;
+}
+
+@mixin code-inline {
+  display: inline;
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
+@mixin code-block {
+  display: block;
+  overflow: auto;
+  white-space: pre;
 }
 
 @mixin foundation-typography-helpers {
@@ -103,5 +150,15 @@ $cite-pseudo-content: '\2014 \0020' !default;
 
   .cite-block {
     @include cite-block;
+  }
+
+  .code-inline {
+    @include code-base;
+    @include code-inline;
+  }
+
+  .code-block {
+    @include code-base;
+    @include code-block;
   }
 }

--- a/scss/typography/_helpers.scss
+++ b/scss/typography/_helpers.scss
@@ -92,6 +92,8 @@ $code-block-margin-bottom: 1.5rem !default;
   }
 }
 
+/// Add basic styles for a code helper.
+/// See `code-inline` and `code-block` mixins.
 @mixin code-style {
   border: $code-border;
   background-color: $code-background;
@@ -101,6 +103,8 @@ $code-block-margin-bottom: 1.5rem !default;
   color: $code-color;
 }
 
+/// Make code helper from the `code-style` mixin inline.
+/// Used to generate `.code-inline`
 @mixin code-inline {
   display: inline;
   max-width: 100%;
@@ -109,6 +113,8 @@ $code-block-margin-bottom: 1.5rem !default;
   padding: $code-padding;
 }
 
+/// Make code helper from the `code-style` mixin a block.
+/// Used to generate `.code-block`
 @mixin code-block {
   display: block;
   overflow: auto;

--- a/scss/typography/_helpers.scss
+++ b/scss/typography/_helpers.scss
@@ -70,10 +70,17 @@ $code-background: $light-gray !default;
 /// @type List
 $code-border: 1px solid $medium-gray !default;
 
-/// Padding around text of `.code-inline` and `.code-block` components.
+/// Padding around text of the `.code-inline` component.
 /// @type Number | List
 $code-padding: rem-calc(2 5 1) !default;
 
+/// Padding around text of the `.code-block` component.
+/// @type Number | List
+$code-block-padding: 1rem !default;
+
+/// Margin under the `.code-block` component.
+/// @type Number
+$code-block-margin-bottom: 1.5rem !default;
 
 @mixin cite-block {
   display: block;
@@ -85,9 +92,7 @@ $code-padding: rem-calc(2 5 1) !default;
   }
 }
 
-@mixin code-base {
-  padding: $code-padding;
-
+@mixin code-style {
   border: $code-border;
   background-color: $code-background;
 
@@ -100,12 +105,17 @@ $code-padding: rem-calc(2 5 1) !default;
   display: inline;
   max-width: 100%;
   word-wrap: break-word;
+
+  padding: $code-padding;
 }
 
 @mixin code-block {
   display: block;
   overflow: auto;
   white-space: pre;
+
+  padding: $code-block-padding;
+  margin-bottom: $code-block-margin-bottom;
 }
 
 @mixin foundation-typography-helpers {
@@ -153,12 +163,12 @@ $code-padding: rem-calc(2 5 1) !default;
   }
 
   .code-inline {
-    @include code-base;
+    @include code-style;
     @include code-inline;
   }
 
   .code-block {
-    @include code-base;
+    @include code-style;
     @include code-block;
   }
 }


### PR DESCRIPTION
Changes
* add `code-inline` and `code-block` mixins and classes in ` typography/_helpers`
* remove `<code>` defaults properties
* add `$enable-code-inline` option to control wether `<code>` is based on `.code-inline
* add docs for `code-inline` and `code-block` in typography-base

Closes #9614