### PR TITLE
 fix: change the calculation of box dimensions, fixes IE behavior

### DIFF
--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -74,21 +74,27 @@ function GetDimensions(elem){
   }
 
   var rect = elem.getBoundingClientRect(),
-      parRect = elem.parentNode.getBoundingClientRect(),
-      winRect = document.body.getBoundingClientRect(),
+      par = elem.parentNode,
+      parRect = par.getBoundingClientRect(),
+      win = document.body,
+      winRect = win.getBoundingClientRect(),
+      elemWidth = Math.max(elem.scrollWidth, elem.offsetWidth, elem.clientWidth),
+      elemHeight = Math.max(elem.scrollHeight, elem.offsetHeight, elem.clientHeight),
+      parWidth = Math.max(par.scrollWidth, par.offsetWidth, par.clientWidth),
+      parHeight = Math.max(par.scrollHeight, par.offsetHeight, par.clientHeight),
       winY = window.pageYOffset,
       winX = window.pageXOffset;
 
   return {
-    width: rect.width,
-    height: rect.height,
+    width: elemWidth,
+    height: elemHeight,
     offset: {
       top: rect.top + winY,
       left: rect.left + winX
     },
     parentDims: {
-      width: parRect.width,
-      height: parRect.height,
+      width: parWidth,
+      height: parHeight,
       offset: {
         top: parRect.top + winY,
         left: parRect.left + winX

--- a/js/foundation.util.box.js
+++ b/js/foundation.util.box.js
@@ -76,25 +76,20 @@ function GetDimensions(elem){
   var rect = elem.getBoundingClientRect(),
       par = elem.parentNode,
       parRect = par.getBoundingClientRect(),
-      win = document.body,
-      winRect = win.getBoundingClientRect(),
-      elemWidth = Math.max(elem.scrollWidth, elem.offsetWidth, elem.clientWidth),
-      elemHeight = Math.max(elem.scrollHeight, elem.offsetHeight, elem.clientHeight),
-      parWidth = Math.max(par.scrollWidth, par.offsetWidth, par.clientWidth),
-      parHeight = Math.max(par.scrollHeight, par.offsetHeight, par.clientHeight),
+      winRect = document.body.getBoundingClientRect(),
       winY = window.pageYOffset,
       winX = window.pageXOffset;
 
   return {
-    width: elemWidth,
-    height: elemHeight,
+    width: elem.clientWidth,
+    height: elem.clientHeight,
     offset: {
       top: rect.top + winY,
       left: rect.left + winX
     },
     parentDims: {
-      width: parWidth,
-      height: parHeight,
+      width: par.clientWidth,
+      height: par.clientHeight,
       offset: {
         top: parRect.top + winY,
         left: parRect.left + winX


### PR DESCRIPTION
IE11 does not properly calculate `getBoundingClientRect` and produces values like `199.9998779296875`

![image](https://user-images.githubusercontent.com/827205/37571407-73dd0106-2afc-11e8-86ee-1ffc9d469094.png)

jQuery uses a different approach depending on the node type:
https://github.com/jquery/jquery/blob/master/src/dimensions.js#L35-L41

But we should probably use `clientHeight` and `clientWidth`:

https://github.com/nefe/You-Dont-Need-jQuery#2.2

