### PR TITLE
fix: open Drilldrown with the currently opened (sub)menu height #11416

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -61,6 +61,11 @@ class Drilldown extends Plugin {
     this.$submenuAnchors = this.$element.find('li.is-drilldown-submenu-parent').children('a');
     this.$submenus = this.$submenuAnchors.parent('li').children('[data-submenu]').attr('role', 'group');
     this.$menuItems = this.$element.find('li').not('.js-drilldown-back').attr('role', 'treeitem').find('a');
+
+    // Set the main menu as current by default (unless a submenu is selected)
+    // Used to set the wrapper height when the drilldown is closed/reopened from any (sub)menu
+    this.$currentMenu = this.$element;
+
     this.$element.attr('data-mutate', (this.$element.attr('data-drilldown') || GetYoDigits(6, 'drilldown')));
 
     this._prepareMenu();
@@ -128,10 +133,6 @@ class Drilldown extends Plugin {
     // set wrapper
     this.$wrapper = this.$element.parent();
     this.$wrapper.css(this._getMaxDims());
-
-    // Set the main menu as current by default (unless a submenu is selected)
-    // Used to set the wrapper height when the drilldown is closed/reopened from any (sub)menu
-    this.$currentMenu = this.$element;
   }
 
   _resize() {

--- a/test/javascript/components/drilldown.js
+++ b/test/javascript/components/drilldown.js
@@ -26,6 +26,15 @@ describe('Drilldown Menu', function() {
     <li><a href="#Item-3"> Item 3</a></li>
   </ul>`;
 
+  var templateWithToggler = `
+    <div>
+      <button id="trigger" data-toggle="target" type="button">Toggler</button>
+      <div id="target" class="is-hidden" data-toggler="is-hidden">
+        ${template}
+      </div>
+    </div>
+  `;
+
   afterEach(function() {
     plugin.destroy();
     document.activeElement.blur();
@@ -218,6 +227,41 @@ describe('Drilldown Menu', function() {
     });
   });
 
+  describe('toggle events', function () {
+
+    this.timeout(0);
+    var $trigger, $target, $menu, togglerPlugin;
+
+    beforeEach(function () {
+      $html = $(templateWithToggler).appendTo('body');
+      $trigger = $html.find('#trigger');
+      $target = $html.find('#target');
+      $menu = $html.find('#m1');
+
+      togglerPlugin = new Foundation.Toggler($target, {});
+      plugin = new Foundation.Drilldown($menu, {});
+    });
+
+    it('correctly resize when opened', function () {
+      // Open the Drilldown
+      $trigger.focus().trigger('click');
+
+      $menu.height().should.be.within(110, 120);
+    });
+
+    it('correctly resize when closed', function () {
+      // Open then close the Drilldown
+      $trigger.focus().trigger('click');
+      $trigger.focus().trigger('click');
+
+      $menu.height().should.be.equal(0);
+    });
+
+    afterEach(function () {
+      togglerPlugin.destroy();
+    });
+
+  });
 
   describe('keyboard events', function() {
     // Currently not testable, as triggered event won't move on focus

--- a/test/javascript/components/drilldown.js
+++ b/test/javascript/components/drilldown.js
@@ -228,7 +228,6 @@ describe('Drilldown Menu', function() {
 
   describe('toggle events', function () {
 
-    this.timeout(0);
     var $trigger, $target, $wrapper, togglerPlugin;
 
     beforeEach(function () {

--- a/test/javascript/components/drilldown.js
+++ b/test/javascript/components/drilldown.js
@@ -230,23 +230,25 @@ describe('Drilldown Menu', function() {
   describe('toggle events', function () {
 
     this.timeout(0);
-    var $trigger, $target, $menu, togglerPlugin;
+    var $trigger, $target, $wrapper, togglerPlugin;
 
     beforeEach(function () {
       $html = $(templateWithToggler).appendTo('body');
       $trigger = $html.find('#trigger');
       $target = $html.find('#target');
-      $menu = $html.find('#m1');
+      $target = $html.find('#target');
 
       togglerPlugin = new Foundation.Toggler($target, {});
-      plugin = new Foundation.Drilldown($menu, {});
+      plugin = new Foundation.Drilldown($html.find('[data-drilldown]'), { autoHeight: true });
+
+      $wrapper = $html.find('.is-drilldown');
     });
 
     it('correctly resize when opened', function () {
       // Open the Drilldown
       $trigger.focus().trigger('click');
 
-      $menu.height().should.be.within(110, 120);
+      $wrapper.height().should.be.within(110, 120);
     });
 
     it('correctly resize when closed', function () {
@@ -254,7 +256,7 @@ describe('Drilldown Menu', function() {
       $trigger.focus().trigger('click');
       $trigger.focus().trigger('click');
 
-      $menu.height().should.be.equal(0);
+      $wrapper.height().should.be.equal(0);
     });
 
     afterEach(function () {

--- a/test/javascript/components/drilldown.js
+++ b/test/javascript/components/drilldown.js
@@ -4,12 +4,11 @@ describe('Drilldown Menu', function() {
   var template = `<ul class="menu" data-drilldown style="width: 200px" id="m1">
     <li>
       <a href="#">Item 1</a>
-      <ul class="menu">
+      <ul id="Menu-1" class="menu">
         <li>
           <a href="#">Item 1A</a>
-          <ul class="menu">
+          <ul id="Menu-1A" class="menu">
             <li><a href="#Item-1Aa">Item 1Aa</a></li>
-            <li><a href="#Item-1Ba">Item 1Ba</a></li>
           </ul>
         </li>
         <li><a href="#Item-1B">Item 1B</a></li>
@@ -18,7 +17,7 @@ describe('Drilldown Menu', function() {
     </li>
     <li>
       <a href="#">Item 2</a>
-      <ul class="menu">
+      <ul id="Menu-2" class="menu">
         <li><a href="#Item-2A">Item 2A</a></li>
         <li><a href="#Item-2B">Item 2B</a></li>
       </ul>
@@ -248,6 +247,7 @@ describe('Drilldown Menu', function() {
       // Open the Drilldown
       $trigger.focus().trigger('click');
 
+      // 3 items (including the back button) is around 115px height
       $wrapper.height().should.be.within(110, 120);
     });
 
@@ -257,6 +257,19 @@ describe('Drilldown Menu', function() {
       $trigger.focus().trigger('click');
 
       $wrapper.height().should.be.equal(0);
+    });
+
+    it('correctly resize when reopened on a submenu', function () {
+      // Open the Drilldown
+      $trigger.focus().trigger('click');
+      // Show a submenu with a smaller height
+      plugin._showMenu($html.find('#Menu-1A'));
+      // Close then reopen the the Drilldown
+      $trigger.focus().trigger('click');
+      $trigger.focus().trigger('click');
+
+      // 2 items (including the back button) is around 75px height
+      $wrapper.height().should.be.within(70, 80);
     });
 
     afterEach(function () {


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

When a Drilldown submenu is opened, then the whole Drilldown is closed and reopened, the submenu is still there but the Drilldown takes the height of the main menu.

This pull request fix this bug by using the active (sub)menu height when the Drilldown height is recalculated.

### Changes
- Save the currently opened sub-menu as `$currentMenu`
- When calculating the Drilldown wrapper height, use the currently opened menu height instead of the primary menu.

<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->
- Closes https://github.com/zurb/foundation-sites/issues/11416

## ⚠️ ToDo
- [x] Add unit tests

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [ ] ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.


<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
