### PR TITLE
[WIP]  fix fouc for drilldown menus #11770

### DIFF
--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -91,6 +91,10 @@ $drilldown-arrow-size: 6px !default;
       background: $drilldown-background;
     }
 
+    .no-js & ul {
+      display: none;
+    }
+
     // Applied to submenu <ul>s
     .is-drilldown-submenu {
       position: absolute;


### PR DESCRIPTION
The .no-js fix for preventing FOUC in other components doesn't seem to have been applied to the drilldown component. This results in FOUC for drilldown sub-menus. This applies the .no-js fix to child menus of the drilldown component to prevent the FOUC.

<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

I added the `.no-js` FOUC fix to target the child menus of the drilldown component.

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes #11770 


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [X] I have read and follow the CONTRIBUTING.md document.
- [X] The pull request title and template are correctly filled.
- [X] The pull request targets the right branch (`develop` or `develop-v...`).
- [X] My commits are correctly titled and contain all relevant information.
- [X] I have updated the documentation accordingly to my changes (if relevant).
- [X] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
