### PR TITLE
fix: fix Magellan hash resolution without active link

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -177,7 +177,7 @@ class Magellan extends Plugin {
     let activeHash = '';
     if(activeIdx !== undefined){
       this.$active = this.$links.filter('[href="#' + this.$targets.eq(activeIdx).data('magellan-target') + '"]');
-      activeHash = this.$active[0].getAttribute('href');
+      if (this.$active.length) activeHash = this.$active[0].getAttribute('href');
     }else{
       this.$active = $();
     }


### PR DESCRIPTION
#### Bug

When scrolling in Kitchen Sink page:
> Uncaught TypeError: Cannot read property 'getAttribute' of undefined at 

#### Changes:
* Check if an active link exists when trying to retrieve its hash to updating it in Magellan.

Bug was introduced in https://github.com/zurb/foundation-sites/pull/10906.