### PR TITLE
Use "sass:math" for `percentage` function

### DIFF
--- a/scss/components/_button-group.scss
+++ b/scss/components/_button-group.scss
@@ -6,6 +6,8 @@
 /// @group button-group
 ////
 
+@use "sass:math";
+
 /// Margin for button groups.
 /// @type Number
 $buttongroup-margin: 1rem !default;
@@ -131,7 +133,7 @@ $buttongroup-radius-on-each: true !default;
         &:first-child:nth-last-child(#{$i}) {
           &, &:first-child:nth-last-child(#{$i}) ~ #{$selector} {
             display: inline-block;
-            width: calc(#{percentage(divide(1, $i))} - #{$spacing});
+            width: calc(#{math.percentage(divide(1, $i))} - #{$spacing});
             margin-#{$global-right}: $spacing;
 
             &:last-child {

--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -6,6 +6,8 @@
 /// @group flex-grid
 ////
 
+@use "sass:math";
+
 /// Creates a container for a flex grid row.
 ///
 /// @param {Keyword|List} $behavior [null]
@@ -103,7 +105,7 @@
   flex-wrap: wrap;
 
   > #{$selector} {
-    $pct: percentage(divide(1, $n));
+    $pct: math.percentage(divide(1, $n));
 
     flex: 0 0 $pct;
     max-width: $pct;

--- a/scss/grid/_layout.scss
+++ b/scss/grid/_layout.scss
@@ -6,6 +6,8 @@
 /// @group grid
 ////
 
+@use "sass:math";
+
 /// Sizes child elements so that `$n` number of items appear on each row.
 ///
 /// @param {Number} $n - Number of elements to display per row.
@@ -21,7 +23,7 @@
 ) {
   & > #{$selector} {
     float: $global-left;
-    width: percentage(divide(1, $n));
+    width: math.percentage(divide(1, $n));
 
     // If a $gutter value is passed
     @if($gutter) {

--- a/scss/grid/_position.scss
+++ b/scss/grid/_position.scss
@@ -6,6 +6,8 @@
 /// @group grid
 ////
 
+@use "sass:math";
+
 /// Reposition a column.
 ///
 /// @param {Number|Keyword} $position - It can be:
@@ -32,7 +34,7 @@
 
   // Push/pull
   @else if type-of($position) == 'number' {
-    $offset: percentage(divide($position, $grid-column-count));
+    $offset: math.percentage(divide($position, $grid-column-count));
 
     position: relative;
     #{$global-left}: $offset;

--- a/scss/util/_math.scss
+++ b/scss/util/_math.scss
@@ -145,7 +145,7 @@
     }
   }
 
-  @return percentage(divide($parsed-nominator, $parsed-denominator));
+  @return math.percentage(divide($parsed-nominator, $parsed-denominator));
 }
 
 /// Divide the given `$divident` by the given `$divisor`.

--- a/scss/util/_mixins.scss
+++ b/scss/util/_mixins.scss
@@ -7,6 +7,7 @@
 ////
 
 @use "sass:color";
+@use "sass:math";
 
 // Patch to fix issue #12080
 $-zf-bp-value: null;
@@ -197,7 +198,7 @@ $-zf-bp-value: null;
   @for $i from 2 through $max {
     &:nth-last-child(#{$i}):first-child,
     &:nth-last-child(#{$i}):first-child ~ #{$elem} {
-      width: percentage(divide(1, $i));
+      width: math.percentage(divide(1, $i));
     }
   }
 }

--- a/scss/xy-grid/_layout.scss
+++ b/scss/xy-grid/_layout.scss
@@ -6,6 +6,8 @@
 /// @group xy-grid
 ////
 
+@use "sass:math";
+
 /// Sizes child elements so that `$n` number of items appear on each row.
 ///
 /// @param {Number} $n - Number of elements to display per row.
@@ -28,7 +30,7 @@
   $vertical: false,
   $output: (base size gutters)
 ) {
-  $size: percentage(divide(1, $n));
+  $size: math.percentage(divide(1, $n));
 
   & > #{$selector} {
     @include xy-cell($size, $gutter-output, $gutters, $gutter-type, $gutter-position, $breakpoint, $vertical, $output);


### PR DESCRIPTION
## Description

Calling global `percentage` is deprecated. This uses "sass:math" instead.

## Types of changes
<!-------------------------------------------------------------------
│   What types of changes does your code introduce?
│   Fill with [x] all the boxes that apply:
└------------------------------------------------------------------->
- [ ] Documentation
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [x] Maintenance (refactor, code cleaning, development tools...)


## Checklist
<!-------------------------------------------------------------------
│   Please ensure that all the following points are respected.
│   Fill with [x] the boxes once the rule is respected.
└------------------------------------------------------------------->
- [x] I have read and follow the CONTRIBUTING.md document.
- [x] The pull request title and template are correctly filled.
- [x] The pull request targets the right branch (`develop` or `develop-v...`).
- [x] My commits are correctly titled and contain all relevant information.
- [x] I have updated the documentation accordingly to my changes (if relevant).
- [x] I have added tests to cover my changes (if relevant).


<!------------------------------------------------------------------------------
            For more information, see the CONTRIBUTING.md document         
              Thank you for your pull request and happy coding ;)          
------------------------------------------------------------------------------->
