### PR TITLE
docs: remove out-of-date bug warning in Reponsive Navigation

### DIFF
--- a/docs/pages/responsive-navigation.md
+++ b/docs/pages/responsive-navigation.md
@@ -190,21 +190,6 @@ Just like foundation docs itself (see left sidenav), an accordion menu is great 
 </ul>
 ```
 
-<br>
-<div class="alert callout">
-  <p>
-    <strong>Bug(v6.3.1):</strong> There is a bug within <strong>drilldown-accordion menu</strong> combo. If you set up a responsive menu with drilldown on small, then accordion for medium up, and resize to small and then back to medium the accordions will not work. The bug can be reproduced <a href="http://codepen.io/IamManchanda/pen/OmawKe?editors=1000">here</a> <br>
-    <strong>Good News:</strong> The Bug will be fixed with the upcoming foundation release. If you are specifically using <strong>v6.3.1</strong>, we recommend to use this below patch to fix this.
-  </p>
-</div>
-
-```javascript
-// Patch for a Bug in v6.3.1
-$(window).on('changed.zf.mediaquery', function() {
-  $('.is-accordion-submenu.invisible').removeClass('invisible');
-});
-```
-
 ---
 
 ## Responsive Toggle


### PR DESCRIPTION
Warning was added in https://github.com/zurb/foundation-sites/commit/d93ac93941ae1b01165f0f97fc7f60f6679811d9 (https://github.com/zurb/foundation-sites/pull/10058)

#### See Codepens:
* Bug in v6.3.1: https://codepen.io/IamManchanda/pen/OmawKe
* Resolved in v6.4.3: https://codepen.io/ncoden/pen/XZQBPJ
