### PR TITLE
fix (doc) title-bar fragment in link

### DIFF
--- a/docs/pages/flexbox-mode.md
+++ b/docs/pages/flexbox-mode.md
@@ -54,7 +54,7 @@ Besides the flex grid, these components have flexbox modes:
 - [Menu](menu.html)
 - [Top bar](top-bar.html)
 - [Media object](media-object.html)
-- [Title bar](off-canvas.html#title-bar)
+- [Title bar](off-canvas.html#combining-with-title-bar)
 - [Card](card.html)
 
 In general, all of the components work exactly the same. However, a few of them require slight changes to CSS classes used to work properly. Refer to the documentation for each to find out what's different.


### PR DESCRIPTION
`#title-bar` is not a valid fragment of the _off-canvas_ page