### PR TITLE
fix: fix Tooltip cleaning on destroy #11054

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -292,7 +292,7 @@ class Tooltip extends Positionable {
     this.$element.attr('title', this.template.text())
                  .off('.zf.trigger .zf.tooltip')
                  .removeClass('has-tip top right left')
-                 .removeAttr('aria-describedby aria-haspopup data-disable-hover data-resize data-toggle data-tooltip data-yeti-box');
+                 .removeAttr('aria-describedby data-disable-hover data-resize data-toggle data-tooltip data-yeti-box');
 
     this.template.remove();
   }

--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -291,7 +291,8 @@ class Tooltip extends Positionable {
   _destroy() {
     this.$element.attr('title', this.template.text())
                  .off('.zf.trigger .zf.tooltip')
-                 .removeClass('has-tip top right left')
+                 .removeClass(this.options.triggerClass)
+                 .removeClass('top right left bottom')
                  .removeAttr('aria-describedby data-disable-hover data-resize data-toggle data-tooltip data-yeti-box');
 
     this.template.remove();


### PR DESCRIPTION
Changes:
* remove support for [invalid attribute `aria-haspopup` for tooltips](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup)
* clear the `triggerClass` option instead of `.has-tip` on destroy
* clear the `.bottom` class on destroy alongside others positioning classes.

See #11054
