### PR TITLE
fix: clean SmoothScroll listeners on destroy

### DIFF
--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -50,7 +50,7 @@ class SmoothScroll extends Plugin {
      * @private
      */
     _handleLinkClick(e) {
-        // Follow the link it does not point to an anchor.
+        // Follow the link if it does not point to an anchor.
         if (!$(e.currentTarget).is('a[href^="#"]')) return;
 
         const arrival = e.currentTarget.getAttribute('href');

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -91,6 +91,15 @@ class SmoothScroll extends Plugin {
             }
         );
     }
+
+    /**
+     * Destroys the SmoothScroll instance.
+     * @function
+     */
+    _destroy() {
+        this.$element.off('click.zf.smoothScroll', this._handleLinkClick)
+        this.$element.off('click.zf.smoothScroll', 'a[href^="#"]', this._handleLinkClick);
+    }
 }
 
 /**

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import $ from 'jquery';
 import { GetYoDigits } from './foundation.core.utils';
 import { Plugin } from './foundation.core.plugin';
@@ -30,11 +28,8 @@ class SmoothScroll extends Plugin {
      * @private
      */
     _init() {
-        var id = this.$element[0].id || GetYoDigits(6, 'smooth-scroll');
-        var _this = this;
-        this.$element.attr({
-            'id': id
-        });
+        const id = this.$element[0].id || GetYoDigits(6, 'smooth-scroll');
+        this.$element.attr({ id });
 
         this._events();
     }
@@ -44,19 +39,16 @@ class SmoothScroll extends Plugin {
      * @private
      */
     _events() {
-        var _this = this;
-
-        // click handler function.
-        var handleLinkClick = function(e) {
+        const handleLinkClick = (e) => {
             // Follow the link it does not point to an anchor.
-            if (!$(this).is('a[href^="#"]')) return;
+            if (!$(e.currentTarget).is('a[href^="#"]')) return;
 
-            var arrival = this.getAttribute('href');
+            const arrival = e.currentTarget.getAttribute('href');
 
-            _this._inTransition = true;
+            this._inTransition = true;
 
-            SmoothScroll.scrollToLoc(arrival, _this.options, function() {
-                _this._inTransition = false;
+            SmoothScroll.scrollToLoc(arrival, this.options, () => {
+                this._inTransition = false;
             });
 
             e.preventDefault();
@@ -75,19 +67,19 @@ class SmoothScroll extends Plugin {
      * @function
      */
     static scrollToLoc(loc, options = SmoothScroll.defaults, callback) {
-        // Do nothing if target does not exist to prevent errors
-        if (!$(loc).length) {
-            return false;
-        }
+        const $loc = $(loc);
 
-        var scrollPos = Math.round($(loc).offset().top - options.threshold / 2 - options.offset);
+        // Do nothing if target does not exist to prevent errors
+        if (!$loc.length) return false;
+
+        var scrollPos = Math.round($loc.offset().top - options.threshold / 2 - options.offset);
 
         $('html, body').stop(true).animate(
             { scrollTop: scrollPos },
             options.animationDuration,
             options.animationEasing,
-            function() {
-                if(callback && typeof callback == "function"){
+            () => {
+                if (typeof callback === 'function'){
                     callback();
                 }
             }

--- a/js/foundation.smoothScroll.js
+++ b/js/foundation.smoothScroll.js
@@ -39,24 +39,30 @@ class SmoothScroll extends Plugin {
      * @private
      */
     _events() {
-        const handleLinkClick = (e) => {
-            // Follow the link it does not point to an anchor.
-            if (!$(e.currentTarget).is('a[href^="#"]')) return;
-
-            const arrival = e.currentTarget.getAttribute('href');
-
-            this._inTransition = true;
-
-            SmoothScroll.scrollToLoc(arrival, this.options, () => {
-                this._inTransition = false;
-            });
-
-            e.preventDefault();
-        };
-
-        this.$element.on('click.zf.smoothScroll', handleLinkClick)
-        this.$element.on('click.zf.smoothScroll', 'a[href^="#"]', handleLinkClick);
+        this.$element.on('click.zf.smoothScroll', this._handleLinkClick)
+        this.$element.on('click.zf.smoothScroll', 'a[href^="#"]', this._handleLinkClick);
     }
+
+    /**
+     * Handle the given event to smoothly scroll to the anchor pointed by the event target.
+     * @param {*} e - event
+     * @function
+     * @private
+     */
+    _handleLinkClick(e) {
+        // Follow the link it does not point to an anchor.
+        if (!$(e.currentTarget).is('a[href^="#"]')) return;
+
+        const arrival = e.currentTarget.getAttribute('href');
+
+        this._inTransition = true;
+
+        SmoothScroll.scrollToLoc(arrival, this.options, () => {
+            this._inTransition = false;
+        });
+
+        e.preventDefault();
+    };
 
     /**
      * Function to scroll to a given location on the page.


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

Remove `SmoothScroll` click event listeners (to scroll the the pointed event) on destroy.

### Others changes:
* Use ES6 features in `SmoothScroll`
* Fix various linting issues in `SmoothScroll`
* Move `SmoothScroll` click event handling to its own method
* Fix typo in the `SmoothScroll` click handler


<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
Related to https://github.com/zurb/foundation-sites/pull/11516

## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [x] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- ~~I have updated the documentation accordingly to my changes (if relevant).~~
- ~~I have added tests to cover my changes (if relevant).~~


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
