### PR TITLE
fix: remove the unused tab-expand-max variable

### DIFF
--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -37,10 +37,6 @@ $tab-item-background-hover: $white !default;
 /// @type Number
 $tab-item-padding: 1.25rem 1.5rem !default;
 
-/// Maximum number of `expand-n` classes to include in the CSS.
-/// @type Number
-$tab-expand-max: 6 !default;
-
 /// Default background color of tab content.
 /// @type Color
 $tab-content-background: $white !default;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -800,7 +800,6 @@ $tab-active-color: $primary-color;
 $tab-item-font-size: rem-calc(12);
 $tab-item-background-hover: $white;
 $tab-item-padding: 1.25rem 1.5rem;
-$tab-expand-max: 6;
 $tab-content-background: $white;
 $tab-content-border: $light-gray;
 $tab-content-color: $body-font-color;


### PR DESCRIPTION
This removes the unused `$tab-expand-max` variable.

Closes https://github.com/zurb/foundation-sites/issues/8484