### PR TITLE
chore: temporary disable UMD bundling

### DIFF
--- a/gulp/tasks/javascript.js
+++ b/gulp/tasks/javascript.js
@@ -71,7 +71,7 @@ gulp.task('javascript:plugin-core', function() {
 gulp.task('javascript:plugins', ['javascript:plugin-core'], function () {
   return gulp.src(['js/entries/plugins/*.js', '!js/entries/plugins/foundation.core.js'])
     .pipe(named())
-    .pipe(webpackStream(Object.assign({ externals: pluginsAsExternals }, webpackConfig), webpack2))
+    .pipe(webpackStream(Object.assign({}, webpackConfig, { externals: pluginsAsExternals }), webpack2))
     .pipe(gulp.dest('_build/assets/js/plugins'));
 });
 

--- a/gulp/tasks/javascript.js
+++ b/gulp/tasks/javascript.js
@@ -55,7 +55,12 @@ var webpackConfig = {
     ]
   },
   output: {
-    libraryTarget: 'umd',
+    // ---
+    // FIXME: to resolve before the next release
+    // Temporary disable UMD bundling, waiting for a way to import plugins are externals
+    // See https://github.com/zurb/foundation-sites/pull/10903
+    // ---
+    // libraryTarget: 'umd',
   }
 }
 

--- a/js/entries/plugins/foundation.core.js
+++ b/js/entries/plugins/foundation.core.js
@@ -20,3 +20,5 @@ Foundation.Plugin = Plugin;
 
 
 window.Foundation = Foundation;
+
+export { Foundation }


### PR DESCRIPTION
⚠️  This is not breaking anything, since UMD bundling was not released yet, but this must be resolved before the next release.

> So `develop` is broken because I am too stupid to test correctly a PR before merging it. --'
> Also, the problem in this issue is:
> 1. Webpack transpilation to UMD require a particular format for `externals` (see https://webpack.js.org/configuration/output/#module-definition-systems).
> 2. Exports in Foundation plugins are "named" (and not defaults), so importing them as  `external` require to make external targets objects (in which we can pick up the named plugin). (see https://github.com/zurb/foundation-sites/pull/9965/commits/abfd426baaeb510b9e2d06a82b902036402b1d39)
> 3. External format for UMD does not support the "object target".
Temporary disable UMD bundling, waiting for a way to import plugins are externals

Bug introduced in #10864
Part of #10903