### PR TITLE
tests: run tests on latest stable and LTS releases of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
   - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "6"
-  - "7"
-  - "8"
-  - "9"
+  - "lts/*"
+  - "stable"
 install:
   - npm install -g bower browserstack-runner
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "lts/*"
+  - "lts/boron"
+  - "lts/carbon"
   - "stable"
 install:
   - npm install -g bower browserstack-runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
+  - "4"
+  - "5"
   - "6"
+  - "7"
+  - "8"
+  - "9"
 install:
   - npm install -g bower browserstack-runner
   - npm install


### PR DESCRIPTION
Currently trying to run the testsuite on all Node.js versions (4 and up).