### PR TITLE
fix: fix outdated Browserify transform configuration

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,5 @@
+# Browsers that we support
+last 2 versions
+ie >= 9
+ios >= 7
+android >= 4.4

--- a/docs/assets/img/gulpfile.js
+++ b/docs/assets/img/gulpfile.js
@@ -83,9 +83,7 @@ gulp.task('sass', function() {
       outputStyle: isProduction ? 'compressed' : 'nested'
     })
       .on('error', $.sass.logError))
-    .pipe($.autoprefixer({
-      browsers: ['last 2 versions', 'ie >= 9', 'android >= 4.4', 'ios >= 7']
-    }))
+    .pipe($.autoprefixer()) // uses ".browserslistrc"
     // .pipe(uncss)
     .pipe(gulp.dest('./dist/assets/css'));
 });

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -45,13 +45,6 @@ module.exports = {
     'scss/**/*.scss',
   ],
 
-  CSS_COMPATIBILITY: [
-    'last 2 versions',
-    'ie >= 9',
-    'android >= 4.4',
-    'ios >= 7'
-  ],
-
   // Assets
   ASSETS_FILES: [
     'docs/assets/**/*',

--- a/gulp/tasks/check.js
+++ b/gulp/tasks/check.js
@@ -20,7 +20,7 @@ gulp.task('check:deps', function() {
 gulp.task('check:browserSupport', function() {
   return gulp.src(['_build/assets/css/foundation.css'])
     .pipe(postcss([doiuse({
-      browsers: CONFIG.CSS_COMPATIBILITY,
+      /* browsers: uses ".browserslistrc" */
       onFeatureUsage: function (usageInfo) {
         console.log(usageInfo.message)
       }

--- a/gulp/tasks/customizer.js
+++ b/gulp/tasks/customizer.js
@@ -30,12 +30,6 @@ var utils = require('../utils.js');
 var ARGS = yargs.argv;
 var FOUNDATION_VERSION = require('../../package.json').version;
 var OUTPUT_DIR = ARGS.output || 'custom-build';
-var COMPATIBILITY = [
-  'last 2 versions',
-  'ie >= 9',
-  'android >= 4.4',
-  'ios >= 7'
-];
 var CUSTOMIZER_CONFIG;
 var MODULE_LIST;
 var VARIABLE_LIST;
@@ -102,9 +96,7 @@ gulp.task('customizer:sass', function(done) {
           'node_modules/motion-ui/src'
         ]
       }))
-      .pipe(postcss([autoprefixer({
-        browsers: COMPATIBILITY
-      })]))
+      .pipe(postcss([autoprefixer()])) // uses ".browserslistrc"
       .pipe(gulp.dest(path.join(OUTPUT_DIR, 'css')))
       .pipe(cleancss({ compatibility: 'ie9' }))
       .pipe(rename('foundation.min.css'))

--- a/gulp/tasks/sass.js
+++ b/gulp/tasks/sass.js
@@ -31,9 +31,7 @@ gulp.task('sass:foundation', ['sass:deps'], function() {
     .pipe(sourcemaps.init())
     .pipe(plumber())
     .pipe(sass().on('error', sass.logError))
-    .pipe(postcss([autoprefixer({
-      browsers: CONFIG.CSS_COMPATIBILITY
-    })]))
+    .pipe(postcss([autoprefixer()])) // uses ".browserslistrc"
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('_build/assets/css'))
     .on('finish', function() {
@@ -52,9 +50,7 @@ gulp.task('sass:docs', ['sass:deps'], function() {
     .pipe(sass({
       includePaths: CONFIG.SASS_DOC_PATHS
     }).on('error', sass.logError))
-    .pipe(postcss([autoprefixer({
-      browsers: CONFIG.CSS_COMPATIBILITY
-    })]))
+    .pipe(postcss([autoprefixer()])) // uses ".browserslistrc"
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('_build/assets/css'));
 });

--- a/package.json
+++ b/package.json
@@ -139,9 +139,7 @@
       [
         "babelify",
         {
-          "presets": [
-            "es2015"
-          ]
+          "presets": ["env"]
         }
       ]
     ]


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

Foundation now require the `env` babel preset with a browserlist, but browserify config is oudated and still uses the `es2015` preset.

Changes:
* Use the `env` babel prese for browserify transformation instead of `es2015`
* Move all browserlist configurations to ".browserslistrc" 

Note: browserlist config is kept in ".babelrc" because browserlist external config is not supported by Babel < 7. See https://github.com/browserslist/browserslist

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [ ] ~~I have added tests to cover my changes (if relevant).~~
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
