### PR TITLE
Breakpoint Mixin `max-width` Values

### DIFF
--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -6,7 +6,7 @@
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for($size) {
   $size: map-get($breakpoints, $size);
-  $size: -zf-bp-to-em($size) - .000001;
+  $size: -zf-bp-to-em($size) - .00001;
 
   @include breakpoint($size down) {
     display: none !important;
@@ -20,7 +20,7 @@
   $upper-bound-size: -zf-map-next($breakpoints, $size);
 
   // more often than not this will be correct, just one time round the loop it won't so set in scope here
-  $lower-bound: -zf-bp-to-em($lower-bound-size) - .000001;
+  $lower-bound: -zf-bp-to-em($lower-bound-size) - .00001;
   // test actual lower-bound-size, if 0 set it to 0em
   @if strip-unit($lower-bound-size) == 0 {
     $lower-bound: -zf-bp-to-em($lower-bound-size);

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -6,7 +6,7 @@
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for($size) {
   $size: map-get($breakpoints, $size);
-  $size: -zf-bp-to-em($size) - (1 / 16);
+  $size: -zf-bp-to-em($size) - .000001;
 
   @include breakpoint($size down) {
     display: none !important;
@@ -20,7 +20,7 @@
   $upper-bound-size: -zf-map-next($breakpoints, $size);
 
   // more often than not this will be correct, just one time round the loop it won't so set in scope here
-  $lower-bound: -zf-bp-to-em($lower-bound-size) - (1 / 16);
+  $lower-bound: -zf-bp-to-em($lower-bound-size) - .000001;
   // test actual lower-bound-size, if 0 set it to 0em
   @if strip-unit($lower-bound-size) == 0 {
     $lower-bound: -zf-bp-to-em($lower-bound-size);

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -77,7 +77,7 @@ $breakpoint-classes: (small medium large) !default;
   // Convert any pixel, rem, or unitless value to em
   $bp: -zf-bp-to-em($bp);
   @if $bp-max {
-    $bp-max: -zf-bp-to-em($bp-max) - .000001;
+    $bp-max: -zf-bp-to-em($bp-max) - .00001;
   }
 
   // Conditions to skip media query creation

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -77,7 +77,7 @@ $breakpoint-classes: (small medium large) !default;
   // Convert any pixel, rem, or unitless value to em
   $bp: -zf-bp-to-em($bp);
   @if $bp-max {
-    $bp-max: -zf-bp-to-em($bp-max) - 0.0001;
+    $bp-max: -zf-bp-to-em($bp-max) - .0001;
   }
 
   // Conditions to skip media query creation

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -77,7 +77,7 @@ $breakpoint-classes: (small medium large) !default;
   // Convert any pixel, rem, or unitless value to em
   $bp: -zf-bp-to-em($bp);
   @if $bp-max {
-    $bp-max: -zf-bp-to-em($bp-max) - (1/16);
+    $bp-max: -zf-bp-to-em($bp-max) - 0.0001;
   }
 
   // Conditions to skip media query creation

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -77,7 +77,7 @@ $breakpoint-classes: (small medium large) !default;
   // Convert any pixel, rem, or unitless value to em
   $bp: -zf-bp-to-em($bp);
   @if $bp-max {
-    $bp-max: -zf-bp-to-em($bp-max) - .0001;
+    $bp-max: -zf-bp-to-em($bp-max) - .000001;
   }
 
   // Conditions to skip media query creation

--- a/test/sass/_breakpoint.scss
+++ b/test/sass/_breakpoint.scss
@@ -24,10 +24,10 @@
 
   @include test('Breakpoint (Only Range) [function]') {
     $test: breakpoint(medium only);
-    $expect: '(min-width: 40em) and (max-width: 63.9999em)';
+    $expect: '(min-width: 40em) and (max-width: 63.99999em)';
 
     $test-lowest: breakpoint(small only);
-    $expect-lowest: '(max-width: 39.9999em)';
+    $expect-lowest: '(max-width: 39.99999em)';
 
     $test-highest: breakpoint(xxlarge only);
     $expect-highest: '(min-width: 90em)';
@@ -44,13 +44,13 @@
 
   @include test('Breakpoint (Named Down Range) [function]') {
     $test: breakpoint(medium down);
-    $expect: '(max-width: 63.9999em)';
+    $expect: '(max-width: 63.99999em)';
 
     @include assert-equal($test, $expect,
       'Creates a down range out of a medium breakpoint');
 
     $test-lowest: breakpoint(small down);
-    $expect-lowest: '(max-width: 39.9999em)';
+    $expect-lowest: '(max-width: 39.99999em)';
 
     @include assert-equal($test-lowest, $expect-lowest,
       'Creates a down range out of a small breakpoint');

--- a/test/sass/_breakpoint.scss
+++ b/test/sass/_breakpoint.scss
@@ -24,10 +24,10 @@
 
   @include test('Breakpoint (Only Range) [function]') {
     $test: breakpoint(medium only);
-    $expect: '(min-width: 40em) and (max-width: 63.9375em)';
+    $expect: '(min-width: 40em) and (max-width: 63.9999em)';
 
     $test-lowest: breakpoint(small only);
-    $expect-lowest: '(max-width: 39.9375em)';
+    $expect-lowest: '(max-width: 39.9999em)';
 
     $test-highest: breakpoint(xxlarge only);
     $expect-highest: '(min-width: 90em)';
@@ -44,13 +44,13 @@
 
   @include test('Breakpoint (Named Down Range) [function]') {
     $test: breakpoint(medium down);
-    $expect: '(max-width: 63.9375em)';
+    $expect: '(max-width: 63.9999em)';
 
     @include assert-equal($test, $expect,
       'Creates a down range out of a medium breakpoint');
 
     $test-lowest: breakpoint(small down);
-    $expect-lowest: '(max-width: 39.9375em)';
+    $expect-lowest: '(max-width: 39.9999em)';
 
     @include assert-equal($test-lowest, $expect-lowest,
       'Creates a down range out of a small breakpoint');
@@ -156,5 +156,4 @@
     @include assert-equal(-zf-get-bp-val($config, xlarge), 1,
       'Given a nearby breakpoint, returns the next lowest value');
   }
-
 }


### PR DESCRIPTION
# Why?
Browser windows can be fractions of pixels wide, under certain circumstances (e.g. zoom). In these cases, it is not enough to set the `max-width` to the `em` equivalent of one pixel less.

# What changed?
* updated `max-width` calculation
* updated tests to match new output

# Notes
I recognize this is nearly moving the goalposts and doesn't solve the core problem, but in lieu of a exclusive max-width, 4 places of accuracy seems to be the standard and should work for most.