### PR TITLE
fix: 'small' no longer hard coded as zero breakpoint in xy-grid classes mixins

### DIFF
--- a/scss/xy-grid/_classes.scss
+++ b/scss/xy-grid/_classes.scss
@@ -68,7 +68,7 @@
 
   @include -zf-each-breakpoint() {
     // Responsive "auto" modifier
-    @if not($-zf-size == small) {
+    @if not($-zf-size == $-zf-zero-breakpoint) {
       .grid-x > .#{$-zf-size}-auto {
         @include xy-cell(auto, $gutter-type: none);
       }
@@ -79,7 +79,7 @@
     }
 
     // Responsive "shrink" modifier
-    @if not($-zf-size == small) {
+    @if not($-zf-size == $-zf-zero-breakpoint) {
       .grid-x > .#{$-zf-size}-shrink {
         @extend %-xy-cell-base-shrink-horizontal-#{$-zf-size};
         @include xy-cell-size(shrink, $gutter-type: none);
@@ -267,7 +267,7 @@
 ) {
 
   @include -zf-each-breakpoint() {
-    @if not($-zf-size == small) {
+    @if not($-zf-size == $-zf-zero-breakpoint) {
     }
   }
 
@@ -304,7 +304,7 @@
 
     @include -zf-each-breakpoint() {
       // Responsive "auto" modifier
-      @if not($-zf-size == small) {
+      @if not($-zf-size == $-zf-zero-breakpoint) {
         > .#{$-zf-size}-auto {
           @include xy-cell(auto, $gutter-type: none, $vertical: true);
         }
@@ -315,7 +315,7 @@
       }
 
       // Responsive "shrink" modifier
-      @if not($-zf-size == small) {
+      @if not($-zf-size == $-zf-zero-breakpoint) {
         > .#{$-zf-size}-shrink {
           @extend %-xy-cell-base-shrink-vertical-#{$-zf-size};
           @include xy-cell-size(shrink, $gutter-type: none, $vertical: true);


### PR DESCRIPTION
## Description
When 'small' is no longer your zero breakpoint in your settings, .small-auto and .small-shrink did not get properly set up as 'small' was hard coded as the zero breakpoint.

This pull request replaces the hard coded 'small' with the $-zf-zero-breakpoint value.

## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
