### PR TITLE
fix: respect $gutter-output in the -xy-cell-properties mixin

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -95,7 +95,7 @@
 /// Creates a cell for your grid.
 ///
 /// @param {Keyword|Number} $size [full] - The size of your cell. Can be `full` (default) for 100% width, `auto` to use up available space and `shrink` to use up only required space.
-/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters
+/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters. Always `true` for margin gutters.
 /// @param {Number|Map} $gutters [$grid-margin-gutters] - Map or single value for gutters.
 /// @param {Keyword} $gutter-type [margin] - Map or single value for gutters.
 /// @param {List} $gutter-position [right left] - The position to apply gutters to. Accepts `top`, `bottom`, `left`, `right` in any combination.
@@ -143,7 +143,7 @@
 /// Creates a single breakpoint sized grid. Used to generate our grid classes.
 ///
 /// @param {Keyword|Number} $size [full] - The size of your cell. Can be `full` (default) for 100% width, `auto` to use up available space and `shrink` to use up only required space.
-/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters
+/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters. Always `true` for margin gutters.
 /// @param {Number|Map} $gutters [$grid-margin-gutters] - Map or single value for gutters.
 /// @param {Keyword} $gutter-type [margin] - Map or single value for gutters.
 /// @param {String} $breakpoint [null] - The name of the breakpoint size in your gutters map to get the size from. If using with the `breakpoint()` mixin this will be set automatically unless manually entered.

--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -127,7 +127,7 @@
     // Base flex properties
     @include xy-cell-base($size);
 
-    @if($gutter-type == 'margin') {
+    @if($gutter-output == true && $gutter-type == 'margin') {
       @include -xy-cell-properties($size, $gutter, $vertical);
     }
     @else {
@@ -163,7 +163,7 @@
   $gutter: -zf-get-bp-val($gutters, $breakpoint);
   $gutter-position: if($vertical == true, top bottom, left right);
 
-  @if($gutter-type == 'margin') {
+  @if($gutter-output == true and $gutter-type == 'margin') {
     @include -xy-cell-properties($size, $gutter, $vertical);
   }
   @else {

--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -127,7 +127,7 @@
     // Base flex properties
     @include xy-cell-base($size);
 
-    @if($gutter-output == true && $gutter-type == 'margin') {
+    @if($gutter-output == true and $gutter-type == 'margin') {
       @include -xy-cell-properties($size, $gutter, $vertical);
     }
     @else {

--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -127,14 +127,11 @@
     // Base flex properties
     @include xy-cell-base($size);
 
-    @if($gutter-output == true and $gutter-type == 'margin') {
-      @include -xy-cell-properties($size, $gutter, $vertical);
-    }
-    @else {
-      @include -xy-cell-properties($size, 0, $vertical);
-    }
+    $-gutter-output: if($gutter-type == 'margin', true, $gutter-output);
+    $-gutter-margin: if($gutter-type == 'margin', $gutter, 0);
 
-    @if $gutter-output {
+    @include -xy-cell-properties($size, $-gutter-margin, $vertical);
+    @if ($-gutter-output) {
       @include xy-gutters($gutter, $gutter-type, $gutter-position);
     }
   }
@@ -163,16 +160,11 @@
   $gutter: -zf-get-bp-val($gutters, $breakpoint);
   $gutter-position: if($vertical == true, top bottom, left right);
 
-  @if($gutter-output == true and $gutter-type == 'margin') {
-    @include -xy-cell-properties($size, $gutter, $vertical);
-  }
-  @else {
-    @include -xy-cell-properties($size, 0, $vertical);
-  }
+  $-gutter-output: if($gutter-type == 'margin', true, $gutter-output);
+  $-gutter-margin: if($gutter-type == 'margin', $gutter, 0);
 
-  // If we want to output the gutters
-  @if($gutter-output) {
-    // TODO: Figure out if we need to pass breakpoint in here too.
+  @include -xy-cell-properties($size, $-gutter-margin, $vertical);
+  @if ($-gutter-output) {
     @include xy-gutters($gutter, $gutter-type, $gutter-position);
   }
 }

--- a/scss/xy-grid/_layout.scss
+++ b/scss/xy-grid/_layout.scss
@@ -10,7 +10,7 @@
 ///
 /// @param {Number} $n - Number of elements to display per row.
 /// @param {String} $selector ['.cell'] - Selector(s) to use for child elements.
-/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters
+/// @param {Boolean} $gutter-output [true] - Whether or not to output gutters. Always `true` for margin gutters.
 /// @param {Number|Map} $gutters [$grid-margin-gutters] - Map or single value for gutters.
 /// @param {Keyword} $gutter-type [margin] - Type of gutter to output. Accepts `margin` or `padding`.
 /// @param {List} $gutter-position [right left] - The position to apply gutters to. Accepts `top`, `bottom`, `left`, `right` in any combination.


### PR DESCRIPTION
Currently the gutters are included in the width calculation even if `$gutter-output` is set to `false`.
This should not be the case.

Closes https://github.com/zurb/foundation-sites/issues/11059