### PR TITLE
docs: improve Breakpoints description #12160

### DIFF
--- a/docs/pages/media-queries.md
+++ b/docs/pages/media-queries.md
@@ -91,6 +91,23 @@ $breakpoints: (
 
 Changing the widths of any of the breakpoints is as easy as changing the pixel values in this map. Note that here there are two extra breakpoints: `xlarge` and `xxlarge`. We don't use these for any components, and also don't output any CSS classes that use them by default.
 
+Please note that the order of breakpoints must be in ascending order so that keywords like `down` in the `breakpoint` function below will work as expected e.g.
+
+```js
+├─ xlarge max
+│
+├─ xlarge min
+├─ large max    ┓
+│               │
+├─ large min    │
+├─ medium max   │
+│               │   "xlarge down" Breakpoint
+├─ medium min   │
+├─ small max    │
+│               │
+...
+```
+
 You can change that by modifying the `$breakpoint-classes` variable in your settings file. This is a list of breakpoint names. Adding or removing names from the list will change the CSS class output. It looks like this by default:
 
 ```scss

--- a/docs/pages/media-queries.md
+++ b/docs/pages/media-queries.md
@@ -93,20 +93,6 @@ Changing the widths of any of the breakpoints is as easy as changing the pixel v
 
 Please note that the order of breakpoints must be in ascending order so that keywords like `down` in the `breakpoint` function below will work as expected e.g.
 
-```js
-├─ xlarge max
-│
-├─ xlarge min
-├─ large max    ┓
-│               │
-├─ large min    │
-├─ medium max   │
-│               │   "xlarge down" Breakpoint
-├─ medium min   │
-├─ small max    │
-│               │
-...
-```
 
 You can change that by modifying the `$breakpoint-classes` variable in your settings file. This is a list of breakpoint names. Adding or removing names from the list will change the CSS class output. It looks like this by default:
 


### PR DESCRIPTION
## Description
As noted in #8208, #10006 and #11050 the docs on `$breakpoints` could be improved by stating that any custom values should be added in ascending order so that keywords like "down" can work correctly as expected.

- Closes #12160 

## Types of changes
- [x] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).
