### PR TITLE
Feat (Abide):  Immediate Feedback - #12058

### DIFF
--- a/docs/pages/abide.md
+++ b/docs/pages/abide.md
@@ -229,6 +229,23 @@ attribute, for example:
 </form>
 ```
 
+## Immediate Feedback
+
+When you need to show an input as being in an error state immediately, add the `[data-abide-has-error]` attribute to the input.
+Add `is-visible` class to the Form Error to show the error text.
+
+```html
+<form data-abide novalidate>
+  <label>
+    Email
+    <!-- Add "data-abide-has-error" -->
+    <input id="immediateFeedback" aria-describedby="immediateFeedback" type="email" required data-abide-has-error>
+    <!-- Add "is-visible" -->
+    <span id="immediateFeedbackError" class="form-error is-visible">Email is taken.</span>
+  </label>
+</form>
+```
+
 ---
 
 ## Ignored Inputs

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -46,6 +46,13 @@ class Abide extends Plugin {
       $globalErrors.each((i, error) => this.addGlobalErrorA11yAttributes($(error)));
     }
 
+    // Provide immediate validation feedback marked inputs marked with `[data-abide-has-error]`
+    this.$inputs.each((i, input) => {
+      let $input = $(input);
+      if (this.shouldSkipValidation($input)) return;
+      if ($input.is('[data-abide-has-error]')) this.addErrorClasses($input);
+    });
+
     this._events();
   }
 
@@ -132,6 +139,17 @@ class Abide extends Plugin {
    */
   disableValidation() {
     this.isEnabled = false;
+  }
+
+  /**
+   * Checks if validiation should be skipped for the given $el.
+   * Don't validate ignored inputs or hidden inputs or disabled inputs.
+   * @param {Object} element - jQuery object to check for required attribute
+   * @returns {Boolean} - true if validation shoudl be skipped for this element
+   */
+  shouldSkipValidation($el) {
+    // don't validate ignored inputs or hidden inputs or disabled inputs
+    return $el.is('[data-abide-ignore]') || $el.is('[type="hidden"]') || $el.is('[disabled]')
   }
 
   /**
@@ -443,7 +461,7 @@ class Abide extends Plugin {
     }
 
     // don't validate ignored inputs or hidden inputs or disabled inputs
-    if ($el.is('[data-abide-ignore]') || $el.is('[type="hidden"]') || $el.is('[disabled]')) {
+    if (this.shouldSkipValidation($el)) {
       return true;
     }
 

--- a/test/javascript/components/abide.js
+++ b/test/javascript/components/abide.js
@@ -36,9 +36,24 @@ describe('Abide', function() {
     });
   });
 
+  describe('setup', function () {
+    it('adds error classes to elements with `[data-abide-has-error]` attribute', function() {
+      $html = $(`
+        <form data-abide novalidate>
+          <label for="x"></label>
+          <input id="x" data-abide-has-error>
+        </form>
+      `).appendTo('body');
+      plugin = new Foundation.Abide($html, {});
+
+      $html.find('label').should.have.class(plugin.options.labelErrorClass);
+      $html.find('input').should.have.class(plugin.options.inputErrorClass);
+    });
+  });
+
   describe('validateForm()', function() {
     it('returns true after validation is disabled', function() {
-      $html = $("<form data-abide novalidate><input required type='text'><input type='submit'></form>").appendTo("body");
+      $html = $(`<form data-abide novalidate><input required type='text'><input type='submit'></form>`).appendTo("body");
       plugin = new Foundation.Abide($html, {});
 
       plugin.disableValidation();


### PR DESCRIPTION
## Description

This feature allows developers to display inputs with error markup immediately on page load.

The most likely use-case is when the server rejects the form submission and the form needs to be displayed with one or more inputs shown as having errors.

This functionality is opt-in by using the `[data-abide-has-error]` attribute and therefore will not impact existing developers using Foundation.

Likewise, this functionality does not alter or affect the existing Abide functionality as described in the unit tests.

### Example of use

When you need to show an input as being in an error state immediately, add the `[data-abide-has-error]` attribute to the input.

Elements marked with `[data-abide-has-error]` are updated immediately with the appropriate error classes.

It is expected that each marked input will have a corresponding Form Error that is set to visible with `is-visible`.

```html
<form data-abide novalidate>
  <label>
    Email
    <!-- Add "data-abide-has-error" -->
    <input id="immediateFeedback" aria-describedby="immediateFeedback" type="email" required data-abide-has-error>
    <!-- Add "is-visible" -->
    <span id="immediateFeedbackError" class="form-error is-visible">Email is taken.</span>
  </label>
</form>
```

### Difficulties and Reasoning

Prior to this feature, an HTML form would need to be manually marked up with all the required classes, data attributes, and aria attributes.

It was expected that developers would follow the documentation as specified in the [Error State example](https://get.foundation/sites/docs/abide.html#error-state) in the Abide documentation.

Comparing the documentation to `addErrorClasses()`, the documentation slightly differs from the actual implementation. `addErrorClasses()` adds a the `[data-invalid]` attribute, which is not documented in the [Error State example](https://get.foundation/sites/docs/abide.html#error-state). 

This premise highlights the reason why it is preferable to add this functionality to Abide, rather than relying on the user to manually add the required markup; The implementation will likely change over time.  Manual implementation is brittle.

This feature gives the user a hook, `[data-abide-has-error]`, to utilize the existing functionality provided by `addErrorClasses()`.  As long as the hook, `[data-abide-has-error]`, remains, the implementation within Abide can change and it will not break the developer's code.

- Closes #12058 


## Types of changes
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).
