### PR TITLE
feat: add back official `disableForTouch` option for Tooltip #9995

### DIFF
--- a/js/foundation.tooltip.js
+++ b/js/foundation.tooltip.js
@@ -191,12 +191,15 @@ class Tooltip extends Positionable {
    * @private
    */
   _events() {
-    var _this = this;
-    var $template = this.template;
+    const _this = this;
+    const hasTouch = 'ontouchstart' in window || (typeof window.ontouchstart !== 'undefined');
+    const $template = this.template;
     var isFocus = false;
 
-    if (!this.options.disableHover) {
+    // `disableForTouch: Fully disable the tooltip on touch devices
+    if (hasTouch && this.options.disableForTouch) return;
 
+    if (!this.options.disableHover) {
       this.$element
       .on('mouseenter.zf.tooltip', function(e) {
         if (!_this.isActive) {
@@ -210,6 +213,13 @@ class Tooltip extends Positionable {
         if (!isFocus || (_this.isClick && !_this.options.clickOpen)) {
           _this.hide();
         }
+      });
+    }
+
+    if (hasTouch) {
+      this.$element
+      .on('tap.zf.tooltip touchend.zf.tooltip', function (e) {
+        _this.isActive ? _this.hide() : _this.show();
       });
     }
 
@@ -230,13 +240,6 @@ class Tooltip extends Positionable {
       this.$element.on('mousedown.zf.tooltip', function(e) {
         e.stopImmediatePropagation();
         _this.isClick = true;
-      });
-    }
-
-    if (!this.options.disableForTouch) {
-      this.$element
-      .on('tap.zf.tooltip touchend.zf.tooltip', function(e) {
-        _this.isActive ? _this.hide() : _this.show();
       });
     }
 
@@ -300,7 +303,6 @@ class Tooltip extends Positionable {
 }
 
 Tooltip.defaults = {
-  disableForTouch: false,
   /**
    * Time, in ms, before a tooltip should open on hover.
    * @option
@@ -329,6 +331,15 @@ Tooltip.defaults = {
    * @default false
    */
   disableHover: false,
+  /**
+   * Disable the tooltip for touch devices.
+   * This can be useful to make elements with a tooltip on it trigger their
+   * action on the first tap instead of displaying the tooltip.
+   * @option
+   * @type {booelan}
+   * @default false
+   */
+  disableForTouch: false,
   /**
    * Optional addtional classes to apply to the tooltip template on init.
    * @option


### PR DESCRIPTION
### Changes:
* Add documentation for the `disableForTouch` option
* Prevent any event to be triggerd on touch with `disableForTouch`, including mouse enter/leave and focus events

Note: this is a "feature" as the `disableForTouch` was never documented. _If it ain't in writing it don't exist_.

Closes https://github.com/zurb/foundation-sites/issues/9995