### PR TITLE
tests: remove test for inconsistent behavior of `getfnname`

### DIFF
--- a/test/javascript/util/core.js
+++ b/test/javascript/util/core.js
@@ -92,14 +92,6 @@ describe('Foundation core', function() {
       name.should.be.equal('A');
     });
 
-    it('should handle a function expression', function() {
-      var B = function(){}; 
-      var name = Foundation.getFnName(B);
-
-      name.should.be.a('string');
-      name.should.be.equal('');
-    });
-    
     it('should handle a named function expression', function() {
       var D = function foo(){};
       var name = Foundation.getFnName(D);
@@ -108,7 +100,7 @@ describe('Foundation core', function() {
       name.should.be.equal('foo');
     });
   });
-  
+
   describe('transitionEnd()', function() {
   });
 


### PR DESCRIPTION
Remove a test of `getfnname()` for the following case:

```js
const test = function() {};
getfnname(test);
```

This test produce different results across browsers due to the lack of support for some for them (IE/Edge and the phantomjs env) of inferred names of anonymous functions.

Note: there is plenty of NPM packages to detect function names that seems far more complex than our `getfnname`.

See:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
* https://github.com/zurb/foundation-sites/pull/10941#issuecomment-366105628