### PR TITLE
fix: fix various bugs with "Tap" events and "closeOnClick" options #11423

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -13,6 +13,7 @@ import { Triggers } from './foundation.util.triggers';
  * @module foundation.dropdown
  * @requires foundation.util.keyboard
  * @requires foundation.util.box
+ * @requires foundation.util.touch
  * @requires foundation.util.triggers
  */
 class Dropdown extends Positionable {

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -29,7 +29,8 @@ class Dropdown extends Positionable {
     this.options = $.extend({}, Dropdown.defaults, this.$element.data(), options);
     this.className = 'Dropdown'; // ie9 back compat
 
-    // Triggers init is idempotent, just need to make sure it is initialized
+    // Touch and Triggers init are idempotent, just need to make sure they are initialized
+    Touch.init($);
     Triggers.init($);
 
     this._init();
@@ -219,8 +220,8 @@ class Dropdown extends Positionable {
   _addBodyHandler() {
      var $body = $(document.body).not(this.$element),
          _this = this;
-     $body.off('click.zf.dropdown')
-          .on('click.zf.dropdown', function(e){
+     $body.off('click.zf.dropdown tap.zf.dropdown')
+          .on('click.zf.dropdown tap.zf.dropdown', function (e) {
             if(_this.$anchors.is(e.target) || _this.$anchors.find(e.target).length) {
               return;
             }
@@ -228,7 +229,7 @@ class Dropdown extends Positionable {
               return;
             }
             _this.close();
-            $body.off('click.zf.dropdown');
+            $body.off('click.zf.dropdown tap.zf.dropdown');
           });
   }
 
@@ -320,7 +321,7 @@ class Dropdown extends Positionable {
   _destroy() {
     this.$element.off('.zf.trigger').hide();
     this.$anchors.off('.zf.dropdown');
-    $(document.body).off('click.zf.dropdown');
+    $(document.body).off('click.zf.dropdown tap.zf.dropdown');
 
   }
 }

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -31,7 +31,8 @@ class Reveal extends Plugin {
     this.className = 'Reveal'; // ie9 back compat
     this._init();
 
-    // Triggers init is idempotent, just need to make sure it is initialized
+    // Touch and Triggers init are idempotent, just need to make sure they are initialized
+    Touch.init($);
     Triggers.init($);
 
     Keyboard.register('Reveal', {
@@ -160,7 +161,7 @@ class Reveal extends Plugin {
     });
 
     if (this.options.closeOnClick && this.options.overlay) {
-      this.$overlay.off('.zf.reveal').on('click.zf.reveal', function(e) {
+      this.$overlay.off('.zf.reveal').on('click.zf.dropdown tap.zf.dropdown', function(e) {
         if (e.target === _this.$element[0] ||
           $.contains(_this.$element[0], e.target) ||
             !$.contains(document, e.target)) {
@@ -365,7 +366,7 @@ class Reveal extends Plugin {
     this.focusableElements = Keyboard.findFocusable(this.$element);
 
     if (!this.options.overlay && this.options.closeOnClick && !this.options.fullScreen) {
-      $('body').on('click.zf.reveal', function(e) {
+      $('body').on('click.zf.dropdown tap.zf.dropdown', function(e) {
         if (e.target === _this.$element[0] ||
           $.contains(_this.$element[0], e.target) ||
             !$.contains(document, e.target)) { return; }
@@ -423,7 +424,7 @@ class Reveal extends Plugin {
     }
 
     if (!this.options.overlay && this.options.closeOnClick) {
-      $('body').off('click.zf.reveal');
+      $('body').off('click.zf.dropdown tap.zf.dropdown');
     }
 
     this.$element.off('keydown.zf.reveal');

--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -12,6 +12,7 @@ import { Triggers } from './foundation.util.triggers';
  * Reveal module.
  * @module foundation.reveal
  * @requires foundation.util.keyboard
+ * @requires foundation.util.touch
  * @requires foundation.util.triggers
  * @requires foundation.util.mediaQuery
  * @requires foundation.util.motion if using animations

--- a/js/foundation.util.touch.js
+++ b/js/foundation.util.touch.js
@@ -19,7 +19,6 @@ function onTouchEnd(e) {
   this.removeEventListener('touchmove', onTouchMove);
   this.removeEventListener('touchend', onTouchEnd);
 
-
   // If the touch did not moved, consider it as a "tap"
   if (!didMoved) {
     var tapEvent = $.Event('tap', startEvent || e);

--- a/js/foundation.util.touch.js
+++ b/js/foundation.util.touch.js
@@ -19,7 +19,7 @@ function onTouchEnd(e) {
   this.removeEventListener('touchmove', onTouchMove);
   this.removeEventListener('touchend', onTouchEnd);
 
-  // If the touch did not moved, consider it as a "tap"
+  // If the touch did not move, consider it as a "tap"
   if (!didMoved) {
     var tapEvent = $.Event('tap', startEvent || e);
     $(this).trigger(tapEvent);

--- a/js/foundation.util.touch.js
+++ b/js/foundation.util.touch.js
@@ -11,19 +11,22 @@ var startPosX,
     startPosY,
     startTime,
     elapsedTime,
+    startEvent,
     isMoving = false,
     didMoved = false;
 
-function onTouchEnd() {
+function onTouchEnd(e) {
   this.removeEventListener('touchmove', onTouchMove);
   this.removeEventListener('touchend', onTouchEnd);
 
 
   // If the touch did not moved, consider it as a "tap"
   if (!didMoved) {
-    $(this).trigger('tap');
+    var tapEvent = $.Event('tap', startEvent || e);
+    $(this).trigger(tapEvent);
   }
 
+  startEvent = null;
   isMoving = false;
   didMoved = false;
 }
@@ -47,8 +50,10 @@ function onTouchMove(e) {
     // }
     if(dir) {
       e.preventDefault();
-      onTouchEnd.call(this);
-      $(this).trigger('swipe', dir).trigger(`swipe${dir}`);
+      onTouchEnd.apply(this, arguments);
+      $(this)
+        .trigger($.Event('swipe', e), dir)
+        .trigger($.Event(`swipe${dir}`, e));
     }
   }
 
@@ -59,6 +64,7 @@ function onTouchStart(e) {
   if (e.touches.length == 1) {
     startPosX = e.touches[0].pageX;
     startPosY = e.touches[0].pageY;
+    startEvent = e;
     isMoving = true;
     didMoved = false;
     startTime = new Date().getTime();

--- a/js/foundation.util.touch.js
+++ b/js/foundation.util.touch.js
@@ -11,25 +11,33 @@ var startPosX,
     startPosY,
     startTime,
     elapsedTime,
-    isMoving = false;
+    isMoving = false,
+    didMoved = false;
 
 function onTouchEnd() {
-  //  alert(this);
   this.removeEventListener('touchmove', onTouchMove);
   this.removeEventListener('touchend', onTouchEnd);
+
+
+  // If the touch did not moved, consider it as a "tap"
+  if (!didMoved) {
+    $(this).trigger('tap');
+  }
+
   isMoving = false;
+  didMoved = false;
 }
 
 function onTouchMove(e) {
   if ($.spotSwipe.preventDefault) { e.preventDefault(); }
 
-  // Moved: swipe
   if(isMoving) {
     var x = e.touches[0].pageX;
     var y = e.touches[0].pageY;
     var dx = startPosX - x;
     var dy = startPosY - y;
     var dir;
+    didMoved = true;
     elapsedTime = new Date().getTime() - startTime;
     if(Math.abs(dx) >= $.spotSwipe.moveThreshold && elapsedTime <= $.spotSwipe.timeThreshold) {
       dir = dx > 0 ? 'left' : 'right';
@@ -43,18 +51,16 @@ function onTouchMove(e) {
       $(this).trigger('swipe', dir).trigger(`swipe${dir}`);
     }
   }
-  // Otherwise: tap
-  else {
-    $(this).trigger('tap');
-  }
 
 }
 
 function onTouchStart(e) {
+
   if (e.touches.length == 1) {
     startPosX = e.touches[0].pageX;
     startPosY = e.touches[0].pageY;
     isMoving = true;
+    didMoved = false;
     startTime = new Date().getTime();
     this.addEventListener('touchmove', onTouchMove, false);
     this.addEventListener('touchend', onTouchEnd, false);
@@ -83,6 +89,7 @@ class SpotSwipe {
   _init() {
     var $ = this.$;
     $.event.special.swipe = { setup: init };
+    $.event.special.tap = { setup: init };
 
     $.each(['left', 'up', 'down', 'right'], function () {
       $.event.special[`swipe${this}`] = { setup: function(){
@@ -146,7 +153,8 @@ Touch.setupTouchHandler = function($) {
   };
 };
 
-Touch.init = function($) {
+Touch.init = function ($) {
+
   if(typeof($.spotSwipe) === 'undefined') {
     Touch.setupSpotSwipe($);
     Touch.setupTouchHandler($);

--- a/test/visual/dropdown/close-on-click.html
+++ b/test/visual/dropdown/close-on-click.html
@@ -23,7 +23,7 @@
 
           <hr>
 
-          <p>This dropdown will close if you click anywhere outside of it.</p>
+          <p>This dropdown will close if you click (desktop) or tap without swiping (mobile) anywhere outside of it.</p>
 
           <button class="dropdown button" type="button" data-toggle="dropdown2">Toggle Dropdown</button>
           <div id="dropdown2" class="dropdown-pane" data-dropdown data-close-on-click="true">

--- a/test/visual/reveal/close-on-click.html
+++ b/test/visual/reveal/close-on-click.html
@@ -17,21 +17,21 @@
 
           <h1>Reveal: closeOnClick option</h1>
 
-          <p>This modal should not close when clicking/taping outside of it.</p>
+          <p>This modal should not close when clicking/tapping outside of it.</p>
           <p><button class="button" data-open="exampleModal1">Open modal</button></p>
 
           <div class="reveal" id="exampleModal1" data-reveal data-close-on-click="false">
-            <p>Clicking/taping outside of me SHOULD NOT close me.</p>
+            <p>Clicking/tapping outside of me SHOULD NOT close me.</p>
             <p><button class="button" data-close="exampleModal1">Close</button></p>
           </div>
 
           <hr>
 
-          <p>This modal should close when clicking (desktop) or taping without swiping (mobile) outside of it.</p>
+          <p>This modal should close when clicking (desktop) or tapping without swiping (mobile) outside of it.</p>
           <p><button class="button" data-open="exampleModal2">Open modal</button></p>
 
           <div class="reveal" id="exampleModal2" data-reveal data-close-on-click="true">
-            <p>Clicking (desktop) or taping without swiping (mobile) outside of me SHOULD close me.</p>
+            <p>Clicking (desktop) or tapping without swiping (mobile) outside of me SHOULD close me.</p>
             <p><button class="button" data-close="exampleModal2">Close</button></p>
           </div>
 

--- a/test/visual/reveal/close-on-click.html
+++ b/test/visual/reveal/close-on-click.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<!--[if IE 9]><html class="lt-ie10" lang="en" > <![endif]-->
+<html class="no-js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <title>Foundation for Sites Testing</title>
+    <link href="../motion-ui/dist/motion-ui.css" rel="stylesheet" />
+    <link href="../assets/css/foundation.css" rel="stylesheet" />
+  </head>
+  <body>
+
+    <div class="grid-container">
+      <div class="grid-x grid-padding-x">
+        <div class="cell">
+
+          <h1>Reveal: closeOnClick option</h1>
+
+          <p>This modal should not close when clicking/taping outside of it.</p>
+          <p><button class="button" data-open="exampleModal1">Open modal</button></p>
+
+          <div class="reveal" id="exampleModal1" data-reveal data-close-on-click="false">
+            <p>Clicking/taping outside of me SHOULD NOT close me.</p>
+            <p><button class="button" data-close="exampleModal1">Close</button></p>
+          </div>
+
+          <hr>
+
+          <p>This modal should close when clicking (desktop) or taping without swiping (mobile) outside of it.</p>
+          <p><button class="button" data-open="exampleModal2">Open modal</button></p>
+
+          <div class="reveal" id="exampleModal2" data-reveal data-close-on-click="true">
+            <p>Clicking (desktop) or taping without swiping (mobile) outside of me SHOULD close me.</p>
+            <p><button class="button" data-close="exampleModal2">Close</button></p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <script src="../assets/js/vendor.js"></script>
+    <script src="../assets/js/foundation.js"></script>
+    <script>
+      $(document).foundation();
+    </script>
+
+  </body>
+</html>


### PR DESCRIPTION
<!--- --------------------------------------------------------------------- -->
<!---                 Please fill the following template                    -->
<!---             Your pull request may be ignored otherwise                -->
<!--- --------------------------------------------------------------------- -->

## Description
<!--- Describe your changes in detail. Include any relevant information     -->
<!--- (reasons, difficulties, links to web references, related issues...)   -->

Fix various buges related to the touch `tap` event and the `closeOnClick` options of Dropdown and Reveal.

<!--- Bugs and new features/improvements must be presented and discussed in -->
<!--- an issue first. Please create one if there is no issue related to     -->
<!--- this pull request.                                                    -->
- Closes #11423

### Fixes
* Fix the "tap" event triggering in Touch 
* Support mobile "tap" for the `closeOnClick` options in Dropdown and Reveal (#11423)
* Keep the original target (and others event datas) in `tap`/`swipe` events in Touch

### Others changes
* Update test description for the Dropdown `closeOnClick` option
* Add visual test for the Reveal `closeOnClick` option

### 💥 BREAKING CHANGE
* `foundation.utils.touch.js` is now required for `foundation.dropdown.js` and `foundation.reveal.js`. If you import the Foundation Dropdown or Reveal plugins manually, make sure to import the "Touch" utility as well.

## Types of changes
<!--- What types of changes does your code introduce?                       -->
<!--- Put an `x` in all the boxes that apply:                               -->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to change)

## Checklist (all required):
<!--- Go over all the following points, and put an `x` in the boxes.        -->
<!--- If you're unsure about any of these, don't hesitate to ask.           -->
- [x] I have read and follow the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] There are no other pull request similar to this one.
- [x] The pull request title is descriptive.
- [x] The template is fully and correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
- [x] All new and existing tests passed.

<!--- --------------------------------------------------------------------- -->
<!---       For more information, see the CONTRIBUTING.md document          -->
<!---         Thank you for your pull request and happy coding ;)           -->
<!--- --------------------------------------------------------------------- -->
