### PR TITLE
docs: fix the id of the example code for the click trigger

### DIFF
--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -105,7 +105,7 @@ To create a click trigger that opens the panel, add the attribute `data-open` or
 </div>
 
 ```html_example
-<button type="button" class="button" data-toggle="offCanvasLeft">Open Menu</button>
+<button type="button" class="button" data-toggle="offCanvas">Open Menu</button>
 ```
 
 ### Close Button


### PR DESCRIPTION
This PR fixes the code example to use the default off-canvas ID in the docs.

See https://github.com/zurb/foundation-sites/issues/10548