### PR TITLE
fix: do not validate submit input in Abide #9190

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -141,7 +141,9 @@ class Abide extends Plugin {
       $error = $el.parent().find(this.options.formErrorSelector);
     }
 
-    $error = $error.add(this.$element.find(`[data-form-error-for="${id}"]`));
+    if (id) {
+      $error = $error.add(this.$element.find(`[data-form-error-for="${id}"]`));
+    }
 
     return $error;
   }

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -31,7 +31,10 @@ class Abide extends Plugin {
    * @private
    */
   _init() {
-    this.$inputs = this.$element.find('input, textarea, select');
+    this.$inputs = $.merge(                               // Consider as input to validate:
+      this.$element.find('input').not('[type=submit]'),   // * all input fields expect submit
+      this.$element.find('textarea, select')              // * all textareas and select fields
+    );
     const $globalErrors = this.$element.find('[data-abide-error]');
 
     // Add a11y attributes to all fields


### PR DESCRIPTION
### Changes:
* do not validate submit input in Abide
  This prevent `input[type=submit]` to be considered as "valid" and hide others fields errors.
* ignore empty `formErrorFor` in Abide
  This prevent `[data-form-error-for]` to be controlled by all fields.

Closes #9190