### PR TITLE
fix: fix completion callback called too many time in deploy task

### DIFF
--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -46,7 +46,7 @@ gulp.task('deploy:version', function() {
 });
 
 // Generates compiled CSS and JS files and sourcemaps and puts them in the dist/ folder
-gulp.task('deploy:dist', function(done) {
+gulp.task('deploy:dist', function() {
   sequence('sass:foundation', 'javascript:foundation', function() {
     var cssFilter = filter(['**/*.css'], { restore: true });
     var jsFilter  = filter(['**/*.js'], { restore: true });

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -96,8 +96,6 @@ gulp.task('deploy:dist', function(done) {
       .pipe(tsFilter)
         .pipe(gulp.dest('./dist/js'))
         .pipe(tsFilter.restore)
-
-      .on('finish', done);
   });
 });
 

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -25,6 +25,9 @@ gulp.task('deploy:prep', function(cb) {
   sequence('deploy:prompt', 'deploy:version', 'deploy:dist', 'deploy:plugins', 'deploy:settings', cb);
 });
 
+gulp.task('deploy:dist', function (cb) {
+  sequence('sass:foundation', 'javascript:foundation', 'deploy:dist:files', cb);
+});
 
 gulp.task('deploy:prompt', function(cb) {
   inquirer.prompt([{
@@ -41,62 +44,60 @@ gulp.task('deploy:prompt', function(cb) {
 // Bumps the version number in any file that has one
 gulp.task('deploy:version', function() {
   return gulp.src(CONFIG.VERSIONED_FILES, { base: process.cwd() })
-    .pipe(replace(CURRENT_VERSION, NEXT_VERSION))
-    .pipe(gulp.dest('.'));
+  .pipe(replace(CURRENT_VERSION, NEXT_VERSION))
+  .pipe(gulp.dest('.'));
 });
 
 // Generates compiled CSS and JS files and sourcemaps and puts them in the dist/ folder
-gulp.task('deploy:dist', function() {
-  sequence('sass:foundation', 'javascript:foundation', function() {
-    var cssFilter = filter(['**/*.css'], { restore: true });
-    var jsFilter  = filter(['**/*.js'], { restore: true });
-    var cssSourcemapFilter = filter(['**/*.css.map'], { restore: true });
-    var jsSourcemapFilter = filter(['**/*.js.map'], { restore: true });
-    var tsFilter  = filter(['**/*.ts'], { restore: true });
+gulp.task('deploy:dist:files', function() {
+  var cssFilter = filter(['**/*.css'], { restore: true });
+  var jsFilter  = filter(['**/*.js'], { restore: true });
+  var cssSourcemapFilter = filter(['**/*.css.map'], { restore: true });
+  var jsSourcemapFilter = filter(['**/*.js.map'], { restore: true });
+  var tsFilter  = filter(['**/*.ts'], { restore: true });
 
-    return gulp.src(CONFIG.DIST_FILES)
-      .pipe(plumber())
+  return gulp.src(CONFIG.DIST_FILES)
+    .pipe(plumber())
 
-      // --- Source maps ---
-      // * Copy sourcemaps to the dist folder
-      // This is done first to avoid collision with minified-sourcemaps.
-      .pipe(cssSourcemapFilter)
-        .pipe(gulp.dest('./dist/css'))
-        .pipe(cssSourcemapFilter.restore)
-      .pipe(jsSourcemapFilter)
-        .pipe(gulp.dest('./dist/js'))
-        .pipe(jsSourcemapFilter.restore)
+    // --- Source maps ---
+    // * Copy sourcemaps to the dist folder
+    // This is done first to avoid collision with minified-sourcemaps.
+    .pipe(cssSourcemapFilter)
+      .pipe(gulp.dest('./dist/css'))
+      .pipe(cssSourcemapFilter.restore)
+    .pipe(jsSourcemapFilter)
+      .pipe(gulp.dest('./dist/js'))
+      .pipe(jsSourcemapFilter.restore)
 
-      // --- Source files ---
-      // * Copy source files to dist folder
-      // * Create minified files
-      // * Create minified-sourcemaps based on standard sourcemaps.
-      //   Sourcemaps are initialized before the ".min" renaming to be able retrieve
-      //   original sourcemaps from source names.
-      .pipe(cssFilter)
-        .pipe(gulp.dest('./dist/css'))
-        .pipe(sourcemaps.init({ loadMaps: true }))
-        .pipe(rename({ suffix: '.min' }))
-        .pipe(cleancss({ compatibility: 'ie9' }))
-        .pipe(sourcemaps.write('.'))
-        .pipe(gulp.dest('./dist/css'))
-        .pipe(cssFilter.restore)
+    // --- Source files ---
+    // * Copy source files to dist folder
+    // * Create minified files
+    // * Create minified-sourcemaps based on standard sourcemaps.
+    //   Sourcemaps are initialized before the ".min" renaming to be able retrieve
+    //   original sourcemaps from source names.
+    .pipe(cssFilter)
+      .pipe(gulp.dest('./dist/css'))
+      .pipe(sourcemaps.init({ loadMaps: true }))
+      .pipe(rename({ suffix: '.min' }))
+      .pipe(cleancss({ compatibility: 'ie9' }))
+      .pipe(sourcemaps.write('.'))
+      .pipe(gulp.dest('./dist/css'))
+      .pipe(cssFilter.restore)
 
-      .pipe(jsFilter)
-        .pipe(gulp.dest('./dist/js'))
-        .pipe(sourcemaps.init({ loadMaps: true }))
-        .pipe(rename({ suffix: '.min' }))
-        .pipe(uglify())
-        .pipe(sourcemaps.write('.'))
-        .pipe(gulp.dest('./dist/js'))
-        .pipe(jsFilter.restore)
+    .pipe(jsFilter)
+      .pipe(gulp.dest('./dist/js'))
+      .pipe(sourcemaps.init({ loadMaps: true }))
+      .pipe(rename({ suffix: '.min' }))
+      .pipe(uglify())
+      .pipe(sourcemaps.write('.'))
+      .pipe(gulp.dest('./dist/js'))
+      .pipe(jsFilter.restore)
 
-      // --- TypeScript files ---
-      // * Copy typescript files to the dist folder
-      .pipe(tsFilter)
-        .pipe(gulp.dest('./dist/js'))
-        .pipe(tsFilter.restore)
-  });
+    // --- TypeScript files ---
+    // * Copy typescript files to the dist folder
+    .pipe(tsFilter)
+      .pipe(gulp.dest('./dist/js'))
+      .pipe(tsFilter.restore);
 });
 
 // Copies standalone JavaScript plugins to dist/ folder


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

Fixes the `task completion callback called too many times` error in the `deploy:dist` gulp task caused by the callback called multiple times.

### Changes:
- Refactor the `deploy:dist` task and move its logics to `deploy:dist:files` in order to make gulp dealing directly with the `gulp-filter` stream and detect its end
- Rely on the gulp stream end detection instead of `on('finish')` as the later can be called multiple times with `gulp-filter`.

See commits for more details

**[This fix is compatible with v6.5]**

## Motivation and Context
<!--- Why is this change required? What problem does it solve?              -->

When running `gulp deploy:dist`, we got the following error:

```
[23:37:52] Error: task completion callback called too many times
    at finish (/Users/ncoden/Documents/Documents/Projects/Programmation/Web/2016/Foundation/foundation-sites/node_modules/orchestrator/lib/runTask.js:15:10)
    at /Users/ncoden/Documents/Documents/Projects/Programmation/Web/2016/Foundation/foundation-sites/node_modules/orchestrator/lib/runTask.js:52:4
    at f (/Users/ncoden/Documents/Documents/Projects/Programmation/Web/2016/Foundation/foundation-sites/node_modules/orchestrator/node_modules/once/once.js:17:25)
    at Duplex.onend (/Users/ncoden/Documents/Documents/Projects/Programmation/Web/2016/Foundation/foundation-sites/node_modules/orchestrator/node_modules/end-of-stream/index.js:31:18)
    at emitNone (events.js:111:20)
    at Duplex.emit (events.js:208:7)
    at endReadableNT (/Users/ncoden/Documents/Documents/Projects/Programmation/Web/2016/Foundation/foundation-sites/node_modules/readable-stream/lib/_stream_readable.js:1010:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

It is caused by the `done` callaback called multiple times in `.on('finish', done);`, because the `finish` event is triggered for each completed `.dest(...)`, and that (thanks to `gulp-filter`) there is multiple `.dest(...)` attached to the same stream.

Gulp doesn't _need_ `done` to be called in this case and can infer the task end from the stream itself.

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [ ] ~~I have added tests to cover my changes (if relevant).~~
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
