### PR TITLE
feat: dynamically generate Close Button sizes from "$closebutton-size"

### DIFF
--- a/scss/components/_close-button.scss
+++ b/scss/components/_close-button.scss
@@ -16,7 +16,9 @@ $closebutton-z-index: 10 !default;
 
 /// Button size to use as default
 /// @type String
-/// @see $closebutton-size, $closebutton-offset-horizontal, $closebutton-offset-vertical
+/// @see $closebutton-size
+/// @see $closebutton-offset-horizontal
+/// @see $closebutton-offset-vertical
 $closebutton-default-size: medium !default;
 
 /// Right (or left) offset(s) for a close button.

--- a/scss/components/_close-button.scss
+++ b/scss/components/_close-button.scss
@@ -14,6 +14,11 @@ $closebutton-position: right top !default;
 /// @type Number
 $closebutton-z-index: 10 !default;
 
+/// Button size to use as default
+/// @type String
+/// @see $closebutton-size, $closebutton-offset-horizontal, $closebutton-offset-vertical
+$closebutton-default-size: medium !default;
+
 /// Right (or left) offset(s) for a close button.
 /// @type Number|Map
 $closebutton-offset-horizontal: (
@@ -28,7 +33,7 @@ $closebutton-offset-vertical: (
   medium: 0.5rem,
 ) !default;
 
-/// Default font size(s) of the close button.
+/// Size(s) of the close button. Used to generate sizing modifiers.
 /// @type Number|Map
 $closebutton-size: (
   small: 1.5em,
@@ -101,7 +106,20 @@ $closebutton-color-hover: $black !default;
   .close-button {
     @include close-button;
 
-    &.small { @include close-button-size(small) }
-    &, &.medium { @include close-button-size(medium) }
+    // Generate a placeholder and a class for each size
+    @each $name, $size in $closebutton-size {
+      @at-root {
+        %zf-close-button--#{$name} {
+          @include close-button-size($name);
+        }
+      }
+
+      &.#{$name} {
+        @extend %zf-close-button--#{$name};
+      }
+    }
+
+    // Use by default the placeholder of the default size
+    @extend %zf-close-button--#{$closebutton-default-size};
   }
 }


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

Make the Close Button sizing modifiers (`small`, `medium`...) dynamically generated from the `$closebutton-size` map.

### Changes
- Use `$closebutton-size` to generate placeholders and classes.
- Add `$closebutton-default-size` to indicate in the `$closebutton-size` map the size to use by default.

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes https://github.com/zurb/foundation-sites/issues/11569


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- ~~I have added tests to cover my changes (if relevant).~~


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
