### PR TITLE
Fix link to XY Grid

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -18,7 +18,7 @@ tags:
 ## Importing
 
 <div class="callout alert">
-  **From Foundation v6.4, the Float Grid is disabled by default**, replaced by the new [XY Grid](xy-grid.html). Unless you need to support IE 10, it is recommended to use the XY Grid.
+  **From Foundation v6.4, the Float Grid is disabled by default**, replaced by the new [XY Grid](./xy-grid.html). Unless you need to support IE 10, it is recommended to use the XY Grid.
 </div>
 
 To use the Float Grid in Foundation v6.4+, you need to:


### PR DESCRIPTION
The link to the XY Grid points here:
https://foundation.zurb.com/xy-grid.html (/xy-grid.html)
Point it to the right place:
https://foundation.zurb.com/sites/docs/xy-grid.html (./xy-grid.html)
