### PR TITLE
[Support] fix: fix reference to component in `Magellan._events`

### DIFF
--- a/js/foundation.magellan.js
+++ b/js/foundation.magellan.js
@@ -99,7 +99,7 @@ class Magellan extends Plugin {
         'scrollme.zf.trigger': _this._updateActive.bind(_this)
       }).on('click.zf.magellan', 'a[href^="#"]', function(e) {
         e.preventDefault();
-        var arrival   = _this.getAttribute('href');
+        var arrival = this.getAttribute('href');
         _this.scrollToLoc(arrival);
       });
     } else {
@@ -109,7 +109,7 @@ class Magellan extends Plugin {
           'scrollme.zf.trigger': _this._updateActive.bind(_this)
         }).on('click.zf.magellan', 'a[href^="#"]', function(e) {
           e.preventDefault();
-          var arrival   = _this.getAttribute('href');
+          var arrival = this.getAttribute('href');
           _this.scrollToLoc(arrival);
         });
       });


### PR DESCRIPTION
Support PR for `master` of https://github.com/zurb/foundation-sites/pull/11076.
Reason: we need to deploy this on master now to update the docs. This problem should be avoided in future releases by removing the `develop`/`master` division and use `master` for releases only.

> `this.getAttribute` should point to the event target `a[href^="#"]`, not the component instance.
> 
> Bug was introduced in https://github.com/zurb/foundation-sites/pull/10988 (6371c6da3de11adf3dce181ec5b7cd5959fe5f8d)
