### PR TITLE
fix(accordion): adds role="presentation" to accordion items #11659

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -44,6 +44,8 @@ class Accordion extends Plugin {
 
     this.$element.attr('role', 'tablist');
     this.$tabs = this.$element.children('[data-accordion-item]');
+    
+    this.$tabs.attr({'role': 'presentation'});
 
     this.$tabs.each(function(idx, el) {
       var $el = $(el),

--- a/test/javascript/components/accordion.js
+++ b/test/javascript/components/accordion.js
@@ -39,6 +39,13 @@ describe('Accordion', function() {
       plugin.$element.should.be.an('object');
       plugin.options.should.be.an('object');
     });
+
+    it('applies role="presentation" to the list item to conform with WAI', function () {
+      $html = $(template).appendTo('body');
+      plugin = new Foundation.Accordion($html, {allowAllClosed: true});
+
+      $html.find('.accordion-item').eq(0).should.have.attr('role', 'presentation');
+    });
   });
 
   describe('up()', function(done) {


### PR DESCRIPTION
Adds `role="presentation"` to accordion items to comply with WAI. Includes the respective unit test.

fix #11659

<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->
Adds `role="presentation"` to the accordion items as outlined in #11659.
Includes a test within the accordion constructor describe group, it was placed within this group as it's not functionally related to any other describe group.
...

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes #11659 


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
