### PR TITLE
Fix wrong responsive spacing prototype classes 

### DIFF
--- a/scss/prototype/_spacing.scss
+++ b/scss/prototype/_spacing.scss
@@ -160,10 +160,10 @@ $prototype-spacers-count: 3 !default;
                   // Top Side
                   &-#{$prop}-#{$dir}-#{$spacer} {
                     @if ($prop == margin) { 
-                      margin: $spacer; 
+                      @include margin-direction($dir, $spacer);
                     }
                     @else if ($prop == padding) { 
-                      padding: $spacer; 
+                      @include padding-direction($dir, $spacer);
                     }
                   }
                 }


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->
When `$prototype-spacing-breakpoints` is set to true, responsive prototype classes for **Spacing** are generated with wrong CSS declarations.
For example `.large-margin-left-1` is generated like:
```
.large-margin-left-1 {
    margin: 0;
}
```
but should be: 
```
.large-margin-left-1 {
    margin-left: $some-size;
}
```
<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes [#11236](https://github.com/zurb/foundation-sites/issues/11236)


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
