### PR TITLE
fix: ensure Dropdown aria-labelledby to have an ID #11572

### DIFF
--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -68,16 +68,20 @@ class Dropdown extends Positionable {
       this.$parent = null;
     }
 
-    // Do not change the `labelledby` if it is defined
-    var labelledby = this.$element.attr('aria-labelledby')
-      || this.$currentAnchor.attr('id')
-      || GetYoDigits(6, 'dd-anchor');
+    // Set [aria-describedby] on the Dropdown if it is not set
+    if (typeof this.$element.attr('aria-describedby') === 'undefined') {
+      // Get the anchor ID or create one
+      if (typeof this.$currentAnchor.attr('id') === 'undefined') {
+        this.$currentAnchor.attr('id', GetYoDigits(6, 'dd-anchor'));
+      };
+
+      this.$element.attr('aria-labelledby', this.$currentAnchor.attr('id'));
+    }
 
     this.$element.attr({
       'aria-hidden': 'true',
       'data-yeti-box': $id,
       'data-resize': $id,
-      'aria-labelledby': labelledby
     });
 
     super._init();

--- a/js/foundation.dropdown.js
+++ b/js/foundation.dropdown.js
@@ -68,8 +68,8 @@ class Dropdown extends Positionable {
       this.$parent = null;
     }
 
-    // Set [aria-describedby] on the Dropdown if it is not set
-    if (typeof this.$element.attr('aria-describedby') === 'undefined') {
+    // Set [aria-labelledby] on the Dropdown if it is not set
+    if (typeof this.$element.attr('aria-labelledby') === 'undefined') {
       // Get the anchor ID or create one
       if (typeof this.$currentAnchor.attr('id') === 'undefined') {
         this.$currentAnchor.attr('id', GetYoDigits(6, 'dd-anchor'));


### PR DESCRIPTION
Closes https://github.com/zurb/foundation-sites/issues/11572

<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

Currently, Dropdown generate a random id for `aria-labelledby` if it is not set to target the anchor. But the anchor id is never set.

This pull request fix this by setting the anchor id with the generated one if the anchor doens't have an ID already.

Closes https://github.com/zurb/foundation-sites/issues/11572

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- ~~I have updated the documentation accordingly to my changes (if relevant).~~
- ~~I have added tests to cover my changes (if relevant).~~


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
