### PR TITLE
build: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
   - node_js: "stable"
     env: ZF_TRAVIS_COMMAND=test:javascript:browserstack
 
-install: npm install
+before_install:  npm install -g npm@latest
+install: npm ci
 script: npm run $ZF_TRAVIS_COMMAND
 
 notifications:


### PR DESCRIPTION
`npm ci` can be faster and is meant for CI. This PR is meant for evaluating the new ci command and testig the performance and compare the logs of Travis CI.

https://docs.npmjs.com/cli/ci
http://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable