### PR TITLE
fix: add aria-expanded to the toggler trigger

### DIFF
--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -126,7 +126,11 @@ class Toggler extends Plugin {
   }
 
   _updateARIA(isOn) {
-    this.$element.attr('aria-expanded', isOn ? true : false);
+    var id = this.$element[0].id;
+    $(`[data-open="${id}"], [data-close="${id}"], [data-toggle="${id}"]`)
+      .attr({
+        'aria-expanded': isOn ? true : false
+      });
   }
 
   /**

--- a/js/foundation.toggler.js
+++ b/js/foundation.toggler.js
@@ -58,9 +58,10 @@ class Toggler extends Plugin {
     // Add ARIA attributes to triggers
     var id = this.$element[0].id;
     $(`[data-open="${id}"], [data-close="${id}"], [data-toggle="${id}"]`)
-      .attr('aria-controls', id);
-    // If the target is hidden, add aria-hidden
-    this.$element.attr('aria-expanded', this.$element.is(':hidden') ? false : true);
+      .attr({
+        'aria-controls': id,
+        'aria-expanded': this.$element.is(':hidden') ? false : true
+      });
   }
 
   /**

--- a/test/javascript/components/toggler.js
+++ b/test/javascript/components/toggler.js
@@ -106,13 +106,22 @@ describe('Toggler', function() {
 
     it('updates aria-expanded after the class is toggled', function() {
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
+      var $triggers = $(`<div>
+          <a data-open="toggler">Open</a>
+          <a data-close="toggler">Close</a>
+          <a data-toggle="toggler">Toggle</a>
+        </div>`).appendTo('body');
       plugin = new Foundation.Toggler($html, {});
 
       plugin._toggleClass();
-      $('#toggler').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
 
       plugin._toggleClass();
-      $('#toggler').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
     });
   });
 
@@ -121,11 +130,19 @@ describe('Toggler', function() {
     it('animates an invisible element in', function(done) {
       var $css = $('<style>#toggler { display: none; }</style>').appendTo('body');
       $html = $('<div id="toggler" data-toggler data-animate="fade-in fade-out"></div>').appendTo('body');
+      var $triggers = $(`<div>
+          <a data-open="toggler">Open</a>
+          <a data-close="toggler">Close</a>
+          <a data-toggle="toggler">Toggle</a>
+        </div>`).appendTo('body');
+
       plugin = new Foundation.Toggler($html, {});
 
       $html.on('on.zf.toggler', function() {
         $('#toggler').should.be.visible;
-        $('#toggler').should.have.attr('aria-expanded', 'true');
+        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
+        $triggers.find('[data-close]').should.have.attr('aria-expanded', 'true');
+        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
         $css.remove();
         done();
       });
@@ -135,11 +152,19 @@ describe('Toggler', function() {
 
     it('animates an visible element out', function(done) {
       $html = $('<div id="toggler" data-toggler data-animate="fade-in fade-out"></div>').appendTo('body');
+      var $triggers = $(`<div>
+          <a data-open="toggler">Open</a>
+          <a data-close="toggler">Close</a>
+          <a data-toggle="toggler">Toggle</a>
+        </div>`).appendTo('body');
+
       plugin = new Foundation.Toggler($html, {});
 
       $html.on('off.zf.toggler', function() {
         $('#toggler').should.be.hidden;
-        $('#toggler').should.have.attr('aria-expanded', 'false');
+        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
+        $triggers.find('[data-close]').should.have.attr('aria-expanded', 'false');
+        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
         done();
       });
 

--- a/test/javascript/components/toggler.js
+++ b/test/javascript/components/toggler.js
@@ -58,17 +58,31 @@ describe('Toggler', function() {
 
     it('sets aria-expanded to true if the element is visible', function() {
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
+      var $triggers = $(`<div>
+          <a data-open="toggler">Open</a>
+          <a data-close="toggler">Close</a>
+          <a data-toggle="toggler">Toggle</a>
+        </div>`).appendTo('body');
       plugin = new Foundation.Toggler($html, {});
 
-      $('#toggler').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
     });
 
     it('sets aria-expanded to false if the element is invisible', function() {
       var $css = $('<style>#toggler { display: none }</style>').appendTo('body');
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
+      var $triggers = $(`<div>
+          <a data-open="toggler">Open</a>
+          <a data-close="toggler">Close</a>
+          <a data-toggle="toggler">Toggle</a>
+        </div>`).appendTo('body');
       plugin = new Foundation.Toggler($html, {});
 
-      $('#toggler').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
       $css.remove();
     });
   });

--- a/test/javascript/components/toggler.js
+++ b/test/javascript/components/toggler.js
@@ -7,6 +7,14 @@ describe('Toggler', function() {
     $html.remove();
   });
 
+  function appendTriggers() {
+    return $(`<div>
+      <a data-open="toggler">Open</a>
+      <a data-close="toggler">Close</a>
+      <a data-toggle="toggler">Toggle</a>
+    </div>`).appendTo('body')
+  }
+
   describe('constructor()', function() {
     it('stores the element and plugin options', function() {
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
@@ -42,47 +50,29 @@ describe('Toggler', function() {
 
     it('adds Aria attributes to click triggers', function() {
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
-      var $triggers = $(`<div>
-          <a data-open="toggler">Open</a>
-          <a data-close="toggler">Close</a>
-          <a data-toggle="toggler">Toggle</a>
-        </div>`).appendTo('body');
+      var $triggers = appendTriggers();
       plugin = new Foundation.Toggler($html, {});
 
-      $triggers.find('[data-open]').should.have.attr('aria-controls', 'toggler');
-      $triggers.find('[data-close]').should.have.attr('aria-controls', 'toggler');
-      $triggers.find('[data-toggle]').should.have.attr('aria-controls', 'toggler');
+      $triggers.find('[data-open], [data-close], [data-toggle]').should.have.attr('aria-controls', 'toggler');
 
       $triggers.remove();
     });
 
     it('sets aria-expanded to true if the element is visible', function() {
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
-      var $triggers = $(`<div>
-          <a data-open="toggler">Open</a>
-          <a data-close="toggler">Close</a>
-          <a data-toggle="toggler">Toggle</a>
-        </div>`).appendTo('body');
+      var $triggers = appendTriggers();
       plugin = new Foundation.Toggler($html, {});
 
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
-      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'true');
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-open], [data-close], [data-toggle]').should.have.attr('aria-expanded', 'true');
     });
 
     it('sets aria-expanded to false if the element is invisible', function() {
       var $css = $('<style>#toggler { display: none }</style>').appendTo('body');
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
-      var $triggers = $(`<div>
-          <a data-open="toggler">Open</a>
-          <a data-close="toggler">Close</a>
-          <a data-toggle="toggler">Toggle</a>
-        </div>`).appendTo('body');
+      var $triggers = appendTriggers();
       plugin = new Foundation.Toggler($html, {});
 
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
-      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'false');
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-open], [data-close], [data-toggle]').should.have.attr('aria-expanded', 'false');
       $css.remove();
     });
   });
@@ -106,22 +96,14 @@ describe('Toggler', function() {
 
     it('updates aria-expanded after the class is toggled', function() {
       $html = $('<div id="toggler" data-toggler="class"></div>').appendTo('body');
-      var $triggers = $(`<div>
-          <a data-open="toggler">Open</a>
-          <a data-close="toggler">Close</a>
-          <a data-toggle="toggler">Toggle</a>
-        </div>`).appendTo('body');
+      var $triggers = appendTriggers();
       plugin = new Foundation.Toggler($html, {});
 
       plugin._toggleClass();
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
-      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'true');
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
+      $triggers.find('[data-open], [data-close], [data-toggle]').should.have.attr('aria-expanded', 'true');
 
       plugin._toggleClass();
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
-      $triggers.find('[data-close]').should.have.attr('aria-expanded', 'false');
-      $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
+      $triggers.find('[data-open], [data-close], [data-toggle]').should.have.attr('aria-expanded', 'false');
     });
   });
 
@@ -130,19 +112,11 @@ describe('Toggler', function() {
     it('animates an invisible element in', function(done) {
       var $css = $('<style>#toggler { display: none; }</style>').appendTo('body');
       $html = $('<div id="toggler" data-toggler data-animate="fade-in fade-out"></div>').appendTo('body');
-      var $triggers = $(`<div>
-          <a data-open="toggler">Open</a>
-          <a data-close="toggler">Close</a>
-          <a data-toggle="toggler">Toggle</a>
-        </div>`).appendTo('body');
 
       plugin = new Foundation.Toggler($html, {});
 
       $html.on('on.zf.toggler', function() {
         $('#toggler').should.be.visible;
-        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
-        $triggers.find('[data-close]').should.have.attr('aria-expanded', 'true');
-        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'true');
         $css.remove();
         done();
       });
@@ -150,21 +124,13 @@ describe('Toggler', function() {
       plugin._toggleAnimate();
     });
 
-    it('animates an visible element out', function(done) {
+    it('animates a visible element out', function(done) {
       $html = $('<div id="toggler" data-toggler data-animate="fade-in fade-out"></div>').appendTo('body');
-      var $triggers = $(`<div>
-          <a data-open="toggler">Open</a>
-          <a data-close="toggler">Close</a>
-          <a data-toggle="toggler">Toggle</a>
-        </div>`).appendTo('body');
 
       plugin = new Foundation.Toggler($html, {});
 
       $html.on('off.zf.toggler', function() {
         $('#toggler').should.be.hidden;
-        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
-        $triggers.find('[data-close]').should.have.attr('aria-expanded', 'false');
-        $triggers.find('[data-open]').should.have.attr('aria-expanded', 'false');
         done();
       });
 


### PR DESCRIPTION
The `aria-expanded` attribute should be on the trigger not the container of the toggled element(s).

References:
https://www.w3.org/WAI/GL/wiki/Using_aria-expanded_to_indicate_the_state_of_a_collapsible_element
http://3needs.org/en/testing/code/aria-expanded.html
http://www.3needs.org/en/testing/code/aria-expanded-code.html

Closes https://github.com/zurb/foundation-sites/issues/11049