### PR TITLE
test: minimize interchange debouce test race condition

### DIFF
--- a/js/foundation.util.triggers.js
+++ b/js/foundation.util.triggers.js
@@ -241,17 +241,14 @@ Triggers.Initializers.addGlobalListeners = function() {
 }
 
 
-Triggers.init = function($, Foundation) {
-  if (typeof($.triggersInitialized) === 'undefined') {
-    let $document = $(document);
-
-    onLoad($(window), function () {
+Triggers.init = function ($, Foundation) {
+  onLoad($(window), function () {
+    if ($.triggersInitialized !== true) {
       Triggers.Initializers.addSimpleListeners();
       Triggers.Initializers.addGlobalListeners();
-    });
-
-    $.triggersInitialized = true;
-  }
+      $.triggersInitialized = true;
+    }
+  });
 
   if(Foundation) {
     Foundation.Triggers = Triggers;


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

This pull request prevent some race condition by improving the interchange debounce test precision caused by an asynchronous usage of timeouts. Timeout delays are most often not respected and the differences between several timeouts running in parrallel can be huge. 

Partially replaces https://github.com/zurb/foundation-sites/pull/11214

### Changes:
* Initialize Triggers manually to control and test the debounce time
* Nest the timeout that trigger "resize" to make the delay between the last "resize" and the test check more precise (a bit more than the debounce time).
* #11258

### Note about the race condition:
I don't think it is possible to fully remove any race condition in this test. We want to test a behavior within a 10ms delay but we have no certainty that the used timeout will be triggered when expected and not latter.

We can increase the debounce time used in the test to ensure that all the "resize" will be triggered within the debounce interval.

An other solution could be to trigger a huge number of "resize" events and test if `_reflow` got called up to one time per debounce interval. But how to be synchronised with these debounce interval, and could this make the test way too specific ?

### Note about the commit convention:
I was not sure before wether of the `fix` or `test` prefix we should use for this "test fix". According to the [Angular commit convention](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type) it should be `test`:
> test: Adding missing tests or correcting existing tests

<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

## ⚠️ Require:
* #11258 fix: prevent to initialize Triggers twice before window is loaded (@ncoden)

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
