### PR TITLE
docs: remove the unused data-btm-offset-pct in reveal

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -521,13 +521,6 @@ Reveal.defaults = {
    */
   fullScreen: false,
   /**
-   * Percentage of screen height the modal should push up from the bottom of the view.
-   * @option
-   * @type {number}
-   * @default 10
-   */
-  btmOffsetPct: 10,
-  /**
    * Allows the modal to generate an overlay div, which will cover the view when modal opens.
    * @option
    * @type {boolean}


### PR DESCRIPTION
`data-btm-offset-pct` is unused but stil referenced in the docs.

Closes https://github.com/zurb/foundation-sites/issues/9727