### PR TITLE
chore: update foundation-docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5405,7 +5405,7 @@
       "optional": true
     },
     "foundation-docs": {
-      "version": "git+https://github.com/zurb/foundation-docs.git#856ca900f5fae6557a74530d1eeaf7b244736d28",
+      "version": "git+https://github.com/zurb/foundation-docs.git#5a925cad940daa43d49e4bfc91c875388e09ead3",
       "dev": true
     },
     "foundation-emails": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "clipboard": "^1.7.1",
     "corejs-typeahead": "^1.1.1",
     "doiuse": "^2.6.0",
-    "foundation-docs": "git+https://github.com/zurb/foundation-docs.git#856ca900f5fae6557a74530d1eeaf7b244736d28",
+    "foundation-docs": "git+https://github.com/zurb/foundation-docs.git#5a925cad940daa43d49e4bfc91c875388e09ead3",
     "gulp": "^3.8.10",
     "gulp-add-src": "^0.2.0",
     "gulp-babel": "^6.1.1",


### PR DESCRIPTION
Update `foundation-docs` to the latest version

See:
- https://github.com/zurb/foundation-docs/pull/24
- https://github.com/zurb/foundation-docs/pull/23
