### PR TITLE
Fix: Do not return unitless zeroes from -zf-to-rem, as these do not work as values within css calc()

### DIFF
--- a/scss/util/_unit.scss
+++ b/scss/util/_unit.scss
@@ -95,11 +95,6 @@ $global-font-size: 100% !default;
     $value: divide(strip-unit($value), strip-unit($base)) * 1rem;
   }
 
-  // Turn 0rem into 0
-  @if $value == 0rem {
-    $value: 0;
-  }
-
   @return $value;
 }
 


### PR DESCRIPTION
## Description
Zero gutters used to work fine with the XY grid.
After I recently upgraded several sites to Foundation 6.7.4, I found that at some point there's been a breaking change. I tracked the problem down to invalid `calc()`s being generated for cell widths, due to `-zf-to-rem()` returning zero values without a unit suffix. This patch fixed my problems; See the issue for further discussion though.

- Closes #12325 


## Types of changes
- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).