### PR TITLE
fix: use fallback gutter for fallback breakpoint in XY cell #11194

### DIFF
--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -110,6 +110,8 @@
   $breakpoint: null,
   $vertical: false
 ) {
+  $bp-is-fallback: false;
+
   @if($breakpoint == null) {
     // If `$bp-size` is available then use this, otherwise revert to the smallest bp.
     @if(variable-exists(-zf-size) and type-of($-zf-size) != 'number') and $-zf-size != null {
@@ -117,11 +119,16 @@
     }
     @else {
       $breakpoint: $-zf-zero-breakpoint;
+      $bp-is-fallback: true;
     }
   }
 
-  // Get the gutter for the passed breakpoint/value.
+  // Get the gutter for the given breakpoint/value.
   $gutter: -zf-get-bp-val($gutters, $breakpoint);
+  // If the breakpoint is a fallback, use a fallback gutter as well
+  @if ($bp-is-fallback == true and $gutter == null) {
+    $gutter: 0;
+  }
 
   @if($gutter != null) {
     // Base flex properties


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

When no breakpoint is passed to `xy-cell` and a fallback "zero" breakpoint is used, use a fallback gutter as well if it is not found. This way, an implicit behavior stay implicit and a warning is thrown only if a breakpoint was explicitely given.

The following code:
```scss
$breakpoints: (
  xsmall: 0,
  small: 330px,
  medium: 640px,
  large: 1024px,
  xlarge: 1200px,
  xxlarge: 1440px
);

// (...)

.my-cell {
  @include xy-cell(12);
}
```

Now generate (instead of throwing a warning):
```scss
.test {
  width: 100%;
  margin-right: 0;
  margin-left: 0;
}
```

<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->
Closes https://github.com/zurb/foundation-sites/issues/11194

## Motivation and Context
<!--- Why is this change required? What problem does it solve?              -->

Breakpoint could be added to `$breakpoints` while `$grid-margin-gutters` is left unchanged. A custom zero breakpoint like `xsmall` can be added before `small`. In this case, `@include xy-cell(12);` will fail because `xy-cell` will search for a gutter value for `xsmall`.

As `xy-cell` fallback to `xsmall` implicitly, I expect all values direved from it to also have a fallback, unless we require a zero-breakpoint value to be declared in all breakpoint-related values.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [ ] ~~I have added tests to cover my changes (if relevant).~~
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
