### PR TITLE
feat: filter elements with plugins from reflow method

### DIFF
--- a/docs/pages/javascript.md
+++ b/docs/pages/javascript.md
@@ -149,6 +149,8 @@ $.ajax('assets/partials/kitten-carousel.html', function(data) {
 });
 ```
 
+Plugins that are already initialized will be ignored. However for performances reasons, we recommend calling `.foundation()` only on the DOM nodes that changed.
+
 ---
 
 ## Adding Content to Plugins

--- a/docs/pages/javascript.md
+++ b/docs/pages/javascript.md
@@ -149,7 +149,7 @@ $.ajax('assets/partials/kitten-carousel.html', function(data) {
 });
 ```
 
-Plugins that are already initialized will be ignored. However for performances reasons, we recommend calling `.foundation()` only on the DOM nodes that changed.
+Plugins that are already initialized will be ignored. However for performance reasons, we recommend calling `.foundation()` only on the DOM nodes that changed.
 
 ---
 

--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -149,18 +149,15 @@ var Foundation = {
       var plugin = _this._plugins[name];
 
       // Localize the search to all elements inside elem, as well as elem itself, unless elem === document
-      var $elem = $(elem).find('[data-'+name+']').addBack('[data-'+name+']');
+      var $elem = $(elem).find('[data-'+name+']').addBack('[data-'+name+']').filter(function () {
+        return typeof $(this).data("zfPlugin") === "undefined";
+      });
 
       // For each plugin found, initialize it
       $elem.each(function() {
         var $el = $(this),
             opts = {};
-        // Don't double-dip on plugins
-        if ($el.data('zfPlugin')) {
-          console.warn("Tried to initialize "+name+" on an element that already has a Foundation plugin.");
-          return;
-        }
-
+            
         if($el.attr('data-options')){
           var thing = $el.attr('data-options').split(';').forEach(function(e, i){
             var opt = e.split(':').map(function(el){ return el.trim(); });


### PR DESCRIPTION
Filter elements with plugins from reflow method:
- Add filter method to find to line 152 of foundation.core.js
- Remove warning from subsequest each method

## Description
Foundation sites warns "Tried to initialize x on an element that already has a foundation plugin" in the reflow method in foundation.core.js. The elements that already have the foundation plugin can easily be filtered before applying the filter. If the elements are filtered properly the warning would be unnecessary.

A codepen to illustrate the issue is here:

https://codepen.io/thoughtassassin/pen/KRBqqa?editors=1011

Open the console to see the warnings when you click the "Toggle" button.                                                 

## Motivation and Context
In the React app that I am working on I call $(document).foundation() in the componentDidMount method and in componentDidUpdate method. componentDidMount initializes the elements when the app loads. componentDidUpdate initializes new elements in the DOM. However, when the method is called in componentDidMount, the elements that already have plugins initialized throw the warning.

The QA engineer that is testing the app doesn't like seeing these warnings. Even though it seems mostly harmless, it would be nice to remove the warnings when using $(document).foundation() to initialize elements that have not been initialized.

## Screenshots (if appropriate):

## Types of changes
Added a filter to the find and addBack methods on $elem in the reflow method in foundation.core.js to remove elements that already have a "zfPlugin." I also removed the warning that was thrown in the forEach method of $elem that follows.

- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.
