### PR TITLE
docs: fix clashing IDs in form checkboxes

### DIFF
--- a/docs/pages/kitchen-sink.md
+++ b/docs/pages/kitchen-sink.md
@@ -553,15 +553,15 @@ description: Everything but.
   <div class="grid-x grid-margin-x">
     <fieldset class="cell large-6">
       <legend>Choose Your Favorite</legend>
-      <input type="radio" name="pokemon" value="Red" id="pokemonRed" required><label for="pokemonRed">Red</label>
-      <input type="radio" name="pokemon" value="Blue" id="pokemonBlue"><label for="pokemonBlue">Blue</label>
-      <input type="radio" name="pokemon" value="Yellow" id="pokemonYellow"><label for="pokemonYellow">Yellow</label>
+      <input type="radio" name="pokemon" value="Red" id="formRed" required><label for="formRed">Red</label>
+      <input type="radio" name="pokemon" value="Blue" id="formBlue"><label for="formBlue">Blue</label>
+      <input type="radio" name="pokemon" value="Yellow" id="formYellow"><label for="formYellow">Yellow</label>
     </fieldset>
     <fieldset class="cell large-6">
       <legend>Check these out</legend>
-      <input id="checkbox1" type="checkbox"><label for="checkbox1">Checkbox 1</label>
-      <input id="checkbox2" type="checkbox"><label for="checkbox2">Checkbox 2</label>
-      <input id="checkbox3" type="checkbox"><label for="checkbox3">Checkbox 3</label>
+      <input id="formCheckbox1" type="checkbox"><label for="formCheckbox1">Checkbox 1</label>
+      <input id="formCheckbox2" type="checkbox"><label for="formCheckbox2">Checkbox 2</label>
+      <input id="formCheckbox3" type="checkbox"><label for="formCheckbox3">Checkbox 3</label>
     </fieldset>
   </div>
   <div class="grid-x grid-margin-x">


### PR DESCRIPTION
## Description
Checkbox IDs in the "Forms" component are the same as in "Abide" and clashing with each other. 
I have changed the IDs in "Forms" so they are distinct


## Motivation and Context
If a user clicks the checkbox label "Blue" in "Forms" component it triggers the checkbox in "Abide" which is incorrect and confusing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
