### PR TITLE
fix: prevent ReDoS in URL regex pattern

### DIFF
--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -861,8 +861,15 @@ Abide.defaults = {
     // From CommonRegexJS (@talyssonoc)
     // https://github.com/talyssonoc/CommonRegexJS/blob/e2901b9f57222bc14069dc8f0598d5f412555411/lib/commonregex.js#L76
     // For more restrictive URL Regexs, see https://mathiasbynens.be/demo/url-regex.
-    url: /^(?:(https?|ftps?|file|ssh|sftp):\/\/|www\d{0,3}[.]|[a-z0-9.\-]+\.[a-z]{2,4}\/)(?:[^\s()<>]+(?:\((?:[^\s()<>]+|\([^\s()<>]+\))?\)[^\s()<>]+)*)(?:\((?:[^\s()<>]+|\([^\s()<>]+\))?\)|[^\s`!()\[\]{};:'".,<>?\xab\xbb\u201c\u201d\u2018\u2019])$/,
-
+    url: (function() {
+      const protocol = '(?:https?|ftps?|file|ssh|sftp):\\/\\/';
+      const www      = 'www\\d{0,3}[.]';
+      const domain   = '[a-z0-9.\\-]+[.][a-z]{2,4}\\/';
+      const body = '(?:[^\\s()<>]+|\\((?:[^\\s()<>]+|(?:\\([^\\s()<>]+\\)))*\\))+' +
+                   '(?:\\((?:[^\\s()<>]+|(?:\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:\'".,<>?\\xab\\xbb\\u201c\\u201d\\u2018\\u2019])';
+      return new RegExp(`^((?:${protocol}|${www}|${domain})${body})$`, 'i');
+    })(),
+    
     // abc.de
     domain : /^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,8}$/,
 

--- a/js/foundation.abide.js
+++ b/js/foundation.abide.js
@@ -861,7 +861,7 @@ Abide.defaults = {
     // From CommonRegexJS (@talyssonoc)
     // https://github.com/talyssonoc/CommonRegexJS/blob/e2901b9f57222bc14069dc8f0598d5f412555411/lib/commonregex.js#L76
     // For more restrictive URL Regexs, see https://mathiasbynens.be/demo/url-regex.
-    url: /^((?:(https?|ftps?|file|ssh|sftp):\/\/|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?\xab\xbb\u201c\u201d\u2018\u2019]))$/,
+    url: /^(?:(https?|ftps?|file|ssh|sftp):\/\/|www\d{0,3}[.]|[a-z0-9.\-]+\.[a-z]{2,4}\/)(?:[^\s()<>]+(?:\((?:[^\s()<>]+|\([^\s()<>]+\))?\)[^\s()<>]+)*)(?:\((?:[^\s()<>]+|\([^\s()<>]+\))?\)|[^\s`!()\[\]{};:'".,<>?\xab\xbb\u201c\u201d\u2018\u2019])$/,
 
     // abc.de
     domain : /^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,8}$/,


### PR DESCRIPTION
## Description
This PR updates the URL validation regex in foundation.abide.js to address the ReDoS vulnerability. I plugged the new regex into -- https://regexr.com/ -- and made sure it matched the same cases as the old one. I used this ReDoS checker -- https://devina.io/redos-checker -- to ensure that the new regex wasn't vulnerable. 
- Closes [#12180](https://github.com/foundation/foundation-sites/issues/12180)


## Types of changes

- [ ] Documentation
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (anything that would change an existing functionality)
- [ ] Maintenance (refactor, code cleaning, development tools...)


## Checklist

- [X] I have read and follow the CONTRIBUTING.md document.
- [X] The pull request title and template are correctly filled.
- [X] The pull request targets the right branch (`develop` or `develop-v...`).
- [X] My commits are correctly titled and contain all relevant information.
- [X] I have updated the documentation accordingly to my changes (if relevant).
- [X] I have added tests to cover my changes (if relevant).
