### PR TITLE
fix: keep a scrollbar on document when Reveal opens #7831

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -324,6 +324,17 @@ class Reveal extends Plugin {
     this.$element.trigger('open.zf.reveal');
   }
 
+  /**
+   * Adds classes and listeners on document required by open modals.
+   *
+   * The following classes are added and updated:
+   * - `.is-reveal-open` - Prevents the scroll on document
+   * - `.zf-has-scroll`  - Displays a disabled scrollbar on document if required like if the
+   *                       scroll was not disabled. This prevent a "shift" of the page content due
+   *                       the scrollbar disappearing when the modal opens.
+   *
+   * @private
+   */
   _addGlobalClasses() {
     const updateScrollbarClass = () => {
       $('html').toggleClass('zf-has-scroll', !!($(document).height() > $(window).height()));
@@ -334,6 +345,10 @@ class Reveal extends Plugin {
     $('html').addClass('is-reveal-open');
   }
 
+  /**
+   * Removes classes and listeners on document that were required by open modals.
+   * @private
+   */
   _removeGlobalClasses() {
     this.$element.off('resizeme.zf.trigger.revealScrollbarListener');
     $('html').removeClass('is-reveal-open');

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -283,7 +283,7 @@ class Reveal extends Plugin {
             'tabindex': -1
           })
           .focus();
-        _this._addRevealOpenClasses();
+        _this._addGlobalClasses();
         Keyboard.trapFocus(_this.$element);
       }
       if (this.options.overlay) {
@@ -313,9 +313,9 @@ class Reveal extends Plugin {
       .focus();
     Keyboard.trapFocus(this.$element);
 
-    this._addRevealOpenClasses();
+    this._addGlobalClasses();
 
-    this._extraHandlers();
+    this._addGlobalListeners();
 
     /**
      * Fires when the modal has successfully opened.
@@ -324,7 +324,7 @@ class Reveal extends Plugin {
     this.$element.trigger('open.zf.reveal');
   }
 
-  _addRevealOpenClasses() {
+  _addGlobalClasses() {
     const updateScrollbarClass = () => {
       $('html').toggleClass('zf-has-scroll', !!($(document).height() > $(window).height()));
     };
@@ -334,7 +334,7 @@ class Reveal extends Plugin {
     $('html').addClass('is-reveal-open');
   }
 
-  _removeRevealOpenClasses() {
+  _removeGlobalClasses() {
     this.$element.off('resizeme.zf.trigger.revealScrollbarListener');
     $('html').removeClass('is-reveal-open');
     $('html').removeClass('zf-has-scroll');
@@ -344,7 +344,7 @@ class Reveal extends Plugin {
    * Adds extra event handlers for the body and window if necessary.
    * @private
    */
-  _extraHandlers() {
+  _addGlobalListeners() {
     var _this = this;
     if(!this.$element) { return; } // If we're in the middle of cleanup, don't freak out
     this.focusableElements = Keyboard.findFocusable(this.$element);
@@ -421,7 +421,7 @@ class Reveal extends Plugin {
       var scrollTop = parseInt($("html").css("top"));
 
       if ($('.reveal:visible').length  === 0) {
-        _this._removeRevealOpenClasses(); // also remove .is-reveal-open from the html element when there is no opened reveal
+        _this._removeGlobalClasses(); // also remove .is-reveal-open from the html element when there is no opened reveal
       }
 
       Keyboard.releaseFocus(_this.$element);
@@ -492,7 +492,7 @@ class Reveal extends Plugin {
       .off(this.onLoadListener);
 
     if ($('.reveal:visible').length  === 0) {
-      this._removeRevealOpenClasses(); // also remove .is-reveal-open from the html element when there is no opened reveal
+      this._removeGlobalClasses(); // also remove .is-reveal-open from the html element when there is no opened reveal
     }
   };
 }

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -325,11 +325,15 @@ class Reveal extends Plugin {
   }
 
   _addRevealOpenClasses() {
+    if ($(document).height() > $(window).height()) {
+      $('html').addClass('zf-has-scroll');
+    }
     $('html').addClass('is-reveal-open');
   }
 
   _removeRevealOpenClasses() {
     $('html').removeClass('is-reveal-open');
+    $('html').removeClass('zf-has-scroll');
   }
 
   /**

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -325,13 +325,17 @@ class Reveal extends Plugin {
   }
 
   _addRevealOpenClasses() {
-    if ($(document).height() > $(window).height()) {
-      $('html').addClass('zf-has-scroll');
-    }
+    const updateScrollbarClass = () => {
+      $('html').toggleClass('zf-has-scroll', !!($(document).height() > $(window).height()));
+    };
+
+    this.$element.on('resizeme.zf.trigger.revealScrollbarListener', () => updateScrollbarClass());
+    updateScrollbarClass();
     $('html').addClass('is-reveal-open');
   }
 
   _removeRevealOpenClasses() {
+    this.$element.off('resizeme.zf.trigger.revealScrollbarListener');
     $('html').removeClass('is-reveal-open');
     $('html').removeClass('zf-has-scroll');
   }

--- a/scss/components/_reveal.scss
+++ b/scss/components/_reveal.scss
@@ -132,7 +132,15 @@ $reveal-overlay-background: rgba($black, 0.45) !default;
   html.is-reveal-open {
     position: fixed;
     width: 100%;
-    overflow: hidden;
+    overflow-y: hidden;
+
+    &.zf-has-scroll {
+      overflow-y: scroll;
+    }
+
+    body { // sass-lint:disable-line no-qualifying-elements
+      overflow-y: hidden;
+    }
   }
 
   // Overlay


### PR DESCRIPTION
## Description

#11065 was intented to avoid double scrollbars from a Reveal modal, but removing all scrollbars when the modal opens changes the page content width and the content shift. This is a regression of #7831.

The current solution is a mix between the two previous fixes:
* Modal may have a scrollbar or not, following its content height
* Body has no scrollbar and prevent any scroll
* Document may have a scrollbar, following its content height (controlled in JS)

So the body content never shift, as the document has a scrollbar when a Reveal modal is open only if it already had one before.

## Changes:
* add the zf-has-scroll global html modifer and toggle it on Reveal opening/closing and on window resizing
* always prevent scroll on body instead of html tag like in #10583
