### PR TITLE
fix: remove $-zf-size from non-responsive XY Grid classes generation

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -273,11 +273,11 @@
     }
 
     > .auto {
-      @include xy-cell-static(auto, false, $breakpoint: $-zf-size, $vertical: true);
+      @include xy-cell-static(auto, false, $vertical: true);
     }
 
     > .shrink {
-      @include xy-cell-static(shrink, false, $breakpoint: $-zf-size, $vertical: true);
+      @include xy-cell-static(shrink, false, $vertical: true);
     }
 
 


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

This PR resolve and issue with `$-zf-size` being used outside of a breakpoint and without fallback, leading to various warnings and discreet side-effects.

`$-zf-size` is only set within breakpoints. Breakpoints are not expected to be used for the `xy-vertical-grid-classes()` mixin.

**[This fix is compatible with v6.5]**

<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->
- Closes https://github.com/zurb/foundation-sites/issues/11359

## Motivation and Context
<!--- Why is this change required? What problem does it solve?              -->

Note: a more appropriate fix would be to rely on the `xy-cell()` mixin instead of `xy-cell-static()` to fully support explicit/implicit/null breakpoint option. However this may introduce breaking changes, so this will be kept for v6.6.0.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [ ] ~~I have added tests to cover my changes (if relevant).~~
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
