### PR TITLE
docs: remove box-shadow from variable table cells

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -485,3 +485,8 @@ a.docs-banner {
 .docs-nav-container {
   overflow: auto;
 }
+
+.docs-variable-table td.shadow {
+  box-shadow: none;
+}
+


### PR DESCRIPTION
This removes the wrong box-shadow on cells in the Sass variables table.

Currently it is like this:
![bildschirmfoto 2018-03-28 um 12 13 58](https://user-images.githubusercontent.com/827205/38023090-a11b29f4-3281-11e8-90f1-108155e4cc6f.png)

See https://foundation.zurb.com/sites/docs/off-canvas.html
