### PR TITLE
fix: set tabindex to 0 for all tabs to make them accessible

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -66,7 +66,7 @@ class Tabs extends Plugin {
         'aria-controls': hash,
         'aria-selected': isActive,
         'id': linkId,
-        'tabindex': isActive ? '0' : '-1'
+        'tabindex': '0'
       });
 
       $tabContent.attr({
@@ -319,7 +319,7 @@ class Tabs extends Plugin {
       .find('[role="tab"]')
       .attr({
         'aria-selected': 'false',
-        'tabindex': -1
+        'tabindex': '0'
       });
 
     $(`#${$target_anchor.attr('aria-controls')}`)


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

Currently the tabs plugin sets inactive tabs to a tabindex with the value `-1` but it should be always `0`.

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes https://github.com/zurb/foundation-sites/issues/11590


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [ ] I have read and follow the CONTRIBUTING.md document.
- [ ] The pull request title and template are correctly filled.
- [ ] The pull request targets the right branch (`develop` or `develop-v...`).
- [ ] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
