### PR TITLE
 fix: clear "is-active" class when menu is closed in AccordionMenu 

### DIFF
--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -272,7 +272,7 @@ class AccordionMenu extends Plugin {
       _this.$element.trigger('up.zf.accordionMenu', [$target]);
     });
 
-    var $menus = $target.find('[data-submenu]').slideUp(0).addBack().attr('aria-hidden', true);
+    var $menus = $target.find('[data-submenu]').slideUp(0).addBack().removeClass('is-active').attr('aria-hidden', true);
 
     if(this.options.submenuToggle) {
       $menus.prev('.submenu-toggle').attr('aria-expanded', false);

--- a/js/foundation.accordionMenu.js
+++ b/js/foundation.accordionMenu.js
@@ -233,13 +233,13 @@ class AccordionMenu extends Plugin {
    * @fires AccordionMenu#down
    */
   down($target) {
-    var _this = this;
-
     if(!this.options.multiOpen) {
       this.up(this.$element.find('.is-active').not($target.parentsUntil(this.$element).add($target)));
     }
 
-    $target.addClass('is-active').attr({'aria-hidden': false});
+    $target
+      .addClass('is-active')
+      .attr({ 'aria-hidden': false });
 
     if(this.options.submenuToggle) {
       $target.prev('.submenu-toggle').attr({'aria-expanded': true});
@@ -248,12 +248,12 @@ class AccordionMenu extends Plugin {
       $target.parent('.is-accordion-submenu-parent').attr({'aria-expanded': true});
     }
 
-    $target.slideDown(_this.options.slideSpeed, function () {
+    $target.slideDown(this.options.slideSpeed, () => {
       /**
        * Fires when the menu is done opening.
        * @event AccordionMenu#down
        */
-      _this.$element.trigger('down.zf.accordionMenu', [$target]);
+      this.$element.trigger('down.zf.accordionMenu', [$target]);
     });
   }
 
@@ -263,23 +263,28 @@ class AccordionMenu extends Plugin {
    * @fires AccordionMenu#up
    */
   up($target) {
-    var _this = this;
-    $target.slideUp(_this.options.slideSpeed, function () {
+    const $submenus = $target.find('[data-submenu]');
+    const $allmenus = $target.add($submenus);
+
+    $submenus.slideUp(0);
+    $allmenus
+      .removeClass('is-active')
+      .attr('aria-hidden', true);
+
+    if(this.options.submenuToggle) {
+      $allmenus.prev('.submenu-toggle').attr('aria-expanded', false);
+    }
+    else {
+      $allmenus.parent('.is-accordion-submenu-parent').attr('aria-expanded', false);
+    }
+
+    $target.slideUp(this.options.slideSpeed, () => {
       /**
        * Fires when the menu is done collapsing up.
        * @event AccordionMenu#up
        */
-      _this.$element.trigger('up.zf.accordionMenu', [$target]);
+      this.$element.trigger('up.zf.accordionMenu', [$target]);
     });
-
-    var $menus = $target.find('[data-submenu]').slideUp(0).addBack().removeClass('is-active').attr('aria-hidden', true);
-
-    if(this.options.submenuToggle) {
-      $menus.prev('.submenu-toggle').attr('aria-expanded', false);
-    }
-    else {
-      $menus.parent('.is-accordion-submenu-parent').attr('aria-expanded', false);
-    }
   }
 
   /**

--- a/test/javascript/components/accordionMenu.js
+++ b/test/javascript/components/accordionMenu.js
@@ -43,18 +43,24 @@ describe('Accordion Menu', function() {
       plugin.options.should.be.an('object');
     });
   });
-  
+
   describe('up()', function() {
     it('closes the targeted submenu', function(done) {
       $html = $(template).appendTo('body');
       plugin = new Foundation.AccordionMenu($html);
+      const $submenu = $html.find('.is-accordion-submenu').eq(0);
 
       // Open it first
-      plugin.down($html.find('.is-accordion-submenu').eq(0));
-      
-      plugin.up($html.find('.is-accordion-submenu').eq(0));
+      plugin.down($submenu);
+
+      plugin.up($submenu);
+
       setTimeout(() => {
-        $html.find('.is-accordion-submenu').eq(0).should.be.hidden;
+        // Should be hidden
+        $submenu.should.be.hidden;
+        // Should have attributes updated and without active classe
+        $submenu.should.have.attr('aria-hidden', 'true');
+        $submenu.should.not.have.class('is-active');
         done();
       }, 1);
     });
@@ -89,9 +95,15 @@ describe('Accordion Menu', function() {
     it('opens the targeted submenu', function() {
       $html = $(template).appendTo('body');
       plugin = new Foundation.AccordionMenu($html, {});
+      const $submenu = $html.find('.is-accordion-submenu').eq(0);
 
-      plugin.down($html.find('.is-accordion-submenu').eq(0));
-      $html.find('.is-accordion-submenu').eq(0).should.be.visible;
+      plugin.down($submenu);
+
+      // Should be visible
+      $submenu.should.be.visible;
+      // Should have attributes updated and with an active classe
+      $submenu.should.have.attr('aria-hidden', 'false');
+      $submenu.should.have.class('is-active');
     });
 
     it('toggles attributes of title of the targeted submenu', function() {
@@ -108,7 +120,7 @@ describe('Accordion Menu', function() {
 
       // Open another one first
       plugin.down($html.find('.is-accordion-submenu').eq(0));
-      
+
       plugin.down($html.find('.is-accordion-submenu').eq(2));
       $html.find('.is-accordion-submenu').eq(0).should.be.hidden;
     });
@@ -119,7 +131,7 @@ describe('Accordion Menu', function() {
 
       // Open another one first
       plugin.down($html.find('.is-accordion-submenu').eq(0));
-      
+
       plugin.down($html.find('.is-accordion-submenu').eq(2));
       $html.find('.is-accordion-submenu').eq(0).should.be.visible;
     });


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

### Changes
- Remove the `is-active` class when the AccordionMenu menu is closed
- Add tests to check aria attributes & class when AccordionMenu is opened/closed
- Simplify AccordionMenu `up()` and `down()` methods



<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes https://github.com/zurb/foundation-sites/issues/11383


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- ~~I have updated the documentation accordingly to my changes (if relevant).~~
- [x] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
