### PR TITLE
fix: close reveal only on click-event starting outside modal

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -7,7 +7,7 @@ import { Keyboard } from './foundation.util.keyboard';
 import { MediaQuery } from './foundation.util.mediaQuery';
 import { Motion } from './foundation.util.motion';
 import { Triggers } from './foundation.util.triggers';
-import { Touch } from './foundation.util.touch'
+import { Touch } from './foundation.util.touch';
 
 /**
  * Reveal module.
@@ -163,7 +163,7 @@ class Reveal extends Plugin {
     });
 
     if (this.options.closeOnClick && this.options.overlay) {
-      this.$overlay.off('.zf.reveal').on('click.zf.dropdown tap.zf.dropdown', function(e) {
+      this.$overlay.off('.zf.reveal').on('mousedown.zf.reveal', function(e) {
         if (e.target === _this.$element[0] ||
           $.contains(_this.$element[0], e.target) ||
             !$.contains(document, e.target)) {

--- a/test/javascript/components/reveal.js
+++ b/test/javascript/components/reveal.js
@@ -377,7 +377,7 @@ describe('Reveal', function() {
       	done();
       });
 
-      plugin.$overlay.trigger('click');
+      plugin.$overlay.trigger('mousedown');
     });
     it('not closes a modal on overlay click if closeOnClick option is true', function(done) {
       $html = $(template).appendTo('body');


### PR DESCRIPTION
## Description

This pr changes the `_events` binding on the `reveal` component to use the `mousedown` jQuery event instead of the `click` jQuery event so that modals don't close unless a click event begins outside of a the modal area, fixing the issue linked below.

- Closes https://github.com/zurb/foundation-sites/issues/11789


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document
              Thank you for your pull request and happy coding ;)
------------------------------------------------------------------------------->
