### PR TITLE
Documentation: Fix options name for "In-Canvas to Off-Canvas" code example

### DIFF
--- a/docs/pages/off-canvas.md
+++ b/docs/pages/off-canvas.md
@@ -360,7 +360,7 @@ With this feature you can have a standard page element move off-canvas at a part
 <button type="button" class="button hide-for-large" data-toggle="inCanvasExample">
   Open in-canvas that is off-canvas now
 </button>
-<div class="off-canvas position-right" id="inCanvasExample" data-off-canvas data-options="inCanvasFor:large;">
+<div class="off-canvas position-right" id="inCanvasExample" data-off-canvas data-options="inCanvasOn:large;">
   <div class="callout">I'm in-canvas for medium screen size and move off-canvas for medium down.</div>
 </div>
 ```


### PR DESCRIPTION
The corresponding code example said "inCanvasFor:large;", which leads to a false object property when executed.

The correct property name in foundation.offcanvas.js line ~151 is `this.options.inCanvasOn`
