### PR TITLE
docs: fix check for flexbox-mode is-active class in component list

### DIFF
--- a/docs/partials/component-list.html
+++ b/docs/partials/component-list.html
@@ -24,9 +24,9 @@
       </div>
     </li>
 
-    <li class="accordion-item {{#ifpage 'global' 'rtl' 'flexbox' 'sass' 'javascript' 'javascript-utilities' 'media-queries'}}is-active{{/ifpage}}" data-accordion-item>
+    <li class="accordion-item {{#ifpage 'global' 'rtl' 'flexbox-mode' 'sass' 'javascript' 'javascript-utilities' 'media-queries'}}is-active{{/ifpage}}" data-accordion-item>
       <a href="#" class="accordion-title">Setup</a>
-      <div class="accordion-content {{#ifpage 'global' 'rtl' 'flexbox' 'sass' 'javascript' 'javascript-utilities' 'media-queries'}}is-active{{/ifpage}}" data-tab-content>
+      <div class="accordion-content {{#ifpage 'global' 'rtl' 'flexbox-mode' 'sass' 'javascript' 'javascript-utilities' 'media-queries'}}is-active{{/ifpage}}" data-tab-content>
         <ul class="docs-nav-subcategory">
           <li{{#ifpage 'global'}} class="current"{{/ifpage}}><a href="global.html">Global Styles</a></li>
           <li{{#ifpage 'rtl'}} class="current"{{/ifpage}}><a href="rtl.html">Right-to-Left Support</a></li>


### PR DESCRIPTION
Currently the sidenav with the component list is not open when we are on https://foundation.zurb.com/sites/docs/flexbox-mode.html

This PR solves it.