### PR TITLE
fix: always use absolute positioning to prevent jumping Orbit slider

### DIFF
--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -344,11 +344,10 @@ class Orbit extends Plugin {
 
       if (this.options.useMUI && !this.$element.is(':hidden')) {
         Motion.animateIn(
-          $newSlide.addClass('is-active').css({'position': 'absolute', 'top': 0}),
+          $newSlide.addClass('is-active'),
           this.options[`animInFrom${dirIn}`],
           function(){
-            $newSlide.css({'position': 'relative', 'display': 'block'})
-            .attr('aria-live', 'polite');
+            $newSlide.attr('aria-live', 'polite');
         });
 
         Motion.animateOut(

--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -149,8 +149,9 @@ class Orbit extends Plugin {
       temp = this.getBoundingClientRect().height;
       $(this).attr('data-slide', counter);
 
-      if (!/mui/g.test($(this)[0].className) && _this.$slides.filter('.is-active')[0] !== _this.$slides.eq(counter)[0]) {//if not the active slide, set css position and display property
-        $(this).css({'position': 'relative', 'display': 'none'});
+      // hide all slides but the active one
+      if (!/mui/g.test($(this)[0].className) && _this.$slides.filter('.is-active')[0] !== _this.$slides.eq(counter)[0]) {
+        $(this).css({'display': 'none'});
       }
       max = temp > max ? temp : max;
       counter++;

--- a/js/foundation.orbit.js
+++ b/js/foundation.orbit.js
@@ -347,7 +347,7 @@ class Orbit extends Plugin {
           $newSlide.addClass('is-active'),
           this.options[`animInFrom${dirIn}`],
           function(){
-            $newSlide.attr('aria-live', 'polite');
+            $newSlide.css({'display': 'block'}).attr('aria-live', 'polite');
         });
 
         Motion.animateOut(

--- a/scss/components/_orbit.scss
+++ b/scss/components/_orbit.scss
@@ -67,6 +67,7 @@ $orbit-control-zindex: 10 !default;
 /// Adds styles for the individual slides of an Orbit slider. These styles are used on the `.orbit-slide` class.
 @mixin orbit-slide {
   width: 100%;
+  position: absolute;
 
   &.no-motionui {
     &.is-active {


### PR DESCRIPTION
Before and after a slide is animted its position attribute is changed between `absolute` and `relative` which can produce a jump of the element after a slide change.

Closes https://github.com/zurb/foundation-sites/issues/11082