### PR TITLE
switch to Node.js 8 to use package-lock.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "8"
 install:
   - npm install -g bower browserstack-runner
   - npm install


### PR DESCRIPTION
This is not the best solution but still recommended as the only issue and cause is phantomjs 1.x and it just affects the unit tests in this specific environment.