### PR TITLE
fix: add the search input cancel button in Chrome/Safari again

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -43,6 +43,7 @@ $medium-gray: #cacaca !default;
 /// Color used for dark gray UI items.
 /// @type Color
 $dark-gray: #8a8a8a !default;
+$dark-gray: #8a8a8a !default;
 
 /// Color used for black ui items.
 /// @type Color
@@ -135,6 +136,11 @@ $global-color-pick-contrast-tolerance: 0 !default;
 
 @mixin foundation-global-styles {
   @include -zf-normalize;
+
+  // Add the search input cancel button in Chrome/Safari again
+  [type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: searchfield-cancel-button;
+  }
 
   // These styles are applied to a <meta> tag, which is read by the Foundation JavaScript
   .foundation-mq {

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -43,7 +43,6 @@ $medium-gray: #cacaca !default;
 /// Color used for dark gray UI items.
 /// @type Color
 $dark-gray: #8a8a8a !default;
-$dark-gray: #8a8a8a !default;
 
 /// Color used for black ui items.
 /// @type Color


### PR DESCRIPTION
Currently all modern browsers support the search input cancel button.
So removing it in normalize-scss makes no more sense.

In fact normalize 8.0.0 added it back, see https://github.com/necolas/normalize.css/commit/f7c98c4c859c15363763f10a439b63d85b9afba0

But the used [normalize-scss](https://github.com/JohnAlbin/normalize-scss) still relies on an old version of normalize.

References:
https://github.com/JohnAlbin/normalize-scss/issues/131
https://github.com/necolas/normalize.css/issues/685

Closes https://github.com/zurb/foundation-sites/issues/11015