### PR TITLE
chore: add sourcemaps for JS and minified files #10999

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -79,7 +79,8 @@ module.exports = {
     './_build/assets/css/foundation-prototype.css.map',
     './_build/assets/css/foundation-rtl.css',
     './_build/assets/css/foundation-rtl.css.map',
-    '_build/assets/js/foundation.js'
+    '_build/assets/js/foundation.js',
+    '_build/assets/js/foundation.js.map'
   ],
 
   // Tests

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -70,15 +70,13 @@ gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function(
     // * Create minified files
     // * Create minified-sourcemaps based on standard sourcemaps.
     //   Sourcemaps are initialized before the ".min" renaming to be able retrieve
-    //   original sourcemaps (based on the source name), then renamed manually.
+    //   original sourcemaps from source names.
     .pipe(cssFilter)
       .pipe(gulp.dest('./dist/css'))
       .pipe(sourcemaps.init({ loadMaps: true }))
       .pipe(rename({ suffix: '.min' }))
       .pipe(cleancss({ compatibility: 'ie9' }))
-      .pipe(sourcemaps.write('.', {
-        mapFile: function(path) { return path.replace('.css.map', '.min.css.map'); }
-      }))
+      .pipe(sourcemaps.write('.'))
       .pipe(gulp.dest('./dist/css'))
       .pipe(cssFilter.restore)
 
@@ -87,9 +85,7 @@ gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function(
       .pipe(sourcemaps.init({ loadMaps: true }))
       .pipe(rename({ suffix: '.min' }))
       .pipe(uglify())
-      .pipe(sourcemaps.write('.', {
-        mapFile: function(path) { return path.replace('.js.map', '.min.js.map'); }
-      }))
+      .pipe(sourcemaps.write('.'))
       .pipe(gulp.dest('./dist/js'));
 });
 

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -45,22 +45,32 @@ gulp.task('deploy:version', function() {
     .pipe(gulp.dest('.'));
 });
 
-// Generates compiled CSS and JS files and puts them in the dist/ folder
+// Generates compiled CSS and JS files and sourcemaps and puts them in the dist/ folder
 gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function() {
   var cssFilter = filter(['**/*.css'], { restore: true });
   var jsFilter  = filter(['**/*.js'], { restore: true });
   var cssSourcemapFilter = filter(['**/*.css.map'], { restore: true });
   var jsSourcemapFilter = filter(['**/*.js.map'], { restore: true });
 
-  console.log(CONFIG.DIST_FILES)
   return gulp.src(CONFIG.DIST_FILES)
     .pipe(plumber())
+
+    // --- Source maps ---
+    // * Copy sourcemaps to the dist folder
+    // This is done first to avoid collision with minified-sourcemaps.
     .pipe(cssSourcemapFilter)
       .pipe(gulp.dest('./dist/css'))
       .pipe(cssSourcemapFilter.restore)
     .pipe(jsSourcemapFilter)
       .pipe(gulp.dest('./dist/js'))
       .pipe(jsSourcemapFilter.restore)
+
+    // --- Source files ---
+    // * Copy source files to dist folder
+    // * Create minified files
+    // * Create minified-sourcemaps based on standard sourcemaps.
+    //   Sourcemaps are initialized before the ".min" renaming to be able retrieve
+    //   original sourcemaps (based on the source name), then renamed manually.
     .pipe(cssFilter)
       .pipe(gulp.dest('./dist/css'))
       .pipe(sourcemaps.init({ loadMaps: true }))

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -47,8 +47,9 @@ gulp.task('deploy:version', function() {
 // Generates compiled CSS and JS files and puts them in the dist/ folder
 gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function() {
   var cssFilter = filter(['**/*.css'], { restore: true });
-  var sourcemapFilter = filter(['**/*.css.map'], { restore: true });
   var jsFilter  = filter(['**/*.js'], { restore: true });
+  var cssSourcemapFilter = filter(['**/*.css.map'], { restore: true });
+  var jsSourcemapFilter = filter(['**/*.js.map'], { restore: true });
 
   console.log(CONFIG.DIST_FILES)
   return gulp.src(CONFIG.DIST_FILES)
@@ -59,14 +60,17 @@ gulp.task('deploy:dist', ['sass:foundation', 'javascript:foundation'], function(
       .pipe(rename({ suffix: '.min' }))
       .pipe(gulp.dest('./dist/css'))
     .pipe(cssFilter.restore)
-    .pipe(sourcemapFilter)
+    .pipe(cssSourcemapFilter)
       .pipe(gulp.dest('./dist/css'))
-    .pipe(sourcemapFilter.restore)
+    .pipe(cssSourcemapFilter.restore)
     .pipe(jsFilter)
       .pipe(gulp.dest('./dist/js'))
       .pipe(uglify())
       .pipe(rename({ suffix: '.min' }))
-      .pipe(gulp.dest('./dist/js'));
+    .pipe(gulp.dest('./dist/js'))
+    .pipe(jsSourcemapFilter)
+      .pipe(gulp.dest('./dist/js'))
+    .pipe(jsSourcemapFilter.restore);
 });
 
 // Copies standalone JavaScript plugins to dist/ folder

--- a/gulp/tasks/javascript.js
+++ b/gulp/tasks/javascript.js
@@ -6,6 +6,7 @@ var rename = require('gulp-rename');
 var webpackStream = require('webpack-stream');
 var webpack2 = require('webpack');
 var named = require('vinyl-named');
+var sourcemaps = require('gulp-sourcemaps');
 
 var CONFIG = require('../config.js');
 
@@ -61,7 +62,9 @@ var webpackConfig = {
     // See https://github.com/zurb/foundation-sites/pull/10903
     // ---
     // libraryTarget: 'umd',
-  }
+  },
+  // https://github.com/shama/webpack-stream#source-maps
+  devtool: 'source-map'
 }
 
 // Core has to be dealt with slightly differently due to bootstrapping externals
@@ -70,20 +73,26 @@ var webpackConfig = {
 gulp.task('javascript:plugin-core', function() {
   return gulp.src('js/entries/plugins/foundation.core.js')
     .pipe(named())
+    .pipe(sourcemaps.init())
     .pipe(webpackStream(webpackConfig, webpack2))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('_build/assets/js/plugins'));
 });
 gulp.task('javascript:plugins', ['javascript:plugin-core'], function () {
   return gulp.src(['js/entries/plugins/*.js', '!js/entries/plugins/foundation.core.js'])
     .pipe(named())
+    .pipe(sourcemaps.init())
     .pipe(webpackStream(Object.assign({}, webpackConfig, { externals: pluginsAsExternals }), webpack2))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('_build/assets/js/plugins'));
 });
 
 gulp.task('javascript:foundation', ['javascript:plugins'], function() {
   return gulp.src('js/entries/foundation.js')
     .pipe(named())
+    .pipe(sourcemaps.init())
     .pipe(webpackStream(webpackConfig, webpack2))
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('_build/assets/js'));
 });
 //gulp.task('javascript:foundation', function() {


### PR DESCRIPTION
#### Changes:
* add sourcemaps for js files (`foundation.js` and all plugins)
* add sourcemaps for minified files (`foundation.min.js`, `foundation-*.min.css`)
* improve documentation for `dist:javascript` gulp task

Related to https://github.com/zurb/foundation-sites/pull/10998 (@DanielRuf)
Closes https://github.com/zurb/foundation-sites/issues/10999 (@ncoden)