### PR TITLE
docs: clarify usage of body overflow in XY Grid grid-frame example

### DIFF
--- a/docs/pages/xy-grid.md
+++ b/docs/pages/xy-grid.md
@@ -303,7 +303,7 @@ The XY grid incorporates the grid frame from Foundation for Apps plus many other
 To start, add `.grid-frame` to the grid. This sets the grid to be 100vh (the full height of the browser window).
 
 <div class="callout warning">
-  Please note to use `.grid-margin-x` or `.grid-margin-y` with `.grid-frame` you need to hide the overflow on the body like so: `body {overflow: hidden;}`.
+  Please note that to use `.grid-margin-x` or `.grid-margin-y` with `.grid-frame` you need to hide the overflow on the body like so: `body {overflow: hidden;}`. However, take care not to unintentionally hide overflow body content on small screens when using `.medium-grid-frame`.
 </div>
 
 Here's an example of what you can do:


### PR DESCRIPTION
Based on [#11273 [DOCS] Clarify usage of body overflow hiding re .medium-grid-frame example in docs](https://github.com/zurb/foundation-sites/pull/11273) opened by @paxperscientiam. The original pull request was based on `zurb:master`.

---

## Description
Per PR #11191 and my own [comment](https://github.com/zurb/foundation-sites/issues/11191#issuecomment-389658664), I have added commentary warning re hiding body overflow.

## Motivation and Context
My motivation is to help others that may or may have blindly add `body{overflow:hidden;}` to their code per current suggestion and wind up with a webpage that won't scroll on small screens.

Hope that makes sense!

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
