### PR TITLE
chore: switch to jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![npm version](https://badge.fury.io/js/foundation-sites.svg)](https://badge.fury.io/js/foundation-sites)
 [![Bower version](https://badge.fury.io/bo/foundation-sites.svg)](https://badge.fury.io/bo/foundation-sites)
 [![Gem Version](https://badge.fury.io/rb/foundation-rails.svg)](https://badge.fury.io/rb/foundation-rails)
-[![CDNJS](https://img.shields.io/cdnjs/v/foundation.svg)](https://cdnjs.com/libraries/foundation)
 [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/foundation-sites/badge?style=rounded)](https://www.jsdelivr.com/package/npm/foundation-sites)
 [![dependencies Status](https://david-dm.org/zurb/foundation-sites/status.svg)](https://david-dm.org/zurb/foundation-sites)
 [![devDependencies Status](https://david-dm.org/zurb/foundation-sites/dev-status.svg)](https://david-dm.org/zurb/foundation-sites?type=dev)

--- a/docs/assets/partials/sticky-nav.html
+++ b/docs/assets/partials/sticky-nav.html
@@ -1,5 +1,4 @@
 <head>
-  <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.1.1/foundation.min.css"> -->
   <link href="../css/docs.css" rel="stylesheet" />
   <style>
       .title-bar {

--- a/docs/layout/default.html
+++ b/docs/layout/default.html
@@ -10,7 +10,6 @@
   <title>{{#unlesspage 'index'}}{{title}} | {{/unlesspage}}Foundation for Sites 6 Docs</title>
   <link href="assets/css/docs.css?t=1" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
-  <!-- <link rel="stylesheet" href="./node_modules/motion-ui/dist/motion-ui.css" /> -->
   <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 <body>

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -211,31 +211,31 @@ After you selected "Foundation for Sites", Foundation CLI will ask you which tem
 
 ## CDN Links
 
-The folks at [cdnjs](https://cdnjs.com) host the compressed Foundation CSS and JavaScript for us. Just drop one of these `<script>` tags into your HTML and you're set:
+The folks at [jsDelivr](https://www.jsdelivr.com) host the compressed Foundation CSS and JavaScript for us. Just drop one of these `<script>` tags into your HTML and you're set:
 
 ```html
 <!-- Compressed CSS -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.4.3/css/foundation.min.css" integrity="sha256-GSio8qamaXapM8Fq9JYdGNTvk/dgs+cMLgPeevOYEx0= sha384-wAweiGTn38CY2DSwAaEffed6iMeflc0FMiuptanbN4J+ib+342gKGpvYRWubPd/+ sha512-QHEb6jOC8SaGTmYmGU19u2FhIfeG+t/hSacIWPpDzOp5yygnthL3JwnilM7LM1dOAbJv62R+/FICfsrKUqv4Gg==" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation.min.css" integrity="sha256-GSio8qamaXapM8Fq9JYdGNTvk/dgs+cMLgPeevOYEx0= sha384-wAweiGTn38CY2DSwAaEffed6iMeflc0FMiuptanbN4J+ib+342gKGpvYRWubPd/+ sha512-QHEb6jOC8SaGTmYmGU19u2FhIfeG+t/hSacIWPpDzOp5yygnthL3JwnilM7LM1dOAbJv62R+/FICfsrKUqv4Gg==" crossorigin="anonymous">
 
 <!-- Compressed JavaScript -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.4.3/js/foundation.min.js" integrity="sha256-mRYlCu5EG+ouD07WxLF8v4ZAZYCA6WrmdIXyn1Bv9Vk= sha384-KzKofw4qqetd3kvuQ5AdapWPqV1ZI+CnfyfEwZQgPk8poOLWaabfgJOfmW7uI+AV sha512-0gHfaMkY+Do568TgjJC2iMAV0dQlY4NqbeZ4pr9lVUTXQzKu8qceyd6wg/3Uql9qA2+3X5NHv3IMb05wb387rA==" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/js/foundation.min.js" integrity="sha256-mRYlCu5EG+ouD07WxLF8v4ZAZYCA6WrmdIXyn1Bv9Vk= sha384-KzKofw4qqetd3kvuQ5AdapWPqV1ZI+CnfyfEwZQgPk8poOLWaabfgJOfmW7uI+AV sha512-0gHfaMkY+Do568TgjJC2iMAV0dQlY4NqbeZ4pr9lVUTXQzKu8qceyd6wg/3Uql9qA2+3X5NHv3IMb05wb387rA==" crossorigin="anonymous"></script>
 ```
 
 From Foundation 6.4, flex is enabled by default and **only the new XY Grid is availaible**. However, others CSS versions are availaible for backward compatibility and the most common usage cases. For others uses and advanced customization, we recommand to build Foundation with custom settings (see others installation methods).
 
 ```html
 <!-- foundation-float.css: Compressed CSS with legacy Float Grid -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.4.3/css/foundation-float.css" integrity="sha256-+8r1EkvIoWpxT8CKbSw/rCQWttnazW9mLPg6xT+/2EM= sha384-/oMoU6QUFos1xR2dsyh5fVXoR6wHSKUxQdbvR1ARssj8Crq8z39z3dGnGiI3O807 sha512-8QyAfdtYntymd5OgASE6/GHuN3hbySbEJaORYvMjfki5uwRCpUPiAsWv/BzHS7O3aZCmlYJzkY9lYQnUT6sw/Q==" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation-float.min.css" integrity="sha256-TPcVVrzfTETpAWQ8HhBHIMT7+DbszMr5n3eFi+UwIl8= sha384-+aXh7XSzITwlvjelsNWuL1A9rT8pWGaiqMMeUjtKcsWIfzT1oV8Mp3oYxmjPK8Gv sha512-cArttU/Yh+PzfQ/dhCdfBiU9+su+fuCwFxLrlLbvuJE/ynUbstaKweVPs7Hdbok9jlv9cwt+xdk20wRz7oYErQ==" crossorigin="anonymous">
 
 <!-- foundation-prototype.css: Compressed CSS with prototyping classes -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.4.3/css/foundation-prototype.css" integrity="sha256-IHU5CkoOGpVMODA9ql3Lz609uhGwwFlLNSpAMoOY2us= sha384-5YVbhp4eWqCZTvk9iGqw9BkE2y1uCHERnmqPZvhLCL9i6KQnOx81Om6HTedy5umY sha512-8OOpCEIwIj4l3EltIZSpEQe5sqoppE02Tv1PsnCFPI5SOZ7qVGeT0nvxRlUfCkvPD5ZzMD3aOpuGkd/fM4rJ0A==" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation-prototype.min.css" integrity="sha256-JyhZsgvsqjrdl9GPOILi/zyc+z4dcwXiyP1Q7cwWlM0= sha384-GtUT6gOaCY/S1ggTUOnqe5CQAEAZ6oVTmMq3X4vfZrvp+tLgjBEmwVxJnukor+o0 sha512-x3+KBxBjFh8PGncrfDOsJhntYDBFdJxmpb211THYkQOaGWvk7ckZG6prGUpZqz85AXgiispjow06+bDnIxnWDQ==" crossorigin="anonymous">
 
 <!-- foundation-rtl.css: Compressed CSS with right-to-left reading direction -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.4.3/css/foundation-rtl.min.css" integrity="sha256-Az+E7JXW71Srarkum5QPTdnobddg2GqI1i8+nMusgLk= sha384-eBKuNtkGVmsJD0uNnWoKYYVnzDT0PXV+XNyAgmmZwYVn7MSNcaR4i5HjOpSRd0o6 sha512-d0RjiDZM/0NlD+7Y2DhUGuAUdwDIL5lS3GPAD0HEayEcrhuLuRiPYOgFWZik+gsFzsykxSn0KO6jim7ev8kIig==" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation-rtl.min.css" integrity="sha256-Az+E7JXW71Srarkum5QPTdnobddg2GqI1i8+nMusgLk= sha384-eBKuNtkGVmsJD0uNnWoKYYVnzDT0PXV+XNyAgmmZwYVn7MSNcaR4i5HjOpSRd0o6 sha512-d0RjiDZM/0NlD+7Y2DhUGuAUdwDIL5lS3GPAD0HEayEcrhuLuRiPYOgFWZik+gsFzsykxSn0KO6jim7ev8kIig==" crossorigin="anonymous">
 ```
 
 <div class="text-center">
-  <a href="https://cdnjs.com/libraries/foundation" class="button" target="_blank">See all CDN files and versions</a>
+  <a href="https://www.jsdelivr.com/package/npm/foundation-sites?path=dist" class="button" target="_blank">See all CDN files and versions</a>
 </div>
 
 ---

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -224,13 +224,13 @@ The folks at [jsDelivr](https://www.jsdelivr.com) host the compressed Foundation
 From Foundation 6.4, flex is enabled by default and **only the new XY Grid is availaible**. However, others CSS versions are availaible for backward compatibility and the most common usage cases. For others uses and advanced customization, we recommand to build Foundation with custom settings (see others installation methods).
 
 ```html
-<!-- foundation-float.css: Compressed CSS with legacy Float Grid -->
+<!-- foundation-float.min.css: Compressed CSS with legacy Float Grid -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation-float.min.css" integrity="sha256-TPcVVrzfTETpAWQ8HhBHIMT7+DbszMr5n3eFi+UwIl8= sha384-+aXh7XSzITwlvjelsNWuL1A9rT8pWGaiqMMeUjtKcsWIfzT1oV8Mp3oYxmjPK8Gv sha512-cArttU/Yh+PzfQ/dhCdfBiU9+su+fuCwFxLrlLbvuJE/ynUbstaKweVPs7Hdbok9jlv9cwt+xdk20wRz7oYErQ==" crossorigin="anonymous">
 
-<!-- foundation-prototype.css: Compressed CSS with prototyping classes -->
+<!-- foundation-prototype.min.css: Compressed CSS with prototyping classes -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation-prototype.min.css" integrity="sha256-JyhZsgvsqjrdl9GPOILi/zyc+z4dcwXiyP1Q7cwWlM0= sha384-GtUT6gOaCY/S1ggTUOnqe5CQAEAZ6oVTmMq3X4vfZrvp+tLgjBEmwVxJnukor+o0 sha512-x3+KBxBjFh8PGncrfDOsJhntYDBFdJxmpb211THYkQOaGWvk7ckZG6prGUpZqz85AXgiispjow06+bDnIxnWDQ==" crossorigin="anonymous">
 
-<!-- foundation-rtl.css: Compressed CSS with right-to-left reading direction -->
+<!-- foundation-rtl.min.css: Compressed CSS with right-to-left reading direction -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.4.3/dist/css/foundation-rtl.min.css" integrity="sha256-Az+E7JXW71Srarkum5QPTdnobddg2GqI1i8+nMusgLk= sha384-eBKuNtkGVmsJD0uNnWoKYYVnzDT0PXV+XNyAgmmZwYVn7MSNcaR4i5HjOpSRd0o6 sha512-d0RjiDZM/0NlD+7Y2DhUGuAUdwDIL5lS3GPAD0HEayEcrhuLuRiPYOgFWZik+gsFzsykxSn0KO6jim7ev8kIig==" crossorigin="anonymous">
 ```
 

--- a/docs/pages/motion-ui.md
+++ b/docs/pages/motion-ui.md
@@ -72,7 +72,7 @@ Or, another way to start using Motion UI is through a CDN.
 
 ```html
 <!-- Insert this within your head tag and after foundation.css -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/motion-ui/1.1.1/motion-ui.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/motion-ui@1.2.3/dist/motion-ui.min.css" />
 
 ```
 

--- a/test/visual/accordion-menu/accordionmenu.html
+++ b/test/visual/accordion-menu/accordionmenu.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/active-menu-flex.html
+++ b/test/visual/menu/active-menu-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
     <style>

--- a/test/visual/menu/active-menu-float.html
+++ b/test/visual/menu/active-menu-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/basic-menu-flex.html
+++ b/test/visual/menu/basic-menu-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/basic-menu-float.html
+++ b/test/visual/menu/basic-menu-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/expanded-menu-flex.html
+++ b/test/visual/menu/expanded-menu-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/expanded-menu-float.html
+++ b/test/visual/menu/expanded-menu-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-dropdownmenu-alignment-flex.html
+++ b/test/visual/menu/horizontal-dropdownmenu-alignment-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-dropdownmenu-alignment-float.html
+++ b/test/visual/menu/horizontal-dropdownmenu-alignment-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-menu-alignment-flex.html
+++ b/test/visual/menu/horizontal-menu-alignment-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/horizontal-menu-alignment-float.html
+++ b/test/visual/menu/horizontal-menu-alignment-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-centered-flex.html
+++ b/test/visual/menu/menu-centered-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-centered-float.html
+++ b/test/visual/menu/menu-centered-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-form-flex.html
+++ b/test/visual/menu/menu-form-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-form-float.html
+++ b/test/visual/menu/menu-form-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-text-flex.html
+++ b/test/visual/menu/menu-text-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/menu-text-float.html
+++ b/test/visual/menu/menu-text-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/nested-menu-flex.html
+++ b/test/visual/menu/nested-menu-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/nested-menu-float.html
+++ b/test/visual/menu/nested-menu-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/responsive-menu-flex.html
+++ b/test/visual/menu/responsive-menu-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/responsive-menu-float.html
+++ b/test/visual/menu/responsive-menu-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/simple-menu-flex.html
+++ b/test/visual/menu/simple-menu-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/simple-menu-float.html
+++ b/test/visual/menu/simple-menu-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-accordionmenu-alignment-flex.html
+++ b/test/visual/menu/vertical-accordionmenu-alignment-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-accordionmenu-alignment-float.html
+++ b/test/visual/menu/vertical-accordionmenu-alignment-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-drilldownmenu-alignment-flex.html
+++ b/test/visual/menu/vertical-drilldownmenu-alignment-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-drilldownmenu-alignment-float.html
+++ b/test/visual/menu/vertical-drilldownmenu-alignment-float.html
@@ -8,7 +8,6 @@
     <title>Vertical Drillodwn</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-dropdownmenu-alignment-flex.html
+++ b/test/visual/menu/vertical-dropdownmenu-alignment-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-dropdownmenu-alignment-float.html
+++ b/test/visual/menu/vertical-dropdownmenu-alignment-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-menu-alignment-flex.html
+++ b/test/visual/menu/vertical-menu-alignment-flex.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/menu/vertical-menu-alignment-float.html
+++ b/test/visual/menu/vertical-menu-alignment-float.html
@@ -8,7 +8,6 @@
     <title>All Foundation Menu Options - Flexbox</title>
     <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
     <link href="../assets/css/foundation-float.css" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/foundicons/3.0.0/foundation-icons.css" rel="stylesheet">
 
     <style>
       h1 {

--- a/test/visual/orbit/orbit.html
+++ b/test/visual/orbit/orbit.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Foundation for Sites Testing</title>
     <link href="../assets/css/foundation.css" rel="stylesheet" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/motion-ui/1.2.2/motion-ui.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/motion-ui@1.2.3/dist/motion-ui.min.css">
     <style>
 
     </style>


### PR DESCRIPTION
Switch to jsDelivr which use the npm ecosystem and are always uptodate.

https://metafizzy.co/blog/switching-out-cdnjs-for-unpkg/

Closes https://github.com/zurb/foundation-sites/issues/11019