### PR TITLE
fix: lower breakpoint max value precision to avoid rounding #11313

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -105,7 +105,7 @@ $global-text-direction: ltr !default;
 
 /// Enables flexbox for components that support it.
 /// @type Boolean
-$global-flexbox: false !default;
+$global-flexbox: true !default;
 
 /// Enabled responsive breakpoints for prototypes if applicable
 /// @type Boolean

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -105,7 +105,7 @@ $global-text-direction: ltr !default;
 
 /// Enables flexbox for components that support it.
 /// @type Boolean
-$global-flexbox: true !default;
+$global-flexbox: false !default;
 
 /// Enabled responsive breakpoints for prototypes if applicable
 /// @type Boolean

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -6,7 +6,10 @@
 /// @param {Keyword} $size - Breakpoint to use. **Must be a breakpoint defined in `$breakpoints`.**
 @mixin show-for($size) {
   $size: map-get($breakpoints, $size);
-  $size: -zf-bp-to-em($size) - .00001;
+  // Max value is 0.2px under the next breakpoint (0.02 / 16 = 0.00125).
+  // Use a precision under 1px to support browser zoom, but not to low to avoid rounding.
+  // See https://github.com/zurb/foundation-sites/issues/11313
+  $size: -zf-bp-to-em($size) - .00125;
 
   @include breakpoint($size down) {
     display: none !important;
@@ -20,7 +23,7 @@
   $upper-bound-size: -zf-map-next($breakpoints, $size);
 
   // more often than not this will be correct, just one time round the loop it won't so set in scope here
-  $lower-bound: -zf-bp-to-em($lower-bound-size) - .00001;
+  $lower-bound: -zf-bp-to-em($lower-bound-size) - .00125;
   // test actual lower-bound-size, if 0 set it to 0em
   @if strip-unit($lower-bound-size) == 0 {
     $lower-bound: -zf-bp-to-em($lower-bound-size);

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -76,8 +76,11 @@ $breakpoint-classes: (small medium large) !default;
 
   // Convert any pixel, rem, or unitless value to em
   $bp: -zf-bp-to-em($bp);
+  // Max value is 0.2px under the next breakpoint (0.02 / 16 = 0.00125).
+  // Use a precision under 1px to support browser zoom, but not to low to avoid rounding.
+  // See https://github.com/zurb/foundation-sites/issues/11313
   @if $bp-max {
-    $bp-max: -zf-bp-to-em($bp-max) - .00001;
+    $bp-max: -zf-bp-to-em($bp-max) - .00125;
   }
 
   // Conditions to skip media query creation

--- a/test/sass/_breakpoint.scss
+++ b/test/sass/_breakpoint.scss
@@ -24,10 +24,10 @@
 
   @include test('Breakpoint (Only Range) [function]') {
     $test: breakpoint(medium only);
-    $expect: '(min-width: 40em) and (max-width: 63.99999em)';
+    $expect: '(min-width: 40em) and (max-width: 63.99875em)';
 
     $test-lowest: breakpoint(small only);
-    $expect-lowest: '(max-width: 39.99999em)';
+    $expect-lowest: '(max-width: 39.99875em)';
 
     $test-highest: breakpoint(xxlarge only);
     $expect-highest: '(min-width: 90em)';
@@ -44,13 +44,13 @@
 
   @include test('Breakpoint (Named Down Range) [function]') {
     $test: breakpoint(medium down);
-    $expect: '(max-width: 63.99999em)';
+    $expect: '(max-width: 63.99875em)';
 
     @include assert-equal($test, $expect,
       'Creates a down range out of a medium breakpoint');
 
     $test-lowest: breakpoint(small down);
-    $expect-lowest: '(max-width: 39.99999em)';
+    $expect-lowest: '(max-width: 39.99875em)';
 
     @include assert-equal($test-lowest, $expect-lowest,
       'Creates a down range out of a small breakpoint');


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

As seen in #10978, we need a subpixel precision to handle zoomed browsers. But browsers handle sub-pixel mediaqueries badly and a too high precision causes the issue described above. So we have to find the proper balance for a maximum support.

Changes:
* set breakpoint max values to `0.00125em` (`0.02px`)  under the next breakpoint instead of `0.00001`.
* add some comments about the bug.

Closes https://github.com/zurb/foundation-sites/issues/11313

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
