### PR TITLE
fix(reveal): mark correct aria-haspopup value for modal opening controls

### DIFF
--- a/js/foundation.reveal.js
+++ b/js/foundation.reveal.js
@@ -55,7 +55,7 @@ class Reveal extends Plugin {
     this.$anchor = $(`[data-open="${this.id}"]`).length ? $(`[data-open="${this.id}"]`) : $(`[data-toggle="${this.id}"]`);
     this.$anchor.attr({
       'aria-controls': this.id,
-      'aria-haspopup': true,
+      'aria-haspopup': 'dialog',
       'tabindex': 0
     });
 

--- a/test/javascript/components/reveal.js
+++ b/test/javascript/components/reveal.js
@@ -48,7 +48,7 @@ describe('Reveal', function() {
       var $anchor = $('<button data-open="exampleModal1">Open</button>').appendTo('body');
       plugin = new Foundation.Reveal($html, {});
 
-      $anchor.should.have.attr('aria-haspopup', 'true');
+      $anchor.should.have.attr('aria-haspopup', 'dialog');
       $anchor.should.have.attr('aria-controls', $html.attr('id'));
 
       $anchor.remove();


### PR DESCRIPTION
## Description
The correct value for `aria-haspopup` for dialog controlling elements is `dialog`, not `true` which indicates a menu element.

See: https://www.w3.org/TR/wai-aria-1.1/#dialog

Also see: https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup

> A popup element usually appears as a block of content that is on top of other content. Authors MUST ensure that the role of the element that serves as the container for the popup content is menu, listbox, tree, grid, or dialog, and that the value of aria-haspopup matches the role of the popup container.

## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)

## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).