### PR TITLE
docs: fix broken links #10985

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -18,7 +18,7 @@ tags:
 ## Importing
 
 <div class="callout alert">
-  **From Foundation v6.4, the Float Grid is disabled by default**, replaced by the new [XY Grid](/xy-grid.html). Unless you need to support IE 10, it is recommended to use the XY Grid.
+  **From Foundation v6.4, the Float Grid is disabled by default**, replaced by the new [XY Grid](xy-grid.html). Unless you need to support IE 10, it is recommended to use the XY Grid.
 </div>
 
 To use the Float Grid in Foundation v6.4+, you need to:

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -163,7 +163,7 @@ After you selected "Foundation for Sites", Foundation CLI will ask you which tem
 </div>
 
 <p class="text-center">
-  <a href="/starter-projects.html" class="button">See advanced Template installations</a>
+  <a href="starter-projects.html" class="button">See advanced Template installations</a>
 </p>
 
 <div class="callout info">


### PR DESCRIPTION
Changes:
* fix broken link to "XY Grid" in "Float Grid" docs
* fix broken link to "Starter Projects" in "Installation" docs

Closes [#10985 - [The Grid] documentation has broken link](https://github.com/zurb/foundation-sites/issues/10985) (@nigelm)
Related to [#10977 - Fix broken link to XY grid](https://github.com/zurb/foundation-sites/pull/10977) (@ocularrhythm)
