### PR TITLE
docs: fix example for custom validator

### DIFF
--- a/docs/pages/abide.md
+++ b/docs/pages/abide.md
@@ -345,22 +345,23 @@ website: {
 * Add new patterns and validators before or after foundation is initialized
 
 ```javascript
-
-// Set paramaters
-Foundation.Abide.defaults.patterns['dashes_only'] = /^[0-9-]*$/;
-Foundation.Abide.defaults.validators['greater_than'] =
-
-function($el,required,parent) {
-  // parameter 1 is jQuery selector
+function myCustomValidator(
+  $el,      /* jQuery element to validate */
+  required, /* is the element required according to the `[required]` attribute */
+  parent    /* parent of the jQuery element `$el` */
+) {
   if (!required) return true;
   var from = $('#'+$el.attr('data-greater-than')).val(),
       to = $el.val();
   return (parseInt(to) > parseInt(from));
 };
 
-// Init Foundation
-$(document).foundation();
+// Set default options
+Foundation.Abide.defaults.patterns['dashes_only'] = /^[0-9-]*$/;
+Foundation.Abide.defaults.validators['greater_than'] = myCustomValidator;
 
+// Initialize Foundation
+$(document).foundation();
 ```
 ```html
 <input id="phone" type="text" pattern="dashes_only" required >

--- a/docs/pages/abide.md
+++ b/docs/pages/abide.md
@@ -350,9 +350,6 @@ website: {
 Foundation.Abide.defaults.patterns['dashes_only'] = /^[0-9-]*$/;
 Foundation.Abide.defaults.validators['greater_than'] =
 
-// Init Foundation
-$(document).foundation();
-
 function($el,required,parent) {
   // parameter 1 is jQuery selector
   if (!required) return true;
@@ -360,6 +357,10 @@ function($el,required,parent) {
       to = $el.val();
   return (parseInt(to) > parseInt(from));
 };
+
+// Init Foundation
+$(document).foundation();
+
 ```
 ```html
 <input id="phone" type="text" pattern="dashes_only" required >


### PR DESCRIPTION
Foundation initialization was misplaced in the example, hence it was confusing. Discussed in #9773 . Fixes #11033 .