### PR TITLE
fix: fix cell widths overridden by readjusted smaller breakpoints in XY Grid #10468

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -146,12 +146,12 @@
     @include -zf-each-breakpoint() {
 
       // This is purely for responsive gutters - the margin grid has to go back and adjust widths (or heights)
-      // for prior breakpoints based on the responsive gutter.
+      // for all prior breakpoints.
+      // As their gutter is defined with their width/height, even breakpoint without a new margin must be
+      // generated to not having their width/height overrided by re-adjusted smaller breakpoints.
       @if(type-of($grid-margin-gutters) == 'map' and map-has-key($grid-margin-gutters, $-zf-size)) {
         @each $bp in -zf-breakpoints-less-than($-zf-size) {
-          @if(map-has-key($grid-margin-gutters, $bp)) {
-            @include -xy-breakpoint-cell-classes($bp, $-zf-size, $vertical);
-          }
+          @include -xy-breakpoint-cell-classes($bp, $-zf-size, $vertical);
         }
       }
 


### PR DESCRIPTION
### Context

With margin gutters, a cell width is defined with its gutter. This is why we have to readjust all sizes and not only `.cell` when applying the new gutter in a bigger breakpoint. This must include all sizes for smaller breakpoints too. Before this commit there was an optimization that prevent gutters for smaller breakpoints without a new gutter defined to be regenerated. This can seems logical since no gutter was generated for this breakpoint so there is nothing to readjust.

### Bug 

Because the gutter is defined _with the width/height_, the width/height of readjusted gutters (with a custom gutter) overrides the width/height of non-readjusted  gutters (without a custom gutter) even if they are from a bigger breakpoint.

### Changes:
* Readjust gutters for all breakpoints even without new gutter defined
* Add explainaitions

There is no impact on the bundle `foundation.css` size because there is no breakpoint (outside of the last one) defined without a custom gutter. There can be a minimal impact on a user CSS size if ze uses a lot of custom breakpoints.

**Note**: there a reason why grid system always used paddings for grid system: it does not impact the width. All troubles (and a lot of code duplication and specificity issues) we have with the XY Grid comes from that. And apart from redicing by 1 the number of nested HTML tags in a complex grid layout, I don't see a single advantage of margin gutters. @brettsmason @kball Do you have an opinion on this ?

Closes https://github.com/zurb/foundation-sites/issues/10468