### PR TITLE
test: fix interchange debonce test race condition

### DIFF
--- a/test/javascript/index.html
+++ b/test/javascript/index.html
@@ -21,6 +21,7 @@
       chai.should();
     </script>
     <script src="lib/keyboard-event-mock.js"></script>
+    <script src="lib/utils.js"></script>
     <script src="js-tests.js"></script>
     <script>
       mocha.run();

--- a/test/javascript/lib/utils.js
+++ b/test/javascript/lib/utils.js
@@ -1,5 +1,14 @@
 (function (global, $) {
 
+  /**
+  * Try to catch the `do` function every `interval` delay, until it succedes
+  * (does not throw an error) or a given `timout` time passed.
+  * If a `then` function is passed, it is called after `do` succeded.
+  * If a `catch` function is passed, it is called after each time `do` fails.
+  *
+  * @param  {object} opts
+  * @param  {object} opts
+  */
   global.tryInterval = function (opts) {
     var _opts = $.extend({}, opts);
     var totalTime = 0;

--- a/test/javascript/lib/utils.js
+++ b/test/javascript/lib/utils.js
@@ -1,0 +1,34 @@
+(function (global, $) {
+
+  global.tryInterval = function (opts) {
+    var _opts = $.extend({}, opts);
+    var totalTime = 0;
+
+    var interval = setInterval(function () {
+      var succeded = false;
+      var error = null;
+
+      totalTime += _opts.time;
+
+      try {
+        _opts.try();
+        succeded = true;
+      }
+      catch (err) { error = err; }
+
+      if (succeded) {
+        clearInterval(interval);
+        if (typeof _opts.then === 'function') _opts.then();
+      }
+      else if (totalTime > _opts.timeout) {
+        clearInterval(interval);
+        throw error;
+      }
+      else {
+        if (typeof _opts.catch === 'function') _opts.catch(error);
+      }
+
+    }, _opts.interval);
+  };
+
+})(window, jQuery);


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

Timeout delays are most often not respected and the differences between several timeouts running in parrallel can be huge. To prevent race conditions on slower browsers, we now run the debounce test several time to wait for the debounced event to be called, which may be finally called way after the expected time.

This is done using a new `testInterval` utility: it try and catch the given function every `interval` delay, until it succedes (does not throw an error) or a given time passed.

If the debounced event is was called when expected (just after 10ms), we wait and run the test again. If after many tries the debounced event is still not called after 1s, we consider the test as failed.

The test should be now safe enough regarding to race conditions.

### Changes
* Add `testInterval` test utility
* Wait for debounce for slow browsers in Interval debounce test

### References
* Improve https://github.com/zurb/foundation-sites/pull/11259 - test: minimize interchange debouce test race condition (@ncoden)
* Related to https://github.com/zurb/foundation-sites/pull/11275 - test: give time to IE to render elements before testing focus (@ncoden)

## Motivation and Context
<!--- Why is this change required? What problem does it solve?              -->

Fixes the following race condition with IE11:
> [Windows 8.1, Internet Explorer 11.0] Error: "calls reflow on viewport size change once" failed, expected _reflow to be called once but was called 0 times (http://localhost:8888/node_modules/sinon/pkg/sinon-no-sourcemaps.js:165)
>
> -- https://travis-ci.org/zurb/foundation-sites/jobs/379941331#L1128

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
