### PR TITLE
fix: support dynamically added components #8016

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -83,7 +83,7 @@ class Magellan extends Plugin {
           duration: _this.options.animationDuration,
           easing:   _this.options.animationEasing
         };
-    $(window).one('load', function(){
+    if (document.readyState === 'complete') {
       if(_this.options.deepLinking){
         if(location.hash){
           _this.scrollToLoc(location.hash);
@@ -91,7 +91,17 @@ class Magellan extends Plugin {
       }
       _this.calcPoints();
       _this._updateActive();
-    });
+    } else {
+      $(window).one('load', function(){
+        if(_this.options.deepLinking){
+          if(location.hash){
+            _this.scrollToLoc(location.hash);
+          }
+        }
+        _this.calcPoints();
+        _this._updateActive();
+      });
+    }
 
     this.$element.on({
       'resizeme.zf.trigger': this.reflow.bind(this),

--- a/js/foundation.offcanvas.js
+++ b/js/foundation.offcanvas.js
@@ -159,6 +159,14 @@ class OffCanvas extends Plugin {
   _setMQChecker() {
     var _this = this;
 
+    if (document.readyState === 'complete') {
+      if (MediaQuery.atLeast(_this.options.revealOn)) {
+        _this.reveal(true);
+      } else {
+        _this.reveal(false);
+      }
+    }
+
     $(window).on('changed.zf.mediaquery', function() {
       if (MediaQuery.atLeast(_this.options.revealOn)) {
         _this.reveal(true);

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -78,7 +78,11 @@ class Reveal extends Plugin {
     }
     this._events();
     if (this.options.deepLink && window.location.hash === ( `#${this.id}`)) {
-      $(window).one('load.zf.reveal', this.open.bind(this));
+      if (document.readyState === 'complete') {
+        this.open.bind(this)
+      } else {
+        $(window).one('load.zf.reveal', this.open.bind(this));
+      }
     }
   }
 

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -60,7 +60,7 @@ class Sticky extends Plugin {
 
     this.scrollCount = this.options.checkEvery;
     this.isStuck = false;
-    if (document.readyState === "complete") {
+    if (document.readyState === 'complete') {
 	  //We calculate the container height to have correct values for anchor points offset calculation.
       _this.containerHeight = _this.$element.css("display") == "none" ? 0 : _this.$element[0].getBoundingClientRect().height;
       _this.$container.css('height', _this.containerHeight);

--- a/js/foundation.sticky.js
+++ b/js/foundation.sticky.js
@@ -60,8 +60,8 @@ class Sticky extends Plugin {
 
     this.scrollCount = this.options.checkEvery;
     this.isStuck = false;
-    $(window).one('load.zf.sticky', function(){
-      //We calculate the container height to have correct values for anchor points offset calculation.
+    if (document.readyState === "complete") {
+	  //We calculate the container height to have correct values for anchor points offset calculation.
       _this.containerHeight = _this.$element.css("display") == "none" ? 0 : _this.$element[0].getBoundingClientRect().height;
       _this.$container.css('height', _this.containerHeight);
       _this.elemHeight = _this.containerHeight;
@@ -80,7 +80,29 @@ class Sticky extends Plugin {
         }
       });
       _this._events(id.split('-').reverse().join('-'));
-    });
+    } else {
+      $(window).one('load.zf.sticky', function(){
+        //We calculate the container height to have correct values for anchor points offset calculation.
+        _this.containerHeight = _this.$element.css("display") == "none" ? 0 : _this.$element[0].getBoundingClientRect().height;
+        _this.$container.css('height', _this.containerHeight);
+        _this.elemHeight = _this.containerHeight;
+        if(_this.options.anchor !== ''){
+          _this.$anchor = $('#' + _this.options.anchor);
+        }else{
+          _this._parsePoints();
+        }
+      
+        _this._setSizes(function(){
+          var scroll = window.pageYOffset;
+          _this._calc(false, scroll);
+          //Unstick the element will ensure that proper classes are set.
+          if (!_this.isStuck) {
+            _this._removeSticky((scroll >= _this.topPoint) ? false : true);
+          }
+        });
+        _this._events(id.split('-').reverse().join('-'));
+      });
+    }
   }
 
   /**

--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -244,7 +244,7 @@ Triggers.init = function($, Foundation) {
   if (typeof($.triggersInitialized) === 'undefined') {
     let $document = $(document);
 
-    if(document.readyState === "complete") {
+    if (document.readyState === 'complete') {
       Triggers.Initializers.addSimpleListeners();
       Triggers.Initializers.addGlobalListeners();
     } else {


### PR DESCRIPTION
We have to check for `document.readyState === "complete"` when the window and content is already loaded and more content is loaded afterwards that is needed for the magellan and sticky solution.