### PR TITLE
feat: add zfPluginBase attribute to responsive accordion tabs

### DIFF
--- a/js/foundation.responsiveAccordionTabs.js
+++ b/js/foundation.responsiveAccordionTabs.js
@@ -51,7 +51,7 @@ class ResponsiveAccordionTabs extends Plugin{
    */
   _setup(element, options) {
     this.$element = $(element);
-    this.$element.data('zfPluginBase');
+    this.$element.data('zfPluginBase', this);
     this.options = $.extend({}, ResponsiveAccordionTabs.defaults, this.$element.data(), options);
 
     this.rules = this.$element.data('responsive-accordion-tabs');

--- a/js/foundation.responsiveAccordionTabs.js
+++ b/js/foundation.responsiveAccordionTabs.js
@@ -51,6 +51,7 @@ class ResponsiveAccordionTabs extends Plugin{
    */
   _setup(element, options) {
     this.$element = $(element);
+    this.$element.data('zfPluginBase');
     this.options = $.extend({}, ResponsiveAccordionTabs.defaults, this.$element.data(), options);
 
     this.rules = this.$element.data('responsive-accordion-tabs');


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

This PR adds an additional attribute that provides the only way to access the real plugin instance (ResponsiveAccordionTabs, not Accordion/Tabs) if you haven't used the constructor (`new Foundation.ResponsiveAccordionTabs()`) but something as `$(document).foundation()`

The new attribute lets you e.g. destroy the real instance by doing
```javascript
$(elem).data('zfPluginBase').destroy()
```
what destroys the actual ResponsiveAccordionTabs instance (instead of only the emulated Accordion/Tabs instance)

I haven't add any documentation about this change because I noticed the usage of `$(elem).data('zfPlugin')` isn't documented anywhere either.
Not sure if it was originally meant to be only used internally. However if we do wanna document it we should probably document `zfPlugin` as well (as separate docs PR)

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes https://github.com/foundation/foundation-sites/issues/11905


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
