### PR TITLE
fix: fix history browsing with nested Reveal and deep-linking

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -216,8 +216,8 @@ class Reveal extends Plugin {
    */
   open() {
     // either update or replace browser history
-    if (this.options.deepLink) {
-      var hash = `#${this.id}`;
+    const hash = `#${this.id}`;
+    if (this.options.deepLink && window.location.hash !== hash) {
 
       if (window.history.pushState) {
         if (this.options.updateHistory) {

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -437,13 +437,20 @@ class Reveal extends Plugin {
     }
 
     this.isActive = false;
-     if (_this.options.deepLink) {
-       if (window.history.replaceState) {
-         window.history.replaceState('', document.title, window.location.href.replace(`#${this.id}`, ''));
-       } else {
-         window.location.hash = '';
-       }
-     }
+    // If deepLink and we did not switched to an other modal...
+    if (_this.options.deepLink && window.location.hash === `#${this.id}`) {
+      // Remove the history hash
+      if (window.history.replaceState) {
+        const urlWithoutHash = window.location.pathname + window.location.search;
+        if (this.options.updateHistory) {
+          window.history.pushState({}, '', urlWithoutHash); // remove the hash
+        } else {
+          window.history.replaceState('', document.title, urlWithoutHash);
+        }
+      } else {
+        window.location.hash = '';
+      }
+    }
 
     this.$activeAnchor.focus();
   }

--- a/test/visual/reveal/nested-deep-link.html
+++ b/test/visual/reveal/nested-deep-link.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell">
+          <h1>Reveal: Nested modals with Deep linking</h1>
+
+          <p>When going back in history after closing the last modal, modals should all reapear in the reverse order.</p>
+
+          <p><button class="button" data-open="exampleModal1">Click me for modal 1</button></p>
+
+          <!-- This is the first modal -->
+          <div class="reveal" id="exampleModal1" data-reveal data-deep-link="true" data-update-history="true">
+            <h1>Modal 1</h1>
+            <button class="button" data-open="exampleModal2">Click me for modal 2</button>
+            <button class="close-button" data-close aria-label="Close reveal" type="button">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <!-- This is the nested modal -->
+          <div class="reveal" id="exampleModal2" data-reveal data-deep-link="true" data-update-history="true">
+            <h2>Modal 2</h2>
+            <button class="button" data-open="exampleModal3">Click me for modal 3</button>
+            <button class="close-button" data-close aria-label="Close reveal" type="button">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <!-- This is the nested modal -->
+          <div class="reveal" id="exampleModal3" data-reveal data-deep-link="true" data-update-history="true">
+            <h2>Modal 3</h2>
+            <button class="button" data-open="exampleModal4">Click me for modal 4</button>
+            <button class="close-button" data-close aria-label="Close reveal" type="button">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+          <!-- This is the nested modal -->
+          <div class="reveal" id="exampleModal4" data-reveal data-deep-link="true" data-update-history="true">
+            <h2>Modal 4</h2>
+            <p>Close me, then go back in history. I should reappear, then modals 3, 2 and 1...</p>
+            <button class="close-button" data-close aria-label="Close reveal" type="button">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Changes:
* update history when closing Reveal with `replaceState`
  When closing a Reveal with `replaceState: true`, push a new entry to reset the hash. So going back to the history reopen the modals opened before in reverse order.
* do not update history when opening Reveal with its hash already set (like when going back in history)
* add visual tests for nested Reveal with deep-linking

Closes: #8012
Visual tests are from: https://codepen.io/DanielRuf/pen/OvPpzb
