### PR TITLE
fix: make Toggler target an option #10892

### DIFF
--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -50,7 +50,10 @@ class Toggler extends Plugin {
     }
     // Otherwise, parse toggle class
     else {
-      input = this.$element.data('toggler');
+      input = this.options.toggler;
+      if (typeof input !== 'string' || !input.length) {
+        throw new Error(`The 'toogler' option containing the target class is required, got "${input}"`);
+      }
       // Allow for a . at the beginning of the string
       this.className = input[0] === '.' ? input.slice(1) : input;
     }
@@ -138,6 +141,12 @@ class Toggler extends Plugin {
 }
 
 Toggler.defaults = {
+  /**
+   * Class of the element to toggle. It can be provided with or without "."
+   * @option
+   * @type {string}
+   */
+  toggler: undefined,
   /**
    * Tells the plugin if the element should animated when toggled.
    * @option


### PR DESCRIPTION
Related to: https://github.com/zurb/foundation-sites/issues/10892

> ...toggler as designed is supposed to listen for the toggle event and simply toggle a class. Calling it without a class as an argument should not be valid!
>
> However, I do think it should accept that class as an option and not only as a data attribute, which would allow us to wrap it up more nicely in a vue directive
>
> -- @kball https://github.com/zurb/foundation-sites/issues/10892#issuecomment-362864469