### PR TITLE
chore: remove deprecated mixins

### DIFF
--- a/scss/components/_responsive-embed.scss
+++ b/scss/components/_responsive-embed.scss
@@ -17,9 +17,6 @@ $responsive-embed-ratios: (
   widescreen: 16 by 9,
 ) !default;
 
-// WARNING: Will be removed in version 6.4
-$responsive-embed-ratio: default;
-
 /// Creates a responsive embed container.
 /// @param {String|List} $ratio [default] - Ratio of the container. Can be a key from the `$responsive-embed-ratios` map or a list formatted as `x by y`.
 @mixin responsive-embed($ratio: default) {
@@ -57,14 +54,4 @@ $responsive-embed-ratio: default;
       }
     }
   }
-}
-
-@mixin foundation-flex-video {
-  @warn 'This mixin is being replaced by foundation-responsive-embed(). foundation-flex-video() will be removed in Foundation 6.4.';
-  @include foundation-responsive-embed;
-}
-
-@mixin flex-video($ratio: $responsive-embed-ratio) {
-  @warn 'This mixin is being replaced by responsive-embed(). flex-video() will be removed in Foundation 6.4.';
-  @include responsive-embed($ratio);
 }

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -30,14 +30,6 @@
   @include grid-column-gutter(0);
 }
 
-/// Un-collapse the gutters on a column by re-adding the padding.
-///
-/// @param {Number} $gutter [$grid-column-gutter] - Spacing between columns.
-@mixin grid-column-uncollapse($gutter: $grid-column-gutter) {
-  @warn 'This mixin is being replaced by grid-column-gutter(). grid-column-uncollapse() will be removed in Foundation 6.4.';
-  @include grid-column-gutter($gutters: $gutter);
-}
-
 /// Shorthand for `grid-column-gutter()`.
 /// @alias grid-column-gutter
 @mixin grid-col-gutter(
@@ -51,13 +43,6 @@
 /// @alias grid-column-collapse
 @mixin grid-col-collapse {
   @include grid-column-collapse;
-}
-
-/// Shorthand for `grid-column-uncollapse()`.
-/// @alias grid-column-uncollapse
-@mixin grid-col-uncollapse($gutter: $grid-column-gutter) {
-  @warn 'This mixin is being replaced by grid-col-gutter(). grid-col-uncollapse() will be removed in Foundation 6.4.';
-  @include grid-column-uncollapse($gutter);
 }
 
 /// Sets bottom margin on grid columns to match gutters


### PR DESCRIPTION
`$responsive-embed-ratio`, `foundation-flex-video` and `flex-video` are deprecated and should be already removed in 6.4.