### PR TITLE
fix: remove the unused menu-item-background-hover variable

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -34,10 +34,6 @@ $menu-item-background-active: get-color(primary) !default;
 /// @type Number
 $menu-icon-spacing: 0.25rem !default;
 
-/// Background color for an hovered menu item.
-/// @type Color
-$menu-item-background-hover: $light-gray !default;
-
 /// Backward compatibility for menu state. If true, this duplicate `active` with `is-active`. 
 /// But please note that `active` will be removed in upcoming versions.
 /// @type Boolean


### PR DESCRIPTION
`$menu-item-background-hover` was removed in https://github.com/zurb/foundation-sites/commit/9b7113ccf3ab87df44dfc25d73f11e12c7b85215#diff-e4b53b45b19d558a4a5437c8e871f592

Closes https://github.com/zurb/foundation-sites/issues/10758