### PR TITLE
fix: adjust Keyboard.findFocusable() - sort by tabindex #12164

### DIFF
--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -32,6 +32,32 @@ function findFocusable($element) {
   return $element.find('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]').filter(function() {
     if (!$(this).is(':visible') || $(this).attr('tabindex') < 0) { return false; } //only have visible elements and those that have a tabindex greater or equal 0
     return true;
+  })
+  .sort( function( a, b ) {
+    if ($(a).attr('tabindex') == $(b).attr('tabindex')) {
+      return 0;
+    }
+    let aTabIndex = parseInt($(a).attr('tabindex')),
+      bTabIndex = parseInt($(b).attr('tabindex'));
+    // Undefined is treated the same as 0
+    if (typeof $(a).attr('tabindex') == 'undefined' && bTabIndex > 0) {
+      return 1;
+    }
+    if (typeof $(b).attr('tabindex') == 'undefined' && aTabIndex > 0) {
+      return -1;
+    }
+    if (aTabIndex == 0 && bTabIndex > 0) {
+      return 1;
+    }
+    if (bTabIndex == 0 && aTabIndex > 0) {
+      return -1;
+    }
+    if (aTabIndex < bTabIndex) {
+      return -1;
+    }
+    if (aTabIndex > bTabIndex) {
+      return 1;
+    }
   });
 }
 

--- a/test/javascript/util/keyboard.js
+++ b/test/javascript/util/keyboard.js
@@ -177,6 +177,20 @@ describe('Keyboard util', function() {
 
       $html.remove();
     });
+
+    it('does sort by tabindex', function() {
+      let $html = $(`<div>
+            <a href="#" tabindex="1">Link1</a>
+            <a href="#">Link3</a>
+            <a href="#" tabindex="2">Link2</a>
+          </div>`).appendTo('body');
+
+      let $focusable = Foundation.Keyboard.findFocusable($html);
+
+      $focusable.eq(2)[0].should.be.equal($html.find('a').eq(1)[0]);
+
+      $html.remove();
+    });
   });
 
   describe('trapFocus()', function() {


### PR DESCRIPTION
This ensures first and last focusable are correct in situations where
specific tab ordering is in play

Example: https://codepen.io/d4mation/pen/KKMdPgW vs
https://codepen.io/d4mation/pen/jOrbNyB

<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

This sorts the returned value from `Keyboard.findFocusable()` by `tabindex`.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes #12164


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
