### PR TITLE
Use correct data attribute in responsive toggle description

### DIFF
--- a/docs/pages/responsive-navigation.md
+++ b/docs/pages/responsive-navigation.md
@@ -245,7 +245,7 @@ By default, the title bar will be visible on small screens, and the Menu hides. 
 
 ## Responsive Toggle with animation
 
-To use animations from the Motion UI library, include the <code>data-animation="someAnimationIn someAnimationOut"</code> attribute.
+To use animations from the Motion UI library, include the <code>data-animate="someAnimationIn someAnimationOut"</code> attribute.
 
 
 <div class="primary callout show-for-medium">


### PR DESCRIPTION
## Description
The description of employing animation in a responsive toggle uses an incorrect data attribute ("data-animation"). This PR fixes the description to use the correct one ("data-animate").

- Closes https://github.com/zurb/foundation-sites/issues/11372

## Motivation and Context
Incorrect documentation is confusing.

## Types of changes
- [X] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
- [X] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] There are no other pull request similar to this one.
- [X] The pull request title is descriptive.
- [X] The template is fully and correctly filled.
- [X] The pull request targets the right branch (`develop` or `support/*`).
- [X] My commits are correctly titled and contain all relevant information.
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.
