### PR TITLE
Incorrect variable name in legacy Float Grid docs

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -23,7 +23,7 @@ tags:
 
 To use the Float Grid in Foundation v6.4+, you need to:
 * In CDN link or package managers: import `foundation-float.css` in place of `foundation.css`.
-* In Sass: set both `$xy-grid` and `$global-flex` to `false`.
+* In Sass: set both `$xy-grid` and `$global-flexbox` to `false`.
 
 
 ## Basics


### PR DESCRIPTION
In the docs it states that $global-flex needs to be set to false to enable the float grid, however the variable is $global-flexbox
