### PR TITLE
Remove `clip-path` from `element-invisible` mixin

### DIFF
--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -221,7 +221,6 @@
   overflow: hidden #{$important};
   clip: rect(0,0,0,0) #{$important};
   white-space: nowrap #{$important};
-  clip-path: inset(50%) #{$important};
   border: 0 #{$important};
 }
 
@@ -238,7 +237,6 @@
   overflow: visible #{$important};
   clip: auto #{$important};
   white-space: normal #{$important};
-  clip-path: none #{$important};
 }
 
 /// Vertically centers the element inside of its first non-static parent,


### PR DESCRIPTION
As proposed in [Bootstrap](https://github.com/twbs/bootstrap/pull/25197) and [HTML5BP](https://github.com/h5bp/html5-boilerplate/pull/2025), I recommend to remove `clip-path` for now since it causes severe performance issue in Chrome on scroll, as reported in [Bootrasp's #24906](https://github.com/twbs/bootstrap/issues/24906) and [HTML5BP's #2012](https://github.com/h5bp/html5-boilerplate/issues/2021).
