### PR TITLE
Fix/responsive accordion tabs initial methods

### DIFF
--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -156,8 +156,8 @@ var Foundation = {
       // For each plugin found, initialize it
       $elem.each(function() {
         var $el = $(this),
-            opts = {};
-            
+            opts = { reflow: true };
+
         if($el.attr('data-options')){
           var thing = $el.attr('data-options').split(';').forEach(function(e, i){
             var opt = e.split(':').map(function(el){ return el.trim(); });

--- a/js/foundation.responsiveAccordionTabs.js
+++ b/js/foundation.responsiveAccordionTabs.js
@@ -36,6 +36,11 @@ var MenuPlugins = {
  */
 
 class ResponsiveAccordionTabs extends Plugin{
+  constructor(element, options) {
+    super(element, options);
+    return this.storezfData || this;
+  }
+
   /**
    * Creates a new instance of a responsive accordion tabs.
    * @class

--- a/js/foundation.responsiveAccordionTabs.js
+++ b/js/foundation.responsiveAccordionTabs.js
@@ -38,7 +38,7 @@ var MenuPlugins = {
 class ResponsiveAccordionTabs extends Plugin{
   constructor(element, options) {
     super(element, options);
-    return this.storezfData || this;
+    return this.options.reflow && this.storezfData || this;
   }
 
   /**


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

The Responsive Accordion Tabs plugin is special because (in contrast to all other foundation plugins) it changes its data zfPlugin attribute into another plugin (either Accordion or Tabs).

Foundation's core doesn't consider this and executes the `reflow` method for each new plugin instance:
https://github.com/foundation/foundation-sites/blob/develop/js/foundation.core.js#L168

So the responsive accordion tabs plugin initially sets the correct zfData but gets overriden by reflow. As a result the transformed plugin's method (e.g. `down` for accordion) are initially not available when calling it programmatically.

My PR fixes this by returning the instance stored in zfData (instead of the ResponsiveAccordionTabs instance).

I've bound this new behavior to a `reflow` option so there's no breaking change and people who use `new Foundation.ResponsiveAccordionTabs()` still get the same result.

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes #11884


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
