### PR TITLE
fix: change default width of the reveal to 80%

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -12,7 +12,7 @@ $reveal-background: $white !default;
 
 /// Default width of a modal, with no class applied.
 /// @type Number
-$reveal-width: 600px !default;
+$reveal-width: 80% !default;
 
 /// Default maximum width of a modal.
 /// @type Number


### PR DESCRIPTION
This changes the default width for the reveal to the documented value of `80%`.

Closes #8707 