### PR TITLE
docs: fix the data-deep-link-smudge-delay attribute in the tabs example

### DIFF
--- a/docs/pages/tabs.md
+++ b/docs/pages/tabs.md
@@ -190,7 +190,7 @@ Add the attribute `data-deep-link="true"` to a tabstrip to:
 </p>
 
 ```html_example
-<ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge="500" data-tabs id="deeplinked-tabs">
+<ul class="tabs" data-deep-link="true" data-update-history="true" data-deep-link-smudge="true" data-deep-link-smudge-delay="500" data-tabs id="deeplinked-tabs">
   <li class="tabs-title is-active"><a href="#panel1d" aria-selected="true">Tab 1</a></li>
   <li class="tabs-title"><a href="#panel2d">Tab 2</a></li>
   <li class="tabs-title"><a href="#panel3d">Tab 3</a></li>


### PR DESCRIPTION
Closes https://github.com/zurb/foundation-sites/issues/10090