### PR TITLE
Fix wrong markup in the typography base file

### DIFF
--- a/docs/pages/typography-base.md
+++ b/docs/pages/typography-base.md
@@ -22,7 +22,7 @@ tags:
 This is a paragraph. Paragraphs are preset with a font size, line height and spacing to match the overall vertical rhythm. To show what a paragraph looks like this needs a little more content&mdash;so, did you know that there are storms occurring on Jupiter that are larger than the Earth? Pretty cool. Use the `<strong>` and `<em>` tags to denote text that should be displayed or read with emphasis. Browsers will **bold** and *italicize* the words, while screen readers will read them with *emphasis*.
 
 <div class="callout primary">
-  <p>If the emphasis of a phrase is important, don't make the emphasis purely visual&mdash;use the `<em>` or `<strong>` tags to mark it as well. Both of these tags have built-in styles, but there's no harm in adding additional styles in specific contexts.</p>
+  <p>If the emphasis of a phrase is important, don't make the emphasis purely visual&mdash;use the <code>&lt;em&gt;</code> or <code>&lt;strong&gt;</code> tags to mark it as well. Both of these tags have built-in styles, but there's no harm in adding additional styles in specific contexts.</p>
 </div>
 
 <div class="docs-codepen-container">


### PR DESCRIPTION
## Description

The markup for the [Base Typography](https://get.foundation/sites/docs/typography-base.html) was wrong, causing most of the page to be rendered as bold/italic, because the markdown tags were not rendered within the `<p>` HTML block.

![Screenshot from 2021-11-20 18-05-45](https://user-images.githubusercontent.com/579329/142743362-7fef7df3-8b7f-41d9-bc79-d8188a470e1b.png)

This fixes the issue.

## Types of changes
- [x] Documentation

## Checklist
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
