### PR TITLE
Allow breakpoint mixin to accept a list

### DIFF
--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -449,6 +449,10 @@ We also have a shorthand option for the above which outputs the same CSS:
 }
 ```
 
+<div class="callout warning">
+  If you pass multiple breakpoints to the <code>breakpoint</code> mixin, it will duplicate its content for each of them. Be careful to only use <code>breakpoint</code> with properties that should change across breakpoints.
+</div>
+
 ### Custom Block Grid
 
 Use the `xy-grid-layout()` mixin to create your own block grid.

--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -411,17 +411,34 @@ The cell size calculator can also be accessed as a function. This gives you the 
 
 ### Responsive Grids
 
-Pair `xy-cell` with the `breakpoint()` mixin to make your grid responsive.
+Pair `xy-cell` with the `breakpoint()` mixin to make your grid responsive. The `xy-grid` mixin will automatically detect the breakpoint in which it is, but you can force it with the `$breakpoint` option.
 Refer to the Sass documentation below to learn how each mixin works and the available arguments.
 
 ```scss
-.main-content {
+.my-cell-medium-only-8 {
   @include xy-cell();
 
+  // Generate a cell with a 8/12 width on medium breakpoint only
   @include breakpoint(medium) {
     @include xy-cell(8);
   }
 }
+```
+
+You can also use for more advanced responsive cells:
+
+```scss
+  // ... with a 8/12 width on medium breakpoint and above (with the medium gutters)
+  @include breakpoint(medium up) {
+    @include xy-cell(8);
+  }
+```
+
+```scss
+  // ... with a 8/12 width on medium, large and xlarge (with the corresponding gutters)
+  @include breakpoint(medium, large, xlarge up) {
+    @include xy-cell(8);
+  }
 ```
 
 We also have a shorthand option for the above which outputs the same CSS:

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -137,6 +137,9 @@ $breakpoint-classes: (small medium large) !default;
 ///  - If an em value is passed, the value will be used as-is.
 ///
 /// If multiple values are passed, the mixin will generate a media query for each of them as described above.
+/// Since the content is duplicated for each breakpoint, this mixin should only be used with properties that
+/// change across breakpoints.
+///
 /// @param {Keyword|Number} $values... - Breakpoint name or px/rem/em value to process.
 ///
 /// @output If the breakpoint is "0px and larger", outputs the content as-is. Otherwise, outputs the content wrapped in a media query.

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -135,8 +135,9 @@ $breakpoint-classes: (small medium large) !default;
 ///  - If a pixel value is passed, it will be converted to an em value using `$global-font-size` as the base.
 ///  - If a rem value is passed, the unit will be changed to em.
 ///  - If an em value is passed, the value will be used as-is.
+///  - If a list is passed, the mixin will iterate through the values in the list and function as described above.
 ///
-/// @param {Keyword|Number} $value - Breakpoint name, or px, rem, or em value to process.
+/// @param {Keyword|Number|Array} $value-list - Breakpoint name, px/rem/em value to process, or a list containing either.
 ///
 /// @output If the breakpoint is "0px and larger", outputs the content as-is. Otherwise, outputs the content wrapped in a media query.
 @mixin breakpoint($value-list...) {

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -135,14 +135,14 @@ $breakpoint-classes: (small medium large) !default;
 ///  - If a pixel value is passed, it will be converted to an em value using `$global-font-size` as the base.
 ///  - If a rem value is passed, the unit will be changed to em.
 ///  - If an em value is passed, the value will be used as-is.
-///  - If a list is passed, the mixin will iterate through the values in the list and function as described above.
 ///
-/// @param {Keyword|Number|Array} $value-list - Breakpoint name, px/rem/em value to process, or a list containing either.
+/// If multiple values are passed, the mixin will generate a media query for each of them as described above.
+/// @param {Keyword|Number} $values... - Breakpoint name or px/rem/em value to process.
 ///
 /// @output If the breakpoint is "0px and larger", outputs the content as-is. Otherwise, outputs the content wrapped in a media query.
-@mixin breakpoint($value-list...) {
-  @for $i from 1 through length($value-list) {
-    $value: nth($value-list, $i);
+@mixin breakpoint($values...) {
+  @for $i from 1 through length($values) {
+    $value: nth($values, $i);
     $str: breakpoint($value);
     $bp: index($-zf-breakpoints-keys, $value);
     $pbp: index($-zf-breakpoints-keys, $print-breakpoint);

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -139,40 +139,43 @@ $breakpoint-classes: (small medium large) !default;
 /// @param {Keyword|Number} $value - Breakpoint name, or px, rem, or em value to process.
 ///
 /// @output If the breakpoint is "0px and larger", outputs the content as-is. Otherwise, outputs the content wrapped in a media query.
-@mixin breakpoint($value) {
-  $str: breakpoint($value);
-  $bp: index($-zf-breakpoints-keys, $value);
-  $pbp: index($-zf-breakpoints-keys, $print-breakpoint);
+@mixin breakpoint($value-list...) {
+  @for $i from 1 through length($value-list) {
+    $value: nth($value-list, $i);
+    $str: breakpoint($value);
+    $bp: index($-zf-breakpoints-keys, $value);
+    $pbp: index($-zf-breakpoints-keys, $print-breakpoint);
 
-  $old-zf-size: null;
+    $old-zf-size: null;
 
-  // Make breakpoint size available as a variable
-  @if global-variable-exists(-zf-size) {
-    $old-zf-size: $-zf-size;
-  }
-  $-zf-size: nth($value, 1) !global; // get the first value to account for `only` and `down` keywords
-
-  // If $str is still an empty string, no media query is needed
-  @if $str == '' {
-    @content;
-  }
-
-  // Otherwise, wrap the content in a media query
-  @else {
-    // For named breakpoints less than or equal to $print-breakpoint, add print to the media types
-    @if $bp != null and $bp <= $pbp {
-      @media print, screen and #{$str} {
-        @content;
-       }
+    // Make breakpoint size available as a variable
+    @if global-variable-exists(-zf-size) {
+      $old-zf-size: $-zf-size;
     }
+    $-zf-size: nth($value, 1) !global; // get the first value to account for `only` and `down` keywords
+
+    // If $str is still an empty string, no media query is needed
+    @if $str == '' {
+      @content;
+    }
+
+    // Otherwise, wrap the content in a media query
     @else {
-      @media screen and #{$str} {
-        @content;
+      // For named breakpoints less than or equal to $print-breakpoint, add print to the media types
+      @if $bp != null and $bp <= $pbp {
+        @media print, screen and #{$str} {
+          @content;
+        }
+      }
+      @else {
+        @media screen and #{$str} {
+          @content;
+        }
       }
     }
-  }
 
-  $-zf-size: $old-zf-size !global;
+    $-zf-size: $old-zf-size !global;
+  }
 }
 
 /// Convers the breakpoints map to a URL-encoded string, like this: `key1=value1&key2=value2`. The value is then dropped into the CSS for a special `<meta>` tag, which is read by the Foundation JavaScript. This is how we transfer values from Sass to JavaScript, so they can be defined in one place.


### PR DESCRIPTION
This fixes the following issue whereby gutters aren't set as expected for larger sizes:
```
.my-cell {
      @include xy-cell(12);

      @include breakpoint(medium) {
        @include xy-cell(6/12);
      }
}
```

by allowing the following:
```
.my-cell {
      @include xy-cell(12);

      @include breakpoint(medium, large, xlarge, xxlarge) {
        @include xy-cell(6/12);
      }
}
```

[Changes without white space](https://github.com/zurb/foundation-sites/pull/10939/files?w=1)