### PR TITLE
fix: return to initial state when reseting hash in Accordion & Tabs #11100

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -99,7 +99,7 @@ class Accordion extends Plugin {
 
       if ($anchor && $link) {
         /**
-         * Fires when the zplugin has deeplinked at pageload
+         * Fires when the plugin has deeplinked at pageload
          * @event Accordion#deeplink
          */
         this.$element.trigger('deeplink.zf.accordion', [$link, $anchor]);

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -192,10 +192,6 @@ class Accordion extends Plugin {
    * @function
    */
   down($target) {
-    /**
-     * checking firstTime allows for initial render of the accordion
-     * to render preset is-active panes.
-     */
     if ($target.closest('[data-accordion]').is('[disabled]'))  {
       console.info('Cannot call down on an accordion that is disabled.');
       return;
@@ -216,7 +212,6 @@ class Accordion extends Plugin {
    * @function
    */
   up($target) {
-
     if (this.$element.is('[disabled]')) {
       console.info('Cannot call up on an accordion that is disabled.');
       return;

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -61,6 +61,10 @@ class Accordion extends Plugin {
     });
 
     var $initActive = this.$element.find('.is-active').children('[data-tab-content]');
+    // Remember if we already set up the initial state of the Accordion as it
+    // gives additional privileges in the Accordion methods (like opening
+    // multiple panels even with the "multiExpand" option is disabled)
+    // TODO: refactor and clean this
     this.firstTimeInit = true;
     if ($initActive.length) {
       // Save up the initial hash to return to it later when going back in history
@@ -113,6 +117,7 @@ class Accordion extends Plugin {
     }
 
     this._events();
+    this.firstTimeInit = false;
   }
 
   /**

--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -59,15 +59,25 @@ class Accordion extends Plugin {
 
       $content.attr({'role': 'tabpanel', 'aria-labelledby': linkId, 'aria-hidden': true, 'id': id});
     });
+
     var $initActive = this.$element.find('.is-active').children('[data-tab-content]');
     this.firstTimeInit = true;
-    if($initActive.length){
+    if ($initActive.length) {
+      // Save up the initial hash to return to it later when going back in history
+      this._initialAnchor = $initActive.prev('a').attr('href');
+
       this.down($initActive, this.firstTimeInit);
       this.firstTimeInit = false;
     }
 
     this._checkDeepLink = () => {
       var anchor = window.location.hash;
+
+      // if there is no anchor, return to the initial panel
+      if (!anchor.length && this._initialAnchor) {
+        anchor = this._initialAnchor;
+      }
+
       //need a hash and a relevant anchor in this tabset
       if(anchor.length) {
         var $link = this.$element.find('[href$="'+anchor+'"]'),

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -118,6 +118,10 @@ class Tabs extends Plugin {
       if ($anchor && $anchor.length && $link && $link.length) {
         this.selectTab($anchor, true);
       }
+      // Otherwise, collapse everything
+      else {
+        this._collapse();
+      }
 
       // Roll up a little to show the titles
       if (this.options.deepLinkSmudge) {

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -73,6 +73,11 @@ class Tabs extends Plugin {
         'aria-labelledby': linkId
       });
 
+      // Save up the initial hash to return to it later when going back in history
+      if (isActive) {
+        _this._initialAnchor = `#${hash}`;
+      }
+
       if(!isActive) {
         $tabContent.attr('aria-hidden', 'true');
       }
@@ -85,6 +90,7 @@ class Tabs extends Plugin {
         });
       }
     });
+
     if(this.options.matchHeight) {
       var $images = this.$tabContent.find('img');
 
@@ -98,8 +104,14 @@ class Tabs extends Plugin {
      //current context-bound function to open tabs on page load or history hashchange
     this._checkDeepLink = () => {
       var anchor = window.location.hash;
+
+      // if there is no anchor, return to the initial tab
+      if (!anchor.length && this._initialAnchor) {
+        anchor = this._initialAnchor;
+      }
+
       //need a hash and a relevant anchor in this tabset
-      if(anchor.length) {
+      if (anchor.length) {
         var anchorNoHash = (anchor.indexOf('#') >= 0 ? anchor.slice(1) : anchor);
         var $link = this.$element.find(`[href$="${anchor}"],[data-tabs-target="${anchorNoHash}"]`).first();
         if ($link.length) {

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -234,18 +234,10 @@ class Tabs extends Plugin {
    */
   _handleTabChange($target, historyHandled) {
 
-    /**
-     * Check for active class on target. Collapse if exists.
-     */
+    // With `activeCollapse`, if the target is the active Tab, collapse it.
     if ($target.hasClass(`${this.options.linkActiveClass}`)) {
         if(this.options.activeCollapse) {
-            this._collapseTab($target);
-
-           /**
-            * Fires when the zplugin has successfully collapsed tabs.
-            * @event Tabs#collapse
-            */
-            this.$element.trigger('collapse.zf.tabs', [$target]);
+            this._collapse();
         }
         return;
     }
@@ -321,6 +313,25 @@ class Tabs extends Plugin {
     $(`#${$target_anchor.attr('aria-controls')}`)
       .removeClass(`${this.options.panelActiveClass}`)
       .attr({ 'aria-hidden': 'true' })
+  }
+
+  /**
+   * Collapses the active Tab.
+   * @fires Tabs#collapse
+   * @function
+   */
+  _collapse() {
+    var $activeTab = this.$element.find(`.${this.options.linkClass}.${this.options.linkActiveClass}`);
+
+    if ($activeTab.length) {
+      this._collapseTab($activeTab);
+
+      /**
+      * Fires when the zplugin has successfully collapsed tabs.
+      * @event Tabs#collapse
+      */
+      this.$element.trigger('collapse.zf.tabs', [$activeTab]);
+    }
   }
 
   /**

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -131,7 +131,7 @@ class Tabs extends Plugin {
 
       if ($anchor && $link) {
         /**
-         * Fires when the zplugin has deeplinked at pageload
+         * Fires when the plugin has deeplinked at pageload
          * @event Tabs#deeplink
          */
         this.$element.trigger('deeplink.zf.tabs', [$link, $anchor]);
@@ -333,7 +333,7 @@ class Tabs extends Plugin {
       this._collapseTab($activeTab);
 
       /**
-      * Fires when the zplugin has successfully collapsed tabs.
+      * Fires when the plugin has successfully collapsed tabs.
       * @event Tabs#collapse
       */
       this.$element.trigger('collapse.zf.tabs', [$activeTab]);

--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -101,36 +101,38 @@ class Tabs extends Plugin {
       }
     }
 
-     //current context-bound function to open tabs on page load or history hashchange
+     // Current context-bound function to open tabs on page load or history hashchange
     this._checkDeepLink = () => {
       var anchor = window.location.hash;
 
-      // if there is no anchor, return to the initial tab
+      // If there is no anchor, return to the initial panel
       if (!anchor.length && this._initialAnchor) {
         anchor = this._initialAnchor;
       }
 
-      //need a hash and a relevant anchor in this tabset
-      if (anchor.length) {
-        var anchorNoHash = (anchor.indexOf('#') >= 0 ? anchor.slice(1) : anchor);
-        var $link = this.$element.find(`[href$="${anchor}"],[data-tabs-target="${anchorNoHash}"]`).first();
-        if ($link.length) {
-          this.selectTab($(anchor), true);
+      var anchorNoHash = anchor.indexOf('#') >= 0 ? anchor.slice(1) : anchor;
+      var $anchor = anchorNoHash && $(`#${anchorNoHash}`);
+      var $link = anchor && this.$element.find(`[href$="${anchor}"],[data-tabs-target="${anchorNoHash}"]`).first();
 
-          //roll up a little to show the titles
-          if (this.options.deepLinkSmudge) {
-            var offset = this.$element.offset();
-            $('html, body').animate({ scrollTop: offset.top }, this.options.deepLinkSmudgeDelay);
-          }
+      // If there is an anchor for the hash, select it
+      if ($anchor && $anchor.length && $link && $link.length) {
+        this.selectTab($anchor, true);
+      }
 
-          /**
-            * Fires when the zplugin has deeplinked at pageload
-            * @event Tabs#deeplink
-            */
-           this.$element.trigger('deeplink.zf.tabs', [$link, $(anchor)]);
-         }
-       }
-     }
+      // Roll up a little to show the titles
+      if (this.options.deepLinkSmudge) {
+        var offset = this.$element.offset();
+        $('html, body').animate({ scrollTop: offset.top }, this.options.deepLinkSmudgeDelay);
+      }
+
+      if ($anchor && $link) {
+        /**
+         * Fires when the zplugin has deeplinked at pageload
+         * @event Tabs#deeplink
+         */
+        this.$element.trigger('deeplink.zf.tabs', [$link, $anchor]);
+      }
+    }
 
     //use browser to open a tab, if it exists in this tabset
     if (this.options.deepLink) {
@@ -360,6 +362,7 @@ class Tabs extends Plugin {
 
     this._handleTabChange($target, historyHandled);
   };
+
   /**
    * Sets the height of each panel to the height of the tallest panel.
    * If enabled in options, gets called on media query change.


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

When deep-linking is enabled and the user goes back in the history up to when no hash is set, the active panel or tab does not change and is still the one that was selected the first.

This pull request make Accordion and Tabs displaying the panel or tab that was active at the component initialization.

### Changes:
- Save up the active panel/tab at Accordion/Tabs initialization (`_initialAnchor`)
- Display the initial panel/tab when the hash change to `""`.

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes https://github.com/zurb/foundation-sites/issues/11100
- Replaces [#11101 - feat: add class for active tab when no hash is set in Tabs ](https://github.com/zurb/foundation-sites/issues/11101) (@jamiechong)

## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- ~~I have updated the documentation accordingly to my changes (if relevant).~~
- ~~I have added tests to cover my changes (if relevant).~~


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
