### PR TITLE
fix: fix DropdownMenu closing when touching to scroll #9823

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -74,6 +74,7 @@ class DropdownMenu extends Plugin {
       }
     }
     this.changed = false;
+    this.isTouchMove = false;
     this._events();
   };
 
@@ -270,13 +271,20 @@ class DropdownMenu extends Plugin {
   _addBodyHandler() {
     var $body = $(document.body),
         _this = this;
-    $body.off('mouseup.zf.dropdownmenu touchend.zf.dropdownmenu')
+    $body.off('touchmove.zf.dropdownmenu')
+         .on('touchmove.zf.dropdownmenu', function(){
+           _this.isTouchMove = true;
+         })
+         .off('mouseup.zf.dropdownmenu touchend.zf.dropdownmenu')
          .on('mouseup.zf.dropdownmenu touchend.zf.dropdownmenu', function(e) {
            var $link = _this.$element.find(e.target);
-           if ($link.length) { return; }
+           if ($link.length || _this.isTouchMove){
+             _this.isTouchMove = false;
+             return;
+           }
 
            _this._hide();
-           $body.off('mouseup.zf.dropdownmenu touchend.zf.dropdownmenu');
+           $body.off('mouseup.zf.dropdownmenu touchend.zf.dropdownmenu touchmove.zf.dropdownmenu');
          });
   }
 


### PR DESCRIPTION
This solution fixes this issue #9823.

**Issue:**
On a touchable screen, when you open up a long dropdown menu that goes beyond the viewport boundary -i.e., #9823-, then attempts to **move down/up** to keep interacting with the menu, the menu will disappear! That happens because the current attached events `mouseup.zf.dropdownmenu touchend.zf.dropdownmenu` on the body object cannot figure out if that `touchend` comes after the user **moved down/up** or the user just tapped on the screen, once.

**Solution:**
I added the flag `this.isTouchMove` to help `touchend`'s callback function to figure out if the user was **moving down/up** or just tapped once.