### PR TITLE
fix generated event name

### DIFF
--- a/docs/pages/drilldown-menu.md
+++ b/docs/pages/drilldown-menu.md
@@ -1,5 +1,5 @@
 ---
-title: Drilldown Menu
+title: Drilldown
 description: Drilldown is one of Foundation's three menu patterns, which converts a series of nested lists into a vertical drilldown menu.
 video: 8qPQRXl52hI
 scss: scss/components/_drilldown.scss


### PR DESCRIPTION
As a sidenote, using the title for event names is not a great idea. We should use some variable `fn-name` or similar.