### PR TITLE
Prevent keyboard trap in drilldown subnav

### DIFF
--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -38,8 +38,6 @@ class Drilldown extends Plugin {
       'ARROW_DOWN': 'down',
       'ARROW_LEFT': 'previous',
       'ESCAPE': 'close',
-      'TAB': 'down',
-      'SHIFT_TAB': 'up'
     });
   }
 
@@ -243,16 +241,6 @@ class Drilldown extends Plugin {
             }, 1);
           });
           return true;
-        },
-        up: function() {
-          $prevElement.focus();
-          // Don't tap focus on first element in root ul
-          return !$element.is(_this.$element.find('> li:first-child > a'));
-        },
-        down: function() {
-          $nextElement.focus();
-          // Don't tap focus on last element in root ul
-          return !$element.is(_this.$element.find('> li:last-child > a'));
         },
         close: function() {
           // Don't close on element in root ul

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -210,18 +210,7 @@ class Drilldown extends Plugin {
     var _this = this;
 
     this.$menuItems.add(this.$element.find('.js-drilldown-back > a, .is-submenu-parent-item > a')).on('keydown.zf.drilldown', function(e){
-      var $element = $(this),
-          $elements = $element.parent('li').parent('ul').children('li').children('a'),
-          $prevElement,
-          $nextElement;
-
-      $elements.each(function(i) {
-        if ($(this).is($element)) {
-          $prevElement = $elements.eq(Math.max(0, i-1));
-          $nextElement = $elements.eq(Math.min(i+1, $elements.length-1));
-          return;
-        }
-      });
+      var $element = $(this);
 
       Keyboard.handleKey(e, 'Drilldown', {
         next: function() {

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -149,26 +149,26 @@ class Drilldown extends Plugin {
     var _this = this;
 
     $elem.off('click.zf.drilldown')
-    .on('click.zf.drilldown', function(e){
-      if($(e.target).parentsUntil('ul', 'li').hasClass('is-drilldown-submenu-parent')){
-        e.preventDefault();
-      }
+         .on('click.zf.drilldown', function(e){
+           if($(e.target).parentsUntil('ul', 'li').hasClass('is-drilldown-submenu-parent')){
+             e.preventDefault();
+           }
 
-      // if(e.target !== e.currentTarget.firstElementChild){
-      //   return false;
-      // }
-      _this._show($elem.parent('li'));
+           // if(e.target !== e.currentTarget.firstElementChild){
+           //   return false;
+           // }
+           _this._show($elem.parent('li'));
 
-      if(_this.options.closeOnClick){
-        var $body = $('body');
-        $body.off('.zf.drilldown').on('click.zf.drilldown', function(e){
-          if (e.target === _this.$element[0] || $.contains(_this.$element[0], e.target)) { return; }
-          e.preventDefault();
-          _this._hideAll();
-          $body.off('.zf.drilldown');
-        });
-      }
-    });
+           if(_this.options.closeOnClick){
+             var $body = $('body');
+             $body.off('.zf.drilldown').on('click.zf.drilldown', function(e){
+               if (e.target === _this.$element[0] || $.contains(_this.$element[0], e.target)) { return; }
+               e.preventDefault();
+               _this._hideAll();
+               $body.off('.zf.drilldown');
+             });
+           }
+         });
   }
 
   /**
@@ -195,9 +195,9 @@ class Drilldown extends Plugin {
         scrollPos = parseInt($scrollTopElement.offset().top+_this.options.scrollTopOffset, 10);
     $('html, body').stop(true).animate({ scrollTop: scrollPos }, _this.options.animationDuration, _this.options.animationEasing,function(){
       /**
-        * Fires after the menu has scrolled
-        * @event Drilldown#scrollme
-        */
+       * Fires after the menu has scrolled
+       * @event Drilldown#scrollme
+       */
       if(this===$('html')[0])_this.$element.trigger('scrollme.zf.drilldown');
     });
   }
@@ -319,16 +319,16 @@ class Drilldown extends Plugin {
     var _this = this;
     $elem.off('click.zf.drilldown');
     $elem.children('.js-drilldown-back')
-      .on('click.zf.drilldown', function(e){
-        // console.log('mouseup on back');
-        _this._hide($elem);
+         .on('click.zf.drilldown', function(e){
+           // console.log('mouseup on back');
+           _this._hide($elem);
 
-        // If there is a parent submenu, call show
-        let parentSubMenu = $elem.parent('li').parent('ul').parent('li');
-        if (parentSubMenu.length) {
-          _this._show(parentSubMenu);
-        }
-      });
+           // If there is a parent submenu, call show
+           let parentSubMenu = $elem.parent('li').parent('ul').parent('li');
+           if (parentSubMenu.length) {
+             _this._show(parentSubMenu);
+           }
+         });
   }
 
   /**
@@ -344,7 +344,7 @@ class Drilldown extends Plugin {
           setTimeout(function(){
             _this._hideAll();
           }, 0);
-      });
+        });
   }
 
   /**
@@ -444,7 +444,13 @@ class Drilldown extends Plugin {
     $elem.attr('aria-expanded', true);
 
     this.$currentMenu = $submenu;
-    $submenu.addClass('is-active').removeClass('invisible').attr('aria-hidden', false);
+
+    //hide drilldown parent menu when submenu is open
+    // this removes it from the dom so that the tab key will take the user to the next visible element
+    $elem.parent().closest('ul').addClass('invisible');
+
+    // add visible class to submenu to override invisible class above
+    $submenu.addClass('is-active visible').removeClass('invisible').attr('aria-hidden', false);
     if (this.options.autoHeight) {
       this.$wrapper.css({ height: $submenu.data('calcHeight') });
     }
@@ -465,11 +471,14 @@ class Drilldown extends Plugin {
   _hide($elem) {
     if(this.options.autoHeight) this.$wrapper.css({height:$elem.parent().closest('ul').data('calcHeight')});
     var _this = this;
+
+    $elem.parent().closest('ul').removeClass('invisible');
+
     $elem.parent('li').attr('aria-expanded', false);
     $elem.attr('aria-hidden', true);
     $elem.addClass('is-closing')
          .one(transitionend($elem), function(){
-           $elem.removeClass('is-active is-closing');
+           $elem.removeClass('is-active is-closing visible');
            $elem.blur().addClass('invisible');
          });
     /**
@@ -517,12 +526,12 @@ class Drilldown extends Plugin {
   _destroy() {
     if(this.options.scrollTop) this.$element.off('.zf.drilldown',this._bindHandler);
     this._hideAll();
-	  this.$element.off('mutateme.zf.trigger');
+    this.$element.off('mutateme.zf.trigger');
     Nest.Burn(this.$element, 'drilldown');
     this.$element.unwrap()
-                 .find('.js-drilldown-back, .is-submenu-parent-item').remove()
-                 .end().find('.is-active, .is-closing, .is-drilldown-submenu').removeClass('is-active is-closing is-drilldown-submenu')
-                 .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role');
+        .find('.js-drilldown-back, .is-submenu-parent-item').remove()
+        .end().find('.is-active, .is-closing, .is-drilldown-submenu').removeClass('is-active is-closing is-drilldown-submenu')
+        .end().find('[data-submenu]').removeAttr('aria-hidden tabindex role');
     this.$submenuAnchors.each(function() {
       $(this).off('.zf.drilldown');
     });

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -210,7 +210,18 @@ class Drilldown extends Plugin {
     var _this = this;
 
     this.$menuItems.add(this.$element.find('.js-drilldown-back > a, .is-submenu-parent-item > a')).on('keydown.zf.drilldown', function(e){
-      var $element = $(this);
+      var $element = $(this),
+        $elements = $element.parent('li').parent('ul').children('li').children('a'),
+        $prevElement,
+        $nextElement;
+
+      $elements.each(function(i) {
+        if ($(this).is($element)) {
+          $prevElement = $elements.eq(Math.max(0, i-1));
+          $nextElement = $elements.eq(Math.min(i+1, $elements.length-1));
+          return;
+        }
+      });
 
       Keyboard.handleKey(e, 'Drilldown', {
         next: function() {
@@ -230,6 +241,16 @@ class Drilldown extends Plugin {
             }, 1);
           });
           return true;
+        },
+        up: function() {
+          $prevElement.focus();
+          // Don't tap focus on first element in root ul
+          return !$element.is(_this.$element.find('> li:first-child > a'));
+        },
+        down: function() {
+          $nextElement.focus();
+          // Don't tap focus on last element in root ul
+          return !$element.is(_this.$element.find('> li:last-child > a'));
         },
         close: function() {
           // Don't close on element in root ul

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-sites",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation-sites",
-  "version": "6.6.1",
+  "version": "6.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -70,6 +70,10 @@
     visibility: hidden;
   }
 
+  .visible {
+    visibility: visible !important;
+  }
+
   // Responsive visibility classes
   @each $size in $breakpoint-classes {
     @if $size != $-zf-zero-breakpoint {

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -71,7 +71,7 @@
   }
 
   .visible {
-    visibility: visible !important;
+    visibility: visible;
   }
 
   // Responsive visibility classes

--- a/test/javascript/components/drilldown.js
+++ b/test/javascript/components/drilldown.js
@@ -339,24 +339,6 @@ describe('Drilldown Menu', function() {
 
       $html.find('> li:nth-child(1) > ul').should.have.class('is-closing');
     });
-    it('moves focus to next element on TAB', function() {
-      $html = $(template).appendTo('body');
-      plugin = new Foundation.Drilldown($html, {});
-
-      $html.find('> li:nth-child(1) > a').focus()
-        .trigger(window.mockKeyboardEvent('TAB'));
-
-      document.activeElement.should.be.equal($html.find('> li:nth-child(2) > a')[0]);
-    });
-    it('moves focus to previous element on TAB', function() {
-      $html = $(template).appendTo('body');
-      plugin = new Foundation.Drilldown($html, {});
-
-      $html.find('> li:nth-child(2) > a').focus()
-        .trigger(window.mockKeyboardEvent('TAB', {shift: true}));
-
-      document.activeElement.should.be.equal($html.find('> li:nth-child(1) > a')[0]);
-    });
     it('moves focus to next element on ARROW_DOWN', function() {
       $html = $(template).appendTo('body');
       plugin = new Foundation.Drilldown($html, {});


### PR DESCRIPTION
I have created a new pull request from my personal Github account. It is required that a pull request be opened from a personal account in order to allow edits from maintainers. The original pull request was opened from the utulsa team account.

This replaces https://github.com/foundation/foundation-sites/pull/12025

## Description
1. Remove TAB/SHIFT_TAB from script to allow browser to manage tabbing
While the tab key moves focus appropriately in the dom order within this component. The focus is not visually discernible when the subnav is opened. Since the method to move back up within the dom tree is present via arrow keys and the link at the top of the subnav, I agree with the solution that was proposed in #11641
Broad information about keyboard best practice can be found here: https://www.w3.org/TR/wai-aria-practices/#kbd_generalnav
2. Set root ul visibility:hidden and set subnav to visibility:visible when subnav is open

This will remove it from the dom allowing the user to tab into the next component/area when the subnav is open/visible

Add .visible class for use in drilldown subnav when opened.
These changes are recommented by https://github.com/ntdonley in #11641

...

- Closes https://github.com/foundation/foundation-sites/issues/11641


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [X] I have read and follow the CONTRIBUTING.md document.
- [X] The pull request title and template are correctly filled.
- [X] The pull request targets the right branch (`develop` or `develop-v...`).
- [X] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
