### PR TITLE
fix: add the print media query for the right media query combinations

### DIFF
--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -147,8 +147,10 @@ $breakpoint-classes: (small medium large) !default;
   @for $i from 1 through length($values) {
     $value: nth($values, $i);
     $str: breakpoint($value);
-    $bp: index($-zf-breakpoints-keys, $value);
+    $bp: index($-zf-breakpoints-keys, nth($value, 1));
     $pbp: index($-zf-breakpoints-keys, $print-breakpoint);
+    // Direction of media query (up, down, or only)
+    $dir: if(length($value) > 1, nth($value, 2), up);
 
     $old-zf-size: null;
 
@@ -166,7 +168,7 @@ $breakpoint-classes: (small medium large) !default;
     // Otherwise, wrap the content in a media query
     @else {
       // For named breakpoints less than or equal to $print-breakpoint, add print to the media types
-      @if $bp != null and $bp <= $pbp {
+      @if ($bp != null and $bp == $pbp and ($dir == '' or $dir == 'up' or $dir == 'only')) or ($bp != null and $bp < $pbp and ($dir == '' or $dir == 'up'))  or ($bp != null and $bp >= $pbp and ($dir == 'down')) {
         @media print, screen and #{$str} {
           @content;
         }

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -168,7 +168,9 @@ $breakpoint-classes: (small medium large) !default;
     // Otherwise, wrap the content in a media query
     @else {
       // For named breakpoints less than or equal to $print-breakpoint, add print to the media types
-      @if ($bp != null and $bp == $pbp and ($dir == '' or $dir == 'up' or $dir == 'only')) or ($bp != null and $bp < $pbp and ($dir == '' or $dir == 'up'))  or ($bp != null and $bp >= $pbp and ($dir == 'down')) {
+      // generate print if the breakpoint affects the print-breakpoint (or smaller).
+      // This means the current condition only needs to be extended so 'down' always generates print.
+      @if $bp != null and ($bp <= $pbp or $dir == down) {
         @media print, screen and #{$str} {
           @content;
         }


### PR DESCRIPTION
This covers more `down`, `up` and `only` cases.

Reference: #10976