### PR TITLE
fix: set matchMedia on window to fix issue on IE11, fixes #11358

### DIFF
--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -17,9 +17,10 @@ const defaultQueries = {
 
 
 // matchMedia() polyfill - Test a CSS media type/query in JS.
-// Authors & copyright (c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas, David Knight. Dual MIT/BSD license
-window.matchMedia = window.matchMedia || (function() {
-  'use strict';
+// Authors & copyright(c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas, David Knight. MIT license
+/* eslint-disable */
+window.matchMedia || (window.matchMedia = (function () {
+  "use strict";
 
   // For browsers that support matchMedium api such as IE 9 and webkit
   var styleMedia = (window.styleMedia || window.media);
@@ -33,14 +34,18 @@ window.matchMedia = window.matchMedia || (function() {
     style.type  = 'text/css';
     style.id    = 'matchmediajs-test';
 
-    script && script.parentNode && script.parentNode.insertBefore(style, script);
+    if (!script) {
+      document.head.appendChild(style);
+    } else {
+      script.parentNode.insertBefore(style, script);
+    }
 
     // 'style.currentStyle' is used by IE <= 8 and 'window.getComputedStyle' for all other browsers
     info = ('getComputedStyle' in window) && window.getComputedStyle(style, null) || style.currentStyle;
 
     styleMedia = {
-      matchMedium(media) {
-        var text = `@media ${media}{ #matchmediajs-test { width: 1px; } }`;
+      matchMedium: function (media) {
+        var text = '@media ' + media + '{ #matchmediajs-test { width: 1px; } }';
 
         // 'style.styleSheet' is used by IE <= 8 and 'style.textContent' for all other browsers
         if (style.styleSheet) {
@@ -52,7 +57,7 @@ window.matchMedia = window.matchMedia || (function() {
         // Test if media query is true or false
         return info.width === '1px';
       }
-    }
+    };
   }
 
   return function(media) {
@@ -60,8 +65,9 @@ window.matchMedia = window.matchMedia || (function() {
       matches: styleMedia.matchMedium(media || 'all'),
       media: media || 'all'
     };
-  }
-})();
+  };
+})());
+/* eslint-enable */
 
 var MediaQuery = {
   queries: [],

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -18,7 +18,7 @@ const defaultQueries = {
 
 // matchMedia() polyfill - Test a CSS media type/query in JS.
 // Authors & copyright (c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas, David Knight. Dual MIT/BSD license
-let matchMedia = window.matchMedia || (function() {
+window.matchMedia = window.matchMedia || (function() {
   'use strict';
 
   // For browsers that support matchMedium api such as IE 9 and webkit
@@ -109,7 +109,7 @@ var MediaQuery = {
     var query = this.get(size);
 
     if (query) {
-      return matchMedia(query).matches;
+      return window.matchMedia(query).matches;
     }
 
     return false;
@@ -160,7 +160,7 @@ var MediaQuery = {
     for (var i = 0; i < this.queries.length; i++) {
       var query = this.queries[i];
 
-      if (matchMedia(query.value).matches) {
+      if (window.matchMedia(query.value).matches) {
         matched = query;
       }
     }


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->
This fixes an issue in IE11 with a conflict between window.matchMedia and matchMedia.


<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->
- Closes #11358

## Motivation and Context
<!--- Why is this change required? What problem does it solve?              -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
