### PR TITLE
clear: revert #10555 "Fixes #9151 - Drilldown event issue"

### DIFF
--- a/docs/pages/drilldown-menu.md
+++ b/docs/pages/drilldown-menu.md
@@ -1,5 +1,5 @@
 ---
-title: Drilldown
+title: Drilldown Menu
 description: Drilldown is one of Foundation's three menu patterns, which converts a series of nested lists into a vertical drilldown menu.
 video: 8qPQRXl52hI
 scss: scss/components/_drilldown.scss


### PR DESCRIPTION
This reverts commit 28389c31acc0197f71ed9188bc34e10db028c193, as the event name generation should be fixed by: https://github.com/zurb/foundation-docs/pull/24. This would be better to have the real component name as title of the page, instead of this no-longer useful workaround.

Note: this PR in on `develop` since the original PR was made (unfortunally) on `develop`.

### Changes:
- Revert https://github.com/zurb/foundation-sites/pull/10555  [28389c31acc0197f71ed9188bc34e10db028c193] - `Fixes #9151 - Drilldown event issue`