### PR TITLE
fix: listen for the enter key and trigger a change to emulate change …

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -460,10 +460,10 @@ class Slider extends Plugin {
         curHandle,
         timer;
 
-        const handleChangeEvent = function(e) {
-          const idx = _this.inputs.index($(this));
-          _this._handleEvent(e, _this.handles.eq(idx), $(this).val());
-        };
+      const handleChangeEvent = function(e) {
+        const idx = _this.inputs.index($(this));
+        _this._handleEvent(e, _this.handles.eq(idx), $(this).val());
+      };
 
       // IE only triggers the change event when the input loses focus which strictly follows the HTML specification
       // listen for the enter key and trigger a change

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -460,6 +460,16 @@ class Slider extends Plugin {
         curHandle,
         timer;
 
+      // IE only triggers the change event when the input loses focus which strictly follows the HTML specification
+      // listen for the enter key and trigger a change
+      // @see https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
+      this.inputs.off('keyup.zf.slider').on('keyup.zf.slider', function (e) {
+        if(e.keyCode == 13) {
+          var idx = _this.inputs.index($(this));
+          _this._handleEvent(e, _this.handles.eq(idx), $(this).val());
+        }
+      });
+
       this.inputs.off('change.zf.slider').on('change.zf.slider', function(e) {
         var idx = _this.inputs.index($(this));
         _this._handleEvent(e, _this.handles.eq(idx), $(this).val());

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -460,20 +460,19 @@ class Slider extends Plugin {
         curHandle,
         timer;
 
+        const handleChangeEvent = function(e) {
+          const idx = _this.inputs.index($(this));
+          _this._handleEvent(e, _this.handles.eq(idx), $(this).val());
+        };
+
       // IE only triggers the change event when the input loses focus which strictly follows the HTML specification
       // listen for the enter key and trigger a change
       // @see https://html.spec.whatwg.org/multipage/input.html#common-input-element-events
       this.inputs.off('keyup.zf.slider').on('keyup.zf.slider', function (e) {
-        if(e.keyCode == 13) {
-          var idx = _this.inputs.index($(this));
-          _this._handleEvent(e, _this.handles.eq(idx), $(this).val());
-        }
+        if(e.keyCode == 13) handleChangeEvent.call(this, e);
       });
 
-      this.inputs.off('change.zf.slider').on('change.zf.slider', function(e) {
-        var idx = _this.inputs.index($(this));
-        _this._handleEvent(e, _this.handles.eq(idx), $(this).val());
-      });
+      this.inputs.off('change.zf.slider').on('change.zf.slider', handleChangeEvent);
 
       if (this.options.clickSelect) {
         this.$element.off('click.zf.slider').on('click.zf.slider', function(e) {


### PR DESCRIPTION
IE (11) strictly follows the HTML specification and only triggers `change` when an input loses focus.
Other browsers and Edge also trigger it when the enter key is pressed.

https://html.spec.whatwg.org/multipage/input.html#common-input-element-events

> 4.10.5.5 Common event behaviors
When the input and change events apply (which is the case for all input controls other than buttons and those with the type attribute in the Hidden state), the events are fired to indicate that the user has interacted with the control. The input event fires whenever the user has modified the data of the control. The change event fires when the value is committed, if that makes sense for the control, or else when the control loses focus. In all cases, the input event comes before the corresponding change event (if any).

Also see
http://komlenic.com/231/internet-explorer-onchange-on-enter/
https://www.mediaevent.de/javascript/onchange.html
https://stackoverflow.com/questions/11415142/event-change-in-ie-not-working-when-pressing-enter-button
https://stackoverflow.com/questions/31802122/not-able-to-to-use-onchange-event-in-ie-11-using-jquery

Closes https://github.com/zurb/foundation-sites/issues/11096