### PR TITLE
feat(?): Adds variables for padding of large and small callouts

### DIFF
--- a/scss/components/_callout.scss
+++ b/scss/components/_callout.scss
@@ -26,6 +26,14 @@ $callout-margin: 0 0 1rem 0 !default;
 /// @type Number
 $callout-padding: 1rem !default;
 
+/// Default inner padding for small callouts.
+/// @type Number
+$callout-small-padding: 0.5rem !default;
+
+/// Default inner padding for large callouts.
+/// @type Number
+$callout-large-padding: 3rem !default;
+
 /// Default font color for callouts.
 /// @type Color
 $callout-font-color: $body-font-color !default;
@@ -96,11 +104,11 @@ $callout-link-tint: 30% !default;
     }
 
     &.small {
-      @include callout-size(0.5rem);
+      @include callout-size($callout-small-padding);
     }
 
     &.large {
-      @include callout-size(3rem);
+      @include callout-size($callout-large-padding);
     }
   }
 }

--- a/scss/components/_callout.scss
+++ b/scss/components/_callout.scss
@@ -22,17 +22,13 @@ $callout-border: 1px solid rgba($black, 0.25) !default;
 /// @type Number
 $callout-margin: 0 0 1rem 0 !default;
 
-/// Default inner padding for callouts.
-/// @type Number
-$callout-padding: 1rem !default;
-
-/// Default inner padding for small callouts.
-/// @type Number
-$callout-small-padding: 0.5rem !default;
-
-/// Default inner padding for large callouts.
-/// @type Number
-$callout-large-padding: 3rem !default;
+/// Sizes for Callout paddings.
+/// @type Map
+$callout-sizes: (
+  small: 0.5rem,
+  default: 1rem,
+  large: 3rem,
+) !default;
 
 /// Default font color for callouts.
 /// @type Color
@@ -54,7 +50,7 @@ $callout-link-tint: 30% !default;
 @mixin callout-base() {
   position: relative;
   margin: $callout-margin;
-  padding: $callout-padding;
+  padding: map-get($callout-sizes, default);
 
   border: $callout-border;
   border-radius: $callout-radius;
@@ -103,12 +99,10 @@ $callout-link-tint: 30% !default;
       }
     }
 
-    &.small {
-      @include callout-size($callout-small-padding);
-    }
-
-    &.large {
-      @include callout-size($callout-large-padding);
+    @each $size, $padding in map-remove($callout-sizes, default) {
+      &.#{$size} {
+        @include callout-size($padding);
+      }
     }
   }
 }


### PR DESCRIPTION
Hello.  This is a rather minor PR.

I'm decently new to foundation, but going through things it surprised me that I couldn't change the padding of a small or large callout across my entire theme.  It was pretty simple for me to add a class to my theme to create a callout with the padding I desired, but I thought this capability might be generally appreciated.
