### PR TITLE
fix: use `hashchange` event instead of `popstate` for IE/Edge compatibility

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -146,7 +146,7 @@ class Accordion extends Plugin {
       }
     });
     if(this.options.deepLink) {
-      $(window).on('popstate', this._checkDeepLink);
+      $(window).on('hashchange', this._checkDeepLink);
     }
   }
 
@@ -265,7 +265,7 @@ class Accordion extends Plugin {
     this.$element.find('[data-tab-content]').stop(true).slideUp(0).css('display', '');
     this.$element.find('a').off('.zf.accordion');
     if(this.options.deepLink) {
-      $(window).off('popstate', this._checkDeepLink);
+      $(window).off('hashchange', this._checkDeepLink);
     }
 
   }

--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -108,7 +108,7 @@ class Magellan extends Plugin {
       }
     };
 
-    $(window).on('popstate', this._deepLinkScroll);
+    $(window).on('hashchange', this._deepLinkScroll);
   }
 
   /**
@@ -222,7 +222,7 @@ class Magellan extends Plugin {
       var hash = this.$active[0].getAttribute('href');
       window.location.hash.replace(hash, '');
     }
-    $(window).off('popstate', this._deepLinkScroll);
+    $(window).off('hashchange', this._deepLinkScroll);
   }
 }
 

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -169,12 +169,12 @@ class Reveal extends Plugin {
       });
     }
     if (this.options.deepLink) {
-      $(window).on(`popstate.zf.reveal:${this.id}`, this._handleState.bind(this));
+      $(window).on(`hashchange.zf.reveal:${this.id}`, this._handleState.bind(this));
     }
   }
 
   /**
-   * Handles modal methods on back/forward button clicks or any other event that triggers popstate.
+   * Handles modal methods on back/forward button clicks or any other event that triggers hashchange.
    * @private
    */
   _handleState(e) {

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -94,7 +94,7 @@ class Tabs extends Plugin {
       }
     }
 
-     //current context-bound function to open tabs on page load or history popstate
+     //current context-bound function to open tabs on page load or history hashchange
     this._checkDeepLink = () => {
       var anchor = window.location.hash;
       //need a hash and a relevant anchor in this tabset
@@ -143,7 +143,7 @@ class Tabs extends Plugin {
     }
 
     if(this.options.deepLink) {
-      $(window).on('popstate', this._checkDeepLink);
+      $(window).on('hashchange', this._checkDeepLink);
     }
   }
 
@@ -394,7 +394,7 @@ class Tabs extends Plugin {
     }
 
     if (this.options.deepLink) {
-      $(window).off('popstate', this._checkDeepLink);
+      $(window).off('hashchange', this._checkDeepLink);
     }
 
   }


### PR DESCRIPTION
> We do not even need to listen on all history change. We currently use popstate (checked for Accordion, Magellan, Reveal and Tabs) only for window.location.hash, and could rely on hashchange instead without any problems. No need for a polyfill.

See: https://github.com/zurb/foundation-sites/pull/11006#issuecomment-370193395

#### Events:
* [popstate](https://developer.mozilla.org/en-US/docs/Web/Events/popstate): Edge 14+.
* [hashchange](https://developer.mozilla.org/en-US/docs/Web/Events/hashchange): IE 8+.

#### Updated components:
* Accordion
* Magellan
* Reveal
* Tabs

Previous PR: https://github.com/zurb/foundation-sites/pull/11006 (@DanielRuf)
Closes https://github.com/zurb/foundation-sites/issues/10771 (@hubert-ried)