### PR TITLE
fix: missing !default in _base.scss #12072

### DIFF
--- a/scss/typography/_base.scss
+++ b/scss/typography/_base.scss
@@ -117,7 +117,7 @@ $paragraph-text-rendering: optimizeLegibility !default;
 
 /// Use the `.code-inline` component as default for `<code>` elements.
 /// @type Boolean
-$enable-code-inline: true;
+$enable-code-inline: true !default;
 
 /// Default color for links.
 /// @type Color
@@ -197,7 +197,7 @@ $blockquote-border: 1px solid $medium-gray !default;
 
 /// Use the `.cite-block` component as default for `<cite>` elements.
 /// @type Boolean
-$enable-cite-block: true;
+$enable-cite-block: true !default;
 
 /// Font family for `<kbd>` elements.
 /// @type String | List


### PR DESCRIPTION
## Description

L120 and L200 in the file `scss/typography/_base.scss` are missing `!default` which does not allow user to override `$enable-cite-block` and `$enable-code-inline` via `_settings.scss`.

- Closes #12072 


## Types of changes

- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist

- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
