### PR TITLE
fix: error when switching ResponsiveAccordionTabs from tabs to accordion

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -385,6 +385,10 @@ class Tabs extends Plugin {
     var max = 0,
         _this = this; // Lock down the `this` value for the root tabs object
 
+    if (!this.$tabContent) {
+      return;
+    }
+
     this.$tabContent
       .find(`.${this.options.panelClass}`)
       .css('height', '')


### PR DESCRIPTION
<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->
When switching from tabs to accordion, the tabs instance gets destroyed.
Because destroying tabs and recalculating tabs height in  _setHeight method
rely on the foundatuion mediaquery event, both are executed.
Even if tabs instance got destroyed before.

This behaviour leads to an error in the _setHeight of tabs, because tabs markup is
already destroyed and $tabContent is null.

To prevent this, $tabcontent gets tested to be not falsy.

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->

Closes #12106


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
