### PR TITLE
fix the RegExpEscape definition

### DIFF
--- a/js/entries/foundation.js
+++ b/js/entries/foundation.js
@@ -40,7 +40,7 @@ Foundation.addToJquery($);
 Foundation.rtl = CoreUtils.rtl;
 Foundation.GetYoDigits = CoreUtils.GetYoDigits;
 Foundation.transitionend = CoreUtils.transitionend;
-Foundation.RegExpEscape = RegExpEscape;
+Foundation.RegExpEscape = CoreUtils.RegExpEscape;
 
 Foundation.Box = Box;
 Foundation.onImagesLoaded = onImagesLoaded;


### PR DESCRIPTION
This fixes the build from https://github.com/zurb/foundation-sites/commit/bd21adacf401de64cc1ca1bb2db64d1fe1a6cf03 caused by https://github.com/zurb/foundation-sites/commit/bd21adacf401de64cc1ca1bb2db64d1fe1a6cf03#diff-f9b7d542bfe288e1211c35d7d436c784R43