### PR TITLE
fix: do not test for inferred names in getFnName unit test

### DIFF
--- a/test/javascript/util/core.js
+++ b/test/javascript/util/core.js
@@ -95,6 +95,8 @@ describe('Foundation core', function() {
     it('should handle an anonymous function expression', function() {
       var name = Foundation.getFnName(function(){});
 
+      // Inferred names (i.e. `var name = function() {}`) are not tested as they are widely supported
+      // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Inferred_function_names
       name.should.be.a('string');
       name.should.be.equal('');
     });

--- a/test/javascript/util/core.js
+++ b/test/javascript/util/core.js
@@ -92,7 +92,7 @@ describe('Foundation core', function() {
       name.should.be.equal('A');
     });
 
-    it('should handle an anonymouse function expression', function() {
+    it('should handle an anonymous function expression', function() {
       var name = Foundation.getFnName(function(){});
 
       name.should.be.a('string');

--- a/test/javascript/util/core.js
+++ b/test/javascript/util/core.js
@@ -92,9 +92,8 @@ describe('Foundation core', function() {
       name.should.be.equal('A');
     });
 
-    it('should handle a function expression', function() {
-      var B = function(){}; 
-      var name = Foundation.getFnName(B);
+    it('should handle an anonymouse function expression', function() {
+      var name = Foundation.getFnName(function(){});
 
       name.should.be.a('string');
       name.should.be.equal('');


### PR DESCRIPTION
Inferred names are not widely supported and not recommended at all.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Inferred_function_names

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Browser_compatibility

https://github.com/airbnb/javascript/issues/794

This should fix the last failing unit test.

Ref https://github.com/zurb/foundation-sites/pull/10941