### PR TITLE
more accurate -zf-zero-breakpoint error message

### DIFF
--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -25,7 +25,7 @@ $-zf-zero-breakpoint: small !default;
 $-zf-breakpoints-keys: map-to-list($breakpoints, 'keys');
 
 @if nth(map-values($breakpoints), 1) != 0 {
-  @error 'Your smallest breakpoint (defined in $breakpoints) must be set to "0".';
+  @error 'The first key in the $breakpoints map must have a value of "0".';
 }
 @else {
   $-zf-zero-breakpoint: nth(map-keys($breakpoints), 1);


### PR DESCRIPTION
This PR closes #9268. 

-----

**For version 7:**

- Consider allowing for custom notes within `settings.scss` ([as ncoden notes](https://github.com/zurb/foundation-sites/issues/9268#issuecomment-365112252)). 
- Consider more semantic, mobile-first naming for breakpoints. For example, `small` applies styles to all devices, so should the first key/value in the breakpoints map be `all: 0`? 