### PR TITLE
style: remove extraneous space in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   - node_js: "stable"
     env: ZF_TRAVIS_COMMAND=test:javascript:browserstack
 
-before_install:  npm install -g npm@latest
+before_install: npm install -g npm@latest
 install: npm ci
 script: npm run $ZF_TRAVIS_COMMAND
 


### PR DESCRIPTION
This removes an extraneous space in the Travis CI config that I accidentally left there.