### PR TITLE
fix: optimize & add missing properties in XY Grid responsive cell modifiers

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -68,22 +68,31 @@
   }
 
   @include -zf-each-breakpoint() {
+    // Responsive "auto" modifier
     @if not($-zf-size == small) {
       .grid-x > .#{$-zf-size}-auto {
         @include xy-cell-base(auto);
         @include xy-cell-static(auto, false);
       }
+    }
 
+    %-xy-cell-base-shrink-#{$-zf-size} {
+      @include xy-cell-base(shrink);
+    }
+
+    // Responsive "shrink" modifier
+    @if not($-zf-size == small) {
       .grid-x > .#{$-zf-size}-shrink {
-        @include xy-cell-base(shrink);
+        @extend %-xy-cell-base-shrink-#{$-zf-size};
         @include xy-cell-static(shrink, false);
       }
     }
 
+    // Responsive width modifiers
     @for $i from 1 through $grid-columns {
       // Sizing (percentage)
       .grid-x > .#{$-zf-size}-#{$i} {
-        @include xy-cell-base(shrink);
+        @extend %-xy-cell-base-shrink-#{$-zf-size};
         @include xy-cell-static($i, false, $gutter-type: padding);
       }
     }

--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -76,14 +76,14 @@
       }
     }
 
-    %-xy-cell-base-shrink-#{$-zf-size} {
+    %-xy-cell-base-shrink-horizontal-#{$-zf-size} {
       @include xy-cell-base(shrink);
     }
 
     // Responsive "shrink" modifier
     @if not($-zf-size == small) {
       .grid-x > .#{$-zf-size}-shrink {
-        @extend %-xy-cell-base-shrink-#{$-zf-size};
+        @extend %-xy-cell-base-shrink-horizontal-#{$-zf-size};
         @include xy-cell-static(shrink, false);
       }
     }
@@ -92,7 +92,7 @@
     @for $i from 1 through $grid-columns {
       // Sizing (percentage)
       .grid-x > .#{$-zf-size}-#{$i} {
-        @extend %-xy-cell-base-shrink-#{$-zf-size};
+        @extend %-xy-cell-base-shrink-horizontal-#{$-zf-size};
         @include xy-cell-static($i, false, $gutter-type: padding);
       }
     }
@@ -305,21 +305,31 @@
     }
 
     @include -zf-each-breakpoint() {
+      // Responsive "auto" modifier
       @if not($-zf-size == small) {
         > .#{$-zf-size}-auto {
           @include xy-cell-base(auto);
           @include xy-cell-static(auto, false, $breakpoint: $-zf-size, $vertical: true);
         }
-
-        > .#{$-zf-size}-shrink {
-          @include xy-cell-static(shrink, false, $breakpoint: $-zf-size, $vertical: true);
-        }
-
       }
 
+      %-xy-cell-base-shrink-vertical-#{$-zf-size} {
+        @include xy-cell-base(shrink);
+      }
+
+      // Responsive "shrink" modifier
+      @if not($-zf-size == small) {
+        > .#{$-zf-size}-shrink {
+          @extend %-xy-cell-base-shrink-vertical-#{$-zf-size};
+          @include xy-cell-static(shrink, false, $breakpoint: $-zf-size, $vertical: true);
+        }
+      }
+
+      // Responsive width modifiers
       @for $i from 1 through $grid-columns {
         // Sizing (percentage)
         > .#{$-zf-size}-#{$i} {
+          @extend %-xy-cell-base-shrink-vertical-#{$-zf-size};
           @include xy-cell-static($i, false, $vertical: true, $gutter-type: padding);
         }
       }


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

* Prevent duplicated properties in XY grid responsive horizontal cell widths (see https://diffchecker.com/NWHV8CRG)
* Add missing flex reset in XY Grid responsive vertical cell widths (like #10891 but for vertical cells)

**[This PR is compatible with v6.5]**

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [ ] ~~I have added tests to cover my changes (if relevant).~~
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
