### PR TITLE
fix: remove top and bottom padding from select tags

### DIFF
--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -23,7 +23,7 @@ $select-radius: $global-radius !default;
 
   height: $height;
   margin: 0 0 $form-spacing;
-  padding: $input-padding;
+  padding: 0 $input-padding;
 
   appearance: none;
   border: $input-border;

--- a/scss/forms/_select.scss
+++ b/scss/forms/_select.scss
@@ -23,7 +23,7 @@ $select-radius: $global-radius !default;
 
   height: $height;
   margin: 0 0 $form-spacing;
-  padding: 0 $input-padding;
+  padding: $input-padding;
 
   appearance: none;
   border: $input-border;
@@ -76,6 +76,10 @@ $select-radius: $global-radius !default;
   &[multiple] {
     height: auto;
     background-image: none;
+  }
+  &:not([multiple]) {
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
This removes the unneeded paddings which conflicts with other fonts.

Closes https://github.com/zurb/foundation-sites/issues/7916