### PR TITLE
chore: remove rem-base deprecation note

### DIFF
--- a/docs/pages/global.md
+++ b/docs/pages/global.md
@@ -9,10 +9,6 @@ sass: scss/_global.scss
 
 The default font size is set to 100% of the browser style sheet, usually 16 pixels. This ensures compatibility with browser-based text zoom or user-set defaults. If you're using the Sass version of Foundation, edit the `$global-font-size` variable to change the base font size. This can be a percentage value, or a pixel value.
 
-<div class="alert callout">
-  <p><code>$rem-base</code> was deprecated in version 6.1, in favor of using <code>$global-font-size</code> to define rem calculation.</p>
-</div>
-
 ---
 
 ## Colors


### PR DESCRIPTION
Currently the docs contain the following deprecation note:

> `$rem-base` was deprecated in version 6.1, in favor of using `$global-font-size` to define rem calculation.

So it is a very old notice and we can safely remove it now.