### PR TITLE
fix: typo in $-zf-bp-value name

### DIFF
--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -7,7 +7,7 @@
 ////
 
 // Patch to fix issue #12080
-$-zf-pb-value: null;
+$-zf-bp-value: null;
 
 /// Creates an inner box-shadow for only one side
 ///


### PR DESCRIPTION
## Description

After issue #12080 was fixed in pull request #12195, there was still a warning when compiling SCSS:

```
DEPRECATION WARNING on line 369 of scss/util/_mixins.scss: !global
assignments won't be able to declare new variables in future versions.
Consider adding `$-zf-bp-value: null` at the top level
```

The reason was a typo in the assigned variable name, which had "pb" instead of "bp".

## Types of changes

- [ ] Documentation
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)

## Checklist

- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [ ] I have updated the documentation accordingly to my changes (if relevant).
- [ ] I have added tests to cover my changes (if relevant).