### PR TITLE
docs: center the thumbnails

### DIFF
--- a/docs/pages/thumbnail.md
+++ b/docs/pages/thumbnail.md
@@ -22,13 +22,13 @@ The `.thumbnail` class can be applied directly to an `<img>` element, or an `<a>
 ```
 
 <div class="row">
-  <div class="small-4 columns">
+  <div class="small-4 columns text-center">
     <img class="thumbnail" src="assets/img/thumbnail/01.jpg" alt="Photo of Uranus.">
   </div>
-  <div class="small-4 columns">
+  <div class="small-4 columns text-center">
     <a href="#" class="thumbnail"><img src="assets/img/thumbnail/02.jpg" alt="Photo of Neptune."></a>
   </div>
-  <div class="small-4 columns">
+  <div class="small-4 columns text-center">
     <img class="thumbnail" src="assets/img/thumbnail/03.jpg" alt="Photo of Pluto.">
   </div>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5405,7 +5405,7 @@
       "optional": true
     },
     "foundation-docs": {
-      "version": "git+https://github.com/zurb/foundation-docs.git#5a925cad940daa43d49e4bfc91c875388e09ead3",
+      "version": "git+https://github.com/zurb/foundation-docs.git#60e24283f3d578a97a8507b2263cb685948613b1",
       "dev": true
     },
     "foundation-emails": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "clipboard": "^1.7.1",
     "corejs-typeahead": "^1.1.1",
     "doiuse": "^2.6.0",
-    "foundation-docs": "git+https://github.com/zurb/foundation-docs.git#5a925cad940daa43d49e4bfc91c875388e09ead3",
+    "foundation-docs": "git+https://github.com/zurb/foundation-docs.git#60e24283f3d578a97a8507b2263cb685948613b1",
     "gulp": "^3.8.10",
     "gulp-add-src": "^0.2.0",
     "gulp-babel": "^6.1.1",


### PR DESCRIPTION
https://github.com/zurb/foundation-docs/pull/30

The styles of the thumbnails in the docs use `display: block`
 with auto margins on both sides for exemplary centering them.

But this does not work well with `display: block` on an a tag.
~~`display: table`~~ `text-center` on the parent works much better in this example which is just for the docs and demonstrating the thumbnails.

Closes https://github.com/zurb/foundation-sites/issues/11029