### PR TITLE
feat: automatically pick active menu item color by contrast

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -26,6 +26,10 @@ $menu-simple-margin: 1rem !default;
 /// @type Color
 $menu-item-color-active: $white !default;
 
+/// Alternative text color of an active menu item..
+/// @type Color
+$menu-item-color-alt-active: $black !default;
+
 /// Background color of an active menu item.
 /// @type Color
 $menu-item-background-active: get-color(primary) !default;
@@ -350,7 +354,7 @@ $menu-icons-back-compat: true !default;
 
 @mixin menu-state-active {
   background: $menu-item-background-active;
-  color: $menu-item-color-active;
+  color: color-pick-contrast($menu-item-background-active, ($menu-item-color-active, $menu-item-color-alt-active));
 }
 
 @mixin foundation-menu {

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -473,6 +473,7 @@ $menu-nested-margin: $global-menu-nested-margin;
 $menu-items-padding: $global-menu-padding;
 $menu-simple-margin: 1rem;
 $menu-item-color-active: $white;
+$menu-item-color-alt-active: $black;
 $menu-item-background-active: get-color(primary);
 $menu-icon-spacing: 0.25rem;
 $menu-item-background-hover: $light-gray;


### PR DESCRIPTION
picking text color by contrast instead of hardcoded white for easier color scheme customisation

## Description
while active menu item **background** is taken from customizable color palette, it's **color** is still hardcoded to white and needs to be replaced manually to matching color. 


<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->
- Closes https://github.com/zurb/foundation-sites/issues/11353

## Motivation and Context
For easier color scheme customization the text color could be picked automatically by comparing color contrasts, like its done for styled buttons ( _buttons.scss line 140 ).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)  

Imho, this PR is an improvement. Since auto-picking color by contrast is already implemented for styled buttons, i would expect the same behavior for other styled elements. Therefore the issue is kind of "unexpected behavior". I checked both "fix" and "new feature"

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
