### PR TITLE
docs: improve deepLink options docs

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -294,31 +294,29 @@ Accordion.defaults = {
    */
   allowAllClosed: false,
   /**
-   * Allows the window to scroll to content of pane specified by hash anchor
+   * Link the location hash to the open pane.
+   * Set the location hash when the opened pane changes, and open and scroll to the corresponding pane when the location changes.
    * @option
    * @type {boolean}
    * @default false
    */
   deepLink: false,
-
   /**
-   * Adjust the deep link scroll to make sure the top of the accordion panel is visible
+   * If `deepLink` is enabled, adjust the deep link scroll to make sure the top of the accordion panel is visible
    * @option
    * @type {boolean}
    * @default false
    */
   deepLinkSmudge: false,
-
   /**
-   * Animation time (ms) for the deep link adjustment
+   * If `deepLinkSmudge` is enabled, animation time (ms) for the deep link adjustment
    * @option
    * @type {number}
    * @default 300
    */
   deepLinkSmudgeDelay: 300,
-
   /**
-   * Update the browser history with the open accordion
+   * If `deepLink` is enabled, update the browser history with the open accordion
    * @option
    * @type {boolean}
    * @default false

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -535,14 +535,15 @@ Reveal.defaults = {
    */
   resetOnClose: false,
   /**
-   * Allows the modal to alter the url on open/close, and allows the use of the `back` button to close modals. ALSO, allows a modal to auto-maniacally open on page load IF the hash === the modal's user-set id.
+   * Link the location hash to the modal.
+   * Set the location hash when the modal is opened/closed, and open/close the modal when the location changes.
    * @option
    * @type {boolean}
    * @default false
    */
   deepLink: false,
   /**
-   * Update the browser history with the open modal
+   * If `deepLink` is enabled, update the browser history with the open modal
    * @option
    * @default false
    */

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -398,7 +398,8 @@ class Tabs extends Plugin {
 
 Tabs.defaults = {
   /**
-   * Allows the window to scroll to content of pane specified by hash anchor
+   * Link the location hash to the active pane.
+   * Set the location hash when the active pane changes, and open the corresponding pane when the location changes.
    * @option
    * @type {boolean}
    * @default false
@@ -406,7 +407,7 @@ Tabs.defaults = {
   deepLink: false,
 
   /**
-   * Adjust the deep link scroll to make sure the top of the tab panel is visible
+   * If `deepLink` is enabled, adjust the deep link scroll to make sure the top of the tab panel is visible
    * @option
    * @type {boolean}
    * @default false
@@ -414,7 +415,7 @@ Tabs.defaults = {
   deepLinkSmudge: false,
 
   /**
-   * Animation time (ms) for the deep link adjustment
+   * If `deepLinkSmudge` is enabled, animation time (ms) for the deep link adjustment
    * @option
    * @type {number}
    * @default 300
@@ -422,7 +423,7 @@ Tabs.defaults = {
   deepLinkSmudgeDelay: 300,
 
   /**
-   * Update the browser history with the open tab
+   * If `deepLink` is enabled, update the browser history with the open tab
    * @option
    * @type {boolean}
    * @default false
@@ -430,7 +431,7 @@ Tabs.defaults = {
   updateHistory: false,
 
   /**
-   * Allows the window to scroll to content of active pane on load if set to true.
+   * Allows the window to scroll to content of active pane on load.
    * Not recommended if more than one tab panel per page.
    * @option
    * @type {boolean}


### PR DESCRIPTION
Improve documentation for Accordion, Reveal and Tabs deepLink options.

Changes:
* Give all the effects of `deepLink`
* Mention the dependencies between options