### PR TITLE
Replace deprecated `@elseif` for `@else if`

### DIFF
--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -246,7 +246,7 @@ $table-stack-breakpoint: medium !default;
     }
 
     // Darkens the odd striped table rows.
-    @elseif($table-stripe == odd) {
+    @else if($table-stripe == odd) {
       &:not(.unstriped) tr:nth-of-type(odd):hover {
         background-color: $table-row-stripe-hover;
       }
@@ -262,7 +262,7 @@ $table-stack-breakpoint: medium !default;
     }
 
     // Darkens the odd striped table rows.
-    @elseif($table-stripe == odd) {
+    @else if($table-stripe == odd) {
       &.striped tr:nth-of-type(odd):hover {
         background-color: $table-row-stripe-hover;
       }

--- a/scss/xy-grid/_cell.scss
+++ b/scss/xy-grid/_cell.scss
@@ -26,7 +26,7 @@
   }
 
   // Parsing "n of n" or "n/n" expressions
-  @elseif type-of($size) == 'list' {
+  @else if type-of($size) == 'list' {
     @if length($size) != 3 {
       @error 'Wrong syntax for xy-cell-size(). Use the format "n of n" or "n/n".';
     }
@@ -52,13 +52,13 @@
     min-height: 0px;
     min-width: 0px;
   }
-  @elseif ($size == 'auto') {
+  @else if ($size == 'auto') {
     flex: 1 1 0px; // sass-lint:disable-line zero-unit
   }
-  @elseif ($size == 'shrink') {
+  @else if ($size == 'shrink') {
     flex: 0 0 auto;
   }
-  @elseif ($size == 'grow') {
+  @else if ($size == 'grow') {
     flex: 1 0 auto;
   }
 }
@@ -79,11 +79,11 @@
     $val: if($margin-gutter == 0, 100%, calc(100% - #{rem-calc($margin-gutter)}));
     #{$direction}: $val;
   }
-  @elseif ($size == 'auto') {
+  @else if ($size == 'auto') {
     #{$direction}: auto;
     $val: if($margin-gutter == 0, 100%, calc(100% - #{rem-calc($margin-gutter)}));
   }
-  @elseif ($size == 'shrink') {
+  @else if ($size == 'shrink') {
     #{$direction}: auto;
   }
   @else {

--- a/scss/xy-grid/_gutters.scss
+++ b/scss/xy-grid/_gutters.scss
@@ -34,7 +34,7 @@
       }
     }
   }
-  @elseif (type-of($gutters) == 'number') {
+  @else if (type-of($gutters) == 'number') {
     $gutter: rem-calc($gutters) / 2;
 
     // Loop through each gutter position


### PR DESCRIPTION
## Description
Replace the deprecated `@elseif` to `@else if`

## Motivation and Context
DEPRECATION WARNING from compiler ([dart-sass now being the official compiler](http://sass.logdown.com/posts/7081811))

https://github.com/sass/dart-sass/blob/master/lib/src/parse/scss.dart#L47



## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `support/*`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.
