### PR TITLE
Add check for changes to title attribute before showing tooltip

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -135,6 +135,14 @@ class Tooltip extends Positionable {
     }
 
     var _this = this;
+
+    // Update Tooltip text if title attribute has changed since init 
+    if (this.$element.attr('title') !== '') {
+      this.options.tipText = this.$element.attr('title');
+      this.template.text(this.options.tipText);
+      this.$element.attr('title', '');
+    }
+
     this.template.css('visibility', 'hidden').show();
     this._setPosition();
     this.template.removeClass('top bottom left right').addClass(this.position)
@@ -145,7 +153,6 @@ class Tooltip extends Positionable {
      * @event Closeme#tooltip
      */
     this.$element.trigger('closeme.zf.tooltip', this.template.attr('id'));
-
 
     this.template.attr({
       'data-is-active': true,


### PR DESCRIPTION
Resolves #10898.

Adds a check to see if the title attribute is empty before showing the tooltip. If it's not empty, the `tipText` option is updated with the new title text, the tooltip element is updated with the contents of `tipText`, and the title attribute is reset.