### PR TITLE
feat: add class for active tab when no hash is set in Tabs

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -96,8 +96,13 @@ class Tabs extends Plugin {
     }
 
      //current context-bound function to open tabs on page load or history hashchange
-    this._checkDeepLink = () => {
+    this._checkDeepLink = (useDefaultTabIfNoHash) => {
       var anchor = window.location.hash;
+
+      if (!anchor.length && useDefaultTabIfNoHash !== false) {
+        anchor = this.$element.find(`.${this.options.linkDefaultClass} a`).attr('href') || '';
+      }
+
       //need a hash and a relevant anchor in this tabset
       if(anchor.length) {
         var anchorNoHash = (anchor.indexOf('#') >= 0 ? anchor.slice(1) : anchor);
@@ -122,7 +127,7 @@ class Tabs extends Plugin {
 
     //use browser to open a tab, if it exists in this tabset
     if (this.options.deepLink) {
-      this._checkDeepLink();
+      this._checkDeepLink(false); // do not useDefaultTabIfNoHash on init
     }
 
     this._events();
@@ -306,7 +311,8 @@ class Tabs extends Plugin {
       .attr({
         'aria-selected': 'false',
         'tabindex': -1
-      });
+      })
+      .blur();  // blur to make sure tab loses focus state on deepLink hashchange
 
     $(`#${$target_anchor.attr('aria-controls')}`)
       .removeClass(`${this.options.panelActiveClass}`)
@@ -483,6 +489,15 @@ Tabs.defaults = {
    * @default 'is-active'
    */
   linkActiveClass: 'is-active',
+
+  /**
+   * Class applied to the default `li` in tab link list.
+   * Used for when deepLink is true
+   * @option
+   * @type {string}
+   * @default 'is-default'
+   */
+  linkDefaultClass: 'is-default',
 
   /**
    * Class applied to the content containers.

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -96,11 +96,12 @@ class Tabs extends Plugin {
     }
 
      //current context-bound function to open tabs on page load or history hashchange
-    this._checkDeepLink = (useDefaultTabIfNoHash) => {
+    this._checkDeepLink = () => {
       var anchor = window.location.hash;
 
-      if (!anchor.length && useDefaultTabIfNoHash !== false) {
-        anchor = this.$element.find(`.${this.options.linkDefaultClass} a`).attr('href') || '';
+      if (!anchor.length && this._defaultAnchor) {
+        // if we don't have an anchor, use the default.
+        anchor = this._defaultAnchor;
       }
 
       //need a hash and a relevant anchor in this tabset
@@ -127,7 +128,15 @@ class Tabs extends Plugin {
 
     //use browser to open a tab, if it exists in this tabset
     if (this.options.deepLink) {
-      this._checkDeepLink(false); // do not useDefaultTabIfNoHash on init
+      // The active tab on page load will be our default
+      var activeHash = this.$tabTitles.filter(`.${this.options.linkActiveClass}`).find('a').attr('href');
+
+      this._checkDeepLink();
+
+      if (this.options.updateHistory) {
+        // set this after _checkDeepLink because we don't want to interfere with page load.
+        this._defaultAnchor = activeHash;
+      }
     }
 
     this._events();
@@ -489,15 +498,6 @@ Tabs.defaults = {
    * @default 'is-active'
    */
   linkActiveClass: 'is-active',
-
-  /**
-   * Class applied to the default `li` in tab link list.
-   * Used for when deepLink is true
-   * @option
-   * @type {string}
-   * @default 'is-default'
-   */
-  linkDefaultClass: 'is-default',
 
   /**
    * Class applied to the content containers.


### PR DESCRIPTION
Hey Guys,

This fixes #11100.

It adds a new optional option `linkDefaultClass` which defaults to `is-default`. When using deep linking (`data-deep-link`) in combination with history push state (`data-update-history`)we want to take the user back to the default tab if they back-button to a history state that doesn't have a `location.hash`. This PR achieves that. 

To utilize you must add the `is-default` class to your default tab. 

```
<ul class="tabs" data-deep-link="true" data-update-history="true" data-auto-focus="false" data-tabs id="deeplinked-tabs">
                                  ---------- 
  <li class="tabs-title is-active is-default"><a href="#panel1d" aria-selected="true">Tab 1</a></li>
                                  ---------- 
  <li class="tabs-title"><a href="#panel2d">Tab 2</a></li>
  <li class="tabs-title"><a href="#panel3d">Tab 3</a></li>
  <li class="tabs-title"><a href="#panel4d">Tab 4</a></li>
</ul>
```

See the issue, which includes a Codepen that replicates the bug, for more details. 