### PR TITLE
fix: fix uncentered last column on Float Grid #9952

### DIFF
--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -63,12 +63,8 @@
   // Gutters
   @include grid-column-gutter($gutters: $gutters);
 
-  // Last column alignment
-  @if $grid-column-align-edge {
-    &:last-child:not(:first-child) {
-      float: $global-right;
-    }
-  }
+  // Position
+  @include grid-col-pos(auto);
 }
 
 /// Creates a grid column row. This is the equivalent of adding `.row` and `.column` to the same element.

--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -32,9 +32,15 @@
 /// Reset a position definition.
 @mixin grid-column-unposition {
   position: static;
-  float: $global-left;
   margin-right: 0;
   margin-left: 0;
+
+  float: $global-left;
+  @if $grid-column-align-edge {
+    &:last-child:not(:first-child) {
+      float: $global-right;
+    }
+  }
 }
 
 /// Offsets a column to the right by `$n` columns.

--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -17,8 +17,10 @@
 @mixin grid-column-position($position) {
   // Auto positioning
   @if $position == auto {
-    float: $global-left;
-    clear: none;
+    &, &:last-child:not(:first-child) {
+      float: $global-left;
+      clear: none;
+    }
 
     // Last column alignment
     @if $grid-column-align-edge {

--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -8,14 +8,35 @@
 
 /// Reposition a column.
 ///
-/// @param {Number|Keyword} $position - Direction and amount to move. The column will move equal to the width of the column count specified. A positive number will push the column to the right, while a negative number will pull it to the left. Set to center to center the column.
+/// @param {Number|Keyword} $position - It can be:
+///   * A number: The column will move equal to the width of the column count
+///     specified. A positive number will push the column to the right, while
+///     a negative number will pull it to the left.
+///   * `center`: Column will be centered
+///   * `auto`: Column will be pushed to the left (or to the right for the last column).
 @mixin grid-column-position($position) {
-  @if type-of($position) == 'number' {
+  // Auto positioning
+  @if $position == auto {
+    float: $global-left;
+    clear: none;
+
+    // Last column alignment
+    @if $grid-column-align-edge {
+      &:last-child:not(:first-child) {
+        float: $global-right;
+      }
+    }
+  }
+
+  // Push/pull
+  @else if type-of($position) == 'number' {
     $offset: percentage($position / $grid-column-count);
 
     position: relative;
     #{$global-left}: $offset;
   }
+
+  // Center positioning
   @else if $position == center {
     &, &:last-child:not(:first-child) {
       float: none;
@@ -24,23 +45,18 @@
     margin-right: auto;
     margin-left: auto;
   }
+
   @else {
-    @warn 'Wrong syntax for grid-column-position(). Enter a positive or negative number, or center.';
+    @warn 'Wrong syntax for grid-column-position(). Enter a positive or negative number, "center" or "auto".';
   }
 }
 
 /// Reset a position definition.
 @mixin grid-column-unposition {
+  @include grid-column-position(auto);
   position: static;
   margin-right: 0;
   margin-left: 0;
-
-  float: $global-left;
-  @if $grid-column-align-edge {
-    &:last-child:not(:first-child) {
-      float: $global-right;
-    }
-  }
 }
 
 /// Offsets a column to the right by `$n` columns.

--- a/test/visual/grid/uncentered-columns.html
+++ b/test/visual/grid/uncentered-columns.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+
+    <div class="row column">
+      <h1>Uncentered Columns</h1>
+    </div>
+
+    <div class="row">
+      <div class="small-7 medium-centered large-uncentered columns">
+        <p style="background-color:#eee;">I must be centered on medium only</p>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="small-7 medium-centered large-uncentered columns">
+        <p style="background-color:#eee;">I must be centered on medium only</p>
+      </div>
+      <div class="small-7 medium-centered large-uncentered columns">
+        <p style="background-color:#eee;">I must be centered on medium only</p>
+      </div>
+      <div class="small-7 medium-centered large-uncentered columns">
+        <p style="background-color:#eee;">I must be centered on medium only</p>
+      </div>
+      <div class="small-7 medium-centered large-uncentered columns">
+        <p style="background-color:#eee;">I must be centered on medium only, on the right otherwise</p>
+      </div>
+    </div>
+
+    <div class="row column"><hr></div>
+
+    <div class="row">
+      <div class="small-5 columns">
+        <p style="background-color:#aee;">This blue column is not centered.</p>
+      </div>
+      <div class="small-7 medium-centered large-uncentered columns">
+        <p style="background-color:#fbb;">This pink column should be centered and clear the blue column on medium only.</p>
+      </div>
+      <div class="small-5 columns">
+        <p style="background-color:#aee;">This blue column is not centered.</p>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
#### Changes:
* Reposition the last column on the left/right (according to `$grid-column-align-edge`) when uncentered.
* Refactor `@mixin grid-column-position` to handle all the float positioning and the last column hack in the same place.
* add visual test for Float Grid uncentered columns

Closes https://github.com/zurb/foundation-sites/issues/9952