### PR TITLE
fix: slider handle negative data-start values

### DIFF
--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -428,7 +428,7 @@ class Slider extends Plugin {
     }
     if (val >= 0) {
       left = val % step;
-    } else if (val < 0) {
+    } else {
       left = step + (val % step);
     }
     prev_val = val - left;

--- a/js/foundation.slider.js
+++ b/js/foundation.slider.js
@@ -426,7 +426,11 @@ class Slider extends Plugin {
     else {
       val = value;
     }
-    left = val % step;
+    if (val >= 0) {
+      left = val % step;
+    } else if (val < 0) {
+      left = step + (val % step);
+    }
     prev_val = val - left;
     next_val = prev_val + step;
     if (left === 0) {

--- a/test/javascript/components/slider.js
+++ b/test/javascript/components/slider.js
@@ -153,6 +153,30 @@ describe('Slider', function() {
     });
   });
 
+  describe('adjustValue()', function() {
+    it('handles positive values', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Slider($html, {});
+
+      plugin._adjustValue(null, 1).should.equal(1);
+      plugin._adjustValue(null, 2).should.equal(2);
+      plugin._adjustValue(null, 1.2).should.equal(1);
+      plugin._adjustValue(null, 1.9).should.equal(2);
+      plugin._adjustValue(null, 1.5).should.equal(2);
+    });
+
+    it('handles negative values', function() {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Slider($html, {});
+
+      plugin._adjustValue(null, -1).should.equal(-1);
+      plugin._adjustValue(null, -2).should.equal(-2);
+      plugin._adjustValue(null, -1.2).should.equal(-1);
+      plugin._adjustValue(null, -1.9).should.equal(-2);
+      plugin._adjustValue(null, -1.5).should.equal(-1);
+    });
+  });
+
   describe('keyboard events', function() {
     it('sets value to minimum using HOME', function() {
       $html = $(template).appendTo('body');


### PR DESCRIPTION
## Description
The Slider handles negative data-start values. The change is isolated only in `_adjustValue`.

- Closes https://github.com/zurb/foundation-sites/issues/11390

## Motivation and Context
Having a negative data-start value extends the use cases for the Slider.

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.
