### PR TITLE
refactor: get rid of slash divisions for dart sass compatibility

### DIFF
--- a/scss/components/_accordion-menu.scss
+++ b/scss/components/_accordion-menu.scss
@@ -58,7 +58,7 @@ $accordionmenu-arrow-size: 6px !default;
       @include css-triangle($accordionmenu-arrow-size, $accordionmenu-arrow-color, down);
       position: absolute;
       top: 50%;
-      margin-top: -1 * ($accordionmenu-arrow-size / 2);
+      margin-top: -1 * ($accordionmenu-arrow-size * 0.5);
       #{$global-right}: 1rem;
     }
   }

--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -130,7 +130,7 @@ $buttongroup-radius-on-each: true !default;
         &:first-child:nth-last-child(#{$i}) {
           &, &:first-child:nth-last-child(#{$i}) ~ #{$selector} {
             display: inline-block;
-            width: calc(#{percentage(1 / $i)} - #{$spacing});
+            width: calc(#{percentage(divide(1, $i))} - #{$spacing});
             margin-#{$global-right}: $spacing;
 
             &:last-child {

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -107,7 +107,7 @@ $dropdown-menu-item-background-active: transparent !default;
         @include css-triangle($dropdownmenu-arrow-size, $dropdownmenu-arrow-color, down);
         #{$global-right}: 5px;
         #{$global-left}: auto;
-        margin-top: -1 * ($dropdownmenu-arrow-size / 2);
+        margin-top: -1 * ($dropdownmenu-arrow-size * 0.5);
       }
     }
   }

--- a/scss/components/_table.scss
+++ b/scss/components/_table.scss
@@ -50,7 +50,7 @@ $table-stripe: even !default;
 
 /// Default color for header background.
 /// @type Color
-$table-head-background: smart-scale($table-background, $table-color-scale / 2) !default;
+$table-head-background: smart-scale($table-background, $table-color-scale * 0.5) !default;
 
 /// Default color of header rows on hover.
 /// @type List

--- a/scss/forms/_label.scss
+++ b/scss/forms/_label.scss
@@ -36,7 +36,7 @@ $form-label-line-height: 1.8 !default;
   $input-border-width: get-border-value($input-border, width);
 
   margin: 0 0 $form-spacing;
-  padding: ($form-spacing / 2 + rem-calc($input-border-width)) 0;
+  padding: ($form-spacing * 0.5 + rem-calc($input-border-width)) 0;
 }
 
 @mixin foundation-form-label {

--- a/scss/forms/_range.scss
+++ b/scss/forms/_range.scss
@@ -40,7 +40,7 @@ $slider-radius: $global-radius !default;
 
 @mixin foundation-range-input {
   input[type='range'] {  // sass-lint:disable-line no-qualifying-elements
-    $margin: ($slider-handle-height - $slider-height) / 2;
+    $margin: ($slider-handle-height - $slider-height) * 0.5;
 
     display: block;
     width: 100%;

--- a/scss/forms/_text.scss
+++ b/scss/forms/_text.scss
@@ -52,7 +52,7 @@ $input-border-focus: 1px solid $dark-gray !default;
 
 /// Padding of text inputs.
 /// @type Color
-$input-padding: $form-spacing / 2 !default;
+$input-padding: $form-spacing * 0.5 !default;
 
 /// Box shadow inside text inputs when not focused.
 /// @type Shadow

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -102,7 +102,7 @@
   flex-wrap: wrap;
 
   > #{$selector} {
-    $pct: percentage(1/$n);
+    $pct: percentage(divide(1, $n));
 
     flex: 0 0 $pct;
     max-width: $pct;

--- a/scss/grid/_gutter.scss
+++ b/scss/grid/_gutter.scss
@@ -18,7 +18,7 @@
   $gutters: $grid-column-gutter
 ) {
   @include -zf-breakpoint-value($gutter, $gutters) {
-    $padding: rem-calc($-zf-bp-value) / 2;
+    $padding: rem-calc($-zf-bp-value) * 0.5;
 
     padding-right: $padding;
     padding-left: $padding;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -21,14 +21,14 @@
 ) {
   & > #{$selector} {
     float: $global-left;
-    width: percentage(1/$n);
+    width: percentage(divide(1, $n));
 
     // If a $gutter value is passed
     @if($gutter) {
       // Gutters
       @if type-of($gutter) == 'map' {
         @each $breakpoint, $value in $gutter {
-          $padding: rem-calc($value) / 2;
+          $padding: rem-calc($value) * 0.5;
 
           @include breakpoint($breakpoint) {
             padding-right: $padding;
@@ -37,7 +37,7 @@
         }
       }
       @else if type-of($gutter) == 'number' and strip-unit($gutter) > 0 {
-        $padding: rem-calc($gutter) / 2;
+        $padding: rem-calc($gutter) * 0.5;
         padding-right: $padding;
         padding-left: $padding;
       }
@@ -64,12 +64,12 @@
   @for $i from 1 to $n {
     @if $i == 1 {
       &:nth-child(#{$n}n+1):last-child {
-        margin-left: (100 - 100/$n * $i) / 2 * 1%;
+        margin-left: (100 - divide(100, $n) * $i) * 0.5 * 1%;
       }
     }
     @else {
       &:nth-child(#{$n}n+1):nth-last-child(#{$i}) {
-        margin-left: (100 - 100/$n * $i) / 2 * 1%;
+        margin-left: (100 - divide(100, $n) * $i) * 0.5 * 1%;
       }
     }
   }

--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -32,7 +32,7 @@
 
   // Push/pull
   @else if type-of($position) == 'number' {
-    $offset: percentage($position / $grid-column-count);
+    $offset: percentage(divide($position, $grid-column-count));
 
     position: relative;
     #{$global-left}: $offset;

--- a/scss/grid/_row.scss
+++ b/scss/grid/_row.scss
@@ -80,7 +80,7 @@
 /// @param {Number|Map} $gutters [$grid-column-gutter] - Gutter map or single value to use when inverting margins. Responsive gutter settings by default.
 @mixin grid-row-nest($gutters: $grid-column-gutter) {
   @include -zf-each-breakpoint {
-    $margin: rem-calc(-zf-get-bp-val($gutters, $-zf-size)) / 2 * -1;
+    $margin: rem-calc(-zf-get-bp-val($gutters, $-zf-size)) * 0.5 * -1;
 
     margin-right: $margin;
     margin-left: $margin;

--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -461,7 +461,7 @@ $input-background-focus: $white;
 $input-background-disabled: $light-gray;
 $input-border: 1px solid $medium-gray;
 $input-border-focus: 1px solid $dark-gray;
-$input-padding: $form-spacing / 2;
+$input-padding: $form-spacing * 0.5;
 $input-shadow: inset 0 1px 2px rgba($black, 0.1);
 $input-shadow-focus: 0 0 5px $medium-gray;
 $input-cursor-disabled: not-allowed;
@@ -807,7 +807,7 @@ $table-row-stripe-hover: darken($table-background, $table-color-scale + $table-h
 $table-is-striped: true;
 $table-striped-background: smart-scale($table-background, $table-color-scale);
 $table-stripe: even;
-$table-head-background: smart-scale($table-background, $table-color-scale / 2);
+$table-head-background: smart-scale($table-background, $table-color-scale * 0.5);
 $table-head-row-hover: darken($table-head-background, $table-hover-scale);
 $table-foot-background: smart-scale($table-background, $table-color-scale);
 $table-foot-row-hover: darken($table-foot-background, $table-hover-scale);

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -113,7 +113,7 @@ $breakpoint-classes: (small medium large) !default;
       // Max value is 0.2px under the next breakpoint (0.02 / 16 = 0.00125).
       // Use a precision under 1px to support browser zoom, but not to low to avoid rounding.
       // See https://github.com/foundation/foundation-sites/issues/11313
-      $bp-max: if($hidpi, $bp-next - (1/$std-web-dpi), -zf-bp-to-em($bp-next) - 0.00125);
+      $bp-max: if($hidpi, $bp-next - divide(1, $std-web-dpi), -zf-bp-to-em($bp-next) - 0.00125);
     }
   }
 

--- a/scss/util/_color.scss
+++ b/scss/util/_color.scss
@@ -23,9 +23,9 @@ $contrast-warnings: true !default;
 
   @for $i from 1 through 3 {
     $rgb: nth($rgba, $i);
-    $rgb: $rgb / 255;
+    $rgb: divide($rgb, 255);
 
-    $rgb: if($rgb < 0.03928, $rgb / 12.92, pow(($rgb + 0.055) / 1.055, 2.4));
+    $rgb: if($rgb < 0.03928, divide($rgb, 12.92), pow(divide($rgb + 0.055, 1.055), 2.4));
 
     $rgba2: append($rgba2, $rgb);
   }
@@ -44,13 +44,13 @@ $contrast-warnings: true !default;
   // Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
   $luminance1: color-luminance($color1) + 0.05;
   $luminance2: color-luminance($color2) + 0.05;
-  $ratio: $luminance1 / $luminance2;
+  $ratio: divide($luminance1, $luminance2);
 
   @if $luminance2 > $luminance1 {
-    $ratio: 1 / $ratio;
+    $ratio: divide(1, $ratio);
   }
 
-  $ratio: round($ratio * 10) / 10;
+  $ratio: round($ratio * 10) * 0.1;
 
   @return $ratio;
 }

--- a/scss/util/_direction.scss
+++ b/scss/util/_direction.scss
@@ -23,7 +23,7 @@
 
   // Calculate the opposite place in a circle, with a starting index of 1
   $length: length($dirs);
-  $demi: $length / 2;
+  $demi: $length * 0.5;
   $opposite-place: (($place + $demi - 1) % $length) + 1;
 
   @return nth($dirs, $opposite-place);

--- a/scss/util/_math.scss
+++ b/scss/util/_math.scss
@@ -33,7 +33,7 @@
     $prec2 : pow(10, $prec);
     $exponent: round($exponent * $prec2);
     $denominator: gcd($exponent, $prec2);
-    @return nth-root(pow($base, $exponent / $denominator), $prec2 / $denominator, $prec);
+    @return nth-root(pow($base, divide($exponent, $denominator)), divide($prec2, $denominator), $prec);
   }
 
   $value: $base;
@@ -44,7 +44,7 @@
   }
   @else if $exponent < 1 {
     @for $i from 0 through -$exponent {
-      $value: $value / $base;
+      $value: divide($value, $base);
     }
   }
 
@@ -56,7 +56,7 @@
   $x: 1;
 
   @for $i from 0 through $prec {
-    $x: 1 / $n * (($n - 1) * $x + ($num / pow($x, $n - 1)));
+    $x: divide(1, $n) * (($n - 1) * $x + divide($num, pow($x, $n - 1)));
   }
 
   @return $x;
@@ -68,7 +68,7 @@
 @function ratio-to-percentage($ratio) {
   $w: nth($ratio, 1);
   $h: nth($ratio, 3);
-  @return $h / $w * 100%;
+  @return divide($h, $w) * 100%;
 }
 
 /// Parse the given `$fraction` to numerators and denumerators.
@@ -143,5 +143,5 @@
     }
   }
 
-  @return percentage($parsed-nominator / $parsed-denominator);
+  @return percentage(divide($parsed-nominator, $parsed-denominator));
 }

--- a/scss/util/_math.scss
+++ b/scss/util/_math.scss
@@ -145,3 +145,53 @@
 
   @return percentage(divide($parsed-nominator, $parsed-denominator));
 }
+
+/// Divide the given `$divident` by the given `$divisor`.
+///
+/// @param {Number} $divident - The divident.
+/// @param {Number} $divisor - The divisor.
+/// @param {Number} $precision - The precision decimals for the division.
+///
+/// @return {Number} The product of the division.
+@function divide($dividend, $divisor, $precision: 12) {
+  $sign: if($dividend > 0 and $divisor > 0 or $dividend < 0 and $divisor < 0, 1, -1);
+  $dividend: abs($dividend);
+  $divisor: abs($divisor);
+  @if $dividend == 0 {
+    @return 0;
+  }
+  @if $divisor == 0 {
+    @error "Cannot divide by 0";
+  }
+  $remainder: $dividend;
+  $result: 0;
+  $factor: 10;
+  @while ($remainder > 0 and $precision >= 0) {
+    $quotient: 0;
+    @while ($remainder >= $divisor) {
+      $remainder: $remainder - $divisor;
+      $quotient: $quotient + 1;
+    }
+    $result: $result * 10 + $quotient;
+    $factor: $factor * .1;
+    $remainder: $remainder * 10;
+    $precision: $precision - 1;
+    @if ($precision < 0 and $remainder >= $divisor * 5) {
+      $result: $result + 1;
+    }
+  }
+  $result: $result * $factor * $sign;
+  $dividend-unit: unit($dividend);
+  $divisor-unit: unit($divisor);
+  $unit-map: (
+    "px": 1px,
+    "rem": 1rem,
+    "em": 1em,
+    "%": 1%
+  );
+  @if ($dividend-unit != $divisor-unit and map-has-key($unit-map, $dividend-unit)) {
+    $result: $result * map-get($unit-map, $dividend-unit);
+  }
+
+  @return $result;
+}

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -91,7 +91,7 @@
   $hover-shadow: ();
 
   // Spacing between bars is calculated based on the total height of the icon and the weight of each bar
-  $spacing: ($height - ($weight * $bars)) / ($bars - 1);
+  $spacing: divide($height - ($weight * $bars), $bars - 1);
 
   @if unit($spacing) == 'px' {
     $spacing: floor($spacing);
@@ -192,7 +192,7 @@
   @for $i from 2 through $max {
     &:nth-last-child(#{$i}):first-child,
     &:nth-last-child(#{$i}):first-child ~ #{$elem} {
-      width: percentage(1 / $i);
+      width: percentage(divide(1, $i));
     }
   }
 }

--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -2,6 +2,8 @@
 // https://get.foundation
 // Licensed under MIT Open Source
 
+@import 'math';
+
 ////
 /// @group functions
 ////
@@ -14,7 +16,7 @@ $global-font-size: 100% !default;
 ///
 /// @returns {Number} The same number, sans unit.
 @function strip-unit($num) {
-  @return $num / ($num * 0 + 1);
+  @return divide($num, $num * 0 + 1);
 }
 
 /// Converts one or more pixel values into matching rem values.
@@ -35,7 +37,7 @@ $global-font-size: 100% !default;
   // If the base font size is a %, then multiply it by 16px
   // This is because 100% font size = 16px in most all browsers
   @if unit($base) == '%' {
-    $base: ($base / 100%) * 16px;
+    $base: divide($base, 100%) * 16px;
   }
 
   // Using rem as base allows correct scaling
@@ -86,7 +88,7 @@ $global-font-size: 100% !default;
 
   // Calculate rem if units for $value is not rem or em
   @if unit($value) != 'rem' {
-    $value: strip-unit($value) / strip-unit($base) * 1rem;
+    $value: divide(strip-unit($value), strip-unit($base)) * 1rem;
   }
 
   // Turn 0rem into 0
@@ -114,7 +116,7 @@ $global-font-size: 100% !default;
 
   // If the base font size is a %, then multiply it by 16px
   @if unit($base) == '%' {
-    $base: ($base / 100%) * 16px;
+    $base: divide($base, 100%) * 16px;
   }
 
   @if unit($base) == 'rem' {
@@ -127,7 +129,7 @@ $global-font-size: 100% !default;
 
   // Now let's convert our value to pixels too
   @if unit($value) == '%' {
-    $value: ($value / 100%) * $base;
+    $value: divide($value, 100%) * $base;
   }
 
   @if unit($value) == 'rem' {
@@ -140,12 +142,12 @@ $global-font-size: 100% !default;
 
   // 'px'
   @if unit($value) == 'px' {
-    @return strip-unit($value) / strip-unit($base);
+    @return divide(strip-unit($value), strip-unit($base));
   }
 
   // assume that line-heights greater than 10 are meant to be absolute in 'px'
   @if unitless($value) and ($value > 10) {
-    @return $value / strip-unit($base);
+    @return divide($value, strip-unit($base));
   }
 
   @return $value;

--- a/scss/xy-grid/_gutters.scss
+++ b/scss/xy-grid/_gutters.scss
@@ -26,7 +26,7 @@
   // Output our margin gutters.
   @if (type-of($gutters) == 'map') {
     @include -zf-breakpoint-value(auto, $gutters) {
-      $gutter: rem-calc($-zf-bp-value) / 2;
+      $gutter: rem-calc($-zf-bp-value) * 0.5;
 
       // Loop through each gutter position
       @each $value in $gutter-position {
@@ -35,7 +35,7 @@
     }
   }
   @else if (type-of($gutters) == 'number') {
-    $gutter: rem-calc($gutters) / 2;
+    $gutter: rem-calc($gutters) * 0.5;
 
     // Loop through each gutter position
     @each $value in $gutter-position {

--- a/scss/xy-grid/_layout.scss
+++ b/scss/xy-grid/_layout.scss
@@ -28,7 +28,7 @@
   $vertical: false,
   $output: (base size gutters)
 ) {
-  $size: percentage(1/$n);
+  $size: percentage(divide(1, $n));
 
   & > #{$selector} {
     @include xy-cell($size, $gutter-output, $gutters, $gutter-type, $gutter-position, $breakpoint, $vertical, $output);

--- a/scss/xy-grid/_position.scss
+++ b/scss/xy-grid/_position.scss
@@ -25,7 +25,7 @@
 
   $offset: $size;
   @if ($gutter-type == 'margin') {
-    $gutter: rem-calc(xy-cell-gutters($gutters, $breakpoint) / 2);
+    $gutter: rem-calc(xy-cell-gutters($gutters, $breakpoint) * 0.5);
     $offset: if($gutter == 0, $size, calc(#{$size} + #{$gutter}));
   }
   @return $offset;

--- a/test/sass/_components.scss
+++ b/test/sass/_components.scss
@@ -9,7 +9,7 @@
 
   @include test('Ratio to Percentage [function]') {
     $test: ratio-to-percentage(3 by 4);
-    $expect: 4 / 3 * 100%;
+    $expect: divide(4, 3) * 100%;
 
     @include assert-equal($test, $expect,
       'Creates a percentage value from a ratio');


### PR DESCRIPTION
## Description
This refactors all slash divisions to either one of these two:
1. Multiplication if the same division is possible with multiplication (e.g. `num / 2` = `num * 0.5`)
2. The added `divide` method which is [ported from Bootstrap](https://github.com/twbs/bootstrap/blob/5c1691ac3a7511e3ae0f1f619bfc0c848090efb5/scss/_functions.scss#L233-L273)

Using these methods allows maintaining backwards compatibility with LibSass as well as to get rid of the deprecation messages using Dart Sass.

The migration has been done using the tool provided on this page:
https://sass-lang.com/documentation/breaking-changes/slash-div

The change made in the migration is to change all references for `math.div` into `divide`.

- Closes #12237
- Related to #12233


## Types of changes

- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [x] Maintenance (refactor, code cleaning, development tools...)


## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).