### PR TITLE
Fix issue #12167 where an invalid Meta tag was injected + issue #11188  Notch support

### DIFF
--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -91,7 +91,7 @@ var MediaQuery = {
     var self = this;
     var $meta = $('meta.foundation-mq');
     if(!$meta.length){
-      $('<meta class="foundation-mq">').appendTo(document.head);
+      $('<meta name="generator" content="Zurb Foundation for Sites 6" class="foundation-mq">').appendTo(document.head);
     }
 
     var extractedStyles = $('.foundation-mq').css('font-family');

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -88,10 +88,22 @@ var MediaQuery = {
       this.isInitialized = true;
     }
 
+    var $metaViewport =  $('meta[name="viewport"]');
+    var $metaViewportFit = $('meta[content*="viewport-fit=cover"]');
+    // add meta viewport tag if not present
+    if (!$metaViewport.length) {
+      $('head').append('<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">');
+    } else {
+      // add viewport-fit=cover if not present which is mandatory for the use of css environment variables
+      if (!$metaViewportFit.length) {
+        $metaViewport.attr('content', (i, value) => `${value || ""}, viewport-fit=cover`);
+      }
+    }
+
     var self = this;
     var $meta = $('meta.foundation-mq');
     if(!$meta.length){
-      $('<meta name="generator" content="Zurb Foundation for Sites 6" class="foundation-mq">').appendTo(document.head);
+      $('<meta name="generator" content="Zurb Foundation for Sites" class="foundation-mq">').appendTo(document.head);
     }
 
     var extractedStyles = $('.foundation-mq').css('font-family');

--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -92,7 +92,7 @@ var MediaQuery = {
     var $metaViewportFit = $('meta[content*="viewport-fit=cover"]');
     // add meta viewport tag if not present
     if (!$metaViewport.length) {
-      $('head').append('<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">');
+      $('<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">').appendTo(document.head);
     } else {
       // add viewport-fit=cover if not present which is mandatory for the use of css environment variables
       if (!$metaViewportFit.length) {
@@ -103,7 +103,7 @@ var MediaQuery = {
     var self = this;
     var $meta = $('meta.foundation-mq');
     if(!$meta.length){
-      $('<meta name="generator" content="Zurb Foundation for Sites" class="foundation-mq">').appendTo(document.head);
+      $('<meta name="generator" content="ZURB Foundation for Sites" class="foundation-mq">').appendTo(document.head);
     }
 
     var extractedStyles = $('.foundation-mq').css('font-family');

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -157,6 +157,17 @@ $global-color-pick-contrast-tolerance: 0 !default;
   body {
     margin: 0;
     padding: 0;
+    
+    // using environment variables to account for non-rectangular displays e.g. phones with nodges
+    padding-top: constant(safe-area-inset-top);
+    padding-right: constant(safe-area-inset-right);
+    padding-bottom: constant(safe-area-inset-bottom);
+    padding-left: constant(safe-area-inset-left);
+
+    padding-top: env(safe-area-inset-top);
+    padding-right: env(safe-area-inset-right);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
 
     background: $body-background;
 


### PR DESCRIPTION
- An invalid Meta tag is injected by foundation.util.mediaquery.js.
Meta tags are supposed to have `name` and `content` parameters set.
- Non-rectangular displays, like phones with notches, aren't supported out of the box.

<!------------------------------------------------------------------------------
                    Please fill the following template.
            For more information, see the CONTRIBUTING.md document
------------------------------------------------------------------------------->

## Description
<!-------------------------------------------------------------------
│   Describe your changes in detail. Include any relevant information:
│   reasons, difficulties, links to web references, related issues...
└------------------------------------------------------------------->

### issue #12167 Invalid meta tag fix:
In `js/foundation.util.mediaQuery.js` an invalid Meta tag was injected on line 94.
No `name` and `content` parameters were set.

I changed line 94 from `$('<meta class="foundation-mq">').appendTo(document.head);` to `$('<meta name="generator" content="ZURB Foundation for Sites" class="foundation-mq">').appendTo(document.head);`

### issue #11188 Notch Support fix:
in **foundation.util.mediaQuery.js** on line ~91 just before:
```
var self = this;
var $meta = $('meta.foundation-mq');
```
 I added:
```
var $metaViewport =  $('meta[name="viewport"]');
var $metaViewportFit = $('meta[content*="viewport-fit=cover"]');
// add meta viewport tag if not present
if (!$metaViewport.length) {
  $('head').append('<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover">');
} else {
  // add viewport-fit=cover if not present which is mandatory for the use of css environment variables
  if (!$metaViewportFit.length) {
    $metaViewport.attr('content', (i, value) => \`${value || ""}, viewport-fit=cover\`);
  }
}
```
to make sure a correct meta viewport tag is present.

in **_global.scss** on line ~161 just after:
```
body {
  margin: 0;
  padding: 0;
```
I added:
```
  // using environment variables to account for non-rectangular displays e.g. phones with notches
  padding-top: constant(safe-area-inset-top);
  padding-right: constant(safe-area-inset-right);
  padding-bottom: constant(safe-area-inset-bottom);
  padding-left: constant(safe-area-inset-left);

  padding-top: env(safe-area-inset-top);
  padding-right: env(safe-area-inset-right);
  padding-bottom: env(safe-area-inset-bottom);
  padding-left: env(safe-area-inset-left);
```
...

<!-------------------------------------------------------------------
│   Bugs and new features/improvements must be presented and
│   discussed in an issue first. Please create one if there is no issue
│   related to this pull request. You can skip this step for minor changes.
└------------------------------------------------------------------->
- Closes/fixes  [#12167](https://github.com/foundation/foundation-sites/issues/12167)
- Closes/fixes [#11188](https://github.com/foundation/foundation-sites/issues/11188)


## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
