### PR TITLE
fix: apply menubar aria role instead of menu

### DIFF
--- a/js/foundation.util.nest.js
+++ b/js/foundation.util.nest.js
@@ -35,7 +35,7 @@ const Nest = {
           .addClass(`submenu ${subMenuClass}`)
           .attr({
             'data-submenu': '',
-            'role': 'menu'
+            'role': 'menubar'
           });
         if(type === 'drilldown') {
           $sub.attr({'aria-hidden': true});


### PR DESCRIPTION
`menu` was used but this is not a valiad aria role. `menubar` is the right aria role.

Closes https://github.com/zurb/foundation-sites/issues/11097