### PR TITLE
fix: reveal sass error with @extend within @media

### DIFF
--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -39,17 +39,6 @@ $reveal-zindex: 1005 !default;
 $reveal-overlay-background: rgba($black, 0.45) !default;
 
 
-// Placeholder selector for medium-and-up modals
-// Prevents duplicate CSS when defining multiple Reveal sizes
-@include breakpoint(medium) {
-  %reveal-centered {
-    right: auto;
-    left: auto;
-    margin: 0 auto;
-  }
-}
-
-
 /// Adds styles for a modal overlay.
 /// @param {Color} $background [$reveal-overlay-background] - Background color of the overlay.
 @mixin reveal-overlay($background: $reveal-overlay-background) {
@@ -102,7 +91,9 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   $max-width: $reveal-max-width
 ) {
   @include breakpoint(medium) {
-    @extend %reveal-centered;
+    right: auto;
+    left: auto;
+    margin: 0 auto;
     width: $width;
     max-width: $max-width;
   }


### PR DESCRIPTION
With foundation-sites@6.4.3/6.4.4-rc1 and gulp@4.0.0 with gulp-sass@3.2.1 I get the following error when I'm using reveal in my project: [@include foundation-reveal();]

> You may not @extend an outer selector from within @media.
> You may not @extend an outer selector from within @media. You may only @extend selectors within the same directive.
> From "@extend %reveal-centered" on line 105 of node_modules/foundation-sites/scss/components/_reveal.scss on line 45 of node_modules/foundation-sites/scss/components/_reveal.scss

To fix this issue I removed the unnecessary placeholder and applied the settings directly within the @media directive.