### PR TITLE
fix: mirror the previous and next button content of Orbit in rtl mode

### DIFF
--- a/scss/components/_orbit.scss
+++ b/scss/components/_orbit.scss
@@ -190,6 +190,14 @@ $orbit-control-zindex: 10 !default;
     @include orbit-next;
   }
 
+  // RTL support
+  @if $global-text-direction == rtl {
+    .orbit-previous,
+    .orbit-next {
+      transform: scale(-1, 1);
+    }
+  }
+
   .orbit-bullets {
     @include orbit-bullets;
   }


### PR DESCRIPTION
Closes https://github.com/zurb/foundation-sites/issues/11008