### PR TITLE
fix: do not add the scrollbar by default

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -62,7 +62,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
 
   display: none;
   background-color: $background;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 /// Adds base styles for a modal.
@@ -130,11 +130,7 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   html.is-reveal-open {
     position: fixed;
     width: 100%;
-    overflow-y: scroll;
-
-    body { // sass-lint:disable-line no-qualifying-elements
-      overflow: hidden;
-    }
+    overflow: hidden;
   }
 
   // Overlay


### PR DESCRIPTION
Using reveal adds a double scrollbar as overflow: scroll is used. We should use overflow: auto instead.

https://codepen.io/DanielRuf/pen/RMRVjO

https://codepen.io/DanielRuf/debug/RMRVjO

Closes https://github.com/zurb/foundation-sites/issues/11064 and https://github.com/zurb/foundation-sites/issues/10824

Codepen with the changes: https://codepen.io/DanielRuf/pen/RMRgNN