### PR TITLE
fix: add missing vertical scrollbar in xy-grid frame

### DIFF
--- a/scss/xy-grid/_frame.scss
+++ b/scss/xy-grid/_frame.scss
@@ -61,7 +61,7 @@
   @if $vertical == true {
     overflow-y: auto;
     max-height: 100%;
-    height: 100%;
+    min-height: 100%;
   } @else {
     overflow-x: auto;
     max-width: 100%;


### PR DESCRIPTION
https://github.com/zurb/foundation-sites/commit/b1924e099540e4e7411a948d776691e1e5746fbf created a regression. `height:100%` removed the scrollbar from the vertical xy-grid frame.

This PR fixes this and uses the recommended `min-height:100%` setting.

Closes https://github.com/zurb/foundation-sites/issues/10793